### PR TITLE
Asynchronous SET NAMES utf8mb4

### DIFF
--- a/game/addons/sourcemod/scripting/sbpp_comms.sp
+++ b/game/addons/sourcemod/scripting/sbpp_comms.sp
@@ -1380,9 +1380,15 @@ public void GotDatabase(Database db, const char[] error, any data)
 	}
 
 	// Set character set to UTF8MB4 in the database
-	char query[128];
-	Format(query, sizeof(query), "SET NAMES utf8mb4");
-	db.Query(Query_ErrorCheck, query);
+	// Use SQL_SetCharset to ensure charset is set synchronously before any operations
+	if (!db.SetCharset("utf8mb4"))
+	{
+		LogError("Failed to set database charset to utf8mb4");
+		// Fallback to async method
+		char query[128];
+		Format(query, sizeof(query), "SET NAMES utf8mb4");
+		db.Query(Query_ErrorCheck, query);
+	}
 
 	// Process queue
 	SQLiteDB.Query(Query_ProcessQueue,

--- a/game/addons/sourcemod/scripting/sbpp_main.sp
+++ b/game/addons/sourcemod/scripting/sbpp_main.sp
@@ -1090,8 +1090,15 @@ public void GotDatabase(Database db, const char[] error, any data)
 
 	char query[1024];
 
-	Format(query, sizeof(query), "SET NAMES utf8mb4");
-	DB.Query(ErrorCheckCallback, query);
+	// Set character set to UTF8MB4 in the database
+	// Use SetCharset to ensure charset is set synchronously before any operations
+	if (!DB.SetCharset("utf8mb4"))
+	{
+		LogToFile(logFile, "Failed to set database charset to utf8mb4, trying async method");
+		// Fallback to async method
+		Format(query, sizeof(query), "SET NAMES utf8mb4");
+		DB.Query(ErrorCheckCallback, query);
+	}
 
 	InsertServerInfo();
 


### PR DESCRIPTION
**Problem Description:**
This change addresses a critical character encoding issue in SourceBans++ that caused garbled text when storing Chinese player names in the database. The root cause was identified as:

1. **Character Set Timing Issue:** 
   The original code used asynchronous `db.Query()` to execute `SET NAMES utf8mb4`, which meant that plugin operations (like INSERT) could begin before the character set configuration was complete.

2. **Asynchronous Execution Risk:**
   When players were banned, if the character set configuration hadn't finished, Chinese characters would be written to the database with incorrect encoding, resulting in garbled text.

**Test Environment:**
- SourceMod 1.12
- MySQL 8.0 database

**Test Cases Executed:**
1. **Chinese player name ban system test**
   - Used players with Chinese names to trigger the ban system
   - Verified that Chinese characters are correctly stored in the database without garbled text

2. **Multi-byte character storage test**
   - Tested storage of various character types:
     - Chinese characters
     - Japanese characters 
     - Special characters and symbols
   - Confirmed all characters are properly encoded and displayed correctly

**Test Results:**
- ✅ All Chinese, Japanese, and special characters are correctly stored in the database
- ✅ No garbled text appears in player names
- ✅ Character set configuration works synchronously before any database operations
- ✅ Error logging functions properly for troubleshooting

**Checklist:**
 ✅My code follows the code style of this project.
 ✅I have read the CONTRIBUTING document.
