### PR TITLE
Remove StripQuotes

### DIFF
--- a/web/includes/system-functions.php
+++ b/web/includes/system-functions.php
@@ -615,13 +615,6 @@ function trunc($text, $len, $byword=true)
     return $text;
 }
 
-function StripQuotes($str)
-{
-    $str = str_replace("'", "", $str);
-    $str = str_replace('"', "", $str);
-    return $str;
-}
-
 function CreateRedBox($title, $content)
 {
     $text = '<div id="msg-red-debug" style="">


### PR DESCRIPTION
**This change needs editing more files! Or the function can only return the text and do nothing!**
<!--- Provide a general summary of your changes in the Title above -->

## Description
StripQuotes is very useless. The game plugin already strips it, so it's like `\"`. The problem is when somebody has quotes on end of his name - then it removes the quote and there is only back slash for the function. So it can looks like (when somebody has for example `Test Name"`):
`RemoveBlock('1234', 'verylonghash123', '', 'Test Name\', 0);`

## Motivation and Context
If I want to remove the ban/comms to someone, who has quotes in his name, I can't - the window cannot pop up, becausee of back slash on the end.

## How Has This Been Tested?
By using SourceBans. So if I want to remove the ban from someone, I must edit the code in the browser and then I can do something.

## Screenshots (if appropriate):
No screens.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
