### PR TITLE
fix(sbpp_comms): remove useless datapack

### DIFF
--- a/game/addons/sourcemod/scripting/include/sourcecomms.inc
+++ b/game/addons/sourcemod/scripting/include/sourcecomms.inc
@@ -31,7 +31,7 @@
 
 #define SBPPComms_VERSION_MAJOR "1"
 #define SBPPComms_VERSION_MINOR "8"
-#define SBPPComms_VERSION_PATCH "3"
+#define SBPPComms_VERSION_PATCH "4"
 
 #define SBPPComms_VERSION   SBPPComms_VERSION_MAJOR..."."...SBPPComms_VERSION_MINOR..."."...SBPPComms_VERSION_PATCH
 

--- a/game/addons/sourcemod/scripting/sbpp_comms.sp
+++ b/game/addons/sourcemod/scripting/sbpp_comms.sp
@@ -94,7 +94,7 @@ ConVar CvarPort;
 Database g_hDatabase;
 Database SQLiteDB;
 
-char 
+char
 	ServerIp[24]
 	, ServerPort[7]
 	, DatabasePrefix[10] = "sb"
@@ -110,13 +110,13 @@ char
 
 float RetryTime = 15.0;
 
-bool 
+bool
 	g_bLate
 	, g_bPlayerAuthentified[MAXPLAYERS + 1] // Bots and players with invalid Steam ID format will always be FALSE
 	, g_bPlayerStatus[MAXPLAYERS + 1] // Player block check status
 	, g_bPlayerVerified[MAXPLAYERS + 1]; // Player has been verified into the database
 
-int 
+int
 	iNumReasons
 	, iNumTimes
 	, g_iTimeMinutes[MAX_TIMES]
@@ -140,11 +140,11 @@ Handle g_hGagExpireTimer[MAXPLAYERS + 1] = { null, ... }
 	, g_hMuteExpireTimer[MAXPLAYERS + 1] = { null, ... };
 
 bType g_MuteType[MAXPLAYERS + 1];
-char 
+char
 	g_sMuteAdminName[MAXPLAYERS + 1][MAX_NAME_LENGTH]
 	, g_sMuteReason[MAXPLAYERS + 1][256]
 	, g_sMuteAdminAuth[MAXPLAYERS + 1][64];
-int 
+int
 	g_iMuteTime[MAXPLAYERS + 1]
 	, g_iMuteLength[MAXPLAYERS + 1] // in sec
 	, g_iMuteLevel[MAXPLAYERS + 1]; // immunity level of admin
@@ -155,7 +155,7 @@ char
 	g_sGagAdminName[MAXPLAYERS + 1][MAX_NAME_LENGTH]
 	, g_sGagReason[MAXPLAYERS + 1][256]
 	, g_sGagAdminAuth[MAXPLAYERS + 1][64];
-int 
+int
 	g_iGagTime[MAXPLAYERS + 1]
 	, g_iGagLength[MAXPLAYERS + 1] // in sec
 	, g_iGagLevel[MAXPLAYERS + 1]; // immunity level of admin
@@ -1877,12 +1877,9 @@ public void Query_VerifyBlock(Database db, DBResultSet results, const char[] err
 
 // TIMER CALL BACKS //
 
-public Action Timer_ClientRecheck(Handle timer, DataPack RetryDP)
+public Action Timer_ClientRecheck(Handle timer, int userid)
 {
-	RetryDP.Reset();
-	int userid = RetryDP.ReadCell();
 	int client = GetClientOfUserId(userid);
-	delete RetryDP;
 
 	if (!client)
 		return Plugin_Stop;
@@ -2149,9 +2146,7 @@ stock void setMute(int client, int length, const char[] clientAuth)
 
 stock void ClientRecheck(int client)
 {
-	DataPack RetryDP = new DataPack();
-	RetryDP.WriteCell(g_iUserIDs[client]);
-	CreateTimer(1.0, Timer_ClientRecheck, RetryDP, TIMER_FLAG_NO_MAPCHANGE);
+	CreateTimer(1.0, Timer_ClientRecheck, g_iUserIDs[client], TIMER_FLAG_NO_MAPCHANGE);
 }
 
 stock bool IsInvalidSteamID(int client)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Pass the userid directly in the timer data instead creating a datapack only for it

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Avoid using useless memory usage
Prevent datapack leaking if the map change during the call

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
