### PR TITLE
Fix fields access error after bans/comms edit

### DIFF
--- a/web/pages/admin.edit.ban.php
+++ b/web/pages/admin.edit.ban.php
@@ -195,7 +195,8 @@ if (isset($_POST['name'])) {
         }
 
         if ($_POST['banlength'] != $lengthrev->fields['length']) {
-            Log::add("m", "Ban length edited", "Ban length for ($lengthrev[authid]) has been updated. Before: $lengthrev[length]; Now: $_POST[banlength]");
+            Log::add("m", "Ban length edited", "Ban length for ({$lengthrev->fields['authid']}) has been updated."
+                . " Before: {$lengthrev->fields['length']}; Now: {$_POST['banlength']}.");
         }
         echo '<script>ShowBox("Ban updated", "The ban has been updated successfully", "green", "index.php?p=banlist' . $pagelink . '");</script>';
     }

--- a/web/pages/admin.edit.comms.php
+++ b/web/pages/admin.edit.comms.php
@@ -136,7 +136,9 @@ if (isset($_POST['name'])) {
             )
         );
         if ($_POST['banlength'] != $lengthrev->fields['length']) {
-            Log::add("m", "Block edited", "Block for ($lengthrev[authid]) has been updated. Before: length ($lengthrev[length]), type ($lengthrev[type]); Now: length ($_POST[banlength]), type ($_POST[type])");
+            Log::add("m", "Block edited", "Block for ({$lengthrev->fields['authid']}) has been updated."
+                . " Before: length ({$lengthrev->fields['length']}), type ({$lengthrev->fields['type']});"
+                . " Now: length ({$_POST['banlength']}), type ({$_POST['type']}).");
         }
         echo '<script>ShowBox("Block updated", "The block has been updated successfully", "green", "index.php?p=commslist' . $pagelink . '");</script>';
     }


### PR DESCRIPTION
Simply fix #603. The solution is pretty straightforward.

I'm not sure if the same kind of error is present in other parts of the system as there are a lot of `SELECT` operations not worth having checked.