### PR TITLE
Fix negative values being accepted in ban commands (solve issue #949)

### DIFF
--- a/game/addons/sourcemod/scripting/sbpp_main.sp
+++ b/game/addons/sourcemod/scripting/sbpp_main.sp
@@ -545,12 +545,11 @@ public Action CommandBanIp(int client, int args)
 	}
 
 	char adminIp[24], adminAuth[64];
-
 	int minutes = StringToInt(time);
 
-	if (minutes < 0)
+	if (!StringToIntEx(time, minutes) || minutes < 0)
 	{
-		ReplyToCommand(client, "%sInvalid duration. Duration must be 0 or higher", Prefix);
+		ReplyToCommand(client, "%sUsage: sm_banip <#userid|name> <time> [reason]", Prefix);
 		return Plugin_Handled;
 	}
 
@@ -684,12 +683,11 @@ public Action CommandAddBan(int client, int args)
 	}
 
 	char adminIp[24], adminAuth[64];
+	int minutes = StringToInt(time);
 
-	int  minutes = StringToInt(time);
-
-	if (minutes < 0)
+	if (!StringToIntEx(time, minutes) || minutes < 0)
 	{
-		ReplyToCommand(client, "%sInvalid duration. Duration must be 0 or higher", Prefix);
+		ReplyToCommand(client, "%sUsage: sm_addban <time> <steamid> [reason]", Prefix);
 		return Plugin_Handled;
 	}
 

--- a/game/addons/sourcemod/scripting/sbpp_main.sp
+++ b/game/addons/sourcemod/scripting/sbpp_main.sp
@@ -450,13 +450,8 @@ public Action CommandBan(int client, int args)
 	GetCmdArg(2, buffer, sizeof(buffer));
 
 	int time = StringToInt(buffer);
-	if (time < 0)
-	{
-		ReplyToCommand(client, "%sInvalid duration. Duration must be 0 or higher", Prefix);
-		return Plugin_Handled;
-	}
 	
-	if (!StringToIntEx(buffer, time))
+	if (!StringToIntEx(buffer, time) || time < 0)
 	{
 		ReplyToCommand(client, "%sUsage: sm_ban <#userid|name> <time|0> [reason]", Prefix);
 		return Plugin_Handled;

--- a/game/addons/sourcemod/scripting/sbpp_main.sp
+++ b/game/addons/sourcemod/scripting/sbpp_main.sp
@@ -450,6 +450,11 @@ public Action CommandBan(int client, int args)
 	GetCmdArg(2, buffer, sizeof(buffer));
 
 	int time = StringToInt(buffer);
+	if (time < 0)
+	{
+		ReplyToCommand(client, "%sInvalid duration. Duration must be 0 or higher", Prefix);
+		return Plugin_Handled;
+	}
 	
 	if (!StringToIntEx(buffer, time))
 	{
@@ -547,6 +552,12 @@ public Action CommandBanIp(int client, int args)
 	char adminIp[24], adminAuth[64];
 
 	int minutes = StringToInt(time);
+
+	if (time < 0)
+	{
+		ReplyToCommand(client, "%sInvalid duration. Duration must be 0 or higher", Prefix);
+		return Plugin_Handled;
+	}
 
 	if (!minutes && client && !(CheckCommandAccess(client, "sm_unban", ADMFLAG_UNBAN | ADMFLAG_ROOT)))
 	{
@@ -680,6 +691,12 @@ public Action CommandAddBan(int client, int args)
 	char adminIp[24], adminAuth[64];
 
 	int  minutes = StringToInt(time);
+
+	if (time < 0)
+	{
+		ReplyToCommand(client, "%sInvalid duration. Duration must be 0 or higher", Prefix);
+		return Plugin_Handled;
+	}
 
 	if (!minutes && client && !(CheckCommandAccess(client, "sm_unban", ADMFLAG_UNBAN | ADMFLAG_ROOT)))
 	{

--- a/game/addons/sourcemod/scripting/sbpp_main.sp
+++ b/game/addons/sourcemod/scripting/sbpp_main.sp
@@ -553,7 +553,7 @@ public Action CommandBanIp(int client, int args)
 
 	int minutes = StringToInt(time);
 
-	if (time < 0)
+	if (minutes < 0)
 	{
 		ReplyToCommand(client, "%sInvalid duration. Duration must be 0 or higher", Prefix);
 		return Plugin_Handled;
@@ -692,7 +692,7 @@ public Action CommandAddBan(int client, int args)
 
 	int  minutes = StringToInt(time);
 
-	if (time < 0)
+	if (minutes < 0)
 	{
 		ReplyToCommand(client, "%sInvalid duration. Duration must be 0 or higher", Prefix);
 		return Plugin_Handled;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The changes add a check on all ban commands to see whether the given duration is 0 or more. If the duration given is smaller than zero, it will tell the player and the ban will not proceed.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The motivation behind this pull request is that this fixes an open issue. Issue #949. According to the issue, banning with a negative time value is useless and only bans the player for the session. With this pull request banning with a negative value should not be possible anymore


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
The changes have been tested on my own community server on a real player. When entering a negative value, we want the entire command to stop after giving the command issuer a warning. This approach should be valid and should not affect any other areas in the code. Values of 0 or higher have also been tested and these do get accepted by the command.

## Screenshots (if appropriate):
![image](https://github.com/sbpp/sourcebans-pp/assets/73174517/d9c4e043-88f0-47d8-b712-8208bf87952a)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
