### PR TITLE
New fix for URL address in KickIt banning messages

### DIFF
--- a/web/pages/admin.kickit.php
+++ b/web/pages/admin.kickit.php
@@ -94,7 +94,7 @@ function KickPlayer($check, int $sid, $num, $type)
                 $GLOBALS['PDO']->bind(':authid', $check);
                 $GLOBALS['PDO']->execute();
 
-                $domain = Host::complete();
+                $domain = str_replace("/pages", "", Host::complete());
                 rcon("kickid $player[id] \"You have been banned by this server, check $domain for more info\"", $sid);
 
                 $objResponse->addAssign("srv_$num", "innerHTML", "<font color='green' size='1'><b><u>Player Found & Kicked!</u></b></font>");
@@ -109,7 +109,7 @@ function KickPlayer($check, int $sid, $num, $type)
                 $GLOBALS['PDO']->bind(':ip', $check);
                 $GLOBALS['PDO']->execute();
 
-                $domain = Host::complete();
+                $domain = str_replace("/pages", "", Host::complete());
                 rcon("kickid $player[id] \"You have been banned by this server, check $domain for more info\"", $sid);
 
                 $objResponse->addAssign("srv_$num", "innerHTML", "<font color='green' size='1'><b><u>Player Found & Kicked!</u></b></font>");


### PR DESCRIPTION
It was returning the /pages as well, and that's not the SourceBans++ main page.

## Description
`$domain` returned https://mydomain.com/bans/pages, and not https://mydomain.com/bans

## Motivation and Context
If I ban someone from the webpanel and using KickIt, the ban messages is not containing the right URL for my SourceBans++ page.

## How Has This Been Tested?
Checking for kick logs.

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
