### PR TITLE
feat(game): automatic github ci build, tag, release

### DIFF
--- a/.github/workflows/plugin.yml
+++ b/.github/workflows/plugin.yml
@@ -1,0 +1,87 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    name: "Build"
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-20.04]
+        include:
+          - os: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v3
+      - name: Build sourcemod plugin
+        uses: maxime1907/action-sourceknight@v1
+        with:
+          cmd: build
+
+      - name: Create package
+        run: |
+          mkdir -p /tmp/package
+          cp -R .sourceknight/package/* /tmp/package
+          cp -R game/addons/sourcemod/configs /tmp/package/common/addons/sourcemod/
+          cp -R game/addons/sourcemod/translations /tmp/package/common/addons/sourcemod/
+      - name: Upload build archive for test runners
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ runner.os }}
+          path: /tmp/package
+
+  tag:
+    name: Tag
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/php81'
+
+      - uses: dev-drprasad/delete-tag-and-release@v0.2.1
+        if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/php81'
+        with:
+          delete_release: true
+          tag_name: latest
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: rickstaa/action-create-tag@v1
+        if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/php81'
+        with:
+          tag: "latest"
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  release:
+    name: Release
+    if: startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/php81'
+    needs: [build, tag]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v3
+
+      - name: Versioning
+        run: |
+          version="latest"
+          if [[ "${{ github.ref_type }}" == 'tag' ]]; then
+            version=`echo $GITHUB_REF | sed "s/refs\/tags\///"`;
+          fi
+          echo "RELEASE_VERSION=$version" >> $GITHUB_ENV
+      - name: Package
+        run: |
+          ls -Rall
+          if [ -d "./Linux/" ]; then
+            cd ./Linux/
+            tar -czf ../${{ github.event.repository.name }}-${{ env.RELEASE_VERSION }}.tar.gz -T <(\ls -1)
+            cd -
+          fi
+      - name: Release
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: '*.tar.gz'
+          tag: ${{ env.RELEASE_VERSION }}
+          file_glob: true
+          overwrite: true

--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,10 @@ Temporary Items
 
 # Composer vendor dir
 /web/includes/vendor
+
+# Plugin compilation
+build/
+release/
+plugins/
+.sourceknight
+.venv

--- a/sourceknight.yaml
+++ b/sourceknight.yaml
@@ -1,0 +1,21 @@
+project:
+  sourceknight: 0.1
+  name: SBPP
+  dependencies:
+    - name: sourcemod
+      type: tar
+      version: 1.11.0-git6934
+      location: https://sm.alliedmods.net/smdrop/1.11/sourcemod-1.11.0-git6934-linux.tar.gz
+      unpack:
+      - source: /addons
+        dest: /addons
+
+  root: /game
+  output: /game/addons/sourcemod/plugins
+  targets:
+    - sbpp_admcfg
+    - sbpp_checker
+    - sbpp_comms
+    - sbpp_main
+    - sbpp_report
+    - sbpp_sleuth


### PR DESCRIPTION
## Description
Adds a github workflow file to automatically build, update and release a latest version of sourcebans-pp plugins

## Motivation and Context
It helps people that dont want to compile plugins to easily download it from the Release part of github.
Also when someone opens a PR about modifying sourcemod plugins code, it will run a build action and make sure it compiles.
You can also tag a version and push it, and it will automatically do a release with the plugins compiled and all necessary resources (configs, translations...)

## How Has This Been Tested?
It has been in use on our fork for like months now

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
