### PR TITLE
Fix ban time miscalculation

### DIFF
--- a/game/addons/sourcemod/scripting/sbpp_sleuth.sp
+++ b/game/addons/sourcemod/scripting/sbpp_sleuth.sp
@@ -203,7 +203,7 @@ public void SQL_CheckHim(Database db, DBResultSet results, const char[] error, D
 				case LENGTH_ORIGINAL:
 				{
 					int length = results.FetchInt(6);
-					int time = length * 60;
+					int time = length / 60;
 
 					BanPlayer(client, time);
 				}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
We've to pass time in minutes as argument when calling **SBPP_BanPlayer** because internally it gets converted to seconds and then stored into database.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
