### PR TITLE
Add a native to ban a steam ID with a parameter to bind the steam ID with a name and a parameter to kick if online.

### DIFF
--- a/game/addons/sourcemod/scripting/include/sourcebanspp.inc
+++ b/game/addons/sourcemod/scripting/include/sourcebanspp.inc
@@ -1,7 +1,7 @@
 // *************************************************************************
 //  This file is part of SourceBans++.
 //
-//  Copyright (C) 2014-2016 SourceBans++ Dev Team <https://github.com/sbpp>
+//  Copyright (C) 2014-2019 SourceBans++ Dev Team <https://github.com/sbpp>
 //
 //  SourceBans++ is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by

--- a/game/addons/sourcemod/scripting/include/sourcebanspp.inc
+++ b/game/addons/sourcemod/scripting/include/sourcebanspp.inc
@@ -73,6 +73,7 @@ native void SBBanPlayer(int iAdmin, int iTarget, int iTime, const char[] sReason
  * @noreturn
  *********************************************************/
 native void SBPP_BanPlayer(int iAdmin, int iTarget, int iTime, const char[] sReason);
+
 /*********************************************************
  * Ban Identity from server
  *

--- a/game/addons/sourcemod/scripting/include/sourcebanspp.inc
+++ b/game/addons/sourcemod/scripting/include/sourcebanspp.inc
@@ -44,8 +44,8 @@ public SharedPlugin __pl_sourcebanspp =
 public void __pl_sourcebanspp_SetNTVOptional()
 {
 	MarkNativeAsOptional("SBBanPlayer");
-	MarkNativeAsOptional("SBBanAuthId");
 	MarkNativeAsOptional("SBPP_BanPlayer");
+	MarkNativeAsOptional("SBPP_BanAuthId");
 	MarkNativeAsOptional("SBPP_ReportPlayer");
 }
 #endif

--- a/game/addons/sourcemod/scripting/include/sourcebanspp.inc
+++ b/game/addons/sourcemod/scripting/include/sourcebanspp.inc
@@ -1,7 +1,7 @@
 // *************************************************************************
 //  This file is part of SourceBans++.
 //
-//  Copyright (C) 2014-2019 SourceBans++ Dev Team <https://github.com/sbpp>
+//  Copyright (C) 2014-2016 SourceBans++ Dev Team <https://github.com/sbpp>
 //
 //  SourceBans++ is free software: you can redistribute it and/or modify
 //  it under the terms of the GNU General Public License as published by
@@ -41,9 +41,10 @@ public SharedPlugin __pl_sourcebanspp =
 };
 
 #if !defined REQUIRE_PLUGIN
-public void __pl_sourcebanspp_SetNTVOptional()
+public __pl_sourcebanspp_SetNTVOptional()
 {
 	MarkNativeAsOptional("SBBanPlayer");
+	MarkNativeAsOptional("SBBanAuthId");
 	MarkNativeAsOptional("SBPP_BanPlayer");
 	MarkNativeAsOptional("SBPP_ReportPlayer");
 }
@@ -72,6 +73,19 @@ native void SBBanPlayer(int iAdmin, int iTarget, int iTime, const char[] sReason
  * @noreturn
  *********************************************************/
 native void SBPP_BanPlayer(int iAdmin, int iTarget, int iTime, const char[] sReason);
+
+/*********************************************************
+ * Ban Identity from server
+ *
+ * @param authid		The authid to ban
+ * @param admin			The admin's client index
+ * @param time			The time to ban the player for (in minutes, 0 = permanent)
+ * @param reason		The reason to ban the player from the server
+ * @param kick			True if to kick the banned player if he is inside the server.
+ * @param name			The name of the banned client that owns the identity.
+ * @noreturn
+ *********************************************************/
+native void SBBanAuthId(const char[] AuthId, int iAdmin, int iTime, const char[] sReason, bool kick=true, const char[] Name="");
 
 /*********************************************************
  * Reports a player

--- a/game/addons/sourcemod/scripting/include/sourcebanspp.inc
+++ b/game/addons/sourcemod/scripting/include/sourcebanspp.inc
@@ -84,7 +84,7 @@ native void SBPP_BanPlayer(int iAdmin, int iTarget, int iTime, const char[] sRea
  * @param name			The name of the banned client that owns the identity.
  * @noreturn
  *********************************************************/
-native void SBPP_BanAccountId(const char[] AuthId, int iAdmin, int iTime, const char[] sReason, bool kick=true, const char[] Name="");
+native void SBPP_BanAccountId(const int AccountId, int iAdmin, int iTime, const char[] sReason, bool kick=true, const char[] Name="");
 
 /*********************************************************
  * Reports a player

--- a/game/addons/sourcemod/scripting/include/sourcebanspp.inc
+++ b/game/addons/sourcemod/scripting/include/sourcebanspp.inc
@@ -41,7 +41,7 @@ public SharedPlugin __pl_sourcebanspp =
 };
 
 #if !defined REQUIRE_PLUGIN
-public __pl_sourcebanspp_SetNTVOptional()
+public void __pl_sourcebanspp_SetNTVOptional()
 {
 	MarkNativeAsOptional("SBBanPlayer");
 	MarkNativeAsOptional("SBBanAuthId");

--- a/game/addons/sourcemod/scripting/include/sourcebanspp.inc
+++ b/game/addons/sourcemod/scripting/include/sourcebanspp.inc
@@ -45,7 +45,7 @@ public void __pl_sourcebanspp_SetNTVOptional()
 {
 	MarkNativeAsOptional("SBBanPlayer");
 	MarkNativeAsOptional("SBPP_BanPlayer");
-	MarkNativeAsOptional("SBPP_BanAuthId");
+	MarkNativeAsOptional("SBPP_BanAccountId");
 	MarkNativeAsOptional("SBPP_ReportPlayer");
 }
 #endif
@@ -73,11 +73,10 @@ native void SBBanPlayer(int iAdmin, int iTarget, int iTime, const char[] sReason
  * @noreturn
  *********************************************************/
 native void SBPP_BanPlayer(int iAdmin, int iTarget, int iTime, const char[] sReason);
-
 /*********************************************************
  * Ban Identity from server
  *
- * @param authid		The authid to ban
+ * @param AccountId		The AccountId to ban as found in GetSteamAccountId
  * @param admin			The admin's client index
  * @param time			The time to ban the player for (in minutes, 0 = permanent)
  * @param reason		The reason to ban the player from the server
@@ -85,7 +84,7 @@ native void SBPP_BanPlayer(int iAdmin, int iTarget, int iTime, const char[] sRea
  * @param name			The name of the banned client that owns the identity.
  * @noreturn
  *********************************************************/
-native void SBBanAuthId(const char[] AuthId, int iAdmin, int iTime, const char[] sReason, bool kick=true, const char[] Name="");
+native void SBPP_BanAccountId(const char[] AuthId, int iAdmin, int iTime, const char[] sReason, bool kick=true, const char[] Name="");
 
 /*********************************************************
  * Reports a player

--- a/game/addons/sourcemod/scripting/sbpp_main.sp
+++ b/game/addons/sourcemod/scripting/sbpp_main.sp
@@ -140,8 +140,8 @@ public APLRes AskPluginLoad2(Handle myself, bool late, char[] error, int err_max
 	RegPluginLibrary("sourcebans++");
 
 	CreateNative("SBBanPlayer", Native_SBBanPlayer);
-	CreateNative("SBBanAuthId", Native_SBBanAuthId);
 	CreateNative("SBPP_BanPlayer", Native_SBBanPlayer);
+	CreateNative("SBPP_BanAuthId", Native_SBBanAuthId);
 	CreateNative("SBPP_ReportPlayer", Native_SBReportPlayer);
 
 	g_hFwd_OnBanAdded = CreateGlobalForward("SBPP_OnBanPlayer", ET_Ignore, Param_Cell, Param_Cell, Param_Cell, Param_String);

--- a/game/addons/sourcemod/scripting/sbpp_main.sp
+++ b/game/addons/sourcemod/scripting/sbpp_main.sp
@@ -141,7 +141,7 @@ public APLRes AskPluginLoad2(Handle myself, bool late, char[] error, int err_max
 
 	CreateNative("SBBanPlayer", Native_SBBanPlayer);
 	CreateNative("SBPP_BanPlayer", Native_SBBanPlayer);
-	CreateNative("SBPP_BanAuthId", Native_SBBanAuthId);
+	CreateNative("SBPP_BanAuthId", Native_SBBanAccountId);
 	CreateNative("SBPP_ReportPlayer", Native_SBReportPlayer);
 
 	g_hFwd_OnBanAdded = CreateGlobalForward("SBPP_OnBanPlayer", ET_Ignore, Param_Cell, Param_Cell, Param_Cell, Param_String);
@@ -2399,8 +2399,8 @@ public int Native_SBBanAccountId(Handle plugin, int numParams)
 		GetClientAuthId(admin, AuthId_Steam2, adminAuth, sizeof(adminAuth));
 	}
 
-	char AuthId[64];
-	SteamAccountIdToSteam2(AccountId, AuthId, sizeof(AuthId));
+	char authid[64];
+	SteamAccountIdToSteam2(AccountId, authid, sizeof(authid));
 	
 	// Pack everything into a data pack so we can retain it
 	DataPack dataPack = new DataPack();
@@ -2877,7 +2877,7 @@ stock void AccountForLateLoading()
 }
 
 
-stock int FindClientByAccountId(const char[] AuthId)
+stock int FindClientByAuthId(const char[] AuthId)
 {
 	char iAuthId[35];
 	
@@ -2896,9 +2896,9 @@ stock int FindClientByAccountId(const char[] AuthId)
 }
 
 
-stock SteamAccountIdToSteam2(int AccountId, char[] buffer, bufferLen)
+stock void SteamAccountIdToSteam2(int AccountId, char[] buffer, int bufferLen)
 {
-	FormatEx(buffer, bufferLen, "STEAM_1:%d:%d", AccountId % 2, RoundFloor(float(AccountId) / 2.0))
+	FormatEx(buffer, bufferLen, "STEAM_1:%d:%d", AccountId % 2, RoundToFloor(float(AccountId) / 2.0));
 }
 
 //Yarr!

--- a/game/addons/sourcemod/scripting/sbpp_main.sp
+++ b/game/addons/sourcemod/scripting/sbpp_main.sp
@@ -2358,7 +2358,7 @@ public int Native_SBBanPlayer(Handle plugin, int numParams)
 /*********************************************************
  * Ban Identity from server
  *
- * @param authid		The authid to ban
+ * @param AccountId		The AccountId to ban as found in GetSteamAccountId
  * @param admin			The admin's client index
  * @param time			The time to ban the player for (in minutes, 0 = permanent)
  * @param reason		The reason to ban the player from the server
@@ -2366,10 +2366,9 @@ public int Native_SBBanPlayer(Handle plugin, int numParams)
  * @param name			The name of the banned client that owns the identity.
  * @noreturn
  *********************************************************/
-public int Native_SBBanAuthId(Handle plugin, int numParams)
+public int Native_SBBanAccountId(Handle plugin, int numParams)
 {
-	char authid[64];
-	GetNativeString(1, authid, sizeof(authid));
+	int AccountId = GetNativeCell(1);
 	
 	int admin = GetNativeCell(2);
 	int time = GetNativeCell(3);
@@ -2400,6 +2399,9 @@ public int Native_SBBanAuthId(Handle plugin, int numParams)
 		GetClientAuthId(admin, AuthId_Steam2, adminAuth, sizeof(adminAuth));
 	}
 
+	char AuthId[64];
+	SteamAccountIdToSteam2(AccountId, AuthId, sizeof(AuthId));
+	
 	// Pack everything into a data pack so we can retain it
 	DataPack dataPack = new DataPack();
 	dataPack.WriteCell(admin);
@@ -2410,7 +2412,6 @@ public int Native_SBBanAuthId(Handle plugin, int numParams)
 	dataPack.WriteString(adminAuth);
 	dataPack.WriteString(adminIp);
 	dataPack.WriteString(name);
-	
 
 	char sQuery[256];
 
@@ -2876,7 +2877,7 @@ stock void AccountForLateLoading()
 }
 
 
-stock int FindClientByAuthId(const char[] AuthId)
+stock int FindClientByAccountId(const char[] AuthId)
 {
 	char iAuthId[35];
 	
@@ -2884,13 +2885,20 @@ stock int FindClientByAuthId(const char[] AuthId)
 	{
 		if(!IsClientInGame(i) || !IsClientAuthorized(i))
 			continue;
-			
+		
 		GetClientAuthId(i, AuthId_Steam2, iAuthId, sizeof(iAuthId));
 		
-		if(StrEqual(AuthId, iAuthId, true))
+		if(StrEqual(AuthId, iAuthId))
 			return i;
 	}
 	
 	return 0;
 }
+
+
+stock SteamAccountIdToSteam2(int AccountId, char[] buffer, bufferLen)
+{
+	FormatEx(buffer, bufferLen, "STEAM_1:%d:%d", AccountId % 2, RoundFloor(float(AccountId) / 2.0))
+}
+
 //Yarr!

--- a/game/addons/sourcemod/scripting/sbpp_main.sp
+++ b/game/addons/sourcemod/scripting/sbpp_main.sp
@@ -2885,7 +2885,7 @@ stock int FindClientByAuthId(const char[] AuthId)
 		if(!IsClientInGame(i) && !IsClientAuthorized(i))
 			continue;
 			
-		GetClientAuthId(i, AuthId_Engine, iAuthId, sizeof(iAuthId));
+		GetClientAuthId(i, AuthId_Steam2, iAuthId, sizeof(iAuthId));
 		
 		if(StrEqual(AuthId, iAuthId, true))
 			return i;

--- a/game/addons/sourcemod/scripting/sbpp_main.sp
+++ b/game/addons/sourcemod/scripting/sbpp_main.sp
@@ -435,7 +435,7 @@ public Action CommandBan(int client, int args)
 
 	if (!time && client && !(CheckCommandAccess(client, "sm_unban", ADMFLAG_UNBAN)))
 	{
-		ReplyToCommand(admin, "%s%t", Prefix, "No Permaban Access");
+		ReplyToCommand(client, "%s%t", Prefix, "No Permaban Access");
 		return Plugin_Handled;
 	}
 
@@ -523,7 +523,7 @@ public Action CommandBanIp(int client, int args)
 
 	if (!minutes && client && !(CheckCommandAccess(client, "sm_unban", ADMFLAG_UNBAN)))
 	{
-		ReplyToCommand(admin, "%s%t", Prefix, "No Permaban Access");
+		ReplyToCommand(client, "%s%t", Prefix, "No Permaban Access");
 		return Plugin_Handled;
 	}
 	if (!client)
@@ -655,7 +655,7 @@ public Action CommandAddBan(int client, int args)
 
 	if (!minutes && client && !(CheckCommandAccess(client, "sm_unban", ADMFLAG_UNBAN)))
 	{
-		ReplyToCommand(admin, "%s%t", Prefix, "No Permaban Access");
+		ReplyToCommand(client, "%s%t", Prefix, "No Permaban Access");
 		return Plugin_Handled;
 	}
 	if (!client)
@@ -2882,7 +2882,7 @@ stock int FindClientByAuthId(const char[] AuthId)
 	
 	for(int i=1;i <= MaxClients;i++)
 	{
-		if(!IsClientInGame(i) && !IsClientAuthorized(i))
+		if(!IsClientInGame(i) || !IsClientAuthorized(i))
 			continue;
 			
 		GetClientAuthId(i, AuthId_Steam2, iAuthId, sizeof(iAuthId));

--- a/game/addons/sourcemod/scripting/sbpp_main.sp
+++ b/game/addons/sourcemod/scripting/sbpp_main.sp
@@ -2377,11 +2377,11 @@ public int Native_SBBanAuthId(Handle plugin, int numParams)
 	GetNativeString(4, reason, 128);
 	
 	bool kick = GetNativeCell(5);
-	char name[64];
+	char name[MAX_NAME_LENGTH + 1];
 	GetNativeString(6, name, 64);
 
 	if (reason[0] == '\0')
-		strcopy(reason, sizeof(reason), "Banned by SourceBans");
+		strcopy(reason, sizeof(reason), "Banned by Sourcemod plugin");
 
 	char adminIp[24], adminAuth[64];
 

--- a/game/addons/sourcemod/scripting/sbpp_main.sp
+++ b/game/addons/sourcemod/scripting/sbpp_main.sp
@@ -433,9 +433,9 @@ public Action CommandBan(int client, int args)
 
 	int time = StringToInt(buffer);
 
-	if (!time && client && !(CheckCommandAccess(client, "sm_unban", ADMFLAG_UNBAN | ADMFLAG_ROOT)))
+	if (!time && client && !(CheckCommandAccess(client, "sm_unban", ADMFLAG_UNBAN)))
 	{
-		ReplyToCommand(client, "You do not have Perm Ban Permission");
+		ReplyToCommand(admin, "%s%t", Prefix, "No Permaban Access");
 		return Plugin_Handled;
 	}
 
@@ -521,9 +521,9 @@ public Action CommandBanIp(int client, int args)
 
 	int minutes = StringToInt(time);
 
-	if (!minutes && client && !(CheckCommandAccess(client, "sm_unban", ADMFLAG_UNBAN | ADMFLAG_ROOT)))
+	if (!minutes && client && !(CheckCommandAccess(client, "sm_unban", ADMFLAG_UNBAN)))
 	{
-		ReplyToCommand(client, "You do not have Perm Ban Permission");
+		ReplyToCommand(admin, "%s%t", Prefix, "No Permaban Access");
 		return Plugin_Handled;
 	}
 	if (!client)
@@ -653,9 +653,9 @@ public Action CommandAddBan(int client, int args)
 
 	int  minutes = StringToInt(time);
 
-	if (!minutes && client && !(CheckCommandAccess(client, "sm_unban", ADMFLAG_UNBAN | ADMFLAG_ROOT)))
+	if (!minutes && client && !(CheckCommandAccess(client, "sm_unban", ADMFLAG_UNBAN)))
 	{
-		ReplyToCommand(client, "You do not have Perm Ban Permission");
+		ReplyToCommand(admin, "%s%t", Prefix, "No Permaban Access");
 		return Plugin_Handled;
 	}
 	if (!client)
@@ -955,7 +955,7 @@ public int MenuHandler_BanTimeList(Menu menu, MenuAction action, int param1, int
 
 			menu.GetItem(param2, time, sizeof(time));
 
-			return (StringToInt(time) > 0 || CheckCommandAccess(param1, "sm_unban", ADMFLAG_UNBAN | ADMFLAG_ROOT)) ? ITEMDRAW_DEFAULT : ITEMDRAW_DISABLED;
+			return (StringToInt(time) > 0 || CheckCommandAccess(param1, "sm_unban", ADMFLAG_UNBAN)) ? ITEMDRAW_DEFAULT : ITEMDRAW_DISABLED;
 		}
 	}
 
@@ -2385,9 +2385,9 @@ public int Native_SBBanAuthId(Handle plugin, int numParams)
 
 	char adminIp[24], adminAuth[64];
 
-	if (!time && admin && !(CheckCommandAccess(admin, "sm_unban", ADMFLAG_UNBAN | ADMFLAG_ROOT)))
+	if (!time && admin && !(CheckCommandAccess(admin, "sm_unban", ADMFLAG_UNBAN)))
 	{
-		ReplyToCommand(admin, "You do not have Perm Ban Permission");
+		ReplyToCommand(admin, "%s%t", Prefix, "No Permaban Access");
 		return false;
 	}
 	if (!admin)

--- a/game/addons/sourcemod/scripting/sbpp_main.sp
+++ b/game/addons/sourcemod/scripting/sbpp_main.sp
@@ -2888,6 +2888,8 @@ stock int FindClientByAuthId(const char[] AuthId)
 		
 		GetClientAuthId(i, AuthId_Steam2, iAuthId, sizeof(iAuthId));
 		
+		iAuthId[6] = '0';
+		
 		if(StrEqual(AuthId, iAuthId))
 			return i;
 	}

--- a/game/addons/sourcemod/scripting/sbpp_main.sp
+++ b/game/addons/sourcemod/scripting/sbpp_main.sp
@@ -2882,10 +2882,7 @@ stock int FindClientByAuthId(const char[] AuthId)
 	
 	for(int i=1;i <= MaxClients;i++)
 	{
-		if(!IsClientInGame(i))
-			continue;
-			
-		else if(!IsClientAuthorized(i))
+		if(!IsClientInGame(i) && !IsClientAuthorized(i))
 			continue;
 			
 		GetClientAuthId(i, AuthId_Engine, iAuthId, sizeof(iAuthId));

--- a/game/addons/sourcemod/scripting/sbpp_main.sp
+++ b/game/addons/sourcemod/scripting/sbpp_main.sp
@@ -624,7 +624,7 @@ public Action CommandAddBan(int client, int args)
 		return Plugin_Handled;
 	}
 
-	char arg_string[256], time[50], authid[50];
+	char arg_string[256], time[11], authid[23];
 
 	GetCmdArgString(arg_string, sizeof(arg_string));
 
@@ -649,7 +649,7 @@ public Action CommandAddBan(int client, int args)
 		arg_string[0] = '\0';
 	}
 
-	char adminIp[24], adminAuth[64];
+	char adminIp[24], adminAuth[23];
 
 	int  minutes = StringToInt(time);
 
@@ -1375,7 +1375,7 @@ public void InsertUnbanCallback(Database db, DBResultSet results, const char[] e
 public void SelectAddbanCallback(Database db, DBResultSet results, const char[] error, DataPack dataPack)
 {
 	int admin, minutes;
-	char adminAuth[30], adminIp[30], authid[20], banReason[256], Query[512], Name[64];
+	char adminAuth[30], adminIp[30], authid[23], banReason[256], Query[512], Name[64];
 	char reason[128];
 
 	dataPack.Reset();
@@ -1430,7 +1430,7 @@ public void InsertAddbanCallback(Database db, DBResultSet results, const char[] 
 {
 	int admin, minutes;
 	bool kick;
-	char authid[20];
+	char authid[23];
 	char reason[128];
 
 	dataPack.Reset();
@@ -1550,7 +1550,7 @@ public void ProcessQueueCallback(Database db, DBResultSet results, const char[] 
 public void AddedFromSQLiteCallback(Database db, DBResultSet results, const char[] error, DataPack dataPack)
 {
 	char buffer[512];
-	char auth[40];
+	char auth[23];
 
 	dataPack.ReadString(auth, sizeof(auth));
 	if (results == null)
@@ -1676,7 +1676,7 @@ public void SQL_OnIPMend(Database db, DBResultSet results, const char[] error, i
 {
 	if (results == null)
 	{
-		char sIP[32], sSteamID[32];
+		char sIP[32], sSteamID[23];
 
 		GetClientAuthId(iClient, AuthId_Steam3, sSteamID, sizeof sSteamID);
 		GetClientIP(iClient, sIP, sizeof sIP);
@@ -2139,7 +2139,7 @@ public void OverridesDone(Database db, DBResultSet results, const char[] error, 
 
 public Action ClientRecheck(Handle timer, any client)
 {
-	char Authid[64];
+	char Authid[23];
 	if (!PlayerStatus[client] && IsClientConnected(client) && GetClientAuthId(client, AuthId_Steam2, Authid, sizeof(Authid)))
 	{
 		OnClientAuthorized(client, Authid);
@@ -2382,7 +2382,7 @@ public int Native_SBBanAccountId(Handle plugin, int numParams)
 	if (reason[0] == '\0')
 		strcopy(reason, sizeof(reason), "Banned by Sourcemod plugin");
 
-	char adminIp[24], adminAuth[64];
+	char adminIp[24], adminAuth[23];
 
 	if (!time && admin && !(CheckCommandAccess(admin, "sm_unban", ADMFLAG_UNBAN)))
 	{
@@ -2399,7 +2399,7 @@ public int Native_SBBanAccountId(Handle plugin, int numParams)
 		GetClientAuthId(admin, AuthId_Steam2, adminAuth, sizeof(adminAuth));
 	}
 
-	char authid[64];
+	char authid[23];
 	SteamAccountIdToSteam2(AccountId, authid, sizeof(authid));
 	
 	// Pack everything into a data pack so we can retain it
@@ -2711,7 +2711,7 @@ stock void PrepareBan(int client, int target, int time, char[] reason, int size)
 	if (!target || !IsClientInGame(target))
 		return;
 
-	char authid[64], name[32], bannedSite[512];
+	char authid[23], name[32], bannedSite[512];
 
 	if (!GetClientAuthId(target, AuthId_Steam2, authid, sizeof(authid)))
 		return;
@@ -2898,7 +2898,7 @@ stock int FindClientByAuthId(const char[] AuthId)
 
 stock void SteamAccountIdToSteam2(int AccountId, char[] buffer, int bufferLen)
 {
-	FormatEx(buffer, bufferLen, "STEAM_1:%d:%d", AccountId % 2, RoundToFloor(float(AccountId) / 2.0));
+	FormatEx( buffer, bufferLen, "STEAM_0:%u:%u", AccountId & 1, AccountId >> 1 );
 }
 
 //Yarr!

--- a/game/addons/sourcemod/scripting/sbpp_main.sp
+++ b/game/addons/sourcemod/scripting/sbpp_main.sp
@@ -141,7 +141,7 @@ public APLRes AskPluginLoad2(Handle myself, bool late, char[] error, int err_max
 
 	CreateNative("SBBanPlayer", Native_SBBanPlayer);
 	CreateNative("SBPP_BanPlayer", Native_SBBanPlayer);
-	CreateNative("SBPP_BanAuthId", Native_SBBanAccountId);
+	CreateNative("SBPP_BanAccountId", Native_SBBanAccountId);
 	CreateNative("SBPP_ReportPlayer", Native_SBReportPlayer);
 
 	g_hFwd_OnBanAdded = CreateGlobalForward("SBPP_OnBanPlayer", ET_Ignore, Param_Cell, Param_Cell, Param_Cell, Param_String);

--- a/game/addons/sourcemod/translations/sbpp_main.phrases.txt
+++ b/game/addons/sourcemod/translations/sbpp_main.phrases.txt
@@ -179,6 +179,10 @@
 		"tr"			"Yönetici: {1}\nSebep: {2}\nSüre: {3}"
 		"chi"			"管理员: {1}\n原因: {2}\n时长: {3}"
 	}
+	"No Permaban Access"
+	{
+		"en"			"You do not have Perm Ban Permission"
+	}
 	"Permabanned Player"
 	{
 		"#format"		"{1:s}"


### PR DESCRIPTION
This is the native's structure, without it it's impossible to ban a steam ID with a name attached to it.

`/*********************************************************
 * Ban Identity from server
 *
 * @param authid		The authid to ban
 * @param admin			The admin's client index
 * @param time			The time to ban the player for (in minutes, 0 = permanent)
 * @param reason		The reason to ban the player from the server
 * @param kick			True if to kick the banned player if he is inside the server.
 * @param name			The name of the banned client that owns the identity.
 * @noreturn
 *********************************************************/
native void SBBanAuthId(const char[] AuthId, int iAdmin, int iTime, const char[] sReason, bool kick=true, const char[] Name="");`