### PR TITLE
feat(main): add forward SBPP_OnClientPreAdminCheck

### DIFF
--- a/game/addons/sourcemod/scripting/include/sourcebanspp.inc
+++ b/game/addons/sourcemod/scripting/include/sourcebanspp.inc
@@ -103,4 +103,12 @@ forward void SBPP_OnBanPlayer(int iAdmin, int iTarget, int iTime, const char[] s
  *********************************************************/
 forward void SBPP_OnReportPlayer(int iReporter, int iTarget, const char[] sReason);
 
+/*********************************************************
+ * Called when OnClientPreAdminCheck is about to be triggered
+ *
+ * @param	part	The AdminCachePart being processed
+ * @return	bBlock	If enabled, blocks the trigger for OnClientPreAdminCheck
+ *********************************************************/
+forward bool SBPP_OnClientPreAdminCheck(AdminCachePart part);
+
 //Yarr!


### PR DESCRIPTION
## Description
Add a forward SBPP_OnClientPreAdminCheck to control when OnClientPostAdminCheck will be called.
We can then return a boolean to block the commands that will trigger OnClientPostAdminCheck:
```
RunAdminCacheChecks(i);
NotifyPostAdminCheck(i);
```
## Motivation and Context
We are using https://github.com/R1KO/Vip-Core and we need to wait for both sourcebans-pp and vip-core to check if the player has a vip and/or an admin status so that we can trigger OnClientPostAdminCheck with the proper sourcemod admin flags

## How Has This Been Tested?
In use on https://nide.gg for about two years implemented throught this module:
- https://github.com/srcdslab/sm-plugin-VIP_SourcemodFlags/blob/master/addons/sourcemod/scripting/VIP_SourcemodFlags.sp#L140

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
