### PR TITLE
Trim whitespace from admin detail fields before saving

### DIFF
--- a/web/pages/admin.edit.admindetails.php
+++ b/web/pages/admin.edit.admindetails.php
@@ -72,9 +72,9 @@ $errorScript = "";
 
 // Form submitted?
 if (isset($_POST['adminname'])) {
-    $a_name           = $_POST['adminname'];
-    $a_steam          = \SteamID\SteamID::toSteam2($_POST['steam']);
-    $a_email          = $_POST['email'];
+    $a_name           = trim($_POST['adminname']);
+    $a_steam          = \SteamID\SteamID::toSteam2(trim($_POST['steam']));
+    $a_email          = trim($_POST['email']);
     $a_serverpass     = $_POST['a_useserverpass'] == "on";
     $pw_changed       = false;
     $serverpw_changed = false;


### PR DESCRIPTION
Trims leading/trailing whitespace from admin name, email, and auth ID fields from POST parameters

## Motivation and Context
Fields were not trimmed and were allowed to persist into the DB like this, which can cause problems later when read out for use as-is without sanitization.  AuthID in particular can store whitespace without being noticed since the field gets trimmed before being displayed on the page.

## How Has This Been Tested?
Tested on Apache web server
Edited admin detail with a copious amount of leading/trailing whitespace in the fields are now properly trimmed.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
