### PR TITLE
chore(deps): pin xpaw/php-source-query-class

### DIFF
--- a/web/composer.json
+++ b/web/composer.json
@@ -22,7 +22,7 @@
         "lcobucci/jwt": "^5.0",
         "maxmind-db/reader": "~1.0",
         "smarty/smarty": "^v5.4",
-        "xpaw/php-source-query-class": "dev-master",
+        "xpaw/php-source-query-class": "^6.0.0",
         "adodb/adodb-php": "^5.22",
         "symfony/mailer": "^7.2",
         "ext-pdo": "*",

--- a/web/composer.lock
+++ b/web/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "22ca493463c1934a272e792d89a6496d",
+    "content-hash": "d69e3672123f834080b9808142157dc4",
     "packages": [
         {
             "name": "adodb/adodb-php",
@@ -1360,27 +1360,26 @@
         },
         {
             "name": "xpaw/php-source-query-class",
-            "version": "dev-master",
+            "version": "6.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/xPaw/PHP-Source-Query.git",
-                "reference": "18423a4efd80cb9786741d1308e0b392e8059a56"
+                "reference": "fe854e0e582b3da4261034bbc0f1e9b1e5e5bd73"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/xPaw/PHP-Source-Query/zipball/18423a4efd80cb9786741d1308e0b392e8059a56",
-                "reference": "18423a4efd80cb9786741d1308e0b392e8059a56",
+                "url": "https://api.github.com/repos/xPaw/PHP-Source-Query/zipball/fe854e0e582b3da4261034bbc0f1e9b1e5e5bd73",
+                "reference": "fe854e0e582b3da4261034bbc0f1e9b1e5e5bd73",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1"
+                "php": ">=8.2"
             },
             "require-dev": {
-                "phpstan/phpstan": "^1.10",
-                "phpstan/phpstan-strict-rules": "^1.6",
-                "phpunit/phpunit": "^10.3"
+                "phpstan/phpstan": "^2.0",
+                "phpstan/phpstan-strict-rules": "^2.0",
+                "phpunit/phpunit": "^12.0"
             },
-            "default-branch": true,
             "type": "library",
             "autoload": {
                 "psr-4": {
@@ -1405,17 +1404,21 @@
                 "team fortress"
             ],
             "support": {
-                "source": "https://github.com/xPaw/PHP-Source-Query/tree/master"
+                "source": "https://github.com/xPaw/PHP-Source-Query/tree/6.0.0"
             },
-            "time": "2024-09-24T20:06:19+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/sponsors/xPaw",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-01-29T10:35:30+00:00"
         }
     ],
     "packages-dev": [],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": {
-        "xpaw/php-source-query-class": 20
-    },
+    "stability-flags": {},
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
@@ -1424,5 +1427,5 @@
         "php": ">=8.2"
     },
     "platform-dev": {},
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.9.0"
 }


### PR DESCRIPTION
## Summary

Pins `xpaw/php-source-query-class` from the unbounded `dev-master` constraint to the tagged `^6.0.0` release in `web/composer.json` (and the corresponding `web/composer.lock` entry).

## Why

`dev-master` resolves to whatever commit is at the upstream HEAD on https://github.com/xPaw/PHP-Source-Query at install time, with no reproducibility, no review of upstream changes, and direct supply-chain exposure to anyone with push access to that repo.

## Version chosen

`^6.0.0` (tag `6.0.0`, commit `fe854e0e582b3da4261034bbc0f1e9b1e5e5bd73`, published 2026-01-29). Rationale:

- Latest stable upstream tag (no rc/beta).
- Requires PHP `>=8.2`, which matches our existing `web/composer.json` `php` platform requirement (`>=8.2`).
- Release notes for 6.0.0 are bug-fix only (no API breaks): incorrect `INVALID_ENGINE` value in `SocketException` fixed, `ord` deprecation warning in `ReadByte` fixed, phpstan array shape types improved.
- Previous lock pointed at upstream commit `18423a4` (~ Sep 2024) which was on the 5.x line; jumping to 6.0.0 just adds the bug fixes above.

## Smoke check

Searched `web/` for actual usage (`grep -rn "SourceQuery" web/`). Three call sites:

- `web/includes/system-functions.php` (rcon())
- `web/pages/page.submit.php`
- `web/includes/sb-callback.php`

All callers use only the high-level public API: `new SourceQuery()`, `Connect()`, `SetRconPassword()`, `Rcon()`, `Disconnect()`, the `SourceQuery::SOURCE` constant, and the `\xPaw\SourceQuery\Exception\AuthenticationException` class. Verified each of these symbols still exists in the installed v6.0.0 source. No `Buffer`/`bootstrap.php` usage in our code, so the v5.0.0 internal renames are not a concern.

## Lock file diff

Only the `xpaw/php-source-query-class` package entry changed (plus the resulting `content-hash` and `stability-flags`, and an incidental `plugin-api-version` bump from running a newer composer locally). No other dependency was touched: `composer update xpaw/php-source-query-class` was used, not a full update.

Closes #1077