### PR TITLE
add gametracker support

### DIFF
--- a/web/themes/default/page_servers.tpl
+++ b/web/themes/default/page_servers.tpl
@@ -40,6 +40,7 @@
                                                 <br />
                                                 <div align='center'>
                                                     <p style="font-size: 13px;">{$server.ip}:{$server.port}</p>
+                                                    <div style='padding-right:13px;'><a href="https://www.gametracker.com/server_info/{$server.ip}:{$server.port}/"><img src='https://cache.gametracker.com/server_info/{$server.ip}:{$server.port}/banner_560x95.png'/></a></div>
                                                     <input type='submit' onclick="document.location = 'steam://connect/{$server.ip}:{$server.port}'" name='button' class='btn game' style='margin:0px;' id='button' value='Join game' />
                                                     <input type='button' onclick="ShowBox('Reloading..','<b>Refreshing the Serverdata...</b><br><i>Please Wait!</i>', 'blue', '', false);document.getElementById('dialog-control').setStyle('display', 'none');xajax_RefreshServer({$server.sid});" name='button' class='btn refresh' style='margin:0;' id='button' value='Refresh' />
                                                 </div>
@@ -52,6 +53,7 @@
                                     <h2 style="color: #333;">No players in the server</h2><br />
                                     <div align='center'>
                                         <p style="font-size: 13px;">{$server.ip}:{$server.port}</p>
+                                        <div style='padding-right:13px;'><a href="https://www.gametracker.com/server_info/{$server.ip}:{$server.port}/"><img src='https://cache.gametracker.com/server_info/{$server.ip}:{$server.port}/banner_560x95.png'/></a></div>
                                         <input type='submit' onclick="document.location = 'steam://connect/{$server.ip}:{$server.port}'" name='button' class='btn game' style='margin:0;' id='button' value='Join game' />
                                         <input type='button' onclick="ShowBox('Reloading..','<b>Refreshing the Serverdata...</b><br><i>Please Wait!</i>', 'blue', '', false);document.getElementById('dialog-control').setStyle('display', 'none');xajax_RefreshServer({$server.sid});" name='button' class='btn refresh' style='margin:0;' id='button' value='Refresh' /><br /><br />
                                     </div>


### PR DESCRIPTION
this adds gametracker display support for servers using the {$server.ip} & {$server.port} variables.

<!--- Provide a general summary of your changes in the Title above -->

## Description
Our community, [GamePunch](http://gamepunch.net), has our servers listed on [GameTracker](http://gametracker.com). We wanted our community members and users to be able to see our server statistics while on SB++.

## Motivation and Context
This is an addition/feature request. If possible (I have not done this yet), add an option in admin settings to enable/disable it if you don't have your server listed on GameTracker. However, it works fine as-is, and will work regardless of the server being "claimed" on their site.

## How Has This Been Tested?
Testing is fairly simple. GameTracker creates an image based on the server's ip and port. An example of this is as follows (for our jailbreak server):
`<a href="https://www.gametracker.com/server_info/74.91.119.5:27015/" target="_blank"><img src="https://cache.gametracker.com/server_info/74.91.119.5:27015/b_560_95_1.png" border="0" width="560" height="95" alt=""/></a>`
By removing the IP and Port and replacing it with the variables already in SB++, it makes adding the picture easy.

## Screenshots (if appropriate):
With players:
[here](https://i.gyazo.com/1f0a0af7f94ed3fa4505cd0e2e117c42.png)
Without players:
[here](https://i.gyazo.com/30d3a21103e319cdaadd065219ef1d93.png)

A working copy can be found [here](http://gamepunch.net/sourcebans)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
