### PR TITLE
Fixed updater query overlap

### DIFF
--- a/web/updater/data/700.php
+++ b/web/updater/data/700.php
@@ -1,17 +1,5 @@
 <?php
 
-$this->dbs->query(
-    "CREATE TABLE IF NOT EXISTS `:prefix_login_tokens` (
-        `jti` varchar(16) NOT NULL,
-        `secret` varchar(64) NOT NULL,
-        `lastAccessed` int(11) NOT NULL,
-        PRIMARY KEY (`jti`),
-        UNIQUE KEY `secret` (`secret`)
-    ) ENGINE=InnoDB DEFAULT CHARSET=:charset;"
-);
-
-$this->dbs->bind(':charset', DB_CHARSET);
-
 $auth = [
     'auth.maxlife' => 1440,
     'auth.maxlife.remember' => 10080,
@@ -24,5 +12,17 @@ foreach ($auth as $setting => $value) {
     $this->dbs->bind(':value', $value);
     $this->dbs->execute();
 }
+
+$this->dbs->query(
+    "CREATE TABLE IF NOT EXISTS `:prefix_login_tokens` (
+        `jti` varchar(16) NOT NULL,
+        `secret` varchar(64) NOT NULL,
+        `lastAccessed` int(11) NOT NULL,
+        PRIMARY KEY (`jti`),
+        UNIQUE KEY `secret` (`secret`)
+    ) ENGINE=InnoDB DEFAULT CHARSET=:charset;"
+);
+
+$this->dbs->bind(':charset', DB_CHARSET);
 
 return $this->dbs->execute();


### PR DESCRIPTION
Patched one SQL query in newest updater script not running due to two overlapping query definitions before execution.

## Description
Reordered the queries so they do not overlap

## Motivation and Context
Script fails to create `:prefix_login_tokens` table when running updater to patch from 605->700

## How Has This Been Tested?
Ran patched script and  `:prefix_login_tokens` table was successfully created.  Additional `auth.maxlifetime` rows in settings table were added as normal.
## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
