### PR TITLE
feat(checker): configure client connect message output

### DIFF
--- a/game/addons/sourcemod/configs/sourcebans/sourcebans.cfg
+++ b/game/addons/sourcemod/configs/sourcebans/sourcebans.cfg
@@ -3,7 +3,7 @@
 *
 * This file contains settings for the SourceBans Source Server Plugin
 * @author SteamFriends Development Team
-* @version 0.0.0.$Rev: 74 $
+* @version 0.0.0.$Rev: 75 $
 * @copyright SteamFriends (www.steamfriends.com)
 * @package SourceBans
 */
@@ -23,6 +23,9 @@
         
         // The Tableprefix you set while installing the webpanel. (default: "sb")
 		"DatabasePrefix"	"sb"
+
+		// Print a message to admins when a player connect if he/she have bans/comms history
+		"PrintCheckOnConnect"	"1"
 
 		// How many seconds to wait before retrying when a players ban fails to be checked. Min = 15.0 Max = 60.0
 		"RetryTime"			"45.0"

--- a/game/addons/sourcemod/scripting/sbpp_checker.sp
+++ b/game/addons/sourcemod/scripting/sbpp_checker.sp
@@ -29,12 +29,13 @@
 
 #include <sourcemod>
 
-#define VERSION "1.8.1"
+#define VERSION "1.8.2"
 #define LISTBANS_USAGE "sm_listbans <#userid|name> - Lists a user's prior bans from Sourcebans"
 #define LISTCOMMS_USAGE "sm_listcomms <#userid|name> - Lists a user's prior comms from Sourcebans"
 #define INVALID_TARGET -1
 #define Prefix "\x04[SourceBans++]\x01 "
 
+bool g_bPrintCheckOnConnect = true;
 char g_DatabasePrefix[10] = "sb";
 SMCParser g_ConfigParser;
 Database g_DB;
@@ -143,6 +144,9 @@ public void OnConnectBanCheck(Database db, DBResultSet results, const char[] err
 
 	g_iBanCounts[client] = bancount;
 	g_iCommsCounts[client] = commcount;
+
+	if (!g_bPrintCheckOnConnect)
+		return;
 
 	if ( bancount && commcount ) {
 		PrintToBanAdmins("%s%t", Prefix, "Ban and Comm Warning", client, bancount, ((bancount > 1 || bancount == 0) ? "s":""), commcount, ((commcount > 1 || commcount == 0) ? "s":""));
@@ -583,6 +587,14 @@ public SMCResult ReadConfig_KeyValue(SMCParser smc, const char[] key, const char
 		if (g_DatabasePrefix[0] == '\0')
 		{
 			g_DatabasePrefix = "sb";
+		}
+	}
+
+	if (strcmp("PrintCheckOnConnect", key, false) == 0)
+	{
+		if (strcmp("0", value, false) == 0)
+		{
+			g_bPrintCheckOnConnect = false;
 		}
 	}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add a new setting to enabled/disable the print of the punishement history message when a client connect

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Some peoples may want the commands for list but do not want to print the message.
To prevent conflict for user who do not update their `sourcebans.cfg`, it's enabled by default and need to be on 0 to be disabled.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
