### PR TITLE
[SBPP Checker] Callback and initial values

### DIFF
--- a/game/addons/sourcemod/scripting/include/sourcebanschecker.inc
+++ b/game/addons/sourcemod/scripting/include/sourcebanschecker.inc
@@ -1,4 +1,4 @@
-﻿// *************************************************************************
+// *************************************************************************
 //  This file is part of SourceBans++.
 //
 //  Copyright (C) 2014-2023 SourceBans++ Dev Team <https://github.com/sbpp>
@@ -53,7 +53,7 @@ public void __pl_sourcebanschecker_SetNTVOptional()
  * Get the number of bans of a client.
  *
  * @param iClient	The client index of who you want to get the number of bans.
- * @return        The number of bans of the client.
+ * @return        The number of bans of the client, or -1 if not yet available.
  *********************************************************/
 native int SBPP_CheckerGetClientsBans(int iClient);
 
@@ -62,6 +62,14 @@ native int SBPP_CheckerGetClientsBans(int iClient);
  * Get the number of comms bans of a client.
  *
  * @param iClient	The client index of who you want to get the number of comms bans.
- * @return        The number of comms bans of the client.
+ * @return        The number of comms bans of the client, or -1 if not yet available.
  *********************************************************/
 native int SBPP_CheckerGetClientsComms(int iClient);
+
+/**********************************************************
+ * Called when the ban counts for a client are checked.
+ * Use the other natives to retrieve values.
+ *
+ * @param iClient	The client index that was checked.
+ **********************************************************/
+forward void SBPP_CheckerClientBanCheckPost(int iClient);

--- a/game/addons/sourcemod/scripting/sbpp_checker.sp
+++ b/game/addons/sourcemod/scripting/sbpp_checker.sp
@@ -39,8 +39,8 @@ char g_DatabasePrefix[10] = "sb";
 SMCParser g_ConfigParser;
 Database g_DB;
 
-int g_iBanCounts[MAXPLAYERS + 1];
-int g_iCommsCounts[MAXPLAYERS + 1];
+int g_iBanCounts[MAXPLAYERS + 1] = {-1, ...};
+int g_iCommsCounts[MAXPLAYERS + 1] = {-1, ...};
 GlobalForward g_fwdClientBanCheckPost;
 
 
@@ -109,14 +109,10 @@ public int Native_SBCheckerGetClientsComms(Handle plugin, int numParams)
 	return g_iCommsCounts[client];
 }
 
-public void OnClientConnected(int client)
-{
-	g_iBanCounts[client] = g_iCommsCounts[client] = -1; // mark as not yet loaded
-}
-
 public void OnClientDisconnect_Post(int client)
 {
-	g_iBanCounts[client] = g_iCommsCounts[client] = -1;
+	g_iBanCounts[client] = -1;
+	g_iCommsCounts[client] = -1;
 }
 
 public void OnClientAuthorized(int client, const char[] auth)

--- a/game/addons/sourcemod/scripting/sbpp_checker.sp
+++ b/game/addons/sourcemod/scripting/sbpp_checker.sp
@@ -29,7 +29,7 @@
 
 #include <sourcemod>
 
-#define VERSION "1.9.0"
+#define VERSION "1.8.1"
 #define LISTBANS_USAGE "sm_listbans <#userid|name> - Lists a user's prior bans from Sourcebans"
 #define LISTCOMMS_USAGE "sm_listcomms <#userid|name> - Lists a user's prior comms from Sourcebans"
 #define INVALID_TARGET -1
@@ -63,8 +63,6 @@ public void OnPluginStart()
 	RegAdminCmd("sm_listcomms", OnListSourceCommsCmd, ADMFLAG_GENERIC, LISTCOMMS_USAGE);
 	RegAdminCmd("sb_reload", OnReloadCmd, ADMFLAG_RCON, "Reload sourcebans config and ban reason menu options");
 	
-	g_fwdClientBanCheckPost = CreateGlobalForward("SBPP_CheckerClientBanCheckPost", ET_Ignore, Param_Cell);
-
 	Database.Connect(OnDatabaseConnected, "sourcebans");
 }
 
@@ -93,6 +91,8 @@ public APLRes AskPluginLoad2(Handle myself, bool late, char[] error, int err_max
 
 	CreateNative("SBPP_CheckerGetClientsBans", Native_SBCheckerGetClientsBans);
 	CreateNative("SBPP_CheckerGetClientsComms", Native_SBCheckerGetClientsComms);
+
+	g_fwdClientBanCheckPost = CreateGlobalForward("SBPP_CheckerClientBanCheckPost", ET_Ignore, Param_Cell);
 
 	return APLRes_Success;
 }


### PR DESCRIPTION
## Description
As user of the SourceBans Checker API I would like to be notified when the bans and commbans counters are actually valid, or at least be provided with fallback values until they are.

## Motivation and Context
As of 1.8.0 the values in g_iBanCounts[client] and g_iCommsCounts[client] remain stale between a disconnect and the async `OnConnectBanCheck` callback. This might cause issues if you want to rely on, or react to these values as soon as they are available. If a plugin is polling values this would currently still give incorrect results for quite some time, even if the the client is ingame AND authorized, thus resetting the values to -1.

## How Has This Been Tested?
- [X] Smoke test in dev server + live env

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
