### PR TITLE
Fixed banlist to work with both MySQL 5.6+ and lower.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Requirements:
  * Webserver
    o PHP 5.4 or higher
      * ini setting: memory_limit greater than or equal to 64M
-   o MySQL 5.6
+   o MySQL 5.0
  * Source Dedicated Server
    o MetaMod: Source
    o SourceMod: Greater Than or Equal To 1.7

--- a/web_upload/init.php
+++ b/web_upload/init.php
@@ -117,6 +117,9 @@ $GLOBALS['log'] = new CSystemLog();
 if( !is_object($GLOBALS['db']) )
 				die();
 				
+$mysql_server_info = $GLOBALS['db']->ServerInfo();
+$GLOBALS['db_version'] = $mysql_server_info['version'];
+
 $debug = $GLOBALS['db']->Execute("SELECT value FROM `".DB_PREFIX."_settings` WHERE setting = 'config.debug';");
 if($debug->fields['value']=="1") {
 	define("DEVELOPER_MODE", true);

--- a/web_upload/pages/page.banlist.php
+++ b/web_upload/pages/page.banlist.php
@@ -37,7 +37,10 @@ if (isset($_GET['page']) && $_GET['page'] > 0)
 	$page = intval($_GET['page']);
 	$pagelink = "&page=".$page;
 }
-$GLOBALS['db']->Execute("set session optimizer_switch='block_nested_loop=off';");
+if (version_compare($GLOBALS['db_version'], "5.6.0") >= 0)
+{
+  $GLOBALS['db']->Execute("set session optimizer_switch='block_nested_loop=off';");
+}
 if (isset($_GET['a']) && $_GET['a'] == "unban" && isset($_GET['id']))
 {
 	if ($_GET['key'] != $_SESSION['banlist_postkey'])


### PR DESCRIPTION
Instead of forcing people to use MySQL 5.6+ servers, it seems better to only send 5.6+ stuff if the server version is 5.6 or above.

The other way around it would just make unnecessary limitations.

References:
https://forums.alliedmods.net/showpost.php?p=2283017&postcount=346
https://forums.alliedmods.net/showpost.php?p=2283249&postcount=349
