### PR TITLE
Emoji ban Fix 2

### DIFF
--- a/game/addons/sourcemod/scripting/sbpp_main.sp
+++ b/game/addons/sourcemod/scripting/sbpp_main.sp
@@ -1032,7 +1032,7 @@ public void GotDatabase(Database db, const char[] error, any data)
 
 	char query[1024];
 
-	DB.SetCharset("utf8");
+	DB.SetCharset("utf8mb4");
 
 	InsertServerInfo();
 


### PR DESCRIPTION
This fix changes the character set of the database so that players with Emoji's in their name can be banned. Since the source engine can't parse Emoji's, the value for the player's emoji is random text in the sourcebans database.

## Description
Replaces all instances of utf8 with utf8mb4

## Motivation and Context
Players with emoji in name could not be banned (because default character set configured by installer does not take into account the 4 bytes needed for emoji).

## How Has This Been Tested?
I installed the plugin change on 10 servers.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
