### PR TITLE
Select Steam ID as default Ban Type on PasteBan action

### DIFF
--- a/web/includes/sb-callback.php
+++ b/web/includes/sb-callback.php
@@ -1585,7 +1585,7 @@ function PasteBan(int $sid, $name, int $type = 0)
             $steam = \SteamID\SteamID::toSteam2($player['steamid']);
             $objResponse->addScript("$('nickname').value = '".addslashes(html_entity_decode($name, ENT_QUOTES))."'");
 
-            $objResponse->addScript("$('type').options[1].selected = true");
+            $objResponse->addScript("$('type').options[0].selected = true");
             $objResponse->addScript("$('steam').value = '$steam'");
             $objResponse->addScript("$('ip').value = '$player[ip]'");
 


### PR DESCRIPTION
## Description
Steam ID is the most effective ban type, and btw Sleuth will catch a player on the same IP.

## Motivation and Context
PasteBan action used, when you rightclick a player and select Ban/Block Comms. A form is automatically filled out with the players data. Without my modification is will select Ban Type: IP Address.
I think a few people would use IP Address as a primary Ban Type.

## How Has This Been Tested?
Modified the corresponding file on my webserver, and used right click / Ban a player, and Steam ID was selected instead of IP Address.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
