### PR TITLE
Add mobile design enhancements

### DIFF
--- a/game/addons/sourcemod/configs/sourcebans/sourcebans.cfg
+++ b/game/addons/sourcemod/configs/sourcebans/sourcebans.cfg
@@ -30,9 +30,8 @@
 		// How often should we process the failed ban queue in minutes
 		"ProcessQueueTime"	"5"
 
-		// Should the plugin automatically add the server to sourcebans 
+		// Should the plugin automaticaly add the server to sourcebans 
 		// (servers without -ip being set on startup need this set to 0)
-		// (2 = YES ADD WITH RCON, 1 = YES ADD WITHOUT RCON, 0 = DO NOT ADD SERVER)
 		"AutoAddServer"		"0"
 
 		// Enable backing up config files after getting admins from database (1 = enabled, 0 = disabled)

--- a/game/addons/sourcemod/scripting/sbpp_main.sp
+++ b/game/addons/sourcemod/scripting/sbpp_main.sp
@@ -47,9 +47,6 @@
 
 #define FLAG_LETTERS_SIZE 26
 
-#define AUTO_ADD_SERVER_DISABLED     0
-#define AUTO_ADD_SERVER_WITH_RCON    2
-
 //#define DEBUG
 
 enum State/* ConfigState */
@@ -97,6 +94,7 @@ bool
 	, loadGroups
 	, loadOverrides
 	, LateLoaded
+	, AutoAdd
 	, g_bConnecting = false
 	, requireSiteLogin = false /* Require a lastvisited from SB site */
 	, backupConfig = true
@@ -106,7 +104,6 @@ bool
 int
 	g_BanTarget[MAXPLAYERS + 1] =  { -1, ... }
 	, g_BanTime[MAXPLAYERS + 1] =  { -1, ... }
-	, AutoAdd = 0
 	, curLoading
 	, serverID = -1
 	, ProcessQueueTime = 5
@@ -1583,20 +1580,9 @@ public void ServerInfoCallback(Database db, DBResultSet results, const char[] er
 	if (!results.RowCount)
 	{
 		// get the game folder name used to determine the mod
-		char desc[64], query[200], rcon[128];
+		char desc[64], query[200];
 		GetGameFolderName(desc, sizeof(desc));
-		Format(rcon, sizeof(rcon), "");
-
-		if (AutoAdd == AUTO_ADD_SERVER_WITH_RCON)
-		{
-		        ConVar cvarRconPassword = FindConVar("rcon_password");
-		        if (cvarRconPassword != null)
-		        {
-		                cvarRconPassword.GetString(rcon, sizeof(rcon));
-		        }		
-		}		
-		
-		FormatEx(query, sizeof(query), "INSERT INTO %s_servers (ip, port, rcon, modid) VALUES ('%s', '%s', '%s', (SELECT mid FROM %s_mods WHERE modfolder = '%s'))", DatabasePrefix, ServerIp, ServerPort, rcon, DatabasePrefix, desc);
+		FormatEx(query, sizeof(query), "INSERT INTO %s_servers (ip, port, rcon, modid) VALUES ('%s', '%s', '', (SELECT mid FROM %s_mods WHERE modfolder = '%s'))", DatabasePrefix, ServerIp, ServerPort, DatabasePrefix, desc);
 		db.Query(ErrorCheckCallback, query);
 	}
 }
@@ -2250,8 +2236,7 @@ public SMCResult ReadConfig_KeyValue(SMCParser smc, const char[] key, const char
 			}
 			else if (strcmp("AutoAddServer", key, false) == 0)
 			{
-				int sAutoAdd = StringToInt(value);
-				AutoAdd = (sAutoAdd < 0 || sAutoAdd > 2) ? 0 : sAutoAdd;
+				AutoAdd = StringToInt(value) == 1;
 			}
 			else if (strcmp("Unban", key, false) == 0)
 			{
@@ -2660,7 +2645,7 @@ stock void InsertServerInfo()
     FormatEx(ServerIp, sizeof(ServerIp), "%d.%d.%d.%d", pieces[0], pieces[1], pieces[2], pieces[3]);
     CvarPort.GetString(ServerPort, sizeof(ServerPort));
 
-    if (AutoAdd != AUTO_ADD_SERVER_DISABLED) {
+    if (AutoAdd != false) {
         FormatEx(query, sizeof(query), "SELECT sid FROM %s_servers WHERE ip = '%s' AND port = '%s'", DatabasePrefix, ServerIp, ServerPort);
         DB.Query(ServerInfoCallback, query);
     }


### PR DESCRIPTION
This pull requests starts on mobile design enhancements. It maintains a desktop first philosophy.

- On the dashboard tab, the player ban blocks and comm block sections are separated bellow 1279px.

- The header is compressed bellow 1279px to better use screen space.

To re-simulate these changes, visit https://develop.bans.redstonend.uk/ Afterwards, reduce the size of your web browser until the width stops scaling on the source-bans interface.

Lastly, I had to use the php81 branch. This was a requirement on my web host for testing purposes.