### PR TITLE
Fix "Invalid Query Handle"

### DIFF
--- a/game_upload/addons/sourcemod/scripting/SourceSleuth.sp
+++ b/game_upload/addons/sourcemod/scripting/SourceSleuth.sp
@@ -184,6 +184,7 @@ public SQL_CheckHim(Handle:owner, Handle:hndl, const String:error[], any:datapac
 	if (hndl == INVALID_HANDLE)
 	{
 		LogError("SourceSleuth: Database query error: %s", error);
+		return;
 	}
 	
 	if (SQL_FetchRow(hndl))


### PR DESCRIPTION
This pull request exits the `SQL_CheckHim` function if the handle is invalid. It resolves memory leaks resulting from trying to call `SQL_FetchRow` with an invalid handle inputted an argument. See Issue #142.
