### PR TITLE
Lessened server lag on player connect due to huge number of bans and gags #897

### DIFF
--- a/game/addons/sourcemod/scripting/sbpp_checker.sp
+++ b/game/addons/sourcemod/scripting/sbpp_checker.sp
@@ -117,26 +117,27 @@ public void OnClientAuthorized(int client, const char[] auth)
 
 	char query[512], ip[30];
 	GetClientIP(client, ip, sizeof(ip));
-	FormatEx(query, sizeof(query), "SELECT COUNT(bid) FROM %s_bans WHERE (type = 0 AND authid LIKE 'STEAM_%:%s') UNION ALL SELECT COUNT(bid) FROM %s_bans WHERE (type = 1 AND ip = '%s') UNION ALL SELECT COUNT(bid) FROM %s_comms WHERE authid LIKE 'STEAM_%:%s'", g_DatabasePrefix, auth[8], g_DatabasePrefix, ip, g_DatabasePrefix, auth[8]);
+	FormatEx(query, sizeof(query), "SELECT COUNT(bid) FROM %s_bans WHERE (type = 0 AND authid LIKE 'STEAM_%%:%s') UNION ALL SELECT COUNT(bid) FROM %s_bans WHERE (type = 1 AND ip = '%s') UNION ALL SELECT COUNT(bid) FROM %s_comms WHERE authid LIKE 'STEAM_%%:%s'", g_DatabasePrefix, auth[8], g_DatabasePrefix, ip, g_DatabasePrefix, auth[8]);
 	g_DB.Query(OnConnectBanCheck, query, GetClientUserId(client), DBPrio_Low);
 }
 
 public void OnConnectBanCheck(Database db, DBResultSet results, const char[] error, any userid)
 {
 	int client = GetClientOfUserId(userid);
+	int steamIdBanCount = 0;
 	if (!client || results == null || !results.FetchRow())
 		return;
 
-	int steamIdBancount = results.FetchInt(0);
+	steamIdBanCount = results.FetchInt(0);
 
 	int ipBanCount = 0;
-	if (results.FetchRow()){
+	if (results.FetchRow()) {
 		ipBanCount = results.FetchInt(0);
 	}
-	int bancount = steamIdBancount + ipBanCount;
+	int bancount = steamIdBanCount + ipBanCount;
 
 	int commcount = 0;
-	if (results.FetchRow()){
+	if (results.FetchRow()) {
 		commcount = results.FetchInt(0);
 	}
 

--- a/game/addons/sourcemod/scripting/sbpp_checker.sp
+++ b/game/addons/sourcemod/scripting/sbpp_checker.sp
@@ -117,7 +117,7 @@ public void OnClientAuthorized(int client, const char[] auth)
 
 	char query[512], ip[30];
 	GetClientIP(client, ip, sizeof(ip));
-	FormatEx(query, sizeof(query), "SELECT COUNT(bid) FROM %s_bans WHERE (type = 0 AND authid LIKE 'STEAM_%:%s') UNION ALL SELECT COUNT(bid) FROM %s_bans WHERE (type = 1 AND ip = '%s') UNION ALL SELECT COUNT(bid) FROM %s_comms WHERE authid LIKE 'STEAM_%:%s'", g_DatabasePrefix, auth[8], ip, g_DatabasePrefix,auth[8]);
+	FormatEx(query, sizeof(query), "SELECT COUNT(bid) FROM %s_bans WHERE (type = 0 AND authid LIKE 'STEAM_%:%s') UNION ALL SELECT COUNT(bid) FROM %s_bans WHERE (type = 1 AND ip = '%s') UNION ALL SELECT COUNT(bid) FROM %s_comms WHERE authid LIKE 'STEAM_%:%s'", g_DatabasePrefix, auth[8], g_DatabasePrefix, ip, g_DatabasePrefix, auth[8]);
 	g_DB.Query(OnConnectBanCheck, query, GetClientUserId(client), DBPrio_Low);
 }
 

--- a/game/addons/sourcemod/scripting/sbpp_checker.sp
+++ b/game/addons/sourcemod/scripting/sbpp_checker.sp
@@ -117,7 +117,7 @@ public void OnClientAuthorized(int client, const char[] auth)
 
 	char query[512], ip[30];
 	GetClientIP(client, ip, sizeof(ip));
-	FormatEx(query, sizeof(query), "SELECT COUNT(bid) FROM %s_bans WHERE ((type = 0 AND authid REGEXP '^STEAM_[0-9]:%s$') OR (type = 1 AND ip = '%s')) UNION SELECT COUNT(bid) FROM %s_comms WHERE authid REGEXP '^STEAM_[0-9]:%s$'", g_DatabasePrefix, auth[8], ip, g_DatabasePrefix,auth[8]);
+	FormatEx(query, sizeof(query), "SELECT COUNT(bid) FROM %s_bans WHERE (type = 0 AND authid LIKE 'STEAM_%:%s') UNION ALL SELECT COUNT(bid) FROM %s_bans WHERE (type = 1 AND ip = '%s') UNION ALL SELECT COUNT(bid) FROM %s_comms WHERE authid LIKE 'STEAM_%:%s'", g_DatabasePrefix, auth[8], ip, g_DatabasePrefix,auth[8]);
 	g_DB.Query(OnConnectBanCheck, query, GetClientUserId(client), DBPrio_Low);
 }
 
@@ -127,9 +127,16 @@ public void OnConnectBanCheck(Database db, DBResultSet results, const char[] err
 	if (!client || results == null || !results.FetchRow())
 		return;
 
-	int bancount = results.FetchInt(0);
+	int steamIdBancount = results.FetchInt(0);
+
+	int ipBanCount = 0;
+	if (results.FetchRow()){
+		ipBanCount = results.FetchInt(0);
+	}
+	int bancount = steamIdBancount + ipBanCount;
+
 	int commcount = 0;
-	if(results.FetchRow()){
+	if (results.FetchRow()){
 		commcount = results.FetchInt(0);
 	}
 


### PR DESCRIPTION
When the number of bans in the SourceBans database becomes higher, logging "Player XYZ has N bans and M comm blocks." becomes a bit more expensive, in some cases potentially lagging the server out for a short period, which can be noticeable and painful depending on the game.

## Description
The SourceBans database has a few indexes on the sb_bans and sb_comms tables. However, the query that is executed once a player connects to the game server does not utilize the indexes at all due to the REGEXP that was present in the WHERE clause. By separating bans by ban type (userId and type), the query can utilize the indexes and thus likely execute the filtering faster than before since now a full table scan is not truly required anymore. Overall, the purpose of this PR is to lessen the lag that was mentioned in #897 as it's something that has helped in one case already.

## Where was it tested?
The code was compiled and installed onto a Left 4 Dead 2 10v10 versus server.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
