### PR TITLE
Fix "Undefined index: HTTPS" warning notice when not using HTTPS

### DIFF
--- a/web/includes/auth/Host.php
+++ b/web/includes/auth/Host.php
@@ -18,7 +18,7 @@ class Host
      */
     public static function protocol()
     {
-        return sprintf('http%s://', ($_SERVER['HTTPS']) ? 's' : '');
+        return sprintf('http%s://', (isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off') ? 's' : '');
     }
 
     /**


### PR DESCRIPTION
When the page is loaded through HTTP instead of HTTPS the login page shows a PHP notice on the page:
`Undefined index: HTTPS`

## Description
Added `isset()` check for `$_SERVER['HTTPS']`  and handle case where a web server config has the value set to `off`.

## Motivation and Context
This error is hidden from public view with `display_errors = Off` in `php.ini` but should still be corrected.

## How Has This Been Tested?
Tested on Linux with Apache 2.4.29 / PHP 7.2.24
Page now loads without the error.  Steam OAuth login redirects appropriately for both HTTP and HTTPS.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
