### PR TITLE
Add missing auth check to function SetupEditServer()

### DIFF
--- a/web/includes/sb-callback.php
+++ b/web/includes/sb-callback.php
@@ -2105,8 +2105,17 @@ function PrepareReban($bid)
  */
 function SetupEditServer($sid)
 {
+    global $userbank;
     $objResponse = new xajaxResponse();
     $sid = (int)$sid;
+
+    if(!$userbank->HasAccess(ADMIN_OWNER|ADMIN_EDIT_SERVERS))
+    {
+        $objResponse->redirect("index.php?p=login&m=no_access", 0);
+        Log::add("w", "Hacking Attempt", "$username tried to edit a server, but doesnt have access.");
+        return $objResponse;
+    }
+
     $server = $GLOBALS['db']->GetRow("SELECT * FROM ".DB_PREFIX."_servers WHERE sid = $sid");
 
     // clear any old stuff


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR adds a missing permission check to the function `SetupEditServer` that could potentially be used to leak rcon passwords.

Thanks to vellichor for finding this issue.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
