### PR TITLE
Try fix "Invalid handle (error 1)"

### DIFF
--- a/game/addons/sourcemod/scripting/sbpp_comms.sp
+++ b/game/addons/sourcemod/scripting/sbpp_comms.sp
@@ -1729,11 +1729,12 @@ public Action:ClientRecheck(Handle:timer, any:userid)
 	g_hPlayerRecheck[client] = INVALID_HANDLE;
 }
 
-public Action:Timer_MuteExpire(Handle:timer, any:userid)
+public Action:Timer_MuteExpire(Handle:timer, Handle:hPack)
 {
-	g_hMuteExpireTimer[client] = INVALID_HANDLE;
+	ResetPack(hPack);
+	g_hMuteExpireTimer[ReadPackCell(hPack)] = INVALID_HANDLE;
 
-	new client = GetClientOfUserId(userid);
+	new client = GetClientOfUserId(ReadPackCell(hPack));
 	if (!client)
 		return;
 
@@ -1750,11 +1751,12 @@ public Action:Timer_MuteExpire(Handle:timer, any:userid)
 		BaseComm_SetClientMute(client, false);
 }
 
-public Action:Timer_GagExpire(Handle:timer, any:userid)
+public Action:Timer_GagExpire(Handle:timer, Handle:hPack)
 {
-	g_hGagExpireTimer[client] = INVALID_HANDLE;
+	ResetPack(hPack);
+	g_hGagExpireTimer[ReadPackCell(hPack)] = INVALID_HANDLE;
 
-	new client = GetClientOfUserId(userid);
+	new client = GetClientOfUserId(ReadPackCell(hPack));
 	if (!client)
 		return;
 
@@ -2845,10 +2847,15 @@ stock CreateMuteExpireTimer(target, remainingTime = 0)
 {
 	if (g_iMuteLength[target] > 0)
 	{
+		new Handle:hPack;
+
 		if (remainingTime)
-			g_hMuteExpireTimer[target] = CreateTimer(float(remainingTime), Timer_MuteExpire, GetClientUserId(target), TIMER_FLAG_NO_MAPCHANGE);
+			g_hMuteExpireTimer[target] = CreateDataTimer(float(remainingTime), Timer_MuteExpire, hPack, TIMER_FLAG_NO_MAPCHANGE);
 		else
-			g_hMuteExpireTimer[target] = CreateTimer(float(g_iMuteLength[target] * 60), Timer_MuteExpire, GetClientUserId(target), TIMER_FLAG_NO_MAPCHANGE);
+			g_hMuteExpireTimer[target] = CreateDataTimer(float(g_iMuteLength[target] * 60), Timer_MuteExpire, hPack, TIMER_FLAG_NO_MAPCHANGE);
+
+		WritePackCell(hPack, target);
+		WritePackCell(hPack, GetClientUserId(target));
 	}
 }
 
@@ -2856,10 +2863,15 @@ stock CreateGagExpireTimer(target, remainingTime = 0)
 {
 	if (g_iGagLength[target] > 0)
 	{
+		new Handle:hPack;
+
 		if (remainingTime)
-			g_hGagExpireTimer[target] = CreateTimer(float(remainingTime), Timer_GagExpire, GetClientUserId(target), TIMER_FLAG_NO_MAPCHANGE);
+			g_hGagExpireTimer[target] = CreateDataTimer(float(remainingTime), Timer_GagExpire, hPack, TIMER_FLAG_NO_MAPCHANGE);
 		else
-			g_hGagExpireTimer[target] = CreateTimer(float(g_iGagLength[target] * 60), Timer_GagExpire, GetClientUserId(target), TIMER_FLAG_NO_MAPCHANGE);
+			g_hGagExpireTimer[target] = CreateDataTimer(float(g_iGagLength[target] * 60), Timer_GagExpire, hPack, TIMER_FLAG_NO_MAPCHANGE);
+
+		WritePackCell(hPack, target);
+		WritePackCell(hPack, GetClientUserId(target));
 	}
 }
 

--- a/game/addons/sourcemod/scripting/sbpp_comms.sp
+++ b/game/addons/sourcemod/scripting/sbpp_comms.sp
@@ -1731,6 +1731,8 @@ public Action:ClientRecheck(Handle:timer, any:userid)
 
 public Action:Timer_MuteExpire(Handle:timer, any:userid)
 {
+	g_hMuteExpireTimer[client] = INVALID_HANDLE;
+
 	new client = GetClientOfUserId(userid);
 	if (!client)
 		return;
@@ -1743,7 +1745,6 @@ public Action:Timer_MuteExpire(Handle:timer, any:userid)
 
 	PrintToChat(client, "%s%t", PREFIX, "Mute expired");
 
-	g_hMuteExpireTimer[client] = INVALID_HANDLE;
 	MarkClientAsUnMuted(client);
 	if (IsClientInGame(client))
 		BaseComm_SetClientMute(client, false);
@@ -1751,6 +1752,8 @@ public Action:Timer_MuteExpire(Handle:timer, any:userid)
 
 public Action:Timer_GagExpire(Handle:timer, any:userid)
 {
+	g_hGagExpireTimer[client] = INVALID_HANDLE;
+
 	new client = GetClientOfUserId(userid);
 	if (!client)
 		return;
@@ -1763,7 +1766,6 @@ public Action:Timer_GagExpire(Handle:timer, any:userid)
 
 	PrintToChat(client, "%s%t", PREFIX, "Gag expired");
 
-	g_hGagExpireTimer[client] = INVALID_HANDLE;
 	MarkClientAsUnGagged(client);
 	if (IsClientInGame(client))
 		BaseComm_SetClientGag(client, false);


### PR DESCRIPTION
Fix #357
Some guy from #357 founded a little bug: if client disconnects after connect (the exact moment "when" is not specified),
This PR should fix this problem.
If timer runs, and client is not in connected, he just terminates without nulling own handle.

## Description
I'll moved handle cleaning.

## Motivation and Context
This is fixes bug from issue #357.
```
Exception reported: Handle FFFFFFFF is invalid (error 1)
Blaming: SourceBans\sbpp_comms.smx
Call stack trace:
[0] CloseHandle
[1] Line 2836, sbpp_comms.sp::CloseMuteExpireTimer
[2] Line 263, sbpp_comms.sp::OnClientDisconnect
```

## How Has This Been Tested?
I did not test it. I can't reproduce a bug.

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
