### PR TITLE
Update Mailer.php

### DIFF
--- a/web/includes/Mail/Mailer.php
+++ b/web/includes/Mail/Mailer.php
@@ -52,7 +52,9 @@ class Mailer
                          ?array $files = null
     ): bool
     {
-        $dsn = "smtp://$this->user:$this->password@$this->host";
+        $encodedUser = urlencode($this->user);
+		$encodedPassword = urlencode($this->password);
+		$dsn = "smtp://$encodedUser:$encodedPassword@$this->host:$this->port";
 
         if ($this->port != null)
             $dsn .= ":$this->port";


### PR DESCRIPTION
username and password must be urlencoded for propper smtp service (otherwise it wont work with some special characters)

<!--- Provide a general summary of your changes in the Title above -->

## Description
Variables change from "$this->password" to this urlencode($this->password).

## Motivation and Context
when special characters are used in e.g. the password, then the smtp service can't handle them via http

## How Has This Been Tested?
I have tested this changes with a password that contained a '?'. The smtp failed before the changes. After url endoding the smtp service works flawless.

## Screenshots (if appropriate):

## Types of changes
urlencoding in the dsn builder for smtp
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
