### PR TITLE
Minor fixes for PHP 8.0 compatibility

### DIFF
--- a/web/includes/auth/Auth.php
+++ b/web/includes/auth/Auth.php
@@ -183,11 +183,7 @@ class Auth
         self::$dbs->query("SELECT 1 FROM `:prefix_login_tokens` WHERE jti = :jti");
         self::$dbs->bind(':jti', $jti, PDO::PARAM_STR);
         $result = self::$dbs->single();
-        if (empty($result)) {
-            return false;
-        } else {
-            return true;
-        }
+        return !empty($result);
     }
 
     /**

--- a/web/includes/auth/Auth.php
+++ b/web/includes/auth/Auth.php
@@ -187,10 +187,14 @@ class Auth
     }
 
     /**
-     * @return mixed
+     * @return string
      */
     private static function getJWTFromCookie()
     {
-        return filter_var($_COOKIE['sbpp_auth'], FILTER_SANITIZE_STRING, FILTER_FLAG_NO_ENCODE_QUOTES);
+        if (isset($_COOKIE['sbpp_auth'])) {
+            return filter_var($_COOKIE['sbpp_auth'], FILTER_SANITIZE_STRING, FILTER_FLAG_NO_ENCODE_QUOTES);
+        } else {
+            return '';
+        }
     }
 }

--- a/web/includes/auth/Auth.php
+++ b/web/includes/auth/Auth.php
@@ -193,8 +193,8 @@ class Auth
     {
         if (isset($_COOKIE['sbpp_auth'])) {
             return filter_var($_COOKIE['sbpp_auth'], FILTER_SANITIZE_STRING, FILTER_FLAG_NO_ENCODE_QUOTES);
-        } else {
-            return '';
         }
+
+        return '';
     }
 }

--- a/web/includes/auth/Auth.php
+++ b/web/includes/auth/Auth.php
@@ -183,7 +183,11 @@ class Auth
         self::$dbs->query("SELECT 1 FROM `:prefix_login_tokens` WHERE jti = :jti");
         self::$dbs->bind(':jti', $jti, PDO::PARAM_STR);
         $result = self::$dbs->single();
-        return (bool)($result[1]);
+        if (empty($result)) {
+            return false;
+        } else {
+            return true;
+        }
     }
 
     /**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
In PHP 8 a number of notices have been converted into warnings. When logged out (cookie not existent) it raised a notice, which is now a warning and opening in a popup, preventing access to SourceBans++.
Also logging in with correct password caused another warning in PHP 8.
This pull request fixes the notices/warnings.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Make SourceBans++ compatible with PHP 8.0.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested with my SourceBans++ installation and PHP 8.0.0.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
