### PR TITLE
Fix debug output after 75cc5b6

### DIFF
--- a/game/addons/sourcemod/scripting/sbpp_comms.sp
+++ b/game/addons/sourcemod/scripting/sbpp_comms.sp
@@ -1241,7 +1241,7 @@ public int PanelHandler_ListTargetReason(Menu menu, MenuAction action, int param
 public void GotDatabase(Database db, const char[] error, any data)
 {
 	#if defined DEBUG
-	PrintToServer("GotDatabase(data: %d, lock: %d, g_h: %d, hndl: %d)", data, g_iConnectLock, g_hDatabase, hndl);
+	PrintToServer("GotDatabase(data: %d, lock: %d, g_h: %d, db: %d)", data, g_iConnectLock, g_hDatabase, db);
 	#endif
 
 	// If this happens to be an old connection request, ignore it.


### PR DESCRIPTION
## Description
Fix debug output after 75cc5b6

## How Has This Been Tested?
Build succeful on SM 1.9, 1.10 and 1.11 when [DEBUG](https://github.com/sbpp/sourcebans-pp/blob/9c297aaa99eb0014cd0497ddc12008e70913a8e9/game/addons/sourcemod/scripting/sbpp_comms.sp#L40) defined.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
