### PR TITLE
fix(comments): Links encodage (#1033)

### DIFF
--- a/web/pages/page.commslist.php
+++ b/web/pages/page.commslist.php
@@ -761,7 +761,7 @@ if (isset($_GET["comment"])) {
         $coment['added']      = Config::time($cotherdata->fields['added']);
         $commentText          = html_entity_decode($cotherdata->fields['commenttxt'], ENT_QUOTES | ENT_HTML5, 'UTF-8');
         $commentText          = encodePreservingBr($commentText);
-        $commentText          = preg_replace('@(https?://([-\w\.]+)+(:\d+)?(/([\w/_\.]*(\?\S+)?)?)?)@', '<a href="\$1" target="_blank">\$1</a>', $commentText);
+        $commentText          = preg_replace('@(https?://([-\w\.]+)+(:\d+)?(/([\w/_\.]*(\?\S+)?)?)?)@', '<a href="$1" target="_blank">$1</a>', $commentText);
         $coment['commenttxt'] = $commentText;
         if ($cotherdata->fields['editname'] != "") {
             $coment['edittime'] = Config::time($cotherdata->fields['edittime']);


### PR DESCRIPTION
## Description
PR #1044 was missing the fix for the *Add Comment* page.

## Motivation and Context
#1033

## How Has This Been Tested?
See second screenshot below.

## Screenshots:

![image](https://github.com/user-attachments/assets/7262fead-a39f-4d8b-8565-c51aeb0e7244)

![image](https://github.com/user-attachments/assets/e90ef942-97c3-4228-9180-a7f4842e46b3)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
