### PR TITLE
integrated comms in checker plugin

### DIFF
--- a/game/addons/sourcemod/scripting/sbpp_checker.sp
+++ b/game/addons/sourcemod/scripting/sbpp_checker.sp
@@ -27,7 +27,7 @@
 #include <sourcemod>
 
 #define VERSION "1.6.3-PRE"
-#define LISTBANS_USAGE "sm_listsbbans <#userid|name> - Lists a user's prior bans from Sourcebans"
+#define LISTBANS_USAGE "sm_listbans <#userid|name> - Lists a user's prior bans from Sourcebans"
 #define INVALID_TARGET -1
 
 new String:g_DatabasePrefix[10] = "sb";

--- a/game/addons/sourcemod/scripting/sbpp_checker.sp
+++ b/game/addons/sourcemod/scripting/sbpp_checker.sp
@@ -51,8 +51,6 @@ public OnPluginStart()
 	LoadTranslations("common.phrases");
 
 	CreateConVar("sbchecker_version", VERSION, "", FCVAR_NOTIFY);
-
-	RegAdminCmd("sm_listsbbans", OnListSourceBansCmd, ADMFLAG_BAN, LISTBANS_USAGE); // for backward compatibility with the old version
 	RegAdminCmd("sm_listbans", OnListSourceBansCmd, ADMFLAG_BAN, LISTBANS_USAGE);
 	RegAdminCmd("sm_listcomms", OnListSourceCommsCmd, ADMFLAG_BAN, LISTCOMMS_USAGE);
 	RegAdminCmd("sb_reload", OnReloadCmd, ADMFLAG_RCON, "Reload sourcebans config and ban reason menu options");

--- a/game/addons/sourcemod/scripting/sbpp_checker.sp
+++ b/game/addons/sourcemod/scripting/sbpp_checker.sp
@@ -53,6 +53,7 @@ public OnPluginStart()
 
 	ShortMessage = CreateConVar("sb_short_message", "0", "Use shorter message for displying prev bans", _, true, 0.0, true, 1.0);
 
+	RegAdminCmd("sm_listsbbans", OnListSourceBansCmd, ADMFLAG_BAN, LISTBANS_USAGE); // for backward compatibility with the old version
 	RegAdminCmd("sm_listbans", OnListSourceBansCmd, ADMFLAG_BAN, LISTBANS_USAGE);
 	RegAdminCmd("sb_reload", OnReloadCmd, ADMFLAG_RCON, "Reload sourcebans config and ban reason menu options");
 

--- a/game/addons/sourcemod/scripting/sbpp_checker.sp
+++ b/game/addons/sourcemod/scripting/sbpp_checker.sp
@@ -455,7 +455,6 @@ public OnListComms(Handle:owner, Handle:hndl, const String:error[], any:pack)
 			strcopy(CommType, sizeof(CommType), "G");
 
 		PrintListResponse(clientuid, client, "%s  %s  %s  %s  %s  %s  %s", createddate, bannedby, lenstring, enddate, CommType, RemoveType, reason);
-		//PrintListResponse(clientuid, client, "%s  %s  %s  %s  %s  %s ", createddate, bannedby, lenstring, enddate, CommType, RemoveType);
 
 	}
 }


### PR DESCRIPTION
As it was already mentioned in #188 this merge request adds support for comms to the checker plugin. So it does add the command sm_listcomms and also shows the amount of comms (if any) when a player joins. Code was successfully tested on our servers, all features seems to work just fine as expected.