### PR TITLE
fix(install): add missing attempts and lockout_until columns to sb_admins

### DIFF
--- a/web/install/includes/sql/struc.sql
+++ b/web/install/includes/sql/struc.sql
@@ -14,6 +14,8 @@ CREATE TABLE IF NOT EXISTS `{prefix}_admins` (
   `srv_flags` varchar(64) default NULL,
   `srv_password` varchar(128) default NULL,
   `lastvisit` int(11) NULL,
+  `attempts` int(11) NOT NULL default '0',
+  `lockout_until` datetime default NULL,
   PRIMARY KEY  (`aid`),
   UNIQUE KEY `user` (`user`)
 ) ENGINE=InnoDB  DEFAULT CHARSET={charset};


### PR DESCRIPTION
## Summary
- Fixes #1068 — fresh 1.8.1 installs cannot log in as admin because `sb_admins` is missing the `attempts` and `lockout_until` columns that the login flow selects (`web/includes/sb-callback.php:175`).
- Bug introduced in #1006: that PR added the columns via the `801` updater (for upgrades from 1.8.0) but did not update `web/install/includes/sql/struc.sql`, so fresh installs were missing them.
- Column types match the `801` updater (`int` and `datetime`), since the login code uses `strtotime()` / `date('Y-m-d H:i:s', ...)` on `lockout_until`.

## Test plan
- [ ] Run a fresh install on a clean DB and verify `sb_admins` contains `attempts` and `lockout_until` columns
- [ ] Verify admin login works on a fresh install
- [ ] Verify the `801` updater still applies cleanly on an existing 1.8.0 install (no change to upgrade path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)