### PR TITLE
Fix cookie domain for non-standard ports.

### DIFF
--- a/web/includes/auth/Auth.php
+++ b/web/includes/auth/Auth.php
@@ -31,7 +31,7 @@ class Auth
         $token = JWT::create($jti, $maxlife, $aid);
         self::updateLastVisit($aid);
 
-        self::setCookie($token->toString(), time() + $maxlife, Host::domain(), Host::isSecure());
+        self::setCookie($token->toString(), time() + $maxlife, Host::cookieDomain(), Host::isSecure());
 
         //Login / Logout requests will trigger GC routine
         self::gc();
@@ -54,7 +54,7 @@ class Auth
 //            self::$dbs->execute();
 //        }
 
-        self::setCookie('', 1, Host::domain(), Host::isSecure());
+        self::setCookie('', 1, Host::cookieDomain(), Host::isSecure());
 
         //Login / Logout requests will trigger GC routine
         self::gc();

--- a/web/includes/auth/Host.php
+++ b/web/includes/auth/Host.php
@@ -16,6 +16,17 @@ class Host
     /**
      * @return string
      */
+    public static function cookieDomain(): string {
+        $domain = self::domain();
+        if( ($p = strpos($domain, ':')) === false ) {
+            return $domain;
+        }
+        return substr($domain, 0, $p);
+    }
+
+    /**
+     * @return string
+     */
     public static function protocol(): string
     {
         return sprintf('http%s://',  self::isSecure() ? 's' : '');


### PR DESCRIPTION
## Description
Currently the cookie domain would be set to whatever the httpd's HTTP_HOST is. But in the case of web servers using non-standard ports, eg: foo.bar.com:8080, this would cause the cookie domain to also be set to foo.bar.com:8080.

The problem is that cookie domains do not account for ports, and subsequent requests will not send the cookie back because the domain that the browser wants is just `foo.bar.com`, not `foo.bar.com:8080`. The end result is that the browser does not send the authentication cookie on subsequent requests, and it appears that authentication simply doesn't work.

This fork adds a simple `Host::cookieDomain()` wrapper around `Host::domain()` to strip off the port, and replaces the relevant usages in the Auth class.

## Motivation and Context
Current behaviour is broken when SB web is run on a non-standard port.

## How Has This Been Tested?
Mocked the Auth workflow locally.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
