### PR TITLE
fix(blockit): Prevent php warnings

### DIFF
--- a/web/pages/admin.blockit.php
+++ b/web/pages/admin.blockit.php
@@ -80,13 +80,13 @@ function BlockPlayer($check, int $sid, $num, $type, int $length)
         return $objResponse;
     }
 
-//    $GLOBALS['PDO']->query("SELECT ip, port FROM `:prefix_servers` WHERE sid = :sid");
-//    $GLOBALS['PDO']->bind(':sid', $sid);
-//    $sdata = $GLOBALS['PDO']->single();
+   $GLOBALS['PDO']->query("SELECT ip, port FROM `:prefix_servers` WHERE sid = :sid");
+   $GLOBALS['PDO']->bind(':sid', $sid);
+   $sdata = $GLOBALS['PDO']->single();
 
     // show hostname instead of the ip, but leave the ip in the title
     $hostsearch = preg_match_all('/hostname:[ ]*(.+)/', $ret, $hostname, PREG_PATTERN_ORDER);
-    $hostname   = trunc(htmlspecialchars($hostname[1][0]), 25);
+    $hostname   = trunc(htmlspecialchars($hostname[1][0] ?? ''), 25);
     if (!empty($hostname))
         $objResponse->addAssign("srvip_$num", "innerHTML", "<font size='1'><span title='" . $sdata['ip'] . ":" . $sdata['port'] . "'>" . $hostname . "</span></font>");
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- Uncommented and fixed the database query to get server data and prevent php warnings for $data
- Added null coalescing operator for hostname array access

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
```
PHP Warning: Undefined variable $sdata in /var/www/vhosts/nide.gg/bans.nide.gg/pages/admin.blockit.php on line 91;
PHP message: PHP Warning: Trying to access array offset on null in /var/www/vhosts/nide.gg/bans.nide.gg/pages/admin.blockit.php on line 91; 
```
But I wonder why @Hackmastr commented this part of the code in smart v5 changes.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Applied fix and run the page with an url like `bans.nide.gg/pages/admin.blockit.php?check=steam_0:1:802859631&type=1&length=60` and do not throw warnings anymore.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
