### PR TITLE
refactor(web): migrate 11 small page files from ADOdb to PDO

### DIFF
--- a/web/exportbans.php
+++ b/web/exportbans.php
@@ -8,24 +8,20 @@ if (!$userbank->HasAccess(ADMIN_OWNER) && !Config::getBool('config.exportpublic'
     if ($_GET['type'] == 'steam') {
         header('Content-Type: application/x-httpd-php php');
         header('Content-Disposition: attachment; filename="banned_user.cfg"');
-        $bans = $GLOBALS['db']->Execute(
-            "SELECT authid FROM `" . DB_PREFIX . "_bans` WHERE length = '0' AND RemoveType IS NULL AND type = '0'"
-        );
-        $num = $bans->RecordCount();
-        for ($x = 0; $x < $num; $x++) {
-            print("banid 0 " . $bans->fields['authid'] . "\r\n");
-            $bans->MoveNext();
+        $bans = $GLOBALS['PDO']->query(
+            "SELECT authid FROM `:prefix_bans` WHERE length = '0' AND RemoveType IS NULL AND type = '0'"
+        )->resultset();
+        foreach ($bans as $ban) {
+            print("banid 0 " . $ban['authid'] . "\r\n");
         }
     } elseif ($_GET['type'] == 'ip') {
         header('Content-Type: application/x-httpd-php php');
         header('Content-Disposition: attachment; filename="banned_ip.cfg"');
-        $bans = $GLOBALS['db']->Execute(
-            "SELECT ip FROM `" . DB_PREFIX . "_bans` WHERE length = '0' AND RemoveType IS NULL AND type = '1'"
-        );
-        $num = $bans->RecordCount();
-        for ($x = 0; $x < $num; $x++) {
-            print("addip 0 " . $bans->fields['ip'] . "\r\n");
-            $bans->MoveNext();
+        $bans = $GLOBALS['PDO']->query(
+            "SELECT ip FROM `:prefix_bans` WHERE length = '0' AND RemoveType IS NULL AND type = '1'"
+        )->resultset();
+        foreach ($bans as $ban) {
+            print("addip 0 " . $ban['ip'] . "\r\n");
         }
     }
 }

--- a/web/getdemo.php
+++ b/web/getdemo.php
@@ -26,10 +26,12 @@ if (strcasecmp($_GET['type'], "B") != 0 && strcasecmp($_GET['type'], "S") != 0) 
     die('Bad type');
 }
 $id   = (int) $_GET['id'];
-$demo = $GLOBALS['db']->GetRow(
-    "SELECT filename, origname FROM `" . DB_PREFIX . "_demos` WHERE demtype=? AND demid=?;",
-    array($_GET['type'], $id)
-);
+$GLOBALS['PDO']->query("SELECT filename, origname FROM `:prefix_demos` WHERE demtype = :type AND demid = :id");
+$GLOBALS['PDO']->bindMultiple([
+    ':type' => $_GET['type'],
+    ':id'   => $id,
+]);
+$demo = $GLOBALS['PDO']->single();
 //Official Fix: https://code.google.com/p/sourcebans/source/detail?r=165
 if (!$demo) {
     die('Demo not found.');

--- a/web/pages/admin.bans.search.php
+++ b/web/pages/admin.bans.search.php
@@ -18,18 +18,17 @@ Page: <http://www.sourcebans.net/> - <http://www.gameconnect.net/>
 *************************************************************************/
 
 global $userbank, $theme;
-$admin_list   = $GLOBALS['db']->GetAll("SELECT * FROM `" . DB_PREFIX . "_admins` ORDER BY user ASC");
-$server_list  = $GLOBALS['db']->Execute("SELECT sid, ip, port FROM `" . DB_PREFIX . "_servers` WHERE enabled = 1");
+$admin_list   = $GLOBALS['PDO']->query("SELECT * FROM `:prefix_admins` ORDER BY user ASC")->resultset();
+$server_list  = $GLOBALS['PDO']->query("SELECT sid, ip, port FROM `:prefix_servers` WHERE enabled = 1")->resultset();
 $servers      = [];
 $serverscript = "<script type=\"text/javascript\">";
-while (!$server_list->EOF) {
+foreach ($server_list as $row) {
     $info = [];
-    $serverscript .= "xajax_ServerHostPlayers('" . $server_list->fields[0] . "', 'id', 'ss" . $server_list->fields[0] . "', '', '', false, 200);";
-    $info['sid']  = $server_list->fields[0];
-    $info['ip']   = $server_list->fields[1];
-    $info['port'] = $server_list->fields[2];
+    $serverscript .= "xajax_ServerHostPlayers('" . $row['sid'] . "', 'id', 'ss" . $row['sid'] . "', '', '', false, 200);";
+    $info['sid']  = $row['sid'];
+    $info['ip']   = $row['ip'];
+    $info['port'] = $row['port'];
     $servers[] = $info;
-    $server_list->MoveNext();
 }
 $serverscript .= "</script>";
 $page = filter_input(INPUT_GET, 'page', FILTER_VALIDATE_INT, ['options' => ['default' => 1, 'min_range' => 1]]);

--- a/web/pages/admin.comms.search.php
+++ b/web/pages/admin.comms.search.php
@@ -23,18 +23,17 @@ Page: <https://forums.alliedmods.net/showthread.php?p=1883705> - <https://github
 *************************************************************************/
 
 global $userbank, $theme;
-$admin_list   = $GLOBALS['db']->GetAll("SELECT * FROM `" . DB_PREFIX . "_admins` ORDER BY user ASC");
-$server_list  = $GLOBALS['db']->Execute("SELECT sid, ip, port FROM `" . DB_PREFIX . "_servers` WHERE enabled = 1");
+$admin_list   = $GLOBALS['PDO']->query("SELECT * FROM `:prefix_admins` ORDER BY user ASC")->resultset();
+$server_list  = $GLOBALS['PDO']->query("SELECT sid, ip, port FROM `:prefix_servers` WHERE enabled = 1")->resultset();
 $servers      = [];
 $serverscript = "<script type=\"text/javascript\">";
-while (!$server_list->EOF) {
+foreach ($server_list as $row) {
     $info = [];
-    $serverscript .= "xajax_ServerHostPlayers('" . $server_list->fields[0] . "', 'id', 'ss" . $server_list->fields[0] . "', '', '', false, 200);";
-    $info['sid']  = $server_list->fields[0];
-    $info['ip']   = $server_list->fields[1];
-    $info['port'] = $server_list->fields[2];
+    $serverscript .= "xajax_ServerHostPlayers('" . $row['sid'] . "', 'id', 'ss" . $row['sid'] . "', '', '', false, 200);";
+    $info['sid']  = $row['sid'];
+    $info['ip']   = $row['ip'];
+    $info['port'] = $row['port'];
     array_push($servers, $info);
-    $server_list->MoveNext();
 }
 $serverscript .= "</script>";
 $page = isset($_GET['page']) ? $_GET['page'] : 1;

--- a/web/pages/admin.edit.adminperms.php
+++ b/web/pages/admin.edit.adminperms.php
@@ -35,7 +35,9 @@ if (!isset($_GET['id']) || !is_numeric($_GET['id'])) {
     PageDie();
 }
 $_GET['id'] = (int) $_GET['id'];
-$admin = $GLOBALS['db']->GetRow("SELECT * FROM " . DB_PREFIX . "_admins WHERE aid = ?", array($_GET['id']));
+$GLOBALS['PDO']->query("SELECT * FROM `:prefix_admins` WHERE aid = :aid");
+$GLOBALS['PDO']->bind(':aid', $_GET['id']);
+$admin = $GLOBALS['PDO']->single();
 
 
 if (!$userbank->GetProperty("user", $_GET['id'])) {

--- a/web/pages/admin.email.php
+++ b/web/pages/admin.email.php
@@ -49,14 +49,16 @@ if (!isset($_GET['type']) || ($_GET['type'] != 's' && $_GET['type'] != 'p')) {
 // Submission
 $email = "";
 if ($_GET['type'] == 's') {
-    $email = $GLOBALS['db']->GetOne('SELECT email FROM `' . DB_PREFIX . '_submissions` WHERE subid = ?', array(
-        $_GET['id']
-    ));
+    $GLOBALS['PDO']->query('SELECT email FROM `:prefix_submissions` WHERE subid = :id');
+    $GLOBALS['PDO']->bind(':id', $_GET['id']);
+    $row   = $GLOBALS['PDO']->single();
+    $email = $row['email'] ?? "";
 } elseif ($_GET['type'] == 'p') {
     // Protest
-    $email = $GLOBALS['db']->GetOne('SELECT email FROM `' . DB_PREFIX . '_protests` WHERE pid = ?', array(
-        $_GET['id']
-    ));
+    $GLOBALS['PDO']->query('SELECT email FROM `:prefix_protests` WHERE pid = :id');
+    $GLOBALS['PDO']->bind(':id', $_GET['id']);
+    $row   = $GLOBALS['PDO']->single();
+    $email = $row['email'] ?? "";
 }
 
 if (empty($email)) {

--- a/web/pages/admin.log.search.php
+++ b/web/pages/admin.log.search.php
@@ -19,7 +19,7 @@ Page: <http://www.sourcebans.net/> - <http://www.gameconnect.net/>
 
 global $theme;
 
-$admin_list = $GLOBALS['db']->GetAll("SELECT * FROM `" . DB_PREFIX . "_admins` ORDER BY user ASC");
+$admin_list = $GLOBALS['PDO']->query("SELECT * FROM `:prefix_admins` ORDER BY user ASC")->resultset();
 $theme->assign('admin_list', $admin_list);
 
 $theme->display('box_admin_log_search.tpl');

--- a/web/pages/admin.mods.php
+++ b/web/pages/admin.mods.php
@@ -28,8 +28,8 @@ new AdminTabs([
     ['name' => 'Add new MOD', 'permission' => ADMIN_OWNER|ADMIN_ADD_MODS]
 ], $userbank, $theme);
 
-$mod_list = $GLOBALS['db']->GetAll("SELECT * FROM `" . DB_PREFIX . "_mods` WHERE mid > 0 ORDER BY name ASC") ;
-$query = $GLOBALS['db']->GetRow("SELECT COUNT(mid) AS cnt FROM `" . DB_PREFIX . "_mods`") ;
+$mod_list = $GLOBALS['PDO']->query("SELECT * FROM `:prefix_mods` WHERE mid > 0 ORDER BY name ASC")->resultset();
+$query = $GLOBALS['PDO']->query("SELECT COUNT(mid) AS cnt FROM `:prefix_mods`")->single();
 $mod_count = $query['cnt'];
 ?>
 <div id="admin-page-content">

--- a/web/pages/page.admin.php
+++ b/web/pages/page.admin.php
@@ -22,16 +22,16 @@ if (!defined("IN_SB")) {
     die();
 }
 global $userbank, $theme;
-$counts = $GLOBALS['db']->GetRow("SELECT
-								 (SELECT COUNT(bid) FROM `" . DB_PREFIX . "_banlog`) AS blocks,
-								 (SELECT COUNT(bid) FROM `" . DB_PREFIX . "_bans`) AS bans,
-								 (SELECT COUNT(bid) FROM `" . DB_PREFIX . "_comms`) AS comms,
-								 (SELECT COUNT(aid) FROM `" . DB_PREFIX . "_admins` WHERE aid > 0) AS admins,
-								 (SELECT COUNT(subid) FROM `" . DB_PREFIX . "_submissions` WHERE archiv = '0') AS subs,
-								 (SELECT COUNT(subid) FROM `" . DB_PREFIX . "_submissions` WHERE archiv > 0) AS archiv_subs,
-								 (SELECT COUNT(pid) FROM `" . DB_PREFIX . "_protests` WHERE archiv = '0') AS protests,
-								 (SELECT COUNT(pid) FROM `" . DB_PREFIX . "_protests` WHERE archiv > 0) AS archiv_protests,
-								 (SELECT COUNT(sid) FROM `" . DB_PREFIX . "_servers`) AS servers");
+$counts = $GLOBALS['PDO']->query("SELECT
+								 (SELECT COUNT(bid) FROM `:prefix_banlog`) AS blocks,
+								 (SELECT COUNT(bid) FROM `:prefix_bans`) AS bans,
+								 (SELECT COUNT(bid) FROM `:prefix_comms`) AS comms,
+								 (SELECT COUNT(aid) FROM `:prefix_admins` WHERE aid > 0) AS admins,
+								 (SELECT COUNT(subid) FROM `:prefix_submissions` WHERE archiv = '0') AS subs,
+								 (SELECT COUNT(subid) FROM `:prefix_submissions` WHERE archiv > 0) AS archiv_subs,
+								 (SELECT COUNT(pid) FROM `:prefix_protests` WHERE archiv = '0') AS protests,
+								 (SELECT COUNT(pid) FROM `:prefix_protests` WHERE archiv > 0) AS archiv_protests,
+								 (SELECT COUNT(sid) FROM `:prefix_servers`) AS servers")->single();
 
 $theme->assign('access_admins', $userbank->HasAccess(ADMIN_OWNER | ADMIN_LIST_ADMINS | ADMIN_ADD_ADMINS | ADMIN_EDIT_ADMINS | ADMIN_DELETE_ADMINS));
 $theme->assign('access_servers', $userbank->HasAccess(ADMIN_OWNER | ADMIN_LIST_SERVERS | ADMIN_ADD_SERVER | ADMIN_EDIT_SERVERS | ADMIN_DELETE_SERVERS));

--- a/web/pages/page.servers.php
+++ b/web/pages/page.servers.php
@@ -31,16 +31,16 @@ if (!defined('IN_HOME')) {
     }
 }
 
-$res     = $GLOBALS['db']->Execute("SELECT se.sid, se.ip, se.port, se.modid, se.rcon, md.icon FROM " . DB_PREFIX . "_servers se LEFT JOIN " . DB_PREFIX . "_mods md ON md.mid=se.modid WHERE se.sid > 0 AND se.enabled = 1 ORDER BY se.modid, se.sid");
+$rows = $GLOBALS['PDO']->query("SELECT se.sid, se.ip, se.port, se.modid, se.rcon, md.icon FROM `:prefix_servers` se LEFT JOIN `:prefix_mods` md ON md.mid=se.modid WHERE se.sid > 0 AND se.enabled = 1 ORDER BY se.modid, se.sid")->resultset();
 $servers = [];
 $i       = 0;
-while (!$res->EOF) {
+foreach ($rows as $row) {
     $info          = [];
-    $info['sid']   = $res->fields[0];
-    $info['ip']    = $res->fields[1];
-    $info['dns']   = gethostbyname($res->fields[1]);
-    $info['port']  = $res->fields[2];
-    $info['icon']  = $res->fields[5];
+    $info['sid']   = $row['sid'];
+    $info['ip']    = $row['ip'];
+    $info['dns']   = gethostbyname($row['ip']);
+    $info['port']  = $row['port'];
+    $info['icon']  = $row['icon'];
     $info['index'] = $i;
     if (defined('IN_HOME')) {
         $info['evOnClick'] = "window.location = 'index.php?p=servers&s=" . $info['index'] . "';";
@@ -49,7 +49,6 @@ while (!$res->EOF) {
     $GLOBALS['server_qry'] .= "xajax_ServerHostPlayers({$info['sid']}, 'servers', '', '" . $i . "', '" . $number . "', '" . defined('IN_HOME') . "', 70);";
     array_push($servers, $info);
     $i++;
-    $res->MoveNext();
 }
 
 $theme->assign('access_bans', ($userbank->HasAccess(ADMIN_OWNER | ADMIN_ADD_BAN) ? true : false));

--- a/web/pages/page.youraccount.php
+++ b/web/pages/page.youraccount.php
@@ -35,11 +35,13 @@ new AdminTabs([
     ['name' => 'Change Email', 'permission' => ALL_WEB]
 ], $userbank, $theme);
 
-$res      = $GLOBALS['db']->Execute("SELECT `srv_password`, `email` FROM `" . DB_PREFIX . "_admins` WHERE `aid` = '" . $userbank->GetAid() . "'");
-$srvpwset = (!empty($res->fields['srv_password']) ? true : false);
+$GLOBALS['PDO']->query("SELECT `srv_password`, `email` FROM `:prefix_admins` WHERE `aid` = :aid");
+$GLOBALS['PDO']->bind(':aid', $userbank->GetAid());
+$res      = $GLOBALS['PDO']->single();
+$srvpwset = !empty($res['srv_password']);
 
 $theme->assign('srvpwset', $srvpwset);
-$theme->assign('email', $res->fields['email']);
+$theme->assign('email', $res['email']);
 $theme->assign('user_aid', $userbank->GetAid());
 $theme->assign('web_permissions', BitToString($userbank->GetProperty("extraflags")));
 $theme->assign('server_permissions', SmFlagsToSb($userbank->GetProperty("srv_flags")));


### PR DESCRIPTION
## Summary
- Converts 12 `$GLOBALS['db']` (ADOdb) call sites across 11 self-contained pages to the existing PDO `Database` wrapper at `web/includes/Database.php`.
- Establishes migration patterns for #1078 by covering every common ADOdb idiom in scope: `GetRow`, `GetAll`, `GetOne`, and `Execute` with `EOF` / `MoveNext` / `->fields[…]` / `RecordCount`.
- No behavior change intended — queries keep their existing parameterisation, and where original code interpolated already-int-cast values it still does (those will be tightened up in their own pass).

Files migrated:
- `web/getdemo.php` — `GetRow` with `?` placeholders → `query`/`bindMultiple`/`single`
- `web/exportbans.php` — `Execute` + `RecordCount` + `MoveNext` → `resultset` + `foreach`
- `web/pages/admin.log.search.php` — `GetAll` → `query(...)->resultset()`
- `web/pages/page.admin.php` — `GetRow` (no params) → `query(...)->single()`
- `web/pages/admin.mods.php` — `GetAll` + `GetRow`
- `web/pages/page.servers.php` — `Execute` + numeric `->fields[i]` → `resultset` + assoc keys
- `web/pages/page.youraccount.php` — `Execute` + `->fields['name']` → `single`
- `web/pages/admin.bans.search.php` — `GetAll` + `Execute` iteration
- `web/pages/admin.comms.search.php` — `GetAll` + `Execute` iteration
- `web/pages/admin.email.php` — `GetOne` with `?` placeholders → `single` + assoc lookup
- `web/pages/admin.edit.adminperms.php` — `GetRow` with `?` placeholders

After this PR there are still ~310 `$GLOBALS['db']` call sites left, including the large cluster in `web/includes/sb-callback.php` and the heavier admin pages. Those will land in follow-up PRs.

Refs #1078

## Test plan
- [ ] PHPStan (CI) passes
- [ ] Manual: download a demo via `getdemo.php`
- [ ] Manual: hit `exportbans.php?type=steam` and `?type=ip` while logged in as owner
- [ ] Manual: load admin home (`page.admin.php`) and confirm counters render
- [ ] Manual: open Servers list (`page.servers.php`) and confirm server cards render with status calls
- [ ] Manual: open "Your account" page and confirm email field is populated and srvpwset toggles correctly
- [ ] Manual: open MODs admin page and confirm list + count render
- [ ] Manual: open Bans search and Comms search filter pages and confirm admin/server dropdowns populate
- [ ] Manual: open Email submission/protest dialog (`admin.email.php`) for both `type=s` and `type=p`
- [ ] Manual: open admin permissions edit page and confirm the existing flags load
- [ ] Manual: open `admin.log.search.php` panel and confirm the admin dropdown populates