### PR TITLE
fix(login): make steamlogin_show actually toggle steam login

### DIFF
--- a/web/themes/default/page_login.tpl
+++ b/web/themes/default/page_login.tpl
@@ -5,7 +5,6 @@
     <tr>
         <td class="listtable_1" style="padding: 15px;">
             <div id="login-content">
-                -{if $steamlogin_show == 1}-
                 <div id="loginUsernameDiv">
                     <label for="loginUsername">Username:</label><br />
                     <input id="loginUsername" class="loginmedium" type="text" name="username"value="" />
@@ -21,19 +20,16 @@
                 <div id="loginRememberMeDiv">
                     <input id="loginRememberMe" type="checkbox" class="checkbox" name="remember" value="checked" vspace="5px" />    <span class="checkbox" style="cursor:pointer;" onclick="($('loginRememberMe').checked?$('loginRememberMe').checked=false:$('loginRememberMe').checked=true)">Remember me</span>
                 </div>
-                -{/if}-
                 <div id="loginSubmit">
+                    -{if $steamlogin_show == 1}-
                     <center><a href="index.php?p=login&o=steam"><img src="images/steamlogin.png"></a></center>
                     <br>
-                    -{if $steamlogin_show == 1}-
-                    -{sb_button text="Login" onclick=$redir class="ok login" id="alogin" style="width: 100%; text-transform: uppercase;" submit=false}-
                     -{/if}-
+                    -{sb_button text="Login" onclick=$redir class="ok login" id="alogin" style="width: 100%; text-transform: uppercase;" submit=false}-
                 </div>
-                -{if $steamlogin_show == 1}-
                 <div id="loginOtherlinks">
                     <a href="index.php?p=lostpassword">Lost your password?</a>
                 </div>
-                -{/if}-
             </div>
         </td>
     </tr>


### PR DESCRIPTION
## Summary
- `web/themes/default/page_login.tpl` had `{if $steamlogin_show == 1}` wrapping the username/password form, the standard Login button, and the "Lost your password?" link. Because the variable is set from `Config::getBool('config.enablesteamlogin')`, setting `config.enablesteamlogin = 0` hid the *normal* login UI instead of the Steam button.
- Removed the three inverted conditions and instead wrap only the Steam login button (image link) in `{if $steamlogin_show == 1}`, so the variable name matches its behavior: enabling steam login shows the steam button, disabling it hides only the steam button while leaving the username/password form intact.
- Controller polarity in `web/pages/page.login.php` is intentionally untouched.

## Test plan
- [ ] In the admin settings, set `config.enablesteamlogin = 1` and confirm the Steam button is visible alongside the username/password form on the login page.
- [ ] Set `config.enablesteamlogin = 0` and confirm the Steam button disappears while the username/password fields, the standard Login button, and the "Lost your password?" link remain visible.
- [ ] Visually confirm Smarty renders the page without template parse errors.

Closes #954

Generated with [Claude Code](https://claude.com/claude-code)