### PR TITLE
fix(comments): Links encodage (#1033)

### DIFF
--- a/web/pages/admin.bans.php
+++ b/web/pages/admin.bans.php
@@ -241,7 +241,7 @@ foreach ($protests as $prot) {
             $cdata['added']      = Config::time($commentres->fields['added']);
             $commentText         = html_entity_decode($commentres->fields['commenttxt'], ENT_QUOTES | ENT_HTML5, 'UTF-8');
             $commentText         = encodePreservingBr($commentText);
-            $commentText         = preg_replace('@(https?://([-\w\.]+)+(:\d+)?(/([\w/_\.]*(\?\S+)?)?)?)@', '<a href="\$1" target="_blank">\$1</a>', $commentText);
+            $commentText         = preg_replace('@(https?://([-\w\.]+)+(:\d+)?(/([\w/_\.]*(\?\S+)?)?)?)@', '<a href="$1" target="_blank">$1</a>', $commentText);
             $cdata['commenttxt'] = $commentText;
 
             if (!empty($commentres->fields['edittime'])) {
@@ -404,7 +404,7 @@ foreach ($protestsarchiv as $prot) {
             $cdata['added']      = Config::time($commentres->fields['added']);
             $commentText         = html_entity_decode($commentres->fields['commenttxt'], ENT_QUOTES | ENT_HTML5, 'UTF-8');
             $commentText         = encodePreservingBr($commentText);
-            $commentText         = preg_replace('@(https?://([-\w\.]+)+(:\d+)?(/([\w/_\.]*(\?\S+)?)?)?)@', '<a href="\$1" target="_blank">\$1</a>', $commentText);
+            $commentText         = preg_replace('@(https?://([-\w\.]+)+(:\d+)?(/([\w/_\.]*(\?\S+)?)?)?)@', '<a href="$1" target="_blank">$1</a>', $commentText);
             $cdata['commenttxt'] = $commentText;
 
             if (!empty($commentres->fields['edittime'])) {
@@ -561,7 +561,7 @@ foreach ($submissions as $sub) {
             $commentText         = html_entity_decode($commentres->fields['commenttxt'], ENT_QUOTES | ENT_HTML5, 'UTF-8');
             $commentText         = encodePreservingBr($commentText);
             // Parse links and wrap them in a <a href=""></a> tag to be easily clickable
-            $commentText         = preg_replace('@(https?://([-\w\.]+)+(:\d+)?(/([\w/_\.]*(\?\S+)?)?)?)@', '<a href="\$1" target="_blank">\$1</a>', $commentText);
+            $commentText         = preg_replace('@(https?://([-\w\.]+)+(:\d+)?(/([\w/_\.]*(\?\S+)?)?)?)@', '<a href="$1" target="_blank">$1</a>', $commentText);
             $cdata['commenttxt'] = $commentText;
 
             if (!empty($commentres->fields['edittime'])) {
@@ -704,7 +704,7 @@ foreach ($submissionsarchiv as $sub) {
             $commentText         = html_entity_decode($commentres->fields['commenttxt'], ENT_QUOTES | ENT_HTML5, 'UTF-8');
             $commentText         = encodePreservingBr($commentText);
             // Parse links and wrap them in a <a href=""></a> tag to be easily clickable
-            $commentText         = preg_replace('@(https?://([-\w\.]+)+(:\d+)?(/([\w/_\.]*(\?\S+)?)?)?)@', '<a href="\$1" target="_blank">\$1</a>', $commentText);
+            $commentText         = preg_replace('@(https?://([-\w\.]+)+(:\d+)?(/([\w/_\.]*(\?\S+)?)?)?)@', '<a href="$1" target="_blank">$1</a>', $commentText);
             $cdata['commenttxt'] = $commentText;
 
             if (!empty($commentres->fields['edittime'])) {

--- a/web/pages/page.banlist.php
+++ b/web/pages/page.banlist.php
@@ -688,7 +688,7 @@ while (!$res->EOF) {
                 $commentText         = html_entity_decode($commentres->fields['commenttxt'], ENT_QUOTES | ENT_HTML5, 'UTF-8');
                 $commentText         = encodePreservingBr($commentText);
                 // Parse links and wrap them in a <a href=""></a> tag to be easily clickable
-                $commentText = preg_replace('@(https?://([-\w\.]+)+(:\d+)?(/([\w/_\.]*(\?\S+)?)?)?)@', '<a href="\$1" target="_blank">\$1</a>', $commentText);
+                $commentText         = preg_replace('@(https?://([-\w\.]+)+(:\d+)?(/([\w/_\.]*(\?\S+)?)?)?)@', '<a href="$1" target="_blank">$1</a>', $commentText);
                 $cdata['commenttxt'] = $commentText;
 
                 if (!empty($commentres->fields['edittime'])) {
@@ -808,7 +808,7 @@ if (isset($_GET["comment"])) {
         $commentText          = html_entity_decode($cotherdata->fields['commenttxt'], ENT_QUOTES | ENT_HTML5, 'UTF-8');
         $commentText          = encodePreservingBr($commentText);
         // Parse links and wrap them in a <a href=""></a> tag to be easily clickable
-        $commentText = preg_replace('@(https?://([-\w\.]+)+(:\d+)?(/([\w/_\.]*(\?\S+)?)?)?)@', '<a href="\$1" target="_blank">\$1</a>', $commentText);
+        $commentText         = preg_replace('@(https?://([-\w\.]+)+(:\d+)?(/([\w/_\.]*(\?\S+)?)?)?)@', '<a href="$1" target="_blank">$1</a>', $commentText);
         $coment['commenttxt'] = $commentText;
 
         if ($cotherdata->fields['editname'] != "") {

--- a/web/pages/page.commslist.php
+++ b/web/pages/page.commslist.php
@@ -647,7 +647,7 @@ while (!$res->EOF) {
                 $commentText         = html_entity_decode($commentres->fields['commenttxt'], ENT_QUOTES | ENT_HTML5, 'UTF-8');
                 $commentText         = encodePreservingBr($commentText);
                 // Parse links and wrap them in a <a href=""></a> tag to be easily clickable
-                $commentText         = preg_replace('@(https?://([-\w\.]+)+(:\d+)?(/([\w/_\.]*(\?\S+)?)?)?)@', '<a href="\$1" target="_blank">\$1</a>', $commentText);
+                $commentText         = preg_replace('@(https?://([-\w\.]+)+(:\d+)?(/([\w/_\.]*(\?\S+)?)?)?)@', '<a href="$1" target="_blank">$1</a>', $commentText);
                 $cdata['commenttxt'] = $commentText;
 
                 if (!empty($commentres->fields['edittime'])) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The issue is that links in comments are being displayed as "$1" instead of the actual URL.
This is caused by how `preg_replace()` is being used in the link processing function.
The `$` character is being escaped with a backslash in the replacement pattern, causing PHP to interpret "\$1" literally instead of replacing it with the captured reference.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
#1033 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
See repro of #1033 

## Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/de368e87-0afe-47c7-8174-8ca753cf5557)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
