### PR TITLE
Hide host name

### DIFF
--- a/web/includes/sb-callback.php
+++ b/web/includes/sb-callback.php
@@ -1223,9 +1223,9 @@ function ServerHostPlayers($sid, $type="servers", $obId="", $tplsid="", $open=""
         $players = $query->GetPlayers();
     } catch (Exception $e) {
         if ($userbank->HasAccess(ADMIN_OWNER)) {
-            $objResponse->addAssign("host_$sid", "innerHTML", "<b>Error connecting</b> (<i>".$server['ip'].":".$server['port']."</i>) <small><a href=\"https://sbpp.github.io/faq/\" title=\"Which ports does the SourceBans webpanel require to be open?\">Help</a></small>");
+            $objResponse->addAssign("host_$sid", "innerHTML", "<b>Error connecting</b> (<i>".gethostbyname($server['ip']).":".$server['port']."</i>) <small><a href=\"https://sbpp.github.io/faq/\" title=\"Which ports does the SourceBans webpanel require to be open?\">Help</a></small>");
         } else {
-            $objResponse->addAssign("host_$sid", "innerHTML", "<b>Error connecting</b> (<i>".$server['ip'].":".$server['port']."</i>)");
+            $objResponse->addAssign("host_$sid", "innerHTML", "<b>Error connecting</b> (<i>".gethostbyname($server['ip']).":".$server['port']."</i>)");
             $objResponse->addAssign("players_$sid", "innerHTML", "N/A");
             $objResponse->addAssign("os_$sid", "innerHTML", "N/A");
             $objResponse->addAssign("vac_$sid", "innerHTML", "N/A");
@@ -1238,7 +1238,7 @@ function ServerHostPlayers($sid, $type="servers", $obId="", $tplsid="", $open=""
             $objResponse->addScript("if($('sid_$sid'))$('sid_$sid').setStyle('color', '#adadad');");
         }
         if ($type == "id") {
-            $objResponse->addAssign("$obId", "innerHTML", "<b>Error connecting</b> (<i>".$server['ip'].":".$server['port']. "</i>)");
+            $objResponse->addAssign("$obId", "innerHTML", "<b>Error connecting</b> (<i>".gethostbyname($server['ip']).":".$server['port']. "</i>)");
         }
         return $objResponse;
     } finally {
@@ -1347,9 +1347,9 @@ function ServerHostPlayers($sid, $type="servers", $obId="", $tplsid="", $open=""
             }
         } else {
             if ($userbank->HasAccess(ADMIN_OWNER)) {
-                $objResponse->addAssign("host_$sid", "innerHTML", "<b>Error connecting</b> (<i>" . $res[1] . ":" . $res[2]. "</i>) <small><a href=\"https://sbpp.github.io/faq/\" title=\"Which ports does the SourceBans webpanel require to be open?\">Help</a></small>");
+                $objResponse->addAssign("host_$sid", "innerHTML", "<b>Error connecting</b> (<i>" . gethostbyname($res[1]) . ":" . $res[2]. "</i>) <small><a href=\"https://sbpp.github.io/faq/\" title=\"Which ports does the SourceBans webpanel require to be open?\">Help</a></small>");
             } else {
-                $objResponse->addAssign("host_$sid", "innerHTML", "<b>Error connecting</b> (<i>" . $res[1] . ":" . $res[2]. "</i>)");
+                $objResponse->addAssign("host_$sid", "innerHTML", "<b>Error connecting</b> (<i>" . gethostbyname($res[1]) . ":" . $res[2]. "</i>)");
                 $objResponse->addAssign("players_$sid", "innerHTML", "N/A");
                 $objResponse->addAssign("os_$sid", "innerHTML", "N/A");
                 $objResponse->addAssign("vac_$sid", "innerHTML", "N/A");
@@ -1372,13 +1372,13 @@ function ServerHostPlayers($sid, $type="servers", $obId="", $tplsid="", $open=""
         if (!empty($info['HostName'])) {
             $objResponse->addAssign("$obId", "innerHTML", trunc($info['HostName'], $trunchostname, false));
         } else {
-            $objResponse->addAssign("$obId", "innerHTML", "<b>Error connecting</b> (<i>".$server['ip'].":".$server['port']. "</i>)");
+            $objResponse->addAssign("$obId", "innerHTML", "<b>Error connecting</b> (<i>".gethostbyname($server['ip']).":".$server['port']. "</i>)");
         }
     } else {
         if (!empty($info['HostName'])) {
             $objResponse->addAssign("ban_server_$type", "innerHTML", trunc($info['HostName'], $trunchostname, false));
         }else{
-            $objResponse->addAssign("ban_server_$type", "innerHTML", "<b>Error connecting</b> (<i>".$server['ip'].":".$server['port']."</i>)");
+            $objResponse->addAssign("ban_server_$type", "innerHTML", "<b>Error connecting</b> (<i>".gethostbyname($server['ip']).":".$server['port']."</i>)");
         }
     }
     return $objResponse;
@@ -1404,7 +1404,7 @@ function ServerHostProperty($sid, $obId, $obProp, $trunchostname)
         $query->Connect($server['ip'], $server['port'], 1, SourceQuery::SOURCE);
         $info = $query->GetInfo();
     } catch (Exception $e) {
-        $objResponse->addAssign("$obId", "$obProp", "Error connecting (".$server['ip'].":".$server['port'].")");
+        $objResponse->addAssign("$obId", "$obProp", "Error connecting (".gethostbyname($server['ip']).":".$server['port'].")");
         return $objResponse;
     } finally {
         $query->Disconnect();
@@ -1413,7 +1413,7 @@ function ServerHostProperty($sid, $obId, $obProp, $trunchostname)
     if(!empty($info['HostName'])) {
         $objResponse->addAssign("$obId", "$obProp", addslashes(trunc($info['HostName'], $trunchostname, false)));
     } else {
-        $objResponse->addAssign("$obId", "$obProp", "Error connecting (".$server['ip'].":".$server['port'].")");
+        $objResponse->addAssign("$obId", "$obProp", "Error connecting (".gethostbyname($server['ip']).":".$server['port'].")");
     }
     return $objResponse;
 }
@@ -1445,7 +1445,7 @@ function ServerHostPlayers_list($sid, $type="servers", $obId="")
             $query->Connect($server['ip'], $server['port'], 1, SourceQuery::SOURCE);
             $info = $query->GetInfo();
         } catch (Exception $e) {
-            $ret .= "<b>Error connecting</b> (<i>".$server['ip'].":".$server['port']."</i>)<br />";
+            $ret .= "<b>Error connecting</b> (<i>".gethostbyname($server['ip']).":".$server['port']."</i>)<br />";
             continue;
         } finally {
             $query->Disconnect();
@@ -1454,7 +1454,7 @@ function ServerHostPlayers_list($sid, $type="servers", $obId="")
         if (!empty($info['HostName'])) {
             $ret .= trunc($info['HostName'], 48, false) . "<br />";
         } else {
-            $ret .= "<b>Error connecting</b> (<i>".$server['ip'].":".$server['port']."</i>)<br />";
+            $ret .= "<b>Error connecting</b> (<i>".gethostbyname($server['ip']).":".$server['port']."</i>)<br />";
         }
     }
 

--- a/web/pages/admin.admins.search.php
+++ b/web/pages/admin.admins.search.php
@@ -35,7 +35,7 @@ while (!$server_list->EOF) {
     $info = array();
     $serverscript .= "xajax_ServerHostPlayers('" . $server_list->fields[0] . "', 'id', 'ss" . $server_list->fields[0] . "', '', '', false, 200);";
     $info['sid']  = $server_list->fields[0];
-    $info['ip']   = $server_list->fields[1];
+    $info['ip']   = gethostbyname($server_list->fields[1]);
     $info['port'] = $server_list->fields[2];
     array_push($servers, $info);
     $server_list->MoveNext();

--- a/web/pages/admin.bans.search.php
+++ b/web/pages/admin.bans.search.php
@@ -34,7 +34,7 @@ while (!$server_list->EOF) {
     $info = array();
     $serverscript .= "xajax_ServerHostPlayers('" . $server_list->fields[0] . "', 'id', 'ss" . $server_list->fields[0] . "', '', '', false, 200);";
     $info['sid']  = $server_list->fields[0];
-    $info['ip']   = $server_list->fields[1];
+    $info['ip']   = gethostbyname($server_list->fields[1]);
     $info['port'] = $server_list->fields[2];
     array_push($servers, $info);
     $server_list->MoveNext();

--- a/web/pages/admin.comms.search.php
+++ b/web/pages/admin.comms.search.php
@@ -39,7 +39,7 @@ while (!$server_list->EOF) {
     $info = array();
     $serverscript .= "xajax_ServerHostPlayers('" . $server_list->fields[0] . "', 'id', 'ss" . $server_list->fields[0] . "', '', '', false, 200);";
     $info['sid']  = $server_list->fields[0];
-    $info['ip']   = $server_list->fields[1];
+    $info['ip']   = gethostbyname($server_list->fields[1]);
     $info['port'] = $server_list->fields[2];
     array_push($servers, $info);
     $server_list->MoveNext();

--- a/web/pages/page.servers.php
+++ b/web/pages/page.servers.php
@@ -48,7 +48,7 @@ while (!$res->EOF) {
     }
     $info          = array();
     $info['sid']   = $res->fields[0];
-    $info['ip']    = $res->fields[1];
+    $info['ip']    = gethostbyname($res->fields[1]);
     $info['port']  = $res->fields[2];
     $info['icon']  = $res->fields[5];
     $info['index'] = $i;

--- a/web/pages/page.submit.php
+++ b/web/pages/page.submit.php
@@ -114,7 +114,7 @@ if (!isset($_POST['subban']) || $_POST['subban'] != 1) {
                     $query->Connect($server['ip'], $server['port'], 1, SourceQuery::SOURCE);
                     $info = $query->GetInfo();
                 } catch (Exception $e) {
-                    $mailserver = "Server: Error Connecting (".$server['ip'].":".$server['port'].")\n";
+                    $mailserver = "Server: Error Connecting (".gethostbyname($server['ip']).":".$server['port'].")\n";
                 } finally {
                     $query->Disconnect();
                 }
@@ -122,7 +122,7 @@ if (!isset($_POST['subban']) || $_POST['subban'] != 1) {
                 if (!empty($info['HostName'])) {
                     $mailserver = "Server: ".$info['HostName']." (".$server['ip'].":".$server['port'].")\n";
                 } else {
-                    $mailserver = "Server: Error Connecting (".$server['ip'].":".$server['port'].")\n";
+                    $mailserver = "Server: Error Connecting (".gethostbyname($server['ip']).":".$server['port'].")\n";
                 }
 
                 $GLOBALS['PDO']->query("SELECT m.mid FROM `:prefix_servers` as s LEFT JOIN `:prefix_mods` as m ON m.mid = s.modid WHERE s.sid = :sid");
@@ -197,7 +197,7 @@ foreach ($servers as $key => $server) {
         $query->Connect($server['ip'], $server['port'], 1, SourceQuery::SOURCE);
         $info = $query->GetInfo();
     } catch (Exception $e) {
-        $servers[$key]['hostname'] = "Error Connecting (".gethostbyname($server['ip']).":".$server['port'].")";
+        $servers[$key]['hostname'] = "Error Connecting (".gethostbyname($server['ip'].":".$server['port'].")";
     } finally {
         $query->Disconnect();
     }

--- a/web/pages/page.submit.php
+++ b/web/pages/page.submit.php
@@ -197,7 +197,7 @@ foreach ($servers as $key => $server) {
         $query->Connect($server['ip'], $server['port'], 1, SourceQuery::SOURCE);
         $info = $query->GetInfo();
     } catch (Exception $e) {
-        $servers[$key]['hostname'] = "Error Connecting (".$server['ip'].":".$server['port'].")";
+        $servers[$key]['hostname'] = "Error Connecting (".gethostbyname($server['ip']).":".$server['port'].")";
     } finally {
         $query->Disconnect();
     }

--- a/web/pages/page.submit.php
+++ b/web/pages/page.submit.php
@@ -197,7 +197,7 @@ foreach ($servers as $key => $server) {
         $query->Connect($server['ip'], $server['port'], 1, SourceQuery::SOURCE);
         $info = $query->GetInfo();
     } catch (Exception $e) {
-        $servers[$key]['hostname'] = "Error Connecting (".gethostbyname($server['ip'].":".$server['port'].")";
+        $servers[$key]['hostname'] = "Error Connecting (".gethostbyname($server['ip']).":".$server['port'].")";
     } finally {
         $query->Disconnect();
     }


### PR DESCRIPTION
## Description
use gethostbyname to show resolved IP

## Motivation and Context
My server was getting ddosed so i switched to using dynamic ip to host my server.  Now for the server to show up on dashboard i need to use a dynamic dns for the Server IP/Domain field so i don't have to manually update the ip when ip changes.  However, i noticed if server is down it'll show the dynamic dns that was used and attackers would just ddosed the dynamic dns.  Hence my motivation to edit sb++ to show resolved IP instead of dynamic dns.  

## How Has This Been Tested?
Add a server using a dynamic dns provided by no-ip.org and turn the server off and check to make sure it shows the ip not the dynamic dns  

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
