### PR TITLE
Add Kick Option to sleuth actions options

### DIFF
--- a/game/addons/sourcemod/scripting/sbpp_sleuth.sp
+++ b/game/addons/sourcemod/scripting/sbpp_sleuth.sp
@@ -37,6 +37,7 @@
 #define LENGTH_CUSTOM 2
 #define LENGTH_DOUBLE 3
 #define LENGTH_NOTIFY 4
+#define LENGTH_KICK 5
 
 #define PREFIX "[SourceSleuth] "
 
@@ -72,7 +73,7 @@ public void OnPluginStart()
 
 	CreateConVar("sm_sourcesleuth_version", PLUGIN_VERSION, "SourceSleuth plugin version", FCVAR_SPONLY | FCVAR_REPLICATED | FCVAR_NOTIFY | FCVAR_DONTRECORD);
 
-	g_cVar_actions = CreateConVar("sm_sleuth_actions", "3", "Sleuth Ban Type: 1 - Original Length, 2 - Custom Length, 3 - Double Length, 4 - Notify Admins Only", 0, true, 1.0, true, 4.0);
+	g_cVar_actions = CreateConVar("sm_sleuth_actions", "3", "Sleuth Ban Type: 1 - Original Length, 2 - Custom Length, 3 - Double Length, 4 - Notify Admins Only, 5 - Kick Client", 0, true, 1.0, true, 5.0);
 	g_cVar_banduration = CreateConVar("sm_sleuth_duration", "0", "Required: sm_sleuth_actions 1: Bantime to ban player if we got a match (0 = permanent (defined in minutes) )", 0);
 	g_cVar_sbprefix = CreateConVar("sm_sleuth_prefix", "sb", "Prexfix for sourcebans tables: Default sb", 0);
 	g_cVar_bansAllowed = CreateConVar("sm_sleuth_bansallowed", "0", "How many active bans are allowed before we act", 0);
@@ -229,6 +230,10 @@ public void SQL_CheckHim(Database db, DBResultSet results, const char[] error, D
 				{
 					/* Notify Admins when a client with an ip on the bans list connects */
 					PrintToAdmins("%s%t", PREFIX, "sourcesleuth_admintext", client, steamid, IP);
+				}
+				case LENGTH_KICK:
+				{
+					KickClient(client, "%s%t", PREFIX, "sourcesleuth_kicktext");
 				}
 			}
 		}

--- a/game/addons/sourcemod/translations/sbpp_sleuth.phrases.txt
+++ b/game/addons/sourcemod/translations/sbpp_sleuth.phrases.txt
@@ -28,4 +28,9 @@
 		"chi"		"玩家 {1} (ID: {2} | IP: {3}) 目前有多次IP封禁"
 		"tr"		"Oyuncu {1} (ID: {2} | IP: {3}) IP adresinde aktif yasaklaması var."
 	}
+	"sourcesleuth_kicktext"
+	{
+		"#format"	""
+		"en"		"You have been kicked for having an active ban on your IP"
+	}
 }


### PR DESCRIPTION
## Description
Edit **sm_sleuth_actions** description for extra option to kick instead of ban or notify
Add new **#define LENGTH_KICK** for kick action
Add in **LENGTH_KICK** case to **SQL_CheckHim** function

Added new translation to sleuth_phrases called **sleuth_kicktext**

## Motivation and Context
Gives server owners the ability to only kick the user from the server instead of fully ban them, giving them more insight as to why they cannot join on an alternate account.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
