### PR TITLE
Updated to prevent double path separator in URL

### DIFF
--- a/web/includes/smarty/Smarty.class.php
+++ b/web/includes/smarty/Smarty.class.php
@@ -1744,7 +1744,11 @@ class Smarty
     function _get_auto_filename($auto_base, $auto_source = null, $auto_id = null)
     {
         $_compile_dir_sep =  $this->use_sub_dirs ? DIRECTORY_SEPARATOR : '^';
-        $_return = $auto_base . DIRECTORY_SEPARATOR;
+        $_return = $auto_base;	//. DIRECTORY_SEPARATOR;
+	if(substr($_return, -1) != DIRECTORY_SEPARATOR)
+	{
+		$_return .= DIRECTORY_SEPARATOR;
+	}
 
         if(isset($auto_id)) {
             // make auto_id safe for directory names

--- a/web/includes/smarty/Smarty.class.php
+++ b/web/includes/smarty/Smarty.class.php
@@ -1744,10 +1744,11 @@ class Smarty
     function _get_auto_filename($auto_base, $auto_source = null, $auto_id = null)
     {
         $_compile_dir_sep =  $this->use_sub_dirs ? DIRECTORY_SEPARATOR : '^';
-        $_return = $auto_base;	//. DIRECTORY_SEPARATOR;
+        $_return = $auto_base;
+	    
 	if(substr($_return, -1) != DIRECTORY_SEPARATOR)
 	{
-		$_return .= DIRECTORY_SEPARATOR;
+	    $_return .= DIRECTORY_SEPARATOR;
 	}
 
         if(isset($auto_id)) {


### PR DESCRIPTION
Updated _get_auto_filename to prevent double path separator (//) in URL by detecting if the string already ends in the path separator. I noticed the double // in some paths on my web server.
