### PR TITLE
Close Datapack Handle

### DIFF
--- a/game_upload/addons/sourcemod/scripting/SourceSleuth.sp
+++ b/game_upload/addons/sourcemod/scripting/SourceSleuth.sp
@@ -166,6 +166,7 @@ public OnClientPostAdminCheck(client)
 			ResetPack(datapack);
 			
 			SQL_TQuery(hDatabase, SQL_CheckHim, query, datapack);
+			CloseHandle(datapack);
 		}
 	}
 }


### PR DESCRIPTION
The datapack handle needs closed when it's done being used. This is the source of anther memory leak.
