### PR TITLE
Add: Board Name function

### DIFF
--- a/web/pages/core/title.php
+++ b/web/pages/core/title.php
@@ -12,6 +12,7 @@ $breadcrumb = [
     ]
 ];
 
+$theme->assign('board_name', Config::get('template.title'));
 $theme->assign('title', $title);
 $theme->assign('breadcrumb', $breadcrumb);
 $theme->display('core/title.tpl');


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add board name based on the configuration title in Settings - Title
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Allow usage of the configured Title in Settings by using `{$board_name}` instead of `{$title}` who return the page name (Ex : Dashboard)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Works in https://bans.nide.gg/ without any errors.
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
