### PR TITLE
Changed the Name of the Server to actually Server in the DB

### DIFF
--- a/web/install/includes/sql/data.sql
+++ b/web/install/includes/sql/data.sql
@@ -57,4 +57,4 @@ INSERT INTO `{prefix}_settings` (`setting`, `value`) VALUES
 ('auth.maxlife.steam', '10080');
 
 INSERT INTO `{prefix}_admins` (`aid` ,	`user` , `authid` ,	`password` , `gid` , `email` ,	`validate` , `extraflags`, `immunity`) VALUES
-(0 , 'CONSOLE', 'STEAM_ID_SERVER', '', '0', '', NULL, '0', 0);
+(0 , 'Server', 'STEAM_ID_SERVER', '', '0', '', NULL, '0', 0);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This actually had to be done. For example, if you have a Plugin using the SBPP_BanPlayer Native, you have to use an Admin ID, 0 stands for the Server, so it also should be named like that on the WebPanel.

## Motivation and Context
Bans given by the Server(Admin ID 0), should also have the Admin name "Server" instead of "CONSOLE" on the WebPanel. "CONSOLE" could be confusing for most Players and i dont see a Point to keep this Name.

## How Has This Been Tested?
I allways do so when i set up SBPP.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
