### PR TITLE
Fix Root Admin unable to delete bans/comms

### DIFF
--- a/web/pages/page.banlist.php
+++ b/web/pages/page.banlist.php
@@ -851,7 +851,7 @@ $theme->assign('hideadminname', (Config::getBool('banlist.hideadminname') && !$u
 $theme->assign('groupban', (Config::getBool('config.enablegroupbanning') && $userbank->HasAccess(ADMIN_OWNER | ADMIN_ADD_BAN)));
 $theme->assign('friendsban', (Config::getBool('config.enablefriendsbanning') && $userbank->HasAccess(ADMIN_OWNER | ADMIN_ADD_BAN)));
 $theme->assign('general_unban', $userbank->HasAccess(ADMIN_OWNER | ADMIN_UNBAN | ADMIN_UNBAN_OWN_BANS | ADMIN_UNBAN_GROUP_BANS));
-$theme->assign('can_delete', $userbank->HasAccess(ADMIN_DELETE_BAN));
+$theme->assign('can_delete', $userbank->HasAccess(ADMIN_OWNER | ADMIN_DELETE_BAN));
 $theme->assign('view_bans', ($userbank->HasAccess(ADMIN_OWNER | ADMIN_EDIT_ALL_BANS | ADMIN_EDIT_OWN_BANS | ADMIN_EDIT_GROUP_BANS | ADMIN_UNBAN | ADMIN_UNBAN_OWN_BANS | ADMIN_UNBAN_GROUP_BANS | ADMIN_DELETE_BAN)));
 $theme->assign('can_export', ($userbank->HasAccess(ADMIN_OWNER) || Config::getBool('config.exportpublic')));
 $theme->display('page_bans.tpl');

--- a/web/pages/page.commslist.php
+++ b/web/pages/page.commslist.php
@@ -799,6 +799,6 @@ $theme->assign('admin_nick', $userbank->GetProperty("user"));
 $theme->assign('admin_postkey', $_SESSION['banlist_postkey']);
 $theme->assign('hideadminname', (Config::getBool('banlist.hideadminname') && !$userbank->is_admin()));
 $theme->assign('general_unban', $userbank->HasAccess(ADMIN_OWNER | ADMIN_UNBAN | ADMIN_UNBAN_OWN_BANS | ADMIN_UNBAN_GROUP_BANS));
-$theme->assign('can_delete', $userbank->HasAccess(ADMIN_DELETE_BAN));
+$theme->assign('can_delete', $userbank->HasAccess(ADMIN_OWNER | ADMIN_DELETE_BAN));
 $theme->assign('view_bans', ($userbank->HasAccess(ADMIN_OWNER | ADMIN_EDIT_ALL_BANS | ADMIN_EDIT_OWN_BANS | ADMIN_EDIT_GROUP_BANS | ADMIN_UNBAN | ADMIN_UNBAN_OWN_BANS | ADMIN_UNBAN_GROUP_BANS | ADMIN_DELETE_BAN)));
 $theme->display('page_comms.tpl');


### PR DESCRIPTION
## Summary
- The `can_delete` template flag in `web/pages/page.banlist.php` and `web/pages/page.commslist.php` only checked `ADMIN_DELETE_BAN`, hiding the Delete action from users whose only permission was `ADMIN_OWNER` (Root Admin / Full Admin Access).
- Server-side delete handlers in both files already permit `ADMIN_OWNER | ADMIN_DELETE_BAN`, so the UI was the only place blocking Root Admins.
- Updated the assignment in both files to `$userbank->HasAccess(ADMIN_OWNER | ADMIN_DELETE_BAN)`, matching the convention used by every other `HasAccess` call on the same page (e.g. `groupban`, `friendsban`, `general_unban`, `view_bans`).

Closes #988

## Test plan
- [ ] Log in as a user whose group only has `ADMIN_OWNER` and confirm the Delete option appears in the bans-list actions dropdown.
- [ ] Same check on the comms-block list page.
- [ ] Verify users without `ADMIN_OWNER` and without `ADMIN_DELETE_BAN` still do not see the Delete option (no regression).
- [ ] Confirm Delete still works end-to-end (server-side handler unchanged).

Generated with [Claude Code](https://claude.com/claude-code)