### PR TITLE
Emoji Ban Fix 1

### DIFF
--- a/game/addons/sourcemod/scripting/sbpp_comms.sp
+++ b/game/addons/sourcemod/scripting/sbpp_comms.sp
@@ -1264,12 +1264,12 @@ public void GotDatabase(Database db, const char[] error, any data)
 	// Set character set to UTF-8 in the database
 	if (GetFeatureStatus(FeatureType_Native, "SQL_SetCharset") == FeatureStatus_Available)
 	{
-		db.SetCharset("utf8");
+		db.SetCharset("utf8mb4");
 	}
 	else
 	{
 		char query[128];
-		FormatEx(query, sizeof(query), "SET NAMES 'UTF8'");
+		FormatEx(query, sizeof(query), "SET NAMES 'utf8mb4' COLLATE 'utf8mb4_unicode_ci''");
 		#if defined LOG_QUERIES
 		LogToFile(logQuery, "Set encoding. QUERY: %s", query);
 		#endif


### PR DESCRIPTION
This fix changes the character set of the database so that players with Emoji's in their name can be banned. Since the source engine can't parse Emoji's, the value for the player's emoji is random text in the sourcebans database.

## Description
Replaces all instances of utf8 with utf8mb4

## Motivation and Context
Players with emoji in name could not be banned (because default character set configured by installer does not take into account the 4 bytes needed for emoji).

## How Has This Been Tested?
I installed the plugin change on 10 servers.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
