### PR TITLE
Fix: prevent php warnings

### DIFF
--- a/web/pages/admin.admins.php
+++ b/web/pages/admin.admins.php
@@ -202,7 +202,7 @@ if (strlen($next) > 0) {
 
 $pages = ceil($admin_count / $AdminsPerPage);
 if ($pages > 1) {
-    $admin_nav .= '&nbsp;<select onchange="changePage(this,\'A\',\'' . ($_GET['advSearch'] ?? '') . '\',\'' . ($_GET['advType'] ?? '') . '\');">';
+    $admin_nav .= '&nbsp;<select onchange="changePage(this,\'A\',\'' . (isset($_GET['advSearch']) ? $_GET['advSearch'] : '') . '\',\'' . (isset($_GET['advType']) ? $_GET['advType'] : '') . '\');">';
     for ($i = 1; $i <= $pages; $i++) {
         if (isset($_GET['page']) && $i === $_GET['page']) {
             $admin_nav .= '<option value="' . $i . '" selected="selected">' . $i . '</option>';


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add check before using $_GET to prevent warnings
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://github.com/sbpp/sourcebans-pp/pull/821 and like [page.banlist.php#L722](https://github.com/sbpp/sourcebans-pp/blob/php81/web/pages/page.banlist.php#L722)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested, no more warnings at all.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
