### PR TITLE
Updated plugin

### DIFF
--- a/game/addons/sourcemod/configs/sourcebans/sourcebans.cfg
+++ b/game/addons/sourcemod/configs/sourcebans/sourcebans.cfg
@@ -81,4 +81,25 @@
 		"No Smoke"	"No Smoke"
 		"No Flash"	"No Flash"
 	}
+
+	/*
+	 * Available time for bans.
+	 * Permanent (0) available only for admins with access for command "sm_unban"
+	 */
+	"BanTime"
+	{
+		// "time in minutes"	"display text"
+
+		"0"						"Permanent"
+		"10"					"10 Minutes"
+		"30"					"30 Minutes"
+		"60"					"1 Hour"
+		"240"					"4 Hours"
+		"1440"					"1 Day"
+		"10080"					"1 Week"
+
+		// Examples:
+		// "43200"					"1 Month"
+		// "525600"				"1 Year"
+	}
 }

--- a/game/addons/sourcemod/scripting/sbpp_main.sp
+++ b/game/addons/sourcemod/scripting/sbpp_main.sp
@@ -58,7 +58,7 @@ enum State/* ConfigState */
 	ConfigStateConfig,
 	ConfigStateReasons,
 	ConfigStateHacking,
-    ConfigStateTime
+	ConfigStateTime
 }
 
 new g_BanTarget[MAXPLAYERS + 1] =  { -1, ... };

--- a/game/addons/sourcemod/scripting/sbpp_main.sp
+++ b/game/addons/sourcemod/scripting/sbpp_main.sp
@@ -2104,8 +2104,8 @@ public SMCResult:ReadConfig_NewSection(Handle:smc, const String:name[], bool:opt
 		} else if (strcmp("HackingReasons", name, false) == 0) {
 			ConfigState = ConfigStateHacking;
 		} else if (strcmp("BanTime", name, false) == 0) {
-            ConfigState = ConfigStateTime;
-        }
+			ConfigState = ConfigStateTime;
+		}
 	}
 	return SMCParse_Continue;
 }


### PR DESCRIPTION
## Description
- Fixed bug when HackingReason menu not cleaned when config reads from scratch.
- Moved available time lengths to config
- Small optimize (_FormatEx()_ works faster than _Format()_)

## Motivation and Context
Items in the HackingReasonMenu duplicates in menu when plugin rereads the configuration file again.
Also, time length for bans has been hardcoded in the code.

My pull fixes duplicating Hacking Reasons in menu, and adds into config section for Time Bans.

## How Has This Been Tested?
I installed plugin on the server. reload him, edit ban time length in config, and reload config. All changes were displayed into game without problems. And hacking reasons not duplicated.

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
