### PR TITLE
fix(security): patch SQL injection vulnerabilities in web panel and plugin

### DIFF
--- a/game/addons/sourcemod/scripting/sbpp_main.sp
+++ b/game/addons/sourcemod/scripting/sbpp_main.sp
@@ -596,10 +596,11 @@ public Action CommandBanIp(int client, int args)
 	dataPack.WriteString(adminAuth);
 	dataPack.WriteString(adminIp);
 
-	char sQuery[256];
+	char sQuery[256], argEscaped[sizeof(arg) * 2 + 1];
+	DB.Escape(arg, argEscaped, sizeof(argEscaped));
 
 	FormatEx(sQuery, sizeof(sQuery), "SELECT bid FROM %s_bans WHERE type = 1 AND ip     = '%s' AND (length = 0 OR ends > UNIX_TIMESTAMP()) AND RemoveType IS NULL",
-		DatabasePrefix, arg);
+		DatabasePrefix, argEscaped);
 
 	DB.Query(SelectBanIpCallback, sQuery, dataPack, DBPrio_High);
 
@@ -646,13 +647,14 @@ public Action CommandUnban(int client, int args)
 	dataPack.WriteString(arg); // Steamid - IP
 	dataPack.WriteString(adminAuth); // Admin SteamID
 
-	char query[256];
+	char query[256], argEscaped[sizeof(arg) * 2 + 1];
+	DB.Escape(arg, argEscaped, sizeof(argEscaped));
 
 	if (strncmp(arg, "STEAM_", 6) == 0)
 	{
-		Format(query, sizeof(query), "SELECT bid FROM %s_bans WHERE (type = 0 AND authid = '%s') AND (length = '0' OR ends > UNIX_TIMESTAMP()) AND RemoveType IS NULL", DatabasePrefix, arg);
+		Format(query, sizeof(query), "SELECT bid FROM %s_bans WHERE (type = 0 AND authid = '%s') AND (length = '0' OR ends > UNIX_TIMESTAMP()) AND RemoveType IS NULL", DatabasePrefix, argEscaped);
 	} else {
-		Format(query, sizeof(query), "SELECT bid FROM %s_bans WHERE (type = 1 AND ip     = '%s') AND (length = '0' OR ends > UNIX_TIMESTAMP()) AND RemoveType IS NULL", DatabasePrefix, arg);
+		Format(query, sizeof(query), "SELECT bid FROM %s_bans WHERE (type = 1 AND ip     = '%s') AND (length = '0' OR ends > UNIX_TIMESTAMP()) AND RemoveType IS NULL", DatabasePrefix, argEscaped);
 	}
 
 	DB.Query(SelectUnbanCallback, query, dataPack);
@@ -734,10 +736,11 @@ public Action CommandAddBan(int client, int args)
 	dataPack.WriteString(adminAuth);
 	dataPack.WriteString(adminIp);
 
-	char sQuery[256];
+	char sQuery[256], authidEscaped[sizeof(authid) * 2 + 1];
+	DB.Escape(authid, authidEscaped, sizeof(authidEscaped));
 
 	FormatEx(sQuery, sizeof sQuery, "SELECT bid FROM %s_bans WHERE type = 0 AND authid = '%s' AND (length = 0 OR ends > UNIX_TIMESTAMP()) AND RemoveType IS NULL",
-		DatabasePrefix, authid);
+		DatabasePrefix, authidEscaped);
 
 	DB.Query(SelectAddbanCallback, sQuery, dataPack, DBPrio_High);
 
@@ -1654,7 +1657,8 @@ public void ServerInfoCallback(Database db, DBResultSet results, const char[] er
 	if (!results.RowCount)
 	{
 		// get the game folder name used to determine the mod
-		char desc[64], query[200], rcon[128];
+		char desc[64], query[512], rcon[128];
+		char descEscaped[sizeof(desc) * 2 + 1], rconEscaped[sizeof(rcon) * 2 + 1];
 		GetGameFolderName(desc, sizeof(desc));
 		Format(rcon, sizeof(rcon), "");
 
@@ -1667,7 +1671,10 @@ public void ServerInfoCallback(Database db, DBResultSet results, const char[] er
 			}
 		}
 
-		FormatEx(query, sizeof(query), "INSERT INTO %s_servers (ip, port, rcon, modid) VALUES ('%s', '%s', '%s', (SELECT mid FROM %s_mods WHERE modfolder = '%s'))", DatabasePrefix, ServerIp, ServerPort, rcon, DatabasePrefix, desc);
+		db.Escape(desc, descEscaped, sizeof(descEscaped));
+		db.Escape(rcon, rconEscaped, sizeof(rconEscaped));
+
+		FormatEx(query, sizeof(query), "INSERT INTO %s_servers (ip, port, rcon, modid) VALUES ('%s', '%s', '%s', (SELECT mid FROM %s_mods WHERE modfolder = '%s'))", DatabasePrefix, ServerIp, ServerPort, rconEscaped, DatabasePrefix, descEscaped);
 		db.Query(ErrorCheckCallback, query);
 	}
 }

--- a/web/includes/sb-callback.php
+++ b/web/includes/sb-callback.php
@@ -3626,9 +3626,11 @@ function AddBlock($nickname, $type, $steam, $length, $reason)
 function PrepareReblock($bid)
 {
     $objResponse = new xajaxResponse();
+    $bid = (int)$bid;
 
     $ban = $GLOBALS['db']->GetRow(
-        "SELECT name, authid, type, length, reason FROM ".DB_PREFIX."_comms WHERE bid = '".$bid."';"
+        "SELECT name, authid, type, length, reason FROM ".DB_PREFIX."_comms WHERE bid = ?;",
+        array($bid)
     );
 
     // clear any old stuff
@@ -3665,6 +3667,7 @@ function generatePassword()
 function PrepareBlockFromBan($bid)
 {
     $objResponse = new xajaxResponse();
+    $bid = (int)$bid;
 
     // clear any old stuff
     $objResponse->addScript("$('nickname').value = ''");
@@ -3672,7 +3675,7 @@ function PrepareBlockFromBan($bid)
     $objResponse->addScript("$('txtReason').value = ''");
     $objResponse->addAssign("txtReason", "innerHTML",  "");
 
-    $ban = $GLOBALS['db']->GetRow("SELECT name, authid FROM ".DB_PREFIX."_bans WHERE bid = '".$bid."';");
+    $ban = $GLOBALS['db']->GetRow("SELECT name, authid FROM ".DB_PREFIX."_bans WHERE bid = ?;", array($bid));
 
     // add new stuff
     $objResponse->addScript("$('nickname').value = '" . $ban['name'] . "'");

--- a/web/pages/admin.edit.adminperms.php
+++ b/web/pages/admin.edit.adminperms.php
@@ -25,7 +25,7 @@ global $userbank;
 
 new AdminTabs([], $userbank, $theme);
 
-if (!isset($_GET['id'])) {
+if (!isset($_GET['id']) || !is_numeric($_GET['id'])) {
     echo '<div id="msg-red" >
 	<i class="fas fa-times fa-2x"></i>
 	<b>Error</b>
@@ -34,7 +34,8 @@ if (!isset($_GET['id'])) {
 </div>';
     PageDie();
 }
-$admin = $GLOBALS['db']->GetRow("SELECT * FROM " . DB_PREFIX . "_admins WHERE aid = \"" . $_GET['id'] . "\"");
+$_GET['id'] = (int) $_GET['id'];
+$admin = $GLOBALS['db']->GetRow("SELECT * FROM " . DB_PREFIX . "_admins WHERE aid = ?", array($_GET['id']));
 
 
 if (!$userbank->GetProperty("user", $_GET['id'])) {
@@ -48,7 +49,6 @@ if (!$userbank->GetProperty("user", $_GET['id'])) {
     PageDie();
 }
 
-$_GET['id'] = (int) $_GET['id'];
 if (!$userbank->HasAccess(ADMIN_OWNER | ADMIN_EDIT_ADMINS)) {
     Log::add("w", "Hacking Attempt", $userbank->GetProperty("user")." tried to edit ".$userbank->GetProperty('user', $_GET['id'])."'s permissions, but doesn't have access.");
     echo '<div id="msg-red" >

--- a/web/pages/admin.edit.ban.php
+++ b/web/pages/admin.edit.ban.php
@@ -34,14 +34,15 @@ if (!isset($_GET['id']) || !is_numeric($_GET['id'])) {
     echo '<script>ShowBox("Error", "No ban id specified. Please only follow links!", "red", "index.php?p=admin&c=bans");</script>';
     PageDie();
 }
+$_GET['id'] = (int) $_GET['id'];
 
 $res = $GLOBALS['db']->GetRow("
-    				SELECT bid, ba.ip, ba.type, ba.authid, ba.name, created, ends, length, reason, ba.aid, ba.sid, ad.user, ad.gid, CONCAT(se.ip,':',se.port), se.sid, mo.icon, (SELECT origname FROM " . DB_PREFIX . "_demos WHERE demtype = 'b' AND demid = {$_GET['id']})
+    				SELECT bid, ba.ip, ba.type, ba.authid, ba.name, created, ends, length, reason, ba.aid, ba.sid, ad.user, ad.gid, CONCAT(se.ip,':',se.port), se.sid, mo.icon, (SELECT origname FROM " . DB_PREFIX . "_demos WHERE demtype = 'b' AND demid = ?)
     				FROM " . DB_PREFIX . "_bans AS ba
     				LEFT JOIN " . DB_PREFIX . "_admins AS ad ON ba.aid = ad.aid
     				LEFT JOIN " . DB_PREFIX . "_servers AS se ON se.sid = ba.sid
     				LEFT JOIN " . DB_PREFIX . "_mods AS mo ON mo.mid = se.modid
-    				WHERE bid = {$_GET['id']}");
+    				WHERE bid = ?", array($_GET['id'], $_GET['id']));
 
 if (!$userbank->HasAccess(ADMIN_OWNER | ADMIN_EDIT_ALL_BANS) && (!$userbank->HasAccess(ADMIN_EDIT_OWN_BANS) && $res[8] != $userbank->GetAid()) && (!$userbank->HasAccess(ADMIN_EDIT_GROUP_BANS) && $res->fields['gid'] != $userbank->GetProperty('gid'))) {
     echo '<script>ShowBox("Error", "You don\'t have access to this!", "red", "index.php?p=admin&c=bans");</script>';
@@ -146,7 +147,7 @@ if (isset($_POST['name'])) {
 
     // Only process if there are still no errors
     if ($error == 0) {
-        $lengthrev = $GLOBALS['db']->Execute("SELECT length, authid FROM " . DB_PREFIX . "_bans WHERE bid = '" . (int) $_GET['id'] . "'");
+        $lengthrev = $GLOBALS['db']->Execute("SELECT length, authid FROM " . DB_PREFIX . "_bans WHERE bid = ?", array($_GET['id']));
 
 
         $edit = $GLOBALS['db']->Execute(
@@ -175,7 +176,7 @@ if (isset($_POST['name'])) {
         ));
 
         if (!empty($_POST['dname'])) {
-            $demoid = $GLOBALS['db']->GetRow("SELECT filename FROM `" . DB_PREFIX . "_demos` WHERE demid = '" . $_GET['id'] . "';");
+            $demoid = $GLOBALS['db']->GetRow("SELECT filename FROM `" . DB_PREFIX . "_demos` WHERE demid = ?;", array($_GET['id']));
             @unlink(SB_DEMOS . "/" . $demoid['filename']);
             $edit         = $GLOBALS['db']->Execute(
                 "REPLACE INTO " . DB_PREFIX . "_demos

--- a/web/pages/admin.edit.comms.php
+++ b/web/pages/admin.edit.comms.php
@@ -34,11 +34,12 @@ if (!isset($_GET['id']) || !is_numeric($_GET['id'])) {
     echo '<script>ShowBox("Error", "No block id specified. Please only follow links!", "red", "index.php?p=admin&c=comms");</script>';
     PageDie();
 }
+$_GET['id'] = (int) $_GET['id'];
 
 $res = $GLOBALS['db']->GetRow("SELECT bid, ba.type, ba.authid, ba.name, created, ends, length, reason, ba.aid, ba.sid, ad.user, ad.gid
     FROM " . DB_PREFIX . "_comms AS ba
     LEFT JOIN " . DB_PREFIX . "_admins AS ad ON ba.aid = ad.aid
-    WHERE bid = {$_GET['id']}");
+    WHERE bid = ?", array($_GET['id']));
 
 if (!$userbank->HasAccess(ADMIN_OWNER | ADMIN_EDIT_ALL_BANS) && (!$userbank->HasAccess(ADMIN_EDIT_OWN_BANS) && $res[8] != $userbank->GetAid()) && (!$userbank->HasAccess(ADMIN_EDIT_GROUP_BANS) && $res->fields['gid'] != $userbank->GetProperty('gid'))) {
     echo '<script>ShowBox("Error", "You don\'t have access to this!", "red", "index.php?p=admin&c=comms");</script>';
@@ -118,7 +119,7 @@ if (isset($_POST['name'])) {
 
     // Only process if there are still no errors
     if ($error == 0) {
-        $lengthrev = $GLOBALS['db']->Execute("SELECT length, authid, type FROM " . DB_PREFIX . "_comms WHERE bid = '" . (int) $_GET['id'] . "'");
+        $lengthrev = $GLOBALS['db']->Execute("SELECT length, authid, type FROM " . DB_PREFIX . "_comms WHERE bid = ?", array($_GET['id']));
         $edit = $GLOBALS['db']->Execute(
             "UPDATE " . DB_PREFIX . "_comms SET
             `name` = ?, `type` = ?, `reason` = ?, `authid` = ?,


### PR DESCRIPTION
## Summary

Audits the codebase for SQL injection and patches the exploitable cases in the web panel and the SourceMod plugin.

### Web panel
- **`web/pages/admin.edit.adminperms.php:37`** *(highest impact)* — `$_GET['id']` was concatenated into the SELECT with double quotes **before** the `(int)` cast on line 51, so any user with the edit-admins page open could inject via `?id=1" OR "1"="1` etc. Validation + int cast + parameterized query.
- **`web/pages/admin.edit.ban.php:39,44,178,149`** — `$_GET['id']` interpolated into multiple ban-detail / demo / length lookups; mitigated by `is_numeric()` but still bad practice. Switched to parameterized queries with an explicit int cast.
- **`web/pages/admin.edit.comms.php:41,121`** — same treatment as above.
- **`web/includes/sb-callback.php`** — `PrepareReblock` and `PrepareBlockFromBan` xajax callbacks took `$bid` from the JS client and put it into SQL without an int cast. Added the cast and converted to parameterized queries.

### SourceMod plugin (`sbpp_main.sp`)
- **`CommandBanIp` (line 601)**, **`CommandUnban` (lines 653, 655)**, **`CommandAddBan` (line 739)** — the admin-typed first argument (`arg` / `authid`) was formatted directly into the SQL query. Any admin with these commands could inject via crafted args (e.g. `sm_unban "STEAM_0:0:1' OR '1'='1"`). Now passed through `DB.Escape` before formatting.
- **`ServerInfoCallback` (line 1670)** — auto-add inserted the `rcon_password` cvar and game folder name unescaped. A single quote in an rcon password would break the insert; defense-in-depth says escape both. Now escaped via `db.Escape`.

### Verified safe (no change needed)
- All sites that already do `(int)` cast before the query (`admin.edit.server.php`, `admin.edit.group.php`, the unban/delete loops in `page.banlist.php` / `page.commslist.php`, every xajax callback that casts at function entry).
- Login / lost-password flow — already uses prepared statements.
- Plugin queries that only embed `g_sSteamIDs[]` / `g_sPlayerIP[]` / `GetClientIP()` / `GetClientAuthId()` results — fixed-format engine output, cannot contain quotes.
- `sbpp_report.sp`, `sbpp_admcfg*.sp`, `sbpp_sleuth.sp`, `sbpp_checker.sp` — no exploitable patterns found.

## Test plan
- [ ] Edit an admin's web permissions via `index.php?p=admin&c=admins` → click edit → verify the page loads and shows correct permissions
- [ ] Edit a ban via the ban list → verify detail page populates and saving works
- [ ] Edit a comm/mute block → same
- [ ] Use the "Reblock" / "Block from Ban" buttons (xajax) → verify the form prefills correctly
- [ ] In-game: `sm_banip <name> 30 reason` → ban inserted; `sm_unban <steamid>` → unban works; `sm_addban 30 STEAM_0:0:1 reason` → ban added
- [ ] Auto-add server flow on a fresh server with an rcon password containing a `'` → server row inserted without breaking the query