### PR TITLE
Fix invalid XML response when gameservers use special characters.

### DIFF
--- a/web/includes/sb-callback.php
+++ b/web/includes/sb-callback.php
@@ -1206,6 +1206,7 @@ function ServerHostPlayers($sid, $type="servers", $obId="", $tplsid="", $open=""
     try {
         $query->Connect($server['ip'], $server['port'], 1, SourceQuery::SOURCE);
         $info = $query->GetInfo();
+		$info['HostName'] = preg_replace('/[\x00-\x1f]/','', htmlspecialchars($info['HostName']));
         $players = $query->GetPlayers();
     } catch (Exception $e) {
         if ($userbank->HasAccess(ADMIN_OWNER)) {


### PR DESCRIPTION
## Description
Gameservers like to use special characters, this breaks the XML response in a lot of cases.

## Motivation and Context
A friend asked me to help him fix it.

## How Has This Been Tested?
Visited the sourcebans web page and observed that the gameserver name shows correctly and the XML error no longer exists.

## Screenshots (if appropriate):
https://i.imgur.com/kiHqPWF.png (https://bans.cswarzone.com/index.php?p=servers)

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [X] My code follows the code style of this project.
- [X] I have read the **CONTRIBUTING** document.
