### PR TITLE
Ignore chat triggers for interactive ban reason

### DIFF
--- a/game/addons/sourcemod/scripting/sbpp_main.sp
+++ b/game/addons/sourcemod/scripting/sbpp_main.sp
@@ -35,7 +35,7 @@
 
 #pragma newdecls required
 
-#define SB_VERSION "1.8.1"
+#define SB_VERSION "1.8.2"
 
 #if defined _updater_included
 #define UPDATE_URL "https://sbpp.github.io/updater/updatefile.txt"
@@ -417,7 +417,7 @@ public void Event_OnPlayerName(Handle event, const char[] name, bool dontBroadca
 public Action ChatHook(int client, int args)
 {
 	// is this player preparing to ban someone
-	if (g_ownReasons[client])
+	if (g_ownReasons[client] && !IsChatTrigger())
 	{
 		// get the reason
 		char reason[512];


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Prevent chat triggers to be used a ban reason when plugin is waiting for custom reason

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Follow SourceMod behaviour pushed on [363b4b6](https://github.com/alliedmodders/sourcemod/blob/363b4b687ac4f3b7b61d4cf89d7ac565d7490a2b)
Credits to @Rainyan

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Works like a charm.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
