### PR TITLE
Remove 'Invalid Handle' Error & Add Warning Message

### DIFF
--- a/game_upload/addons/sourcemod/scripting/SourceSleuth.sp
+++ b/game_upload/addons/sourcemod/scripting/SourceSleuth.sp
@@ -253,12 +253,20 @@ public LoadWhiteList()
 	
 	new Handle:fileHandle = OpenFile(path, "r");
 	
-	while (!IsEndOfFile(fileHandle) && ReadFileLine(fileHandle, line, sizeof(line)))
+	if (fileHandle != INVALID_HANDLE)
 	{
-		ReplaceString(line, sizeof(line), "\n", "", false);
+		while (!IsEndOfFile(fileHandle) && ReadFileLine(fileHandle, line, sizeof(line)))
+		{
+			ReplaceString(line, sizeof(line), "\n", "", false);
+			
+			PushArrayString(g_hAllowedArray, line);
+		}
 		
-		PushArrayString(g_hAllowedArray, line);
+		CloseHandle(fileHandle);
 	}
-	
-	CloseHandle(fileHandle);
+	else
+	{
+		LogError("[SM] Warning File: \"configs/sourcesleuth_whitelist.cfg\" missing or inaccessible.");
+		LogError("[SM] Continuing without loading ip address whitelists.");
+	}
 }


### PR DESCRIPTION
**Remove Handle Error. If the file is missing or inaccessible do not try to load it.**
_"[SM] Native "IsEndOfFile" reported: invalid handle 0 (error: 4)"_

**And Add Warning Message**
_"[SM] Warning File: "configs/sourcesleuth_whitelist.cfg" missing or inaccessible."
"[SM] Continuing without loading ip address whitelists."_
