### PR TITLE
Fix session mutes/gags

### DIFF
--- a/game/addons/sourcemod/scripting/sbpp_comms.sp
+++ b/game/addons/sourcemod/scripting/sbpp_comms.sp
@@ -1689,7 +1689,20 @@ public Query_VerifyBlock(Handle:owner, Handle:hndl, const String:error[], any:us
 			{
 				case TYPE_MUTE:
 				{
-					if (g_MuteType[client] < bTime)
+					//Set mute type based on length	
+					if (length > 0)
+						g_MuteType[client] = bTime;
+					else if (length == 0)
+						g_MuteType[client] = bPerm;
+					else
+						g_MuteType[client] = bSess;
+
+					//Perform mute/unmute
+					if (g_MuteType[client] == bSess)
+					{
+						PerformUnMute(client);
+					}
+					else if (g_MuteType[client] > bSess)
 					{
 						PerformMute(client, time, length / 60, sAdmName, sAdmAuth, immunity, sReason, remaining_time);
 						PrintToChat(client, "%s%t", PREFIX, "Muted on connect");
@@ -1697,7 +1710,20 @@ public Query_VerifyBlock(Handle:owner, Handle:hndl, const String:error[], any:us
 				}
 				case TYPE_GAG:
 				{
-					if (g_GagType[client] < bTime)
+					//Set gag type based on length
+					if (length > 0)
+						g_GagType[client] = bTime;
+					else if (length == 0)
+						g_GagType[client] = bPerm;
+					else
+						g_GagType[client] = bSess;
+
+					//Perform gag/ungag
+					if (g_GagType[client] == bSess)
+					{
+						PerformUnGag(client);
+					}
+					else if (g_GagType[client] > bSess)
 					{
 						PerformGag(client, time, length / 60, sAdmName, sAdmAuth, immunity, sReason, remaining_time);
 						PrintToChat(client, "%s%t", PREFIX, "Gagged on connect");


### PR DESCRIPTION
Fixes session mutes/gags.

## Description
See issue #309 for full details.

**Note** With this fix, session mutes/gags are not reapplied when a client disconnects.
However, they will still appear as `ongoing` in the database until the 120 minute mark hits.
Not a huge/major issue but to improve things, a `UnmuteSessions` function could send queries to mark all sessions as expired on reconnect. I thought it would be better to apply this fix first though.

## Motivation and Context
Fixes session mutes/gags which currently act as 120 minute mutes.

## How Has This Been Tested?
Tested with CSGO only with no mute, session mutes/gags, timed mutes/gags and perm mutes/gags.
I am unable to test other games.
Using latest git commit `a80f9063e23e5f54f60e4e5db3f2560845ee740d` for testing.

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.

  