### PR TITLE
Fix for 'Login with Steam' when using custom database port & Updated SourceComms credit link

### DIFF
--- a/web/init.php
+++ b/web/init.php
@@ -96,7 +96,7 @@ if(!defined("DEVELOPER_MODE") && !defined("IS_UPDATE") && file_exists(ROOT."/upd
 define('SB_GIT', true);
 if(!defined('SB_VERSION')){
 	define('SB_VERSION', '1.5.5-dev');
-	define('SB_GITRev', '$Git: 377 $');
+	define('SB_GITRev', '$Git: 380 $');
 }
 define('LOGIN_COOKIE_LIFETIME', (60*60*24*7)*2);
 define('COOKIE_PATH', '/');

--- a/web/steamopenid.php
+++ b/web/steamopenid.php
@@ -81,7 +81,7 @@ $data = steamOauth();
 if($data !== false){
     $data = convert64to32($data);
 
-    $mysqli = new mysqli(DB_HOST, DB_USER, DB_PASS, DB_NAME);
+    $mysqli = new mysqli(DB_HOST, DB_USER, DB_PASS, DB_NAME, DB_PORT);
     if(defined('DB_PREFIX')){ $prfx = DB_PREFIX ."_"; }else{ $prfx = ""; }
 
     $resultado = $mysqli->query("SELECT aid,password FROM " .$prfx ."admins WHERE authid = '" .$data ."'; ");

--- a/web/themes/default/page_comms.tpl
+++ b/web/themes/default/page_comms.tpl
@@ -305,7 +305,7 @@
           	</tr>
           	<!-- ###############[ End Sliding Panel ]################## -->
 		{/foreach}
-	</table><div align="right" style="margin-top: 3px; font-size:7pt">SourceComms plugin &#038;	integration to SourceBans made by <a href="http://steamcommunity.com/id/raleks" target="_blank">Alex</a></div>
+	</table><div align="right" style="margin-top: 3px; font-size:7pt">SourceComms plugin &#038;	integration to SourceBans made by <a href="https://github.com/ppalex7" target="_blank">Alex</a></div>
 </div>
 {literal}
 <script type="text/javascript">window.addEvent('domready', function(){	

--- a/web/themes/sb_default/page_comms.tpl
+++ b/web/themes/sb_default/page_comms.tpl
@@ -305,7 +305,7 @@
           	</tr>
           	<!-- ###############[ End Sliding Panel ]################## -->
 		{/foreach}
-	</table><div align="right" style="margin-top: 3px; font-size:7pt">SourceComms plugin &#038;	integration to SourceBans made by <a href="http://steamcommunity.com/id/raleks" target="_blank">Alex</a></div>
+	</table><div align="right" style="margin-top: 3px; font-size:7pt">SourceComms plugin &#038;	integration to SourceBans made by <a href="https://github.com/ppalex7" target="_blank">Alex</a></div>
 </div>
 {literal}
 <script type="text/javascript">window.addEvent('domready', function(){	

--- a/web/themes/sourcebans_dark/page_comms.tpl
+++ b/web/themes/sourcebans_dark/page_comms.tpl
@@ -305,7 +305,7 @@
           	</tr>
           	<!-- ###############[ End Sliding Panel ]################## -->
 		{/foreach}
-	</table><div align="right" style="margin-top: 3px; font-size:7pt">SourceComms plugin &#038;	integration to SourceBans made by <a href="http://steamcommunity.com/id/raleks" target="_blank">Alex</a></div>
+	</table><div align="right" style="margin-top: 3px; font-size:7pt">SourceComms plugin &#038;	integration to SourceBans made by <a href="https://github.com/ppalex7" target="_blank">Alex</a></div>
 </div>
 {literal}
 <script type="text/javascript">window.addEvent('domready', function(){	


### PR DESCRIPTION
Fix for 'Login with Steam' when using custom database port (possible fix for #172 )

Updated SourceComms credit link from a not used steamcommunity custom
url (could be exploited for social engineering) to Alexandr Duplishchev'
GitHub page.
