### PR TITLE
Fixed bug when admin and target in forward always be -1

### DIFF
--- a/game/addons/sourcemod/scripting/sbpp_comms.sp
+++ b/game/addons/sourcemod/scripting/sbpp_comms.sp
@@ -2989,8 +2989,8 @@ stock SavePunishment(admin = 0, target, type, length = -1, const String:reason[]
 		// all data cached before calling asynchronous functions
 		new Handle:dataPackFwd	= CreateDataPack();
 		new Handle:dataPack		= CreateDataPack();
-		WritePackCell(dataPackFwd, admin);
-		WritePackCell(dataPackFwd, target);
+		WritePackCell(dataPackFwd, admin ? GetClientUserId(admin) : admin);
+		WritePackCell(dataPackFwd, GetClientUserId(target));
 		WritePackCell(dataPackFwd, _:dataPack);
 		WritePackCell(dataPack, length);
 		WritePackCell(dataPack, type);


### PR DESCRIPTION
In **SourceComms_OnBlockAdded()** forward admin and target always be **-1**.

## Description
In **Query_AddBlockInsert()** we converts admin and target ID to Client ID, as if is UserID. But there were already Client ID.
I added conversion to UserID for Datapack handle before executing query.

## Motivation and Context
This is bug.

## How Has This Been Tested?
I uploaded my fixed SourceComms plugin version and [own Discord SB plugin](https://github.com/CrazyHackGUT/Discord/blob/master/addons/sourcemod/scripting/discord_sb.sp), and tries add mute for client. He handle added mute correctly, and push message with mute on my Discord server.
![image](http://i.imgur.com/Db8xp3B.png)
Before fixing the error, my plugin always receives `-1`.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
