### PR TITLE
Improve CanUseSourcebans

### DIFF
--- a/game_upload/addons/sourcemod/scripting/SourceSleuth.sp
+++ b/game_upload/addons/sourcemod/scripting/SourceSleuth.sp
@@ -86,10 +86,7 @@ public OnPluginStart()
 
 public OnAllPluginsLoaded()
 {
-	if (LibraryExists("sourcebans"))
-	{
-		CanUseSourcebans = true;
-	}
+	CanUseSourcebans = LibraryExists("sourcebans");
 }
 
 public OnLibraryAdded(const String:name[])


### PR DESCRIPTION
Cast directly from equals operator instead of an if statement.

Anther commit to follow if required.
