### PR TITLE
Fix "undefined offset" warning notice on ban list page for IP address bans

### DIFF
--- a/web/pages/page.banlist.php
+++ b/web/pages/page.banlist.php
@@ -482,9 +482,7 @@ while (!$res->EOF) {
     $data['type']        = $res->fields['type'];
     $data['steamid']     = $res->fields['authid'];
     $data['communityid'] = $res->fields['community_id'];
-    $steam2id            = $data['steamid'];
-    $steam3parts         = explode(':', $steam2id);
-    $data['steamid3']    = '[U:1:' . ($steam3parts[2] * 2 + $steam3parts[1]) . ']';
+    $data['steamid3']    = \SteamID\SteamID::toSteam3($data['steamid']);
 
     if (Config::getBool('banlist.hideadminname') && !$userbank->is_admin()) {
         $data['admin'] = false;


### PR DESCRIPTION
Ban list page does not properly check for a valid SteamID2 before converting to a SteamID3, which happens for the IP address ban type that does not require a Steam ID (defaults to `0` in the `_bans` table).  This produces warnings due to attempting to manually split the string into parts.

## Description
Switch to using the `SteamID` library, which has a built-in validity check.

## Motivation and Context
This error is hidden from public view with display_errors = Off in php.ini but should still be corrected.

## How Has This Been Tested?
Tested on Linux with Apache 2.4.29 / PHP 7.4.21
Page now loads without the error. 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
