### PR TITLE
Include server ID in Native_SBReportPlayer

### DIFF
--- a/game/addons/sourcemod/scripting/sbpp_main.sp
+++ b/game/addons/sourcemod/scripting/sbpp_main.sp
@@ -2356,7 +2356,7 @@ public int Native_SBReportPlayer(Handle plugin, int numParams)
 	char[] sQuery = new char[512 + (iReasonLen * 2 + 1)];
 
 	Format(sQuery, 512 + (iReasonLen * 2 + 1), "INSERT INTO %s_submissions (`submitted`, `modid`, `SteamId`, `name`, `email`, `reason`, `ip`, `subname`, `sip`, `archiv`, `server`)"
-	... "VALUES ('%d', 0, '%s', '%s', '%s', '%s', '%s', '%s', '%s', 0, '%d')", DatabasePrefix, iTime, sTAuth, sTEscapedName, sRAuth, sEscapedReason, sRIP, sREscapedName, sTIP, serverID);
+	... "VALUES ('%d', 0, '%s', '%s', '%s', '%s', '%s', '%s', '%s', 0, '%d')", DatabasePrefix, iTime, sTAuth, sTEscapedName, sRAuth, sEscapedReason, sRIP, sREscapedName, sTIP, (serverID != -1) ? serverID : 0);
 
 	DataPack ForwardPack = new DataPack();
 

--- a/game/addons/sourcemod/scripting/sbpp_main.sp
+++ b/game/addons/sourcemod/scripting/sbpp_main.sp
@@ -2356,7 +2356,7 @@ public int Native_SBReportPlayer(Handle plugin, int numParams)
 	char[] sQuery = new char[512 + (iReasonLen * 2 + 1)];
 
 	Format(sQuery, 512 + (iReasonLen * 2 + 1), "INSERT INTO %s_submissions (`submitted`, `modid`, `SteamId`, `name`, `email`, `reason`, `ip`, `subname`, `sip`, `archiv`, `server`)"
-	... "VALUES ('%d', 0, '%s', '%s', '%s', '%s', '%s', '%s', '%s', 0, 0)", DatabasePrefix, iTime, sTAuth, sTEscapedName, sRAuth, sEscapedReason, sRIP, sREscapedName, sTIP);
+	... "VALUES ('%d', 0, '%s', '%s', '%s', '%s', '%s', '%s', '%s', 0, '%d')", DatabasePrefix, iTime, sTAuth, sTEscapedName, sRAuth, sEscapedReason, sRIP, sREscapedName, sTIP, serverID);
 
 	DataPack ForwardPack = new DataPack();
 


### PR DESCRIPTION
Server ID was missing from the SQL insert statement

## Description
Substitute current `0` with `serverID` global variable.

## Motivation and Context
Current SQL statement has a hard-coded `0` for the `server` table column, which shows as _other server_ on the ban submissions page.

## How Has This Been Tested?
Compiled and tested on Linux game server with server ID set in config.
Originating server name confirmed to show properly in ban submissions page on web server. 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
