### PR TITLE
feat(checker): Mutes & gags count natives, late load

### DIFF
--- a/game/addons/sourcemod/scripting/include/sourcebanschecker.inc
+++ b/game/addons/sourcemod/scripting/include/sourcebanschecker.inc
@@ -45,6 +45,8 @@ public void __pl_sourcebanschecker_SetNTVOptional()
 {
 	MarkNativeAsOptional("SBPP_CheckerGetClientsBans");
 	MarkNativeAsOptional("SBPP_CheckerGetClientsComms");
+	MarkNativeAsOptional("SBPP_CheckerGetClientsMutes");
+	MarkNativeAsOptional("SBPP_CheckerGetClientsGags");
 }
 #endif
 
@@ -65,3 +67,19 @@ native int SBPP_CheckerGetClientsBans(int iClient);
  * @return        The number of comms bans of the client.
  *********************************************************/
 native int SBPP_CheckerGetClientsComms(int iClient);
+
+/*********************************************************
+ * Get the number of mutes of a client.
+ *
+ * @param iClient	The client index of who you want to get the number of mutes.
+ * @return        The number of mutes of the client.
+ *********************************************************/
+native int SBPP_CheckerGetClientsMutes(int iClient);
+
+/*********************************************************
+ * Get the number of gags of a client.
+ *
+ * @param iClient	The client index of who you want to get the number of gags.
+ * @return        The number of gags of the client.
+ *********************************************************/
+native int SBPP_CheckerGetClientsGags(int iClient);


### PR DESCRIPTION
## Description

1. Edited SQL query to retrieve separate counts for mutes and gags instead of a combined value. The query now returns distinct counts for:

	- Steam ID bans
	- IP bans
	- Voice mutes (type 1)
	- Chat gags (type 2)

2. Created two new natives to provide more granular access to client communication restrictions:

	- `SBPP_CheckerGetClientMutes`: Returns the number of mutes
	- `SBPP_CheckerGetClientGags`: Returns the number of gags

3. Updated existing `SBPP_CheckerGetClientComms `native to maintain backward compatibility by returning the sum of mutes and gags.

## Motivation and Context

This change provides more detailed information about client restrictions, allowing developers to distinguish between different types of communication blocks. This granular access enables better decision-making in plugins that need to handle mutes and gags differently.

## How Has This Been Tested?

Testing was performed on a local SourceMod server with MySQL database running the latest version of SourceBans++. Tests included:

1. Checking counts for clients with various combinations of bans/mutes/gags
1. Verifying backward compatibility of the `SBPP_CheckerGetClientComms` native
1. Validating the accuracy of the new natives

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.

Thanks to @srcdslab for the idea. 