### PR TITLE
Fixing Public Comments checkbox in Settings

### DIFF
--- a/web/pages/admin.settings.php
+++ b/web/pages/admin.settings.php
@@ -352,7 +352,7 @@ $('enable_groupbanning').checked = <?=(int)Config::getBool('config.enablegroupba
 $('enable_friendsbanning').checked = <?=(int)Config::getBool('config.enablefriendsbanning');?>;
 $('enable_adminrehashing').checked = <?=(int)Config::getBool('config.enableadminrehashing');?>;
 $('enable_steamlogin').checked = <?=(int)Config::getBool('config.enablesteamlogin');?>;
-$('enable_publiccomments').checked = <?=(int)Config::getBool('config.publiccomments');?>;
+$('enable_publiccomments').checked = <?=(int)Config::getBool('config.enablepubliccomments');?>;
 <?php
 if (ini_get('safe_mode') == 1) {
     print "$('enable_groupbanning').disabled = true;\n";


### PR DESCRIPTION
## Description
The corresponding checkbox now will be checked if Public Comments is enabled.
Fixing for commit d078fe75c4908d7aeeb1d109893108fd84a1ddcb

## Motivation and Context
The checkbox for Public Comments wasn't checked even if the setting was enabled.

## How Has This Been Tested?
I have previously enabled Public Comments, and with this change the checkbox is checked showing that I have Public Comments already enabled.

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/1230402/66792389-c2434780-eef8-11e9-9ff1-d34337b12b89.png)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
