### PR TITLE
Smarty stripslashes and htmlspecialchars 

### DIFF
--- a/web/includes/SmartyCustomFunctions.php
+++ b/web/includes/SmartyCustomFunctions.php
@@ -55,3 +55,20 @@ function smarty_function_load_template(array $params): void
 {
     require TEMPLATES_PATH . "/{$params['file']}.php";
 }
+
+/**
+ *  Smarty {smarty_stripslashes} function plugin
+ * 
+ * Type:     function<br>
+ * Name:     smarty_stripslashes<br>
+ * Purpose:  custom stripslashes function
+ * @link https://github.com/lechuga16/sourcebans-pp/tree/smarty_stripslashes
+ * @author  Lechuga
+ * @param array $params
+ * @return string
+ * @version 1.0
+ */
+function smarty_stripslashes($string)
+{
+	return stripslashes($string);
+}

--- a/web/includes/SmartyCustomFunctions.php
+++ b/web/includes/SmartyCustomFunctions.php
@@ -72,3 +72,17 @@ function smarty_stripslashes($string)
 {
 	return stripslashes($string);
 }
+
+/**
+ *  Smarty {smarty_htmlspecialchars} function plugin
+ * 
+ * Type:     function<br>
+ * Name:     smarty_htmlspecialchars<br>
+ * Purpose:  custom htmlspecialchars function
+ * @link https://github.com/lechuga16/sourcebans-pp/tree/smarty_stripslashes
+ * @author  Lechuga
+ * @param array $params
+ */
+function smarty_htmlspecialchars($string, $flags = ENT_COMPAT | ENT_HTML401, $encoding = 'UTF-8', $double_encode = true) {
+    return htmlspecialchars($string, $flags, $encoding, $double_encode);
+}

--- a/web/init.php
+++ b/web/init.php
@@ -203,6 +203,7 @@ $theme->setCacheDir(SB_CACHE);
 $theme->registerPlugin(Smarty::PLUGIN_FUNCTION, 'help_icon', 'smarty_function_help_icon');
 $theme->registerPlugin(Smarty::PLUGIN_FUNCTION, 'sb_button', 'smarty_function_sb_button');
 $theme->registerPlugin(Smarty::PLUGIN_FUNCTION, 'load_template', 'smarty_function_load_template');
+$theme->registerPlugin('modifier', 'smarty_stripslashes', 'smarty_stripslashes');
 
 if ((isset($_GET['debug']) && $_GET['debug'] == 1) || DEBUG_MODE) {
     $theme->force_compile = true;

--- a/web/init.php
+++ b/web/init.php
@@ -204,6 +204,7 @@ $theme->registerPlugin(Smarty::PLUGIN_FUNCTION, 'help_icon', 'smarty_function_he
 $theme->registerPlugin(Smarty::PLUGIN_FUNCTION, 'sb_button', 'smarty_function_sb_button');
 $theme->registerPlugin(Smarty::PLUGIN_FUNCTION, 'load_template', 'smarty_function_load_template');
 $theme->registerPlugin('modifier', 'smarty_stripslashes', 'smarty_stripslashes');
+$theme->registerPlugin('modifier', 'smarty_htmlspecialchars', 'smarty_htmlspecialchars');
 
 if ((isset($_GET['debug']) && $_GET['debug'] == 1) || DEBUG_MODE) {
     $theme->force_compile = true;

--- a/web/themes/default/page_admin_bans_submissions.tpl
+++ b/web/themes/default/page_admin_bans_submissions.tpl
@@ -19,7 +19,7 @@
                 <td class="listtable_1" height='16'>
                     <a href="#" onclick="xajax_SetupBan({$sub.subid});return false;">Ban</a> -
                     {if $permissions_editsub}
-                        <a href="#" onclick="RemoveSubmission({$sub.subid}, '{$sub.name|stripslashes}', '1');return false;">Remove</a> -
+                        <a href="#" onclick="RemoveSubmission({$sub.subid}, '{$sub.name|smarty_stripslashes}', '1');return false;">Remove</a> -
                     {/if}
                     <a href="index.php?p=admin&c=bans&o=email&type=s&id={$sub.subid}">Contact</a>
                 </td>

--- a/web/themes/default/page_admin_bans_submissions_archiv.tpl
+++ b/web/themes/default/page_admin_bans_submissions_archiv.tpl
@@ -20,11 +20,11 @@
                     {if $sub.archiv != "2" and $sub.archiv != "3"}
                         <a href="#" onclick="xajax_SetupBan({$sub.subid});">Ban</a> -
                         {if $permissions_editsub}
-                            <a href="#" onclick="RemoveSubmission({$sub.subid}, '{$sub.name|stripslashes}', '2');">Restore</a> -
+                            <a href="#" onclick="RemoveSubmission({$sub.subid}, '{$sub.name|smarty_stripslashes}', '2');">Restore</a> -
                         {/if}
                     {/if}
                     {if $permissions_editsub}
-                        <a href="#" onclick="RemoveSubmission({$sub.subid}, '{$sub.name|stripslashes}', '0');">Delete</a> -
+                        <a href="#" onclick="RemoveSubmission({$sub.subid}, '{$sub.name|smarty_stripslashes}', '0');">Delete</a> -
                     {/if}
                     <a href="index.php?p=admin&c=bans&o=email&type=s&id={$sub.subid}">Contact</a>
                 </td>

--- a/web/themes/default/page_admin_groups_list.tpl
+++ b/web/themes/default/page_admin_groups_list.tpl
@@ -162,7 +162,7 @@
                                         {foreach from=$server_overrides_list[$smarty.foreach.server_admin_group.index] item="override"}
                                             <tr>
                                                 <td width="60%" height="16" class="listtable_1">{$override.type}</td>
-                                                <td width="60%" height="16" class="listtable_1">{$override.name|htmlspecialchars}</td>
+                                                <td width="60%" height="16" class="listtable_1">{$override.name|smarty_htmlspecialchars}</td>
                                                 <td width="60%" height="16" class="listtable_1">{$override.access}</td>
                                             </tr>
                                         {/foreach}

--- a/web/themes/default/page_admin_mods_list.tpl
+++ b/web/themes/default/page_admin_mods_list.tpl
@@ -14,17 +14,17 @@
         </tr>
         {foreach from=$mod_list item="mod" name="gaben"}
             <tr id="mid_{$mod.mid}">
-                <td class="listtable_1" height='16'>{$mod.name|htmlspecialchars}</td>
-                <td class="listtable_1" height='16'>{$mod.modfolder|htmlspecialchars}</td>
+                <td class="listtable_1" height='16'>{$mod.name|smarty_htmlspecialchars}</td>
+                <td class="listtable_1" height='16'>{$mod.modfolder|smarty_htmlspecialchars}</td>
                 <td class="listtable_1" height='16'><img src="images/games/{$mod.icon}" width="16"></td>
-                <td class="listtable_1" height='16'>{$mod.steam_universe|htmlspecialchars}</td>
+                <td class="listtable_1" height='16'>{$mod.steam_universe|smarty_htmlspecialchars}</td>
                 {if $permission_editmods || $permission_deletemods}
                     <td class="listtable_1" height='16'>
                         {if $permission_editmods}
                             <a href="index.php?p=admin&c=mods&o=edit&id={$mod.mid}">Edit</a> -
                         {/if}
                         {if $permission_deletemods}
-                            <a href="#" onclick="RemoveMod('{$mod.name|escape:'quotes'|htmlspecialchars}', '{$mod.mid}');">Delete</a>
+                            <a href="#" onclick="RemoveMod('{$mod.name|escape:'quotes'|smarty_htmlspecialchars}', '{$mod.mid}');">Delete</a>
                         {/if}
                     </td>
                 {/if}

--- a/web/themes/default/page_admin_overrides.tpl
+++ b/web/themes/default/page_admin_overrides.tpl
@@ -29,8 +29,8 @@
                                 </select>
                                 <input type="hidden" name="override_id[]" value="{$override.id}" />
                             </td>
-                            <td class="tablerow1"><input name="override_name[]" value="{$override.name|htmlspecialchars}" /></td>
-                            <td class="tablerow1"><input name="override_flags[]" value="{$override.flags|htmlspecialchars}" /></td>
+                            <td class="tablerow1"><input name="override_name[]" value="{$override.name|smarty_htmlspecialchars}" /></td>
+                            <td class="tablerow1"><input name="override_flags[]" value="{$override.flags|smarty_htmlspecialchars}" /></td>
                         </tr>
                     {/foreach}
                     <tr>

--- a/web/themes/default/page_bans.tpl
+++ b/web/themes/default/page_bans.tpl
@@ -56,7 +56,7 @@
     <br />
     {load_template file='admin.bans.search'}
     <br />
-    <div id="banlist-nav"><a href="index.php?p=banlist&hideinactive={if $hidetext == 'Hide'}true{else}false{/if}{$searchlink|htmlspecialchars}" title="{$hidetext} inactive">{$hidetext} inactive</a> | <i>Total Bans: {$total_bans}</i></div>
+    <div id="banlist-nav"><a href="index.php?p=banlist&hideinactive={if $hidetext == 'Hide'}true{else}false{/if}{$searchlink|smarty_htmlspecialchars}" title="{$hidetext} inactive">{$hidetext} inactive</a> | <i>Total Bans: {$total_bans}</i></div>
     <div id="banlist">
         <table width="100%" cellspacing="0" cellpadding="0" align="center" class="listtable">
             <tr>

--- a/web/themes/default/page_bans.tpl
+++ b/web/themes/default/page_bans.tpl
@@ -87,7 +87,7 @@
                             {if empty($ban.player)}
                                 <i><font color="#677882">no nickname present</font></i>
                             {else}
-                                {$ban.player|escape:'html'|stripslashes}
+                                {$ban.player|escape:'html'|smarty_stripslashes}
                             {/if}
                         </div>
                         {if $ban.demo_available}
@@ -128,7 +128,7 @@
                                         {if empty($ban.player)}
                                             <i><font color="#677882">no nickname present</font></i>
                                         {else}
-                                            {$ban.player|escape:'html'|stripslashes}
+                                            {$ban.player|escape:'html'|smarty_stripslashes}
                                         {/if}
                                     </td>
                                     <!-- ###############[ Start Admin Controls ]################## -->

--- a/web/themes/default/page_comms.tpl
+++ b/web/themes/default/page_comms.tpl
@@ -84,7 +84,7 @@
                             {if empty($ban.player)}
                                 <i><font color="#677882">no nickname present</font></i>
                             {else}
-                                {$ban.player|escape:'html'|stripslashes}
+                                {$ban.player|escape:'html'|smarty_stripslashes}
                             {/if}
                         </div>
                         <div style="float:right;">
@@ -127,7 +127,7 @@
                                         {if empty($ban.player)}
                                             <i><font color="#677882">no nickname present</font></i>
                                         {else}
-                                            {$ban.player|escape:'html'|stripslashes}
+                                            {$ban.player|escape:'html'|smarty_stripslashes}
                                         {/if}
                                     </td>
                                     <!-- ###############[ Start Admin Controls ]################## -->

--- a/web/themes/default/page_comms.tpl
+++ b/web/themes/default/page_comms.tpl
@@ -59,7 +59,7 @@
     <div id="banlist-nav">
         {$ban_nav}
     </div>
-    <a href="index.php?p=commslist&hideinactive={if $hidetext == 'Hide'}true{else}false{/if}{$searchlink|htmlspecialchars}" title="{$hidetext} inactive">{$hidetext} inactive</a>
+    <a href="index.php?p=commslist&hideinactive={if $hidetext == 'Hide'}true{else}false{/if}{$searchlink|smarty_htmlspecialchars}" title="{$hidetext} inactive">{$hidetext} inactive</a>
     <div id="banlist">
         <table width="100%" cellspacing="0" cellpadding="0" align="center" class="listtable">
             <tr>


### PR DESCRIPTION
## Description
Resolved warning for php8.1:
- _Deprecated: Using php-function "stripslashes" as a modifier is deprecated and will be removed in a future release. Use Smarty::registerPlugin to explicitly register a custom modifier. in .../includes/vendor/smarty/smarty/libs/sysplugins/smarty_internal_compile_private_modifier.php on line 114_
- _Deprecated: Using php-function "htmlspecialchars" as a modifier is deprecated and will be removed in a future release. Use Smarty::registerPlugin to explicitly register a custom modifier. in .../includes/vendor/smarty/smarty/libs/sysplugins/smarty_internal_compile_private_modifier.php on line 114_

- I create a function that uses Smarty::registerPlugin called smarty_htmlspecialchars and within it returns htmlspecialchars.
- Another function called smarty_stripslashes that returns stripslashes .

## Motivation and Context
The errors appeared to me in a fork that I am developing with the aim of translating the entire website into Spanish. When I solved them I thought it was a good idea to send the solution.

## How Has This Been Tested?
I am using these changes on my own website, I allowed a few days to check for any further errors.
https://sb.aoc-gamers.com

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
