### PR TITLE
fix(security): add CSRF protection to forms and xajax handlers

### DIFF
--- a/web/includes/SmartyCustomFunctions.php
+++ b/web/includes/SmartyCustomFunctions.php
@@ -75,7 +75,7 @@ function smarty_stripslashes($string)
 
 /**
  *  Smarty {smarty_htmlspecialchars} function plugin
- * 
+ *
  * Type:     function<br>
  * Name:     smarty_htmlspecialchars<br>
  * Purpose:  custom htmlspecialchars function
@@ -85,4 +85,14 @@ function smarty_stripslashes($string)
  */
 function smarty_htmlspecialchars($string, $flags = ENT_COMPAT | ENT_HTML401, $encoding = 'UTF-8', $double_encode = true) {
     return htmlspecialchars($string, $flags, $encoding, $double_encode);
+}
+
+/**
+ * Smarty {csrf_field} function plugin: renders the hidden CSRF token input.
+ */
+function smarty_function_csrf_field()
+{
+    $token = htmlspecialchars(CSRF::token(), ENT_QUOTES, 'UTF-8');
+    $name = htmlspecialchars(CSRF::FIELD_NAME, ENT_QUOTES, 'UTF-8');
+    return '<input type="hidden" name="' . $name . '" value="' . $token . '" />';
 }

--- a/web/includes/page-builder.php
+++ b/web/includes/page-builder.php
@@ -7,6 +7,10 @@
  */
 function route($fallback)
 {
+    if (($_SERVER['REQUEST_METHOD'] ?? '') === 'POST') {
+        CSRF::rejectIfInvalid();
+    }
+
     $page = $_GET['p'] ?? null;
     $categorie = $_GET['c'] ?? null;
     $option = $_GET['o'] ?? null;

--- a/web/includes/sb-callback.php
+++ b/web/includes/sb-callback.php
@@ -113,11 +113,6 @@ function Plogin(string $username, string $password, string $remember = '', strin
         return $objResponse;
     }
     
-    // Initialize session if not already started
-    if (session_status() === PHP_SESSION_NONE) {
-        session_start();
-    }
-
     // Rate limiting configuration
     $maxAttempts = 5;
     $lockoutTime = 10 * 60; // 10 minutes lockout
@@ -3023,7 +3018,6 @@ function RefreshServer($sid)
 {
     $objResponse = new xajaxResponse();
     $sid = (int)$sid;
-    session_start();
     $data = $GLOBALS['db']->GetRow("SELECT ip, port FROM `".DB_PREFIX."_servers` WHERE sid = ?;", array($sid));
 
     $objResponse->addScript("xajax_ServerHostPlayers('".$sid."');");

--- a/web/includes/security/CSRF.php
+++ b/web/includes/security/CSRF.php
@@ -1,0 +1,72 @@
+<?php
+
+/**
+ * Per-session CSRF token issued at session start and validated on every
+ * state-changing request (POST forms and xajax callbacks).
+ */
+class CSRF
+{
+    public const FIELD_NAME = 'csrf_token';
+    public const HEADER_NAME = 'HTTP_X_CSRF_TOKEN';
+
+    private const SESSION_KEY = 'csrf_token';
+
+    /**
+     * Ensures a session is active and a token is bound to it.
+     */
+    public static function init(): void
+    {
+        if (session_status() === PHP_SESSION_NONE) {
+            session_start();
+        }
+        if (empty($_SESSION[self::SESSION_KEY]) || !is_string($_SESSION[self::SESSION_KEY])) {
+            $_SESSION[self::SESSION_KEY] = bin2hex(random_bytes(32));
+        }
+    }
+
+    public static function token(): string
+    {
+        return is_string($_SESSION[self::SESSION_KEY] ?? null) ? $_SESSION[self::SESSION_KEY] : '';
+    }
+
+    public static function validate($token): bool
+    {
+        $expected = self::token();
+        return $expected !== '' && is_string($token) && hash_equals($expected, $token);
+    }
+
+    /**
+     * Pulls a candidate token from POST, GET, or the X-CSRF-Token header.
+     */
+    public static function fromRequest(): ?string
+    {
+        $post = $_POST[self::FIELD_NAME] ?? null;
+        if (is_string($post)) {
+            return $post;
+        }
+        $get = $_GET[self::FIELD_NAME] ?? null;
+        if (is_string($get)) {
+            return $get;
+        }
+        $header = $_SERVER[self::HEADER_NAME] ?? null;
+        return is_string($header) ? $header : null;
+    }
+
+    /**
+     * Sends a 403 response and terminates the request.
+     */
+    public static function reject(): void
+    {
+        http_response_code(403);
+        header('Content-Type: text/plain; charset=utf-8');
+        echo 'CSRF token validation failed. Please reload the page and try again.';
+        exit();
+    }
+
+    public static function rejectIfInvalid(): void
+    {
+        if (!self::validate(self::fromRequest())) {
+            self::reject();
+        }
+    }
+}

--- a/web/includes/xajax.inc.php
+++ b/web/includes/xajax.inc.php
@@ -639,7 +639,22 @@ class xajax
 		$bEndRequest = false;
 		$requestMode = $this->getRequestMode();
 		if ($requestMode == -1) return;
-	
+
+		// CSRF protection: reject any xajax call without a valid token
+		// before dispatching to the registered callback.
+		if (class_exists('CSRF') && !CSRF::validate(CSRF::fromRequest()))
+		{
+			$sContentHeader = "Content-type: text/xml;";
+			if ($this->sEncoding && strlen(trim($this->sEncoding)) > 0)
+				$sContentHeader .= " charset=".$this->sEncoding;
+			header($sContentHeader);
+			$oCsrfResponse = new xajaxResponse($this->sEncoding, $this->bOutputEntities);
+			$oCsrfResponse->addAlert("Security check failed: CSRF token missing or invalid. Please reload the page and try again.");
+			print $oCsrfResponse->getOutput();
+			if ($this->bExitAllowed) exit();
+			return;
+		}
+
 		if ($requestMode == XAJAX_POST)
 		{
 			$sFunctionName = $_POST["xajax"];
@@ -863,6 +878,9 @@ class xajax
 		$html .= "var xajaxDefinedGet=".XAJAX_GET.";\n";
 		$html .= "var xajaxDefinedPost=".XAJAX_POST.";\n";
 		$html .= "var xajaxLoaded=false;\n";
+		if (class_exists('CSRF')) {
+			$html .= "var xajaxCsrfToken=\"".addslashes(CSRF::token())."\";\n";
+		}
 
 		foreach($this->aFunctions as $sFunction => $bExists) {
 			$html .= $this->_wrap($sFunction,$this->aFunctionRequestTypes[$sFunction]);

--- a/web/index.php
+++ b/web/index.php
@@ -22,7 +22,6 @@ include_once(INCLUDES_PATH . "/system-functions.php");
 include_once('config.php');
 include_once(INCLUDES_PATH . "/sb-callback.php");
 $xajax->processRequests();
-session_start();
 include_once(INCLUDES_PATH . "/page-builder.php");
 
 $route = route(Config::get('config.defaultpage'));

--- a/web/init.php
+++ b/web/init.php
@@ -66,6 +66,7 @@ require_once(INCLUDES_PATH.'/vendor/autoload.php');
 //  Initial setup
 // ---------------------------------------------------
 require_once(INCLUDES_PATH.'/security/Crypto.php');
+require_once(INCLUDES_PATH.'/security/CSRF.php');
 
 require_once(INCLUDES_PATH.'/auth/JWT.php');
 
@@ -142,6 +143,12 @@ Auth::init($GLOBALS['PDO']);
 
 $userbank = new CUserManager(Auth::verify());
 
+// ---------------------------------------------------
+// Bind a CSRF token to the session (must run before xajax dispatch
+// and before any form is rendered so the token is available).
+// ---------------------------------------------------
+CSRF::init();
+
 require_once(INCLUDES_PATH.'/Log.php');
 Log::init($GLOBALS['PDO'], $userbank);
 
@@ -210,8 +217,12 @@ $theme->setEscapeHtml(true);
 $theme->registerPlugin(Smarty::PLUGIN_FUNCTION, 'help_icon', 'smarty_function_help_icon');
 $theme->registerPlugin(Smarty::PLUGIN_FUNCTION, 'sb_button', 'smarty_function_sb_button');
 $theme->registerPlugin(Smarty::PLUGIN_FUNCTION, 'load_template', 'smarty_function_load_template');
+$theme->registerPlugin(Smarty::PLUGIN_FUNCTION, 'csrf_field', 'smarty_function_csrf_field');
 $theme->registerPlugin('modifier', 'smarty_stripslashes', 'smarty_stripslashes');
 $theme->registerPlugin('modifier', 'smarty_htmlspecialchars', 'smarty_htmlspecialchars');
+
+$theme->assign('csrf_token', CSRF::token());
+$theme->assign('csrf_field_name', CSRF::FIELD_NAME);
 
 if ((isset($_GET['debug']) && $_GET['debug'] == 1) || DEBUG_MODE) {
     $theme->setForceCompile(true);

--- a/web/pages/admin.uploaddemo.php
+++ b/web/pages/admin.uploaddemo.php
@@ -30,6 +30,7 @@ if (!$userbank->HasAccess(ADMIN_OWNER | ADMIN_ADD_BAN | ADMIN_EDIT_OWN_BANS | AD
 $message = "";
 
 if (isset($_POST['upload'])) {
+    CSRF::rejectIfInvalid();
     if (checkExtension($_FILES['demo_file']['name'], ['zip', 'rar', 'dem', '7z', 'bz2', 'gz'])) {
         $filename = md5(time() . rand(0, 1000));
         move_uploaded_file($_FILES['demo_file']['tmp_name'], SB_DEMOS . "/" . $filename);

--- a/web/pages/admin.uploadicon.php
+++ b/web/pages/admin.uploadicon.php
@@ -28,6 +28,7 @@ if (!$userbank->HasAccess(ADMIN_OWNER | ADMIN_EDIT_MODS | ADMIN_ADD_MODS)) {
 
 $message = "";
 if (isset($_POST['upload'])) {
+    CSRF::rejectIfInvalid();
     if (checkExtension($_FILES['icon_file']['name'], ['gif', 'jpg', 'png'])) {
         move_uploaded_file($_FILES['icon_file']['tmp_name'], SB_ICONS . "/" . $_FILES['icon_file']['name']);
         $message = "<script>window.opener.icon('" . $_FILES['icon_file']['name'] . "');self.close()</script>";

--- a/web/pages/admin.uploadmapimg.php
+++ b/web/pages/admin.uploadmapimg.php
@@ -28,6 +28,7 @@ if (!$userbank->HasAccess(ADMIN_OWNER | ADMIN_ADD_SERVER)) {
 
 $message = "";
 if (isset($_POST['upload'])) {
+    CSRF::rejectIfInvalid();
     if (checkExtension($_FILES['mapimg_file']['name'], ['jpg'])) {
         move_uploaded_file($_FILES['mapimg_file']['tmp_name'], SB_MAPS . "/" . $_FILES['mapimg_file']['name']);
         $message = "<script>window.opener.mapimg('" . $_FILES['mapimg_file']['name'] . "');self.close()</script>";

--- a/web/scripts/xajax.js
+++ b/web/scripts/xajax.js
@@ -95,7 +95,7 @@ else{var xajaxRequestType=sRequestType;}
 var uri=xajaxRequestUri;var value;switch(xajaxRequestType){case xajaxDefinedGet:{var uriGet=uri.indexOf("?")==-1?"?xajax="+encodeURIComponent(sFunction):"&xajax="+encodeURIComponent(sFunction);if(aArgs){for(i=0;i<aArgs.length;i++){value=aArgs[i];if(typeof(value)=="object")
 value=this.objectToXML(value);uriGet+="&xajaxargs[]="+encodeURIComponent(value);}
 }
-uriGet+="&xajaxr="+new Date().getTime();uri+=uriGet;postData=null;}break;case xajaxDefinedPost:{postData="xajax="+encodeURIComponent(sFunction);postData+="&xajaxr="+new Date().getTime();if(aArgs){for(i=0;i <aArgs.length;i++){value=aArgs[i];if(typeof(value)=="object")
+uriGet+="&xajaxr="+new Date().getTime();if(typeof xajaxCsrfToken!="undefined"&&xajaxCsrfToken)uriGet+="&csrf_token="+encodeURIComponent(xajaxCsrfToken);uri+=uriGet;postData=null;}break;case xajaxDefinedPost:{postData="xajax="+encodeURIComponent(sFunction);postData+="&xajaxr="+new Date().getTime();if(typeof xajaxCsrfToken!="undefined"&&xajaxCsrfToken)postData+="&csrf_token="+encodeURIComponent(xajaxCsrfToken);if(aArgs){for(i=0;i <aArgs.length;i++){value=aArgs[i];if(typeof(value)=="object")
 value=this.objectToXML(value);postData=postData+"&xajaxargs[]="+encodeURIComponent(value);}
 }
 }break;default:

--- a/web/themes/default/page_admin_bans_import.tpl
+++ b/web/themes/default/page_admin_bans_import.tpl
@@ -4,6 +4,7 @@
     <h3>Import Bans</h3>
     For more information or help regarding a certain subject move your mouse over the question mark.<br /><br />
     <form action="" method="post" enctype="multipart/form-data">
+        {csrf_field}
         <input type="hidden" name="action" value="importBans" />
         <table width="90%" style="border-collapse:collapse;" id="group.details" cellpadding="3">
             <tr>

--- a/web/themes/default/page_admin_edit_admins_details.tpl
+++ b/web/themes/default/page_admin_edit_admins_details.tpl
@@ -1,4 +1,5 @@
 <form action="" method="post">
+    {csrf_field}
     <div id="admin-page-content">
 
         <div id="add-group">

--- a/web/themes/default/page_admin_edit_admins_group.tpl
+++ b/web/themes/default/page_admin_edit_admins_group.tpl
@@ -1,4 +1,5 @@
 <form action="" method="post">
+    {csrf_field}
     <div id="admin-page-content">
         <div id="add-group">
             <h3>Admin Groups</h3>

--- a/web/themes/default/page_admin_edit_admins_servers.tpl
+++ b/web/themes/default/page_admin_edit_admins_servers.tpl
@@ -1,4 +1,5 @@
 <form action="" method="post">
+    {csrf_field}
     <div id="admin-page-content">
         <div id="add-group">
             <h3>Admin Server Access</h3>

--- a/web/themes/default/page_admin_edit_ban.tpl
+++ b/web/themes/default/page_admin_edit_ban.tpl
@@ -1,4 +1,5 @@
 <form action="" method="post">
+    {csrf_field}
     <div id="admin-page-content">
         <div id="0">
             <div id="msg-green" style="display:none;">

--- a/web/themes/default/page_admin_edit_comms.tpl
+++ b/web/themes/default/page_admin_edit_comms.tpl
@@ -1,4 +1,5 @@
 <form action="" method="post">
+    {csrf_field}
     <div id="admin-page-content">
         <div id="0">
             <div id="msg-green" style="display:none;">

--- a/web/themes/default/page_admin_edit_mod.tpl
+++ b/web/themes/default/page_admin_edit_mod.tpl
@@ -1,4 +1,5 @@
 <form action="" method="post">
+    {csrf_field}
     <div id="add-group">
         <h3>Mod Details</h3>
         For more information or help regarding a certain subject move your mouse over the question mark.<br /><br />

--- a/web/themes/default/page_admin_overrides.tpl
+++ b/web/themes/default/page_admin_overrides.tpl
@@ -10,6 +10,7 @@
     {/if}
         <div id="add-group">
             <form action="" method="post">
+                {csrf_field}
                 <h3>Overrides</h3>
                 With Overrides you can change the flags or permissions on any command, either globally, or for a specific group, without editing plugin source code.<br />
                 <i>Read about <b><a href="http://wiki.alliedmods.net/Overriding_Command_Access_%28SourceMod%29" title="Overriding Command Access (SourceMod)" target="_blank">overriding command access</a></b> in the AlliedModders Wiki!</i><br /><br />

--- a/web/themes/default/page_admin_settings_features.tpl
+++ b/web/themes/default/page_admin_settings_features.tpl
@@ -1,4 +1,5 @@
 <form action="" method="post">
+    {csrf_field}
     <input type="hidden" name="settingsGroup" value="features" />
     <table width="99%" border="0" style="border-collapse:collapse;" id="group.features" cellpadding="3">
         <tr>

--- a/web/themes/default/page_admin_settings_settings.tpl
+++ b/web/themes/default/page_admin_settings_settings.tpl
@@ -1,4 +1,5 @@
 <form action="" method="post">
+    {csrf_field}
     <input type="hidden" name="settingsGroup" value="mainsettings" />
     <table width="99%" border="0" style="border-collapse:collapse;" id="group.details" cellpadding="3">
         <tr>

--- a/web/themes/default/page_protestban.tpl
+++ b/web/themes/default/page_protestban.tpl
@@ -7,6 +7,7 @@
     In order to appeal a ban, you must make sure you are banned via clicking <a href="index.php?p=banlist">here</a> to see if you are banned and for what reason.<br />
     If you are indeed on our ban list and you feel it is unjust or any other circumstances, please fill out the appeal format below.<br /><br />
     <form action="index.php?p=protest" method="post">
+        {csrf_field}
         <input type="hidden" name="subprotest" value="1">
         <table cellspacing='10' width='100%' align='center'>
             <tr>

--- a/web/themes/default/page_submitban.tpl
+++ b/web/themes/default/page_submitban.tpl
@@ -9,6 +9,7 @@
     If you are unsure on how to record evidence within in-game, please click
     <a href="javascript:void(0)" onclick="ShowBox('How To Record Evidence', 'The best way to record evidence on someone breaking the rules would be to use Shadow Play or Plays.TV. Both pieces of software will record your game 24/7 with little to no impact on your game and you simply press a keybind to record the last X amount of minutes of gameplay which is perfect for catching rule breakers.<br /><br /> Alternatively, you can use the old method of using demos. While you are spectating the offending player, press the ` key on your keyboard to show the Developers Console. If this does not show, you will need to go into your Game Settings and enable this. Then type `record [demoname]` and hit enter, the file will then be in your mod folder of your game directory.', 'blue', '', true);">here</a> for an explanation.<br /><br />
     <form action="index.php?p=submit" method="post" enctype="multipart/form-data">
+        {csrf_field}
         <input type="hidden" name="subban" value="1">
         <table cellspacing='10' width='100%' align='center'>
             <tr>

--- a/web/themes/default/page_uploadfile.tpl
+++ b/web/themes/default/page_uploadfile.tpl
@@ -19,6 +19,7 @@
 Plese select the file to upload. The file must either be {$formats} file format.<br>
 <b>{$message nofilter}</b>
 <form action="" method="POST" id="{$form_name}" enctype="multipart/form-data">
+{csrf_field}
 <input name="upload" value="1" type="hidden">
 <input name="{$input_name}" size="25" class="submit-fields" type="file"> <br />
 <button style="background-color: #e9e9e9;


### PR DESCRIPTION
## Summary
- Issues a per-session CSRF token in `web/init.php` after auth bootstrap and exposes it via a Smarty `{csrf_field}` plugin so every POST form renders a hidden `csrf_token` input
- Validates the token in `route()` for every POST and in `xajax::processRequests()` before dispatching any callback; out-of-route POST endpoints (`admin.uploadicon|uploadmapimg|uploaddemo.php`) call `CSRF::rejectIfInvalid()` directly
- Wires the token into `web/scripts/xajax.js` via a server-emitted `xajaxCsrfToken` global so all xajax GET/POST calls automatically include it; removes redundant `session_start()` from `index.php` and `sb-callback.php`

Closes #1073

## Test plan
- [ ] PHPStan level 4 passes (`includes/vendor/bin/phpstan analyse`)
- [ ] Login as admin: token cookie issued, page renders with `xajaxCsrfToken=...` and forms include `<input type="hidden" name="csrf_token" ...>`
- [ ] Submit a normal POST form (e.g. settings save) and confirm it succeeds end-to-end
- [ ] Trigger an xajax action (e.g. AddBan, ClearCache) and confirm success
- [ ] Forge a POST without `csrf_token` (e.g. `curl -X POST -b sbpp_auth=... .../index.php?p=admin&c=settings`) — expect HTTP 403 "CSRF token validation failed."
- [ ] Forge an xajax POST without `csrf_token` — expect a "Security check failed" alert in the XML response and no callback execution
- [ ] Public flows still work: lostpassword (xajax) and submit/protest forms accept submissions when token is present