### PR TITLE
refactor(web): convert @var docblocks to typed properties on core classes

### DIFF
--- a/web/includes/AdminTabs.php
+++ b/web/includes/AdminTabs.php
@@ -5,7 +5,7 @@
  */
 class AdminTabs
 {
-    private $tabs = [];
+    private array $tabs = [];
 
     /**
      * AdminTabs constructor.

--- a/web/includes/CUserManager.php
+++ b/web/includes/CUserManager.php
@@ -21,30 +21,17 @@ Page: <http://www.sourcebans.net/> - <http://www.gameconnect.net/>
 *************************************************************************/
 class CUserManager
 {
-    /**
-     * @var int|mixed
-     */
-    private $aid = -1;
+    private readonly int $aid;
 
-    /**
-     * @var array
-     */
-    private $admins = [];
+    private array $admins = [];
 
-    /**
-     * @var Database
-     */
-    private $dbh;
+    private readonly Database $dbh;
 
-    /**
-     * CUserManager constructor.
-     * @param ?Token $token
-     */
     public function __construct(?Token $token)
     {
         $this->dbh = new Database(DB_HOST, DB_PORT, DB_NAME, DB_USER, DB_PASS, DB_PREFIX, DB_CHARSET);
 
-        $this->aid = $token?->claims()->get('aid') ?? -1;
+        $this->aid = (int)($token?->claims()->get('aid') ?? -1);
 
         $this->GetUserArray($this->aid);
     }
@@ -231,7 +218,7 @@ class CUserManager
         if (is_null($aid)) {
             $aid = $this->aid;
         }
-        if ($aid < 0 || !is_int($aid)) {
+        if ($aid < 0) {
             return false;
         }
 

--- a/web/includes/Database.php
+++ b/web/includes/Database.php
@@ -5,18 +5,11 @@
  */
 class Database
 {
-    /**
-     * @var string
-     */
-    private $prefix;
-    /**
-     * @var PDO
-     */
-    private $dbh;
-    /**
-     * @var PDOStatement
-     */
-    private $stmt;
+    private readonly string $prefix;
+
+    private PDO $dbh;
+
+    private ?PDOStatement $stmt = null;
 
     /**
      * Database constructor.

--- a/web/includes/Log.php
+++ b/web/includes/Log.php
@@ -5,13 +5,8 @@
  */
 class Log
 {
-    /**
-     * @var Database
-     */
     private static ?Database $dbs = null;
-    /**
-     * @var CUserManager
-     */
+
     private static ?CUserManager $user = null;
 
     /**

--- a/web/includes/SteamID/SteamID.php
+++ b/web/includes/SteamID/SteamID.php
@@ -15,14 +15,9 @@ require_once __DIR__ . '/calc/BCMATH.php';
  */
 class SteamID
 {
-    /**
-     * @var string
-     */
-    private static $calcMethod = null;
-    /**
-     * @var array
-     */
-    private static $validFormat = ['Steam2', 'Steam3', 'Steam64'];
+    private static ?string $calcMethod = null;
+
+    private static array $validFormat = ['Steam2', 'Steam3', 'Steam64'];
 
     /**
      * @param  Database|null $dbs

--- a/web/includes/auth/Auth.php
+++ b/web/includes/auth/Auth.php
@@ -7,9 +7,6 @@ use Lcobucci\JWT\Token;
  */
 class Auth
 {
-    /**
-     * @var Database
-     */
     private static ?Database $dbs = null;
 
     /**


### PR DESCRIPTION
## Summary
- Replaces legacy `@var` docblock hints with real PHP 8.2 typed property declarations on `CUserManager`, `Log`, `AdminTabs`, `Database`, `SteamID`, and `Auth`.
- Adds `readonly` to constructor-set properties that are never reassigned: `CUserManager::$aid`, `CUserManager::$dbh`, and `Database::$prefix`. `Database::$dbh` is left mutable because `__destruct` unsets it; static properties are left non-readonly because `static readonly` requires PHP 8.3 and the project floor is 8.2.
- Drops a dead `!is_int($aid)` check in `CUserManager::GetAdmin` that PHPStan now proves unreachable now that `$aid` is typed.

Closes #1079.

## Test plan
- [x] `php -l` passes on every modified file (PHP 8.2)
- [x] PHPStan reports zero errors with the existing baseline (no new entries needed)
- [ ] Smoke-test admin login and the admin tabs in the browser