### PR TITLE
Fix: Cancel command if no time is given as int

### DIFF
--- a/game/addons/sourcemod/scripting/sbpp_main.sp
+++ b/game/addons/sourcemod/scripting/sbpp_main.sp
@@ -431,6 +431,12 @@ public Action CommandBan(int client, int args)
 	GetCmdArg(2, buffer, sizeof(buffer));
 
 	int time = StringToInt(buffer);
+	
+	if (!StringToIntEx(buffer, time))
+	{
+		ReplyToCommand(client, "%sUsage: sm_ban <#userid|name> <time|0> [reason]", Prefix);
+		return Plugin_Handled;
+	}
 
 	if (!time && client && !(CheckCommandAccess(client, "sm_unban", ADMFLAG_UNBAN | ADMFLAG_ROOT)))
 	{


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Before you can use sm_ban <User> <time> <Reason>
If you put text and not int as time the plugin take it as permant length 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Few bans was made due to admins doesn't know how to use the command line correctly.
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
sm_ban <User> <text_instead_of_int> <Reason>
return  [Sourcebans++] Usage: sm_ban <#userid|name> <time|0> [reason]
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
