### PR TITLE
fix(security): URL-encode user input in generated hrefs

### DIFF
--- a/web/includes/SteamID/VanityURL.php
+++ b/web/includes/SteamID/VanityURL.php
@@ -15,7 +15,7 @@ class VanityURL
      */
     public static function resolve($url, $steamApiKey)
     {
-        $endpoint = "https://api.steampowered.com/ISteamUser/ResolveVanityURL/v1/?key=$steamApiKey&vanityurl=$url";
+        $endpoint = 'https://api.steampowered.com/ISteamUser/ResolveVanityURL/v1/?key=' . urlencode($steamApiKey) . '&vanityurl=' . urlencode($url);
 
         //TODO: Rewrite with curl
         $data = json_decode(file_get_contents($endpoint), true);

--- a/web/includes/sb-callback.php
+++ b/web/includes/sb-callback.php
@@ -274,7 +274,7 @@ function LostPassword(string $email)
     $GLOBALS['PDO']->bind(':email', $email);
     $GLOBALS['PDO']->execute();
 
-    $passResetUrl = Host::complete(true) . "/index.php?p=lostpassword&email=$email&validation=$validation";
+    $passResetUrl = Host::complete(true) . '/index.php?p=lostpassword&email=' . urlencode($email) . '&validation=' . urlencode($validation);
 
     $isEmailSent = Mail::send($email, EmailType::PasswordReset, [
         '{link}' => $passResetUrl,
@@ -1653,8 +1653,8 @@ function ServerHostPlayers($sid, $type="servers", $obId="", $tplsid="", $open=""
                                 $objResponse->addScript(
                                     'AddContextMenu("#player_s'.$sid.'p'.$player["Id"].'", "contextmenu", true, "Player Commands", [
                                     {name: "Kick", callback: function(){KickPlayerConfirm('.$sid.', "'.str_replace('"', '\"', $player["Name"]).'", 0);}},
-                                    {name: "Block Comms", callback: function(){window.location = "index.php?p=admin&c=comms&action=pasteBan&sid='.$sid.'&pName='.str_replace('"', '\"', $player["Name"]).'"}},
-                                    {name: "Ban", callback: function(){window.location = "index.php?p=admin&c=bans&action=pasteBan&sid='.$sid.'&pName='.str_replace('"', '\"', $player["Name"]).'"}},
+                                    {name: "Block Comms", callback: function(){window.location = "index.php?p=admin&c=comms&action=pasteBan&sid='.urlencode($sid).'&pName='.urlencode($player["Name"]).'"}},
+                                    {name: "Ban", callback: function(){window.location = "index.php?p=admin&c=bans&action=pasteBan&sid='.urlencode($sid).'&pName='.urlencode($player["Name"]).'"}},
                                     {separator: true},
                                     '.(ini_get('safe_mode')==0 ? '{name: "View Profile", callback: function(){ViewCommunityProfile('.$sid.', "'.str_replace('"', '\"', $player["Name"]).'")}},':'').'
                                     {name: "Send Message", callback: function(){OpenMessageBox('.$sid.', "'.str_replace('"', '\"', $player["Name"]).'", 1)}}
@@ -3317,7 +3317,7 @@ function GetGroups($friendid)
         }
     } else {
         $objResponse->addScript(
-            "ShowBox('Error', 'There was an error retrieving the group data. <br>Maybe the player isn\'t member of any group or his profile is private?<br><a href=\"http://steamcommunity.com/profiles/" . $friendid . "/\" title=\"Community profile\" target=\"_blank\">Community profile</a>', 'red', 'index.php?p=banlist', true);"
+            "ShowBox('Error', 'There was an error retrieving the group data. <br>Maybe the player isn\'t member of any group or his profile is private?<br><a href=\"http://steamcommunity.com/profiles/" . urlencode($friendid) . "/\" title=\"Community profile\" target=\"_blank\">Community profile</a>', 'red', 'index.php?p=banlist', true);"
         );
         $objResponse->addScript("$('steamGroupsText').innerHTML = '<i>No groups...</i>';");
         return $objResponse;

--- a/web/pages/admin.bans.php
+++ b/web/pages/admin.bans.php
@@ -514,7 +514,7 @@ foreach ($submissions as $sub) {
 												WHERE demtype = \"S\" AND demid = " . (int) $sub['subid']);
 
     if ($dem && !empty($dem['filename']) && @file_exists(SB_DEMOS . "/" . $dem['filename'])) {
-        $sub['demo'] = "<a href=\"getdemo.php?id=" . $sub['subid'] . "&type=S\"><i class='fas fa-video fa-lg'></i> Get Demo</a>";
+        $sub['demo'] = '<a href="getdemo.php?id=' . urlencode($sub['subid']) . '&type=S"><i class=\'fas fa-video fa-lg\'></i> Get Demo</a>';
     } else {
         $sub['demo'] = "<a href=\"#\"><i class='fas fa-video-slash fa-lg'></i> No Demo</a>";
     }
@@ -651,7 +651,7 @@ foreach ($submissionsarchiv as $sub) {
 												WHERE demtype = \"S\" AND demid = " . (int) $sub['subid']);
 
     if ($dem && !empty($dem['filename']) && @file_exists(SB_DEMOS . "/" . $dem['filename'])) {
-        $sub['demo'] = "<a href=\"getdemo.php?id=" . $sub['subid'] . "&type=S\"><i class='fas fa-video fa-lg'></i> Get Demo</a>";
+        $sub['demo'] = '<a href="getdemo.php?id=' . urlencode($sub['subid']) . '&type=S"><i class=\'fas fa-video fa-lg\'></i> Get Demo</a>';
     } else {
         $sub['demo'] = "<a href=\"#\"><i class='fas fa-video-slash fa-lg'></i> No Demo</a>";
     }

--- a/web/pages/admin.edit.admingroup.php
+++ b/web/pages/admin.edit.admingroup.php
@@ -73,7 +73,7 @@ if (isset($_POST['wg']) || isset($_GET['wg']) || isset($_GET['sg'])) {
     $password = $GLOBALS['userbank']->GetProperty('password', $_GET['id']);
     $email    = $GLOBALS['userbank']->GetProperty('email', $_GET['id']);
     if ($_POST['wg'] > 0 && (empty($password) || empty($email))) {
-        echo '<script>ShowBox("Error", "Admins have to have a password and email set in order to get web permissions.<br /><a href=\"index.php?p=admin&c=admins&o=editdetails&id=' . $_GET['id'] . '\" title=\"Edit Admin Details\">Set the details</a> first and try again.", "red");</script>';
+        echo '<script>ShowBox("Error", "Admins have to have a password and email set in order to get web permissions.<br /><a href=\"index.php?p=admin&c=admins&o=editdetails&id=' . urlencode($_GET['id']) . '\" title=\"Edit Admin Details\">Set the details</a> first and try again.", "red");</script>';
     } else {
         if (isset($_POST['wg']) && $_POST['wg'] != "-2") {
             if ($_POST['wg'] == -1) {

--- a/web/pages/admin.edit.ban.php
+++ b/web/pages/admin.edit.ban.php
@@ -49,7 +49,7 @@ if (!$userbank->HasAccess(ADMIN_OWNER | ADMIN_EDIT_ALL_BANS) && (!$userbank->Has
     PageDie();
 }
 
-isset($_GET["page"]) ? $pagelink = "&page=" . $_GET["page"] : $pagelink = "";
+isset($_GET["page"]) ? $pagelink = "&page=" . urlencode($_GET["page"]) : $pagelink = "";
 
 $errorScript = "";
 

--- a/web/pages/admin.edit.comms.php
+++ b/web/pages/admin.edit.comms.php
@@ -46,7 +46,7 @@ if (!$userbank->HasAccess(ADMIN_OWNER | ADMIN_EDIT_ALL_BANS) && (!$userbank->Has
     PageDie();
 }
 
-isset($_GET["page"]) ? $pagelink = "&page=" . $_GET["page"] : $pagelink = "";
+isset($_GET["page"]) ? $pagelink = "&page=" . urlencode($_GET["page"]) : $pagelink = "";
 
 $errorScript = "";
 

--- a/web/pages/admin.settings.php
+++ b/web/pages/admin.settings.php
@@ -73,7 +73,7 @@ if (isset($_GET['advSearch'])) {
 //            $_GET['advSearch'] = "";
 //            break;
 //    }
-    $searchlink = "&advSearch=" . $_GET['advSearch'] . "&advType=" . $_GET['advType'];
+    $searchlink = "&advSearch=" . urlencode($_GET['advSearch']) . "&advType=" . urlencode($_GET['advType']);
 } else {
     $searchlink = "";
 }

--- a/web/pages/core/title.php
+++ b/web/pages/core/title.php
@@ -8,7 +8,7 @@ $breadcrumb = [
     ],
     [
         'title' => $title,
-        'url' => 'index.php?p='.filter_input(INPUT_GET, 'p', FILTER_SANITIZE_SPECIAL_CHARS)
+        'url' => 'index.php?p=' . urlencode((string) filter_input(INPUT_GET, 'p', FILTER_SANITIZE_SPECIAL_CHARS))
     ]
 ];
 

--- a/web/pages/page.banlist.php
+++ b/web/pages/page.banlist.php
@@ -271,7 +271,7 @@ if (isset($_GET['searchText'])) {
         $search,
         $search
     )));
-    $searchlink = "&searchText=" . $_GET["searchText"];
+    $searchlink = "&searchText=" . urlencode($_GET["searchText"]);
 } elseif (!isset($_GET['advSearch'])) {
     $res = $GLOBALS['db']->Execute("SELECT bid ban_id, BA.type, BA.ip ban_ip, BA.authid, BA.name player_name, created ban_created, ends ban_ends, length ban_length, reason ban_reason, BA.ureason unban_reason, BA.aid, AD.gid AS gid, adminIp, BA.sid ban_server, country ban_country, RemovedOn, RemovedBy, RemoveType row_type,
 			SE.ip server_ip, AD.user admin_name, AD.gid, MO.icon as mod_icon,
@@ -467,7 +467,7 @@ if (isset($_GET['advSearch'])) {
 
     $res_count  = $GLOBALS['db']->Execute("SELECT count(BA.bid) FROM " . DB_PREFIX . "_bans AS BA
 										  " . ($type == "comment" && $userbank->is_admin() ? "LEFT JOIN " . DB_PREFIX . "_comments AS CO ON BA.bid = CO.bid" : "") . " " . $where . $hideinactive, $advcrit);
-    $searchlink = "&advSearch=" . $_GET['advSearch'] . "&advType=" . $_GET['advType'];
+    $searchlink = "&advSearch=" . urlencode($_GET['advSearch']) . "&advType=" . urlencode($_GET['advType']);
 }
 
 $BanCount = $res_count->fields[0];
@@ -592,8 +592,8 @@ while (!$res->EOF) {
         $data['reban_link'] = false;
     }
     $data['blockcomm_link']  = CreateLinkR('<i class="fas fa-ban fa-lg"></i> Block Comms', "index.php?p=admin&c=comms" . $pagelink . "&blockfromban=" . $res->fields['ban_id'] . "&key=" . $_SESSION['banlist_postkey'] . "#^0");
-    $data['details_link']    = CreateLinkR('click', 'getdemo.php?type=B&id=' . $res->fields['ban_id']);
-    $data['groups_link']     = CreateLinkR('<i class="fas fa-users fa-lg"></i> Show Groups', "index.php?p=admin&c=bans&fid=" . $data['communityid'] . "#^4");
+    $data['details_link']    = CreateLinkR('click', 'getdemo.php?type=B&id=' . urlencode($res->fields['ban_id']));
+    $data['groups_link']     = CreateLinkR('<i class="fas fa-users fa-lg"></i> Show Groups', "index.php?p=admin&c=bans&fid=" . urlencode($data['communityid']) . "#^4");
     $data['friend_ban_link'] = CreateLinkR('<i class="fas fa-trash fa-lg"></i> Ban Friends', '#', '', '_self', false, "BanFriendsProcess('" . $data['communityid'] . "','" . $data['player'] . "');return false;");
     $data['edit_link']       = CreateLinkR('<i class="fas fa-edit fa-lg"></i> Edit Details', "index.php?p=admin&c=bans&o=edit" . $pagelink . "&id=" . $res->fields['ban_id'] . "&key=" . $_SESSION['banlist_postkey']);
 
@@ -612,7 +612,7 @@ while (!$res->EOF) {
     $data['mod_icon'] = '<img src="images/games/' . $modicon . '" alt="MOD" border="0" align="absmiddle" />&nbsp;' . $data['country'];
 
     if ($res->fields['history_count'] > 1) {
-        $data['prevoff_link'] = $res->fields['history_count'] . " " . CreateLinkR("&nbsp;(search)", "index.php?p=banlist&searchText=" . ($data['type'] == 0 ? $data['steamid'] : $res->fields['ban_ip']) . "&Submit");
+        $data['prevoff_link'] = $res->fields['history_count'] . " " . CreateLinkR("&nbsp;(search)", "index.php?p=banlist&searchText=" . urlencode($data['type'] == 0 ? $data['steamid'] : $res->fields['ban_ip']) . "&Submit");
     } else {
         $data['prevoff_link'] = "No previous bans";
     }
@@ -638,8 +638,8 @@ while (!$res->EOF) {
         $data['demo_link']      = CreateLinkR('<i class="fas fa-video-slash fa-lg"></i> No Demos', "#");
     } else {
         $data['demo_available'] = true;
-        $data['demo_quick']     = CreateLinkR('Demo', "getdemo.php?type=B&id=" . $data['ban_id']);
-        $data['demo_link']      = CreateLinkR('<i class="fas fa-video fa-lg"></i> Review Demo', "getdemo.php?type=B&id=" . $data['ban_id']);
+        $data['demo_quick']     = CreateLinkR('Demo', "getdemo.php?type=B&id=" . urlencode($data['ban_id']));
+        $data['demo_link']      = CreateLinkR('<i class="fas fa-video fa-lg"></i> Review Demo', "getdemo.php?type=B&id=" . urlencode($data['ban_id']));
     }
 
 
@@ -724,7 +724,7 @@ while (!$res->EOF) {
 }
 
 if (isset($_GET['advSearch'])) {
-    $advSearchString = "&advSearch=" . (isset($_GET['advSearch']) ? $_GET['advSearch'] : '') . "&advType=" . (isset($_GET['advType']) ? $_GET['advType'] : '');
+    $advSearchString = "&advSearch=" . urlencode(isset($_GET['advSearch']) ? $_GET['advSearch'] : '') . "&advType=" . urlencode(isset($_GET['advType']) ? $_GET['advType'] : '');
 } else {
     $advSearchString = '';
 }
@@ -733,7 +733,7 @@ if ($page > 1) {
     if (isset($_GET['c']) && $_GET['c'] == "bans") {
         $prev = CreateLinkR('<i class="fas fa-arrow-left fa-lg"></i> prev', "javascript:void(0);", "", "_self", false, $prev);
     } else {
-        $prev = CreateLinkR('<i class="fas fa-arrow-left fa-lg"></i> prev', "index.php?p=banlist&page=" . ($page - 1) . (isset($_GET['searchText']) > 0 ? "&searchText=" . $_GET['searchText'] : '' . $advSearchString));
+        $prev = CreateLinkR('<i class="fas fa-arrow-left fa-lg"></i> prev', "index.php?p=banlist&page=" . ($page - 1) . (isset($_GET['searchText']) > 0 ? "&searchText=" . urlencode($_GET['searchText']) : '' . $advSearchString));
     }
 } else {
     $prev = "";
@@ -745,7 +745,7 @@ if ($BansEnd < $BanCount) {
         }
         $next = CreateLinkR('next <i class="fas fa-arrow-right fa-lg"></i>', "javascript:void(0);", "", "_self", false, $nxt);
     } else {
-        $next = CreateLinkR('next <i class="fas fa-arrow-right fa-lg"></i>', "index.php?p=banlist&page=" . ($page + 1) . (isset($_GET['searchText']) ? "&searchText=" . $_GET['searchText'] : '' . $advSearchString));
+        $next = CreateLinkR('next <i class="fas fa-arrow-right fa-lg"></i>', "index.php?p=banlist&page=" . ($page + 1) . (isset($_GET['searchText']) ? "&searchText=" . urlencode($_GET['searchText']) : '' . $advSearchString));
     }
 } else {
     $next = "";

--- a/web/pages/page.commslist.php
+++ b/web/pages/page.commslist.php
@@ -264,7 +264,7 @@ if (isset($_GET['searchText'])) {
         $search,
         $search
     ));
-    $searchlink = "&searchText=" . $_GET["searchText"];
+    $searchlink = "&searchText=" . urlencode($_GET["searchText"]);
 } elseif (!isset($_GET['advSearch'])) {
     $res = $GLOBALS['db']->Execute("SELECT bid ban_id, CO.type, CO.authid, CO.name player_name, created ban_created, ends ban_ends, length ban_length, reason ban_reason, CO.ureason unban_reason, CO.aid, AD.gid AS gid, adminIp, CO.sid ban_server, RemovedOn, RemovedBy, RemoveType row_type,
 		SE.ip server_ip, AD.user admin_name, MO.icon as mod_icon,
@@ -439,7 +439,7 @@ if (isset($_GET['advSearch'])) {
 
     $res_count  = $GLOBALS['db']->Execute("SELECT count(CO.bid) FROM " . DB_PREFIX . "_comms AS CO
 										  " . ($type == "comment" && $userbank->is_admin() ? "LEFT JOIN " . DB_PREFIX . "_comments AS CM ON CO.bid = CM.bid" : "") . " " . $where . $hideinactive, $advcrit);
-    $searchlink = "&advSearch=" . $_GET['advSearch'] . "&advType=" . $_GET['advType'];
+    $searchlink = "&advSearch=" . urlencode($_GET['advSearch']) . "&advType=" . urlencode($_GET['advType']);
 }
 
 $BanCount = $res_count->fields[0];
@@ -594,7 +594,7 @@ while (!$res->EOF) {
     $data['mod_icon'] = '<img src="images/games/' . $modicon . '" alt="MOD" border="0" align="absmiddle" />&nbsp;' . $data['type_icon'];
 
     if ($history_count > 1) {
-        $data['prevoff_link'] = $history_count . " " . CreateLinkR("&nbsp;(search)", "index.php?p=commslist&searchText=" . $data['steamid'] . "&Submit");
+        $data['prevoff_link'] = $history_count . " " . CreateLinkR("&nbsp;(search)", "index.php?p=commslist&searchText=" . urlencode($data['steamid']) . "&Submit");
     } else {
         $data['prevoff_link'] = "No previous blocks";
     }
@@ -683,7 +683,7 @@ while (!$res->EOF) {
 }
 
 if (isset($_GET['advSearch'])) {
-    $advSearchString = "&advSearch=" . (isset($_GET['advSearch']) ? $_GET['advSearch'] : '') . "&advType=" . (isset($_GET['advType']) ? $_GET['advType'] : '');
+    $advSearchString = "&advSearch=" . urlencode(isset($_GET['advSearch']) ? $_GET['advSearch'] : '') . "&advType=" . urlencode(isset($_GET['advType']) ? $_GET['advType'] : '');
 } else {
     $advSearchString = '';
 }
@@ -692,7 +692,7 @@ if ($page > 1) {
     if (isset($_GET['c']) && $_GET['c'] == "comms") {
         $prev = CreateLinkR('<i class="fas fa-arrow-left fa-lg"></i> prev', "javascript:void(0);", "", "_self", false, $prev);
     } else {
-        $prev = CreateLinkR('<i class="fas fa-arrow-left fa-lg"></i> prev', "index.php?p=commslist&page=" . ($page - 1) . (isset($_GET['searchText']) > 0 ? "&searchText=" . $_GET['searchText'] : '' . $advSearchString));
+        $prev = CreateLinkR('<i class="fas fa-arrow-left fa-lg"></i> prev', "index.php?p=commslist&page=" . ($page - 1) . (isset($_GET['searchText']) > 0 ? "&searchText=" . urlencode($_GET['searchText']) : '' . $advSearchString));
     }
 } else {
     $prev = "";
@@ -704,7 +704,7 @@ if ($BansEnd < $BanCount) {
         }
         $next = CreateLinkR('next <i class="fas fa-arrow-right fa-lg"></i>', "javascript:void(0);", "", "_self", false, $nxt);
     } else {
-        $next = CreateLinkR('next <i class="fas fa-arrow-right fa-lg"></i>', "index.php?p=commslist&page=" . ($page + 1) . (isset($_GET['searchText']) ? "&searchText=" . $_GET['searchText'] : '' . $advSearchString));
+        $next = CreateLinkR('next <i class="fas fa-arrow-right fa-lg"></i>', "index.php?p=commslist&page=" . ($page + 1) . (isset($_GET['searchText']) ? "&searchText=" . urlencode($_GET['searchText']) : '' . $advSearchString));
     }
 } else {
     $next = "";

--- a/web/pages/page.home.php
+++ b/web/pages/page.home.php
@@ -53,11 +53,11 @@ while (!$res->EOF) {
 
     if ($res->fields['type'] == 1) {
         if ($userbank->is_admin())
-            $info['search_link'] = "index.php?p=banlist&advSearch=$info[ip]&advType=ip&Submit";
+            $info['search_link'] = 'index.php?p=banlist&advSearch=' . urlencode($info['ip']) . '&advType=ip&Submit';
         else
-            $info['search_link'] = "index.php?p=banlist&advSearch=$info[name]&advType=name";
+            $info['search_link'] = 'index.php?p=banlist&advSearch=' . urlencode($info['name']) . '&advType=name';
     } else {
-        $info['search_link'] = "index.php?p=banlist&advSearch=" . $info['auth'] . "&advType=steamid&Submit";
+        $info['search_link'] = 'index.php?p=banlist&advSearch=' . urlencode($info['auth']) . '&advType=steamid&Submit';
     }
     $info['link_url'] = "window.location = '" . $info['search_link'] . "';";
 
@@ -112,11 +112,11 @@ while (!$res->EOF) {
     $info['ip']      = $res->fields[1];
     if ($res->fields[15] == 1) {
         if ($userbank->is_admin())
-            $info['search_link'] = "index.php?p=banlist&advSearch=$info[ip]&advType=ip&Submit";
+            $info['search_link'] = 'index.php?p=banlist&advSearch=' . urlencode($info['ip']) . '&advType=ip&Submit';
         else
-            $info['search_link'] = "index.php?p=banlist&advSearch=$info[name]&advType=name";
+            $info['search_link'] = 'index.php?p=banlist&advSearch=' . urlencode($info['name']) . '&advType=name';
     } else {
-        $info['search_link'] = "index.php?p=banlist&advSearch=" . $info['authid'] . "&advType=steamid&Submit";
+        $info['search_link'] = 'index.php?p=banlist&advSearch=' . urlencode($info['authid']) . '&advType=steamid&Submit';
     }
     $info['link_url']   = "window.location = '" . $info['search_link'] . "';";
     $info['short_name'] = trunc($cleaned_name, 40);
@@ -175,7 +175,7 @@ while (!$res->EOF) {
     $info['length']      = $ltemp[0];
     $info['icon']        = empty($res->fields[13]) ? 'web.png' : $res->fields[13];
     $info['authid']      = $res->fields['authid'];
-    $info['search_link'] = "index.php?p=commslist&advSearch=" . $info['authid'] . "&advType=steamid&Submit";
+    $info['search_link'] = 'index.php?p=commslist&advSearch=' . urlencode($info['authid']) . '&advType=steamid&Submit';
     $info['link_url']    = "window.location = '" . $info['search_link'] . "';";
     $info['short_name']  = trunc($cleaned_name, 40);
     $info['type']        = $res->fields['type'] == 2 ? "fas fa-comment-slash fa-lg" : "fas fa-microphone-slash fa-lg";

--- a/web/themes/default/page_admin_admins_list.tpl
+++ b/web/themes/default/page_admin_admins_list.tpl
@@ -20,7 +20,7 @@
                     </tr>
                     {foreach from=$admins item="admin"}
                         <tr onmouseout="this.className='tbl_out'" onmouseover="this.className='tbl_hover'" class="tbl_out opener">
-                            <td class="listtable_1" style="padding:3px;">{$admin.user} (<a href="./index.php?p=banlist&advSearch={$admin.aid}&advType=admin" title="Show bans">{$admin.bancount} bans</a> | <a href="./index.php?p=banlist&advSearch={$admin.aid}&advType=nodemo" title="Show bans without demo">{$admin.nodemocount} w.d.</a>)</td>
+                            <td class="listtable_1" style="padding:3px;">{$admin.user} (<a href="./index.php?p=banlist&advSearch={$admin.aid|escape:'url'}&advType=admin" title="Show bans">{$admin.bancount} bans</a> | <a href="./index.php?p=banlist&advSearch={$admin.aid|escape:'url'}&advType=nodemo" title="Show bans without demo">{$admin.nodemocount} w.d.</a>)</td>
                             <td class="listtable_1" style="padding:3px;">{$admin.server_group}</td>
                             <td class="listtable_1" style="padding:3px;">{$admin.web_group}</td>
                         </tr>
@@ -66,16 +66,16 @@
                                                     <ul>
                                                         {if $permission_editadmin}
                                                             <li>
-                                                                <a href="index.php?p=admin&c=admins&o=editdetails&id={$admin.aid}"><i class="fas fa-clipboard-list fa-lg"></i> Edit Details</a>
+                                                                <a href="index.php?p=admin&c=admins&o=editdetails&id={$admin.aid|escape:'url'}"><i class="fas fa-clipboard-list fa-lg"></i> Edit Details</a>
                                                             </li>
                                                             <li>
-                                                                <a href="index.php?p=admin&c=admins&o=editpermissions&id={$admin.aid}"><i class="fas fa-subscript fa-lg"></i> Edit Permissions</a>
+                                                                <a href="index.php?p=admin&c=admins&o=editpermissions&id={$admin.aid|escape:'url'}"><i class="fas fa-subscript fa-lg"></i> Edit Permissions</a>
                                                             </li>
                                                             <li>
-                                                                <a href="index.php?p=admin&c=admins&o=editservers&id={$admin.aid}"><i class="fas fa-server fa-lg"></i> Edit Server Access</a>
+                                                                <a href="index.php?p=admin&c=admins&o=editservers&id={$admin.aid|escape:'url'}"><i class="fas fa-server fa-lg"></i> Edit Server Access</a>
                                                             </li>
                                                             <li>
-                                                                <a href="index.php?p=admin&c=admins&o=editgroup&id={$admin.aid}"><i class="fas fa-users fa-lg"></i> Edit Groups</a>
+                                                                <a href="index.php?p=admin&c=admins&o=editgroup&id={$admin.aid|escape:'url'}"><i class="fas fa-users fa-lg"></i> Edit Groups</a>
                                                             </li>
                                                         {/if}
                                                         {if $permission_deleteadmin}

--- a/web/themes/default/page_admin_bans_protests.tpl
+++ b/web/themes/default/page_admin_bans_protests.tpl
@@ -15,13 +15,13 @@
             </tr>
             {foreach from=$protest_list item="protest"}
                 <tr id="pid_{$protest.pid}" class="opener2 tbl_out" onmouseout="this.className='tbl_out'" onmouseover="this.className='tbl_hover'">
-                    <td class="toggler listtable_1" height='16'><a href="./index.php?p=banlist&advSearch={$protest.authid}&advType=steamid" title="Show ban">{$protest.name}</a></td>
+                    <td class="toggler listtable_1" height='16'><a href="./index.php?p=banlist&advSearch={$protest.authid|escape:'url'}&advType=steamid" title="Show ban">{$protest.name}</a></td>
                     <td class="listtable_1" height='16'>{if $protest.authid!=""}{$protest.authid}{else}{$protest.ip}{/if}</td>
                     <td class="listtable_1" height='16'>
                         {if $permission_editban}
                             <a href="#" onclick="RemoveProtest('{$protest.pid}', '{if $protest.authid!=""}{$protest.authid}{else}{$protest.ip}{/if}', '1');">Remove</a> -
                         {/if}
-                        <a href="index.php?p=admin&c=bans&o=email&type=p&id={$protest.pid}">Contact</a>
+                        <a href="index.php?p=admin&c=bans&o=email&type=p&id={$protest.pid|escape:'url'}">Contact</a>
                     </td>
                 </tr>
                 <tr id="pid_{$protest.pid}a" >

--- a/web/themes/default/page_admin_bans_protests_archiv.tpl
+++ b/web/themes/default/page_admin_bans_protests_archiv.tpl
@@ -15,14 +15,14 @@
             </tr>
             {foreach from=$protest_list_archiv item="protest"}
                 <tr id="apid_{$protest.pid}" class="opener5 tbl_out" onmouseout="this.className='tbl_out'" onmouseover="this.className='tbl_hover'">
-                    <td class="toggler" style="border-bottom: solid 1px #ccc" height='16'>{if $protest.archiv!=2}<a href="./index.php?p=banlist{if $protest.authid!=""}&advSearch={$protest.authid}&advType=steamid{else}&advSearch={$protest.ip}&advType=ip{/if}" title="Show ban">{$protest.name}</a>{else}<i><font color="#677882">ban removed</font></i>{/if}</td>
+                    <td class="toggler" style="border-bottom: solid 1px #ccc" height='16'>{if $protest.archiv!=2}<a href="./index.php?p=banlist{if $protest.authid!=""}&advSearch={$protest.authid|escape:'url'}&advType=steamid{else}&advSearch={$protest.ip|escape:'url'}&advType=ip{/if}" title="Show ban">{$protest.name}</a>{else}<i><font color="#677882">ban removed</font></i>{/if}</td>
                     <td style="border-bottom: solid 1px #ccc" height='16'>{if $protest.authid!=""}{$protest.authid}{else}{$protest.ip}{/if}</td>
                     <td style="border-bottom: solid 1px #ccc" height='16'>
                         {if $permission_editban}
                             <a href="#" onclick="RemoveProtest('{$protest.pid}', '{if $protest.authid!=""}{$protest.authid}{else}{$protest.ip}{/if}', '2');">Restore</a> -
                             <a href="#" onclick="RemoveProtest('{$protest.pid}', '{if $protest.authid!=""}{$protest.authid}{else}{$protest.ip}{/if}', '0');">Delete</a> -
                         {/if}
-                        <a href="index.php?p=admin&c=bans&o=email&type=p&id={$protest.pid}">Contact</a>
+                        <a href="index.php?p=admin&c=bans&o=email&type=p&id={$protest.pid|escape:'url'}">Contact</a>
                     </td>
                 </tr>
                 <tr id="apid_{$protest.pid}a" >

--- a/web/themes/default/page_admin_bans_submissions.tpl
+++ b/web/themes/default/page_admin_bans_submissions.tpl
@@ -21,7 +21,7 @@
                     {if $permissions_editsub}
                         <a href="#" onclick="RemoveSubmission({$sub.subid}, '{$sub.name|smarty_stripslashes}', '1');return false;">Remove</a> -
                     {/if}
-                    <a href="index.php?p=admin&c=bans&o=email&type=s&id={$sub.subid}">Contact</a>
+                    <a href="index.php?p=admin&c=bans&o=email&type=s&id={$sub.subid|escape:'url'}">Contact</a>
                 </td>
             </tr>
             <tr id="sid_{$sub.subid}a">

--- a/web/themes/default/page_admin_bans_submissions_archiv.tpl
+++ b/web/themes/default/page_admin_bans_submissions_archiv.tpl
@@ -26,7 +26,7 @@
                     {if $permissions_editsub}
                         <a href="#" onclick="RemoveSubmission({$sub.subid}, '{$sub.name|smarty_stripslashes}', '0');">Delete</a> -
                     {/if}
-                    <a href="index.php?p=admin&c=bans&o=email&type=s&id={$sub.subid}">Contact</a>
+                    <a href="index.php?p=admin&c=bans&o=email&type=s&id={$sub.subid|escape:'url'}">Contact</a>
                 </td>
             </tr>
             <tr id="asid_{$sub.subid}a">

--- a/web/themes/default/page_admin_groups_list.tpl
+++ b/web/themes/default/page_admin_groups_list.tpl
@@ -27,7 +27,7 @@
                 <td class="listtable_1" height='16'>{$web_admins[$smarty.foreach.web_group.index]}</td>
                 <td class="listtable_1" height='16'>
                     {if $permission_editgroup}
-                        <a href="index.php?p=admin&c=groups&o=edit&type=web&id={$group.gid}">Edit</a>
+                        <a href="index.php?p=admin&c=groups&o=edit&type=web&id={$group.gid|escape:'url'}">Edit</a>
                     {/if}
                     {if $permission_deletegroup}
                         - <a href="#" onclick="RemoveGroup({$group.gid}, '{$group.name}', 'web');">Delete</a>
@@ -65,8 +65,8 @@
                                             <tr>
                                                 <td width="60%" height="16" class="listtable_1">{$web_admin.user}</td>
                                                 {if $permission_editadmin}
-                                                    <td width="20%" height="16" class="listtable_1"><a href="index.php?p=admin&c=admins&o=editgroup&id={$web_admin.aid}" title="Edit Groups">Edit</a></td>
-                                                    <td width="20%" height="16" class="listtable_1"><a href="index.php?p=admin&c=admins&o=editgroup&id={$web_admin.aid}&wg=" title="Remove From Group">Remove</a></td>
+                                                    <td width="20%" height="16" class="listtable_1"><a href="index.php?p=admin&c=admins&o=editgroup&id={$web_admin.aid|escape:'url'}" title="Edit Groups">Edit</a></td>
+                                                    <td width="20%" height="16" class="listtable_1"><a href="index.php?p=admin&c=admins&o=editgroup&id={$web_admin.aid|escape:'url'}&wg=" title="Remove From Group">Remove</a></td>
                                                 {/if}
                                             </tr>
                                         {/foreach}
@@ -104,7 +104,7 @@
                 <td class="listtable_1" height='16'>{$server_admins[$smarty.foreach.server_admin_group.index]}</td>
                 <td class="listtable_1" height='16'>
                     {if $permission_editgroup}
-                        <a href="index.php?p=admin&c=groups&o=edit&type=srv&id={$group.id}">Edit</a>
+                        <a href="index.php?p=admin&c=groups&o=edit&type=srv&id={$group.id|escape:'url'}">Edit</a>
                     {/if}
                     {if $permission_deletegroup}
                         - <a href="#" onclick="RemoveGroup({$group.id}, '{$group.name}', 'srv');">Delete</a>
@@ -142,8 +142,8 @@
                                             <tr>
                                                 <td width="60%" height="16" class="listtable_1">{$server_admin.user}</td>
                                                 {if $permission_editadmin}
-                                                    <td width="20%" height="16" class="listtable_1"><a href="index.php?p=admin&c=admins&o=editgroup&id={$server_admin.aid}" title="Edit Groups">Edit</a></td>
-                                                    <td width="20%" height="16" class="listtable_1"><a href="index.php?p=admin&c=admins&o=editgroup&id={$server_admin.aid}&sg=" title="Remove From Group">Remove</a></td>
+                                                    <td width="20%" height="16" class="listtable_1"><a href="index.php?p=admin&c=admins&o=editgroup&id={$server_admin.aid|escape:'url'}" title="Edit Groups">Edit</a></td>
+                                                    <td width="20%" height="16" class="listtable_1"><a href="index.php?p=admin&c=admins&o=editgroup&id={$server_admin.aid|escape:'url'}&sg=" title="Remove From Group">Remove</a></td>
                                                 {/if}
                                             </tr>
                                         {/foreach}
@@ -201,7 +201,7 @@
                 <td class="listtable_1" height='16'>{$server_counts[$smarty.foreach.server_group.index]}</td>
                 <td class="listtable_1" height='16'>
                     {if $permission_editgroup}
-                        <a href="index.php?p=admin&c=groups&o=edit&type=server&id={$group.gid}">Edit</a>
+                        <a href="index.php?p=admin&c=groups&o=edit&type=server&id={$group.gid|escape:'url'}">Edit</a>
                     {/if}
                     {if $permission_deletegroup}
                         - <a href="#" onclick="RemoveGroup({$group.gid}, '{$group.name}', 'server');">Delete</a>

--- a/web/themes/default/page_admin_mods_list.tpl
+++ b/web/themes/default/page_admin_mods_list.tpl
@@ -21,7 +21,7 @@
                 {if $permission_editmods || $permission_deletemods}
                     <td class="listtable_1" height='16'>
                         {if $permission_editmods}
-                            <a href="index.php?p=admin&c=mods&o=edit&id={$mod.mid}">Edit</a> -
+                            <a href="index.php?p=admin&c=mods&o=edit&id={$mod.mid|escape:'url'}">Edit</a> -
                         {/if}
                         {if $permission_deletemods}
                             <a href="#" onclick="RemoveMod('{$mod.name|escape:'quotes'|smarty_htmlspecialchars}', '{$mod.mid}');">Delete</a>

--- a/web/themes/default/page_admin_servers_list.tpl
+++ b/web/themes/default/page_admin_servers_list.tpl
@@ -22,13 +22,13 @@
                         <td style="border-bottom: solid 1px #ccc" height='16'><img width="16px" height="16px" src="images/games/{$server.icon}"></td>
                         <td style="border-bottom: solid 1px #ccc" height='16'>
                             {if $server.rcon_access}
-                                <a href="index.php?p=admin&c=servers&o=rcon&id={$server.sid}">RCON</a> -
+                                <a href="index.php?p=admin&c=servers&o=rcon&id={$server.sid|escape:'url'}">RCON</a> -
                             {/if}
 
-                            <a href="index.php?p=admin&c=servers&o=admincheck&id={$server.sid}">Admins</a>
+                            <a href="index.php?p=admin&c=servers&o=admincheck&id={$server.sid|escape:'url'}">Admins</a>
 
                             {if $permission_editserver}
-                                - <a href="index.php?p=admin&c=servers&o=edit&id={$server.sid}">Edit</a>
+                                - <a href="index.php?p=admin&c=servers&o=edit&id={$server.sid|escape:'url'}">Edit</a>
                             {/if}
 
                             {if $pemission_delserver}

--- a/web/themes/default/page_bans.tpl
+++ b/web/themes/default/page_bans.tpl
@@ -189,7 +189,7 @@
                                         {if empty($ban.steamid)}
                                             <i><font color="#677882">No Steam3 ID present</font></i>
                                         {else}
-                                            <a href="http://steamcommunity.com/profiles/{$ban.steamid3}" target="_blank">{$ban.steamid3}</a>
+                                            <a href="http://steamcommunity.com/profiles/{$ban.steamid3|escape:'url'}" target="_blank">{$ban.steamid3}</a>
                                         {/if}
                                     </td>
                                 </tr>
@@ -200,7 +200,7 @@
                                             {if empty($ban.steamid)}
                                                 <i><font color="#677882">No Steam Community ID present</font></i>
                                             {else}
-                                                <a href="http://steamcommunity.com/profiles/{$ban.communityid}" target="_blank">{$ban.communityid}</a>
+                                                <a href="http://steamcommunity.com/profiles/{$ban.communityid|escape:'url'}" target="_blank">{$ban.communityid}</a>
                                             {/if}
                                         </td>
                                     </tr>

--- a/web/themes/default/page_comms.tpl
+++ b/web/themes/default/page_comms.tpl
@@ -170,7 +170,7 @@
                                         {if empty($ban.steamid)}
                                             <i><font color="#677882">No Steam3 ID present</font></i>
                                         {else}
-                                            <a href="http://steamcommunity.com/profiles/{$ban.steamid3}" target="_blank">{$ban.steamid3}</a>
+                                            <a href="http://steamcommunity.com/profiles/{$ban.steamid3|escape:'url'}" target="_blank">{$ban.steamid3}</a>
                                         {/if}
                                     </td>
                                 </tr>
@@ -180,7 +180,7 @@
                                         {if empty($ban.steamid)}
                                             <i><font color="#677882">No Steam Community ID present</font></i>
                                         {else}
-                                            <a href="http://steamcommunity.com/profiles/{$ban.communityid}" target="_blank">{$ban.communityid}</a>
+                                            <a href="http://steamcommunity.com/profiles/{$ban.communityid|escape:'url'}" target="_blank">{$ban.communityid}</a>
                                         {/if}
                                     </td>
                                 </tr>


### PR DESCRIPTION
## Summary

Closes #1080.

User-controlled values (player names, IPs, ban subjects, search terms, IDs derived from `$_GET`) were being interpolated directly into query strings on generated `href`s without `urlencode()`. A name containing `&`, `<`, `>`, or `?` could break query parsing and host reflected XSS once the value was echoed back unescaped on the destination page.

This patch wraps every confirmed user-controlled interpolation with `urlencode()` in PHP and `|escape:'url'` in Smarty. It also fixes the array-key syntax `\$info[ip]` -> `\$info['ip']` in `web/pages/page.home.php` (undefined-constant access in PHP 8+).

### Before / After (web/pages/page.home.php)

Before:
```php
\$info['search_link'] = \"index.php?p=banlist&advSearch=\$info[ip]&advType=ip&Submit\";
```

After:
```php
\$info['search_link'] = 'index.php?p=banlist&advSearch=' . urlencode(\$info['ip']) . '&advType=ip&Submit';
```

### Files modified (21)

PHP:
- `web/includes/SteamID/VanityURL.php` (line 18: `\$steamApiKey`, `\$url`)
- `web/includes/sb-callback.php` (lines 277, 1656-1657, 3320: password-reset URL, paste-ban context-menu links, friendid)
- `web/pages/admin.bans.php` (lines 517, 654: `getdemo.php?id=`)
- `web/pages/admin.edit.admingroup.php` (line 76: `\$_GET['id']`)
- `web/pages/admin.edit.ban.php` (line 52: `\$pagelink` from `\$_GET['page']`)
- `web/pages/admin.edit.comms.php` (line 49: `\$pagelink` from `\$_GET['page']`)
- `web/pages/admin.settings.php` (line 76: advSearch/advType)
- `web/pages/core/title.php` (line 11: `\$_GET['p']` breadcrumb)
- `web/pages/page.banlist.php` (lines 274, 470, 595, 615, 641-642, 727, 736, 748: searchText, advSearch/advType, demo links, communityid, prevoff_link)
- `web/pages/page.commslist.php` (lines 267, 442, 597, 686, 695, 707: searchText, advSearch/advType, prevoff_link)
- `web/pages/page.home.php` (lines 56-60, 115-119, 178: search_link interpolations + array-key fix)

Smarty templates (`|escape:'url'`):
- `web/themes/default/page_admin_admins_list.tpl` (lines 23, 69, 72, 75, 78: `\$admin.aid`)
- `web/themes/default/page_admin_bans_protests.tpl` (lines 18, 24: `\$protest.authid`, `\$protest.pid`)
- `web/themes/default/page_admin_bans_protests_archiv.tpl` (lines 18, 25: `\$protest.authid`, `\$protest.ip`, `\$protest.pid`)
- `web/themes/default/page_admin_bans_submissions.tpl` (line 24: `\$sub.subid`)
- `web/themes/default/page_admin_bans_submissions_archiv.tpl` (line 29: `\$sub.subid`)
- `web/themes/default/page_admin_groups_list.tpl` (lines 30, 68-69, 107, 145-146, 204: `\$group.gid`, `\$web_admin.aid`, `\$server_admin.aid`, `\$group.id`)
- `web/themes/default/page_admin_mods_list.tpl` (line 24: `\$mod.mid`)
- `web/themes/default/page_admin_servers_list.tpl` (lines 25, 28, 31: `\$server.sid`)
- `web/themes/default/page_bans.tpl` (lines 192, 203: `\$ban.steamid3`, `\$ban.communityid`)
- `web/themes/default/page_comms.tpl` (lines 173, 183: `\$ban.steamid3`, `\$ban.communityid`)

### Out of scope (follow-ups)

- Several Smarty templates still echo user-controlled values without HTML-escape (e.g. `{\$protest.name}`, `{\$ban.player}`, `{\$commenta.commenttxt}`). That's covered by #1082 and was deliberately left alone here.
- The `changePage` JS helper (`web/scripts/sourcebans.js:1115`) still receives advSearch/advType unencoded and concatenates them into a `window.location` URL. Encoding the upstream PHP fixes the page-bound source, but the JS itself should also encode for consistency — left for a separate change to keep this PR focused on hrefs.

## Test plan

- [ ] Visit dashboard / banlist / commslist with a ban whose name contains `&`, `<`, `>`, `?`, `'` — confirm the search link still navigates to the correct banlist filter.
- [ ] Submit a ban search containing `&advType=ip` literally — confirm pagination prev/next preserves the original search term.
- [ ] Trigger lost-password mail flow with an email containing `+` — confirm the reset link round-trips correctly.
- [ ] Confirm `getdemo.php?id=...` still works for legitimate (numeric) ban IDs.