### PR TITLE
Add two natives to get the number of bans and comms ban of a client.

### DIFF
--- a/game/addons/sourcemod/scripting/include/sourcebanschecker.inc
+++ b/game/addons/sourcemod/scripting/include/sourcebanschecker.inc
@@ -1,0 +1,67 @@
+﻿// *************************************************************************
+//  This file is part of SourceBans++.
+//
+//  Copyright (C) 2014-2019 SourceBans++ Dev Team <https://github.com/sbpp>
+//
+//  SourceBans++ is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, per version 3 of the License.
+//
+//  SourceBans++ is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with SourceBans++. If not, see <http://www.gnu.org/licenses/>.
+//
+//  This file based off work(s) covered by the following copyright(s):
+//
+//   SourceBans 1.4.11
+//   Copyright (C) 2007-2015 SourceBans Team - Part of GameConnect
+//   Licensed under GNU GPL version 3, or later.
+//   Page: <http://www.sourcebans.net/> - <https://github.com/GameConnect/sourcebansv1>
+//
+// *************************************************************************
+
+#if defined _sourcebanschecker_included
+#endinput
+#endif
+#define _sourcebanschecker_included
+
+public SharedPlugin __pl_sourcebanschecker =
+{
+	name = "sourcebans++",
+	file = "sbpp_main.smx",
+	#if defined REQUIRE_PLUGIN
+	required = 1
+	#else
+	required = 0
+	#endif
+};
+
+#if !defined REQUIRE_PLUGIN
+public void __pl_sourcebanschecker_SetNTVOptional()
+{
+	MarkNativeAsOptional("SBCheckerGetClientsBans");
+  MarkNativeAsOptional("SBCheckerGetClientsComms");
+}
+#endif
+
+
+/*********************************************************
+ * Get the number of bans of a client.
+ *
+ * @param iClient	The client index of who you want to get the number of bans.
+ * @return        The number of bans of the client.
+ *********************************************************/
+native int SBCheckerGetClientsBans(int iClient);
+
+
+/*********************************************************
+ * Get the number of comms bans of a client.
+ *
+ * @param iClient	The client index of who you want to get the number of comms bans.
+ * @return        The number of comms bans of the client.
+ *********************************************************/
+native int SBCheckerGetClientsComms(int iClient);

--- a/game/addons/sourcemod/scripting/sbpp_checker.sp
+++ b/game/addons/sourcemod/scripting/sbpp_checker.sp
@@ -39,6 +39,10 @@ char g_DatabasePrefix[10] = "sb";
 SMCParser g_ConfigParser;
 Database g_DB;
 
+int g_iBanCounts[MAXPLAYERS + 1];
+int g_iCommsCounts[MAXPLAYERS + 1];
+
+
 public Plugin myinfo =
 {
 	name = "SourceBans++: Bans Checker",
@@ -106,6 +110,10 @@ public void OnConnectBanCheck(Database db, DBResultSet results, const char[] err
 	if(results.FetchRow()){
 		commcount = results.FetchInt(0);
 	}
+
+	g_iBanCounts[client] = bancount;
+	g_iCommsCounts[client] = commcount;
+
 	if ( bancount && commcount ) {
 		PrintToBanAdmins("%s%t", Prefix, "Ban and Comm Warning", client, bancount, ((bancount > 1 || bancount == 0) ? "s":""), commcount, ((commcount > 1 || commcount == 0) ? "s":""));
 	}

--- a/game/addons/sourcemod/scripting/sbpp_checker.sp
+++ b/game/addons/sourcemod/scripting/sbpp_checker.sp
@@ -84,6 +84,28 @@ public void OnDatabaseConnected(Database db, const char[] error, any data)
 	g_DB = db;
 }
 
+public APLRes AskPluginLoad2(Handle myself, bool late, char[] error, int err_max)
+{
+	RegPluginLibrary("sourcebans++");
+
+	CreateNative("SBCheckerGetClientsBans", Native_SBCheckerGetClientsBans);
+	CreateNative("SBCheckerGetClientsComms", Native_SBCheckerGetClientsComms);
+
+	return APLRes_Success;
+}
+
+public int Native_SBCheckerGetClientsBans(Handle plugin, int numParams)
+{
+	int client = GetNativeCell(1);
+	return g_iBanCounts[client];
+}
+
+public int Native_SBCheckerGetClientsComms(Handle plugin, int numParams)
+{
+	int client = GetNativeCell(1);
+	return g_iCommsCounts[client];
+}
+
 public void OnClientAuthorized(int client, const char[] auth)
 {
 	if (g_DB == null)

--- a/game/addons/sourcemod/translations/sbpp_checker.phrases.txt
+++ b/game/addons/sourcemod/translations/sbpp_checker.phrases.txt
@@ -21,7 +21,7 @@
 		"hu"			"Figyelem: Játékosnak \"{1:N}\" van {2} korábbi kommunikációs tiltása{3}."
 		"chi"			"警告: 玩家 \"{1:N}\" 之前有 {2} 次禁言."
 		"pl"			"Uwaga: Gracz \"{1:N}\" posiada {2} poprzednie blokady czatu{3}."
-		"pt"			"Aviso: O(A) jogador(a) \"{1:N}\" já foi silenciado(a) {2} vez(es){3}.
+		"pt"			"Aviso: O(A) jogador(a) \"{1:N}\" já foi silenciado(a) {2} vez(es){3}."
 		"de"			"Warnung: Spieler \"{1:N}\" hatte bisher {2} Sprachchat ban{3}."
 		"tr"			"Uyarı: Oyuncu \"{1:N}\" daha önceden {2} defa iletişim yasağı aldı."
 		"fr"			"Attentino: Le joueur \"{1:N}\" a déjà reçu {2} blocage{3} de communication."


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Added an include file and two natives for sbppchecker, which allow to get the number of bans and comms ban for a client, synchronously.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
It is useful for calladmin plugins to send information on the target, so admin can decide more easily what to do.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
On the latest version of sbpp, with an external plugin which calls the native when a command is called in the server.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
