### PR TITLE
fix(security): set HttpOnly, SameSite, Secure on auth cookies

### DIFF
--- a/web/includes/auth/Auth.php
+++ b/web/includes/auth/Auth.php
@@ -90,18 +90,14 @@ class Auth
      */
     private static function setCookie(string $data, int $lifetime, string $domain, bool $secure): void
     {
-        if (version_compare(PHP_VERSION, '7.3.0') >= 0) {
-            setcookie('sbpp_auth', $data, [
-                'expires' => $lifetime,
-                'path' => '/',
-                'domain' => $domain,
-                'secure' => $secure,
-                'httponly' => true,
-                'samesite' => 'Lax'
-            ]);
-        } else {
-            setcookie('sbpp_auth', $data, $lifetime, '/', $domain, $secure, true);
-        }
+        setcookie('sbpp_auth', $data, [
+            'expires' => $lifetime,
+            'path' => '/',
+            'domain' => $domain,
+            'secure' => $secure,
+            'httponly' => true,
+            'samesite' => 'Lax'
+        ]);
     }
 
     /**


### PR DESCRIPTION
## Summary

Resolves #1074. The auth cookie helper in `web/includes/auth/Auth.php` previously had two code paths: an array-options call (PHP >= 7.3) and a positional fallback (PHP < 7.3). The fallback was dead code (composer.json requires PHP >= 8.2) and additionally lacked the `samesite` flag entirely. This PR removes the fallback so every cookie write goes through the array form with `HttpOnly`, `SameSite=Lax`, and conditional `Secure`.

## Audit results

Per the issue, I ran:

```
grep -rn "setcookie\|session_set_cookie_params" web/ \
  | grep -v "/vendor/" | grep -v "/tinymce/"
```

Only one source file matched: `web/includes/auth/Auth.php` (lines 94 and 103 pre-fix). There are no `session_set_cookie_params()` calls anywhere in `web/` outside vendored code, and no other `setcookie()` callers exist (no "remember me" cookie, no separate CSRF cookie, no admin-panel cookie, etc.). After the fix, the only remaining match is the array-form `setcookie('sbpp_auth', $data, [...])` call.

## Files changed

- `web/includes/auth/Auth.php` (lines 91-101): removed the `version_compare(PHP_VERSION, '7.3.0')` branch and its positional `setcookie(...)` fallback (which had no `samesite`); kept the existing array-form call as the sole code path. Path (`/`), domain (`Host::cookieDomain()`), expires (`time() + $maxlife` on login, `1` on logout), and `secure` (`Host::isSecure()`) are all preserved.

## HTTPS-detection helper

Reused the existing `Host::isSecure()` helper in `web/includes/auth/Host.php`, which is already passed in by both `Auth::login()` and `Auth::logout()`:

```php
public static function isSecure(): bool
{
    $isHttps = isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] === 'on';
    if (!$isHttps)
        $isHttps = isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER['HTTP_X_FORWARDED_PROTO'] === 'https';
    return $isHttps;
}
```

This keeps detection consistent with `Host::protocol()` and other existing call sites.

## Cookies intentionally skipped

None. The `sbpp_auth` JWT cookie is the only application-set cookie in scope, and it is only ever read server-side (via `$_COOKIE['sbpp_auth']` in `Auth::getJWTFromCookie()`), so `HttpOnly=true` is safe.

## Test plan

- [ ] Log in over HTTPS and confirm the `sbpp_auth` response cookie carries `HttpOnly`, `SameSite=Lax`, and `Secure` (browser devtools / `curl -i`).
- [ ] Log in over plain HTTP (dev) and confirm the cookie carries `HttpOnly`, `SameSite=Lax`, and *no* `Secure` flag (would otherwise be dropped by the browser).
- [ ] Log out and confirm the expiring cookie write also carries the same flags.
- [ ] Confirm `document.cookie` in the browser console does not expose `sbpp_auth`.

Closes #1074