### PR TITLE
refactor(web): finish ADOdb→PDO migration and drop dependency

### DIFF
--- a/web/composer.json
+++ b/web/composer.json
@@ -23,7 +23,6 @@
         "maxmind-db/reader": "~1.0",
         "smarty/smarty": "^v5.4",
         "xpaw/php-source-query-class": "^6.0.0",
-        "adodb/adodb-php": "^5.22",
         "symfony/mailer": "^7.2",
         "ext-pdo": "*",
         "ext-openssl": "*",

--- a/web/composer.lock
+++ b/web/composer.lock
@@ -4,83 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a4b4bb18dbfe86e80bc731079f5f4d22",
+    "content-hash": "b4114823c02b6b75fbed8cd6a22f0653",
     "packages": [
-        {
-            "name": "adodb/adodb-php",
-            "version": "v5.22.11",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/ADOdb/ADOdb.git",
-                "reference": "a741375176f48b084ca9a110c112323fc7101b75"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/ADOdb/ADOdb/zipball/a741375176f48b084ca9a110c112323fc7101b75",
-                "reference": "a741375176f48b084ca9a110c112323fc7101b75",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.0 || ^8.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^8.5"
-            },
-            "type": "library",
-            "autoload": {
-                "files": [
-                    "adodb.inc.php"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause",
-                "LGPL-2.1-or-later"
-            ],
-            "authors": [
-                {
-                    "name": "John Lim",
-                    "email": "jlim@natsoft.com",
-                    "role": "Author"
-                },
-                {
-                    "name": "Damien Regad",
-                    "role": "Current maintainer"
-                },
-                {
-                    "name": "Mark Newnham",
-                    "role": "Developer"
-                }
-            ],
-            "description": "ADOdb is a PHP database abstraction layer library",
-            "homepage": "https://adodb.org/",
-            "keywords": [
-                "abstraction",
-                "database",
-                "layer",
-                "library",
-                "php"
-            ],
-            "support": {
-                "issues": "https://github.com/ADOdb/ADOdb/issues",
-                "source": "https://github.com/ADOdb/ADOdb"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/ADOdb",
-                    "type": "github"
-                },
-                {
-                    "url": "https://github.com/dregad",
-                    "type": "github"
-                },
-                {
-                    "url": "https://thanks.dev/u/gh/adodb",
-                    "type": "thanks_dev"
-                }
-            ],
-            "time": "2025-11-22T15:37:23+00:00"
-        },
         {
             "name": "doctrine/lexer",
             "version": "3.0.1",

--- a/web/includes/auth/handler/NormalAuthHandler.php
+++ b/web/includes/auth/handler/NormalAuthHandler.php
@@ -5,11 +5,10 @@ class NormalAuthHandler
     private $result = false;
 
     public function __construct(
-        private $dbs,
+        private Database $dbs,
         string $username, string $password, bool $remember
     )
     {
-        $this->dbs = $dbs;
         $user = $this->getInfosFromDatabase($username);
 
         $maxlife = (($remember) ? Config::get('auth.maxlife.remember') : Config::get('auth.maxlife')) * 60;
@@ -49,41 +48,18 @@ class NormalAuthHandler
 
     private function updatePasswordHash(string $password, int $aid)
     {
-        $query = "UPDATE ".DB_PREFIX."_admins SET password = ? WHERE aid = ?";
-        $stmt = $this->dbs->Prepare($query);
-
-        if (!$stmt) {
-            error_log("Failed to prepare SQL query for updating password: " . implode(" ", $this->dbs->errorInfo()));
-            return false;
-        }
-
-        $result = $this->dbs->Execute($stmt, array(password_hash($password, PASSWORD_BCRYPT), $aid));
-
-        if (!$result) {
-            error_log("Failed to execute SQL query for updating password: " . implode(" ", $this->dbs->errorInfo()));
-            return false;
-        }
-
-        return true;
+        $this->dbs->query("UPDATE `:prefix_admins` SET password = :password WHERE aid = :aid");
+        $this->dbs->bindMultiple([
+            ':password' => password_hash($password, PASSWORD_BCRYPT),
+            ':aid'      => $aid,
+        ]);
+        return $this->dbs->execute();
     }
 
     private function getInfosFromDatabase(string $username)
     {
-        $query = "SELECT aid, password FROM ".DB_PREFIX."_admins WHERE user = ?";
-        $stmt = $this->dbs->Prepare($query);
-
-        if (!$stmt) {
-            error_log("Failed to prepare SQL query: " . implode(" ", $this->dbs->errorInfo()));
-            return false;
-        }
-
-        $result = $this->dbs->Execute($stmt, array($username));
-
-        if (!$result) {
-            error_log("Failed to execute SQL query: " . implode(" ", $this->dbs->errorInfo()));
-            return false;
-        }
-
-        return $result->fetchRow();
+        $this->dbs->query("SELECT aid, password FROM `:prefix_admins` WHERE user = :user");
+        $this->dbs->bind(':user', $username);
+        return $this->dbs->single();
     }
 }

--- a/web/includes/sb-callback.php
+++ b/web/includes/sb-callback.php
@@ -1968,7 +1968,7 @@ function AddBan($nickname, $type, $steam, $ip, $length, $dfile, $dname, $reason,
             AND type = '0'")->single(array($steam)
         );
 
-        if (intval($chk[0]) > 0) {
+        if (intval($chk['count']) > 0) {
             $objResponse->addScript("ShowBox('Error', 'SteamID: $steam is already banned.', 'red', '');");
             return $objResponse;
         }
@@ -1989,7 +1989,7 @@ function AddBan($nickname, $type, $steam, $ip, $length, $dfile, $dname, $reason,
             "SELECT count(bid) AS count FROM `:prefix_bans` WHERE ip = ? AND (length = 0 OR ends > UNIX_TIMESTAMP()) AND RemovedBy IS NULL AND type = '1'")->single(array($ip)
         );
 
-        if (intval($chk[0]) > 0) {
+        if (intval($chk['count']) > 0) {
             $objResponse->addScript("ShowBox('Error', 'IP: $ip is already banned.', 'red', '');");
             return $objResponse;
         }
@@ -3442,7 +3442,7 @@ function AddBlock($nickname, $type, $steam, $length, $reason)
         "SELECT count(bid) AS count FROM `:prefix_comms` WHERE authid = ? AND (length = 0 OR ends > UNIX_TIMESTAMP()) AND RemovedBy IS NULL AND ".$typeW)->single(array($steam)
     );
 
-    if (intval($chk[0]) > 0) {
+    if (intval($chk['count']) > 0) {
         $objResponse->addScript("ShowBox('Error', 'SteamID: $steam is already blocked.', 'red', '');");
         return $objResponse;
     }

--- a/web/includes/sb-callback.php
+++ b/web/includes/sb-callback.php
@@ -380,7 +380,7 @@ function AddGroup($name, $type, $bitmask, $srvflags)
     $error = 0;
     $query = $GLOBALS['PDO']->query("SELECT `gid` FROM `:prefix_groups` WHERE `name` = ?")->single(array($name));
     $query2 = $GLOBALS['PDO']->query("SELECT `id` FROM `:prefix_srvgroups` WHERE `name` = ?")->single(array($name));
-    if (strlen($name) == 0 || count($query) > 0 || count($query2) > 0) {
+    if (strlen($name) == 0 || $query || $query2) {
         if (strlen($name) == 0) {
             $objResponse->addScript("$('name.msg').setStyle('display', 'block');");
             $objResponse->addScript("$('name.msg').setHTML('Please enter a name for this group.');");
@@ -389,7 +389,7 @@ function AddGroup($name, $type, $bitmask, $srvflags)
             $objResponse->addScript("$('name.msg').setStyle('display', 'block');");
             $objResponse->addScript("$('name.msg').setHTML('You cannot have a comma \',\' in a group name.');");
             $error++;
-        } elseif (count($query) > 0 || count($query2) > 0) {
+        } elseif ($query || $query2) {
             $objResponse->addScript("$('name.msg').setStyle('display', 'block');");
             $objResponse->addScript("$('name.msg').setHTML('A group is already named \'" . $name . "\'');");
             $error++;
@@ -717,7 +717,7 @@ function RemoveAdmin($aid)
     }
     $aid = (int)$aid;
     $gid = $GLOBALS['PDO']->query("SELECT gid, authid, extraflags, user FROM `:prefix_admins` WHERE aid = $aid")->single();
-    if((intval($gid[2]) & ADMIN_OWNER) != 0) {
+    if($gid && (intval($gid['extraflags']) & ADMIN_OWNER) != 0) {
         $objResponse->addAlert("Error: You cannot delete the owner.");
         return $objResponse;
     }
@@ -3246,7 +3246,7 @@ function BanFriends($friendid, $name)
         $GLOBALS['PDO']->bind(':authid', $steam);
         $banned = $GLOBALS['PDO']->single();
 
-        if ((bool)$banned[1]) {
+        if ($banned) {
             $before++;
             continue;
         }

--- a/web/includes/sb-callback.php
+++ b/web/includes/sb-callback.php
@@ -140,7 +140,7 @@ function Plogin(string $username, string $password, string $remember = '', strin
     // Convert remember option to boolean
     $remember = ($remember === 'true') ? true : false;
 
-    $auth = new NormalAuthHandler($GLOBALS['db'], $username, $password, $remember);
+    $auth = new NormalAuthHandler($GLOBALS['PDO'], $username, $password, $remember);
 
     if (!$auth->getResult()) {
         // Increment login attempts and set lockout if needed
@@ -167,82 +167,33 @@ function Plogin(string $username, string $password, string $remember = '', strin
 
 function getUserFromDatabase($username)
 {
-    $query = "SELECT aid, password, attempts, lockout_until FROM ".DB_PREFIX."_admins WHERE user = ?";
-    $stmt = $GLOBALS['db']->Prepare($query);
-
-    if (!$stmt) {
-        error_log("Failed to prepare SQL query for getting user from database.");
-        return false;
-    }
-
-    $result = $GLOBALS['db']->Execute($stmt, array($username));
-
-    if (!$result) {
-        error_log("Failed to execute SQL query for getting user from database.");
-        return false;
-    }
-
-    return $result->fetchRow();
+    $GLOBALS['PDO']->query("SELECT aid, password, attempts, lockout_until FROM `:prefix_admins` WHERE user = :user");
+    $GLOBALS['PDO']->bind(':user', $username);
+    return $GLOBALS['PDO']->single();
 }
 
 function incrementLoginAttempts($username)
 {
-    $query = "UPDATE ".DB_PREFIX."_admins SET attempts = attempts + 1 WHERE user = ?";
-    $stmt = $GLOBALS['db']->Prepare($query);
-
-    if (!$stmt) {
-        error_log("Failed to prepare SQL query for incrementing login attempts.");
-        return false;
-    }
-
-    $result = $GLOBALS['db']->Execute($stmt, array($username));
-
-    if (!$result) {
-        error_log("Failed to execute SQL query for incrementing login attempts.");
-        return false;
-    }
-
-    return true;
+    $GLOBALS['PDO']->query("UPDATE `:prefix_admins` SET attempts = attempts + 1 WHERE user = :user");
+    $GLOBALS['PDO']->bind(':user', $username);
+    return $GLOBALS['PDO']->execute();
 }
 
 function resetLoginAttempts($username)
 {
-    $query = "UPDATE ".DB_PREFIX."_admins SET attempts = 0, lockout_until = NULL WHERE user = ?";
-    $stmt = $GLOBALS['db']->Prepare($query);
-
-    if (!$stmt) {
-        error_log("Failed to prepare SQL query for resetting login attempts.");
-        return false;
-    }
-
-    $result = $GLOBALS['db']->Execute($stmt, array($username));
-
-    if (!$result) {
-        error_log("Failed to execute SQL query for resetting login attempts.");
-        return false;
-    }
-
-    return true;
+    $GLOBALS['PDO']->query("UPDATE `:prefix_admins` SET attempts = 0, lockout_until = NULL WHERE user = :user");
+    $GLOBALS['PDO']->bind(':user', $username);
+    return $GLOBALS['PDO']->execute();
 }
 
 function setLockout($username, $lockoutUntil)
 {
-    $query = "UPDATE ".DB_PREFIX."_admins SET lockout_until = ? WHERE user = ?";
-    $stmt = $GLOBALS['db']->Prepare($query);
-
-    if (!$stmt) {
-        error_log("Failed to prepare SQL query for setting lockout.");
-        return false;
-    }
-
-    $result = $GLOBALS['db']->Execute($stmt, array($lockoutUntil, $username));
-
-    if (!$result) {
-        error_log("Failed to execute SQL query for setting lockout.");
-        return false;
-    }
-
-    return true;
+    $GLOBALS['PDO']->query("UPDATE `:prefix_admins` SET lockout_until = :until WHERE user = :user");
+    $GLOBALS['PDO']->bindMultiple([
+        ':until' => $lockoutUntil,
+        ':user'  => $username,
+    ]);
+    return $GLOBALS['PDO']->execute();
 }
 
 /**
@@ -308,8 +259,10 @@ function CheckSrvPassword($aid, $srv_pass)
         );
         return $objResponse;
     }
-    $res = $GLOBALS['db']->Execute("SELECT `srv_password` FROM `".DB_PREFIX."_admins` WHERE `aid` = '".$aid."'");
-    if($res->fields['srv_password'] != null && $res->fields['srv_password'] != $srv_pass) {
+    $GLOBALS['PDO']->query("SELECT `srv_password` FROM `:prefix_admins` WHERE `aid` = :aid");
+    $GLOBALS['PDO']->bind(':aid', $aid);
+    $res = $GLOBALS['PDO']->single();
+    if($res['srv_password'] != null && $res['srv_password'] != $srv_pass) {
         $objResponse->addScript("$('scurrent.msg').setStyle('display', 'block');");
         $objResponse->addScript("$('scurrent.msg').setHTML('Incorrect password.');");
         $objResponse->addScript("set_error(1);");
@@ -344,12 +297,10 @@ function ChangeSrvPassword($aid, $srv_pass)
     }
 
     if($srv_pass == "NULL") {
-        $GLOBALS['db']->Execute(
-            "UPDATE `" . DB_PREFIX . "_admins` SET `srv_password` = NULL WHERE `aid` = '" . $aid . "'"
-        );
+        $GLOBALS['PDO']->query("UPDATE `:prefix_admins` SET `srv_password` = NULL WHERE `aid` = '" . $aid . "'")->execute();
     } else {
-        $GLOBALS['db']->Execute(
-            "UPDATE `" . DB_PREFIX . "_admins` SET `srv_password` = ? WHERE `aid` = ?", array($srv_pass, $aid)
+        $GLOBALS['PDO']->query(
+            "UPDATE `:prefix_admins` SET `srv_password` = ? WHERE `aid` = ?")->execute(array($srv_pass, $aid)
         );
     }
     $objResponse->addScript(
@@ -401,7 +352,7 @@ function ChangeEmail($aid, $email, $password)
         $objResponse->addScript("set_error(0);");
     }
 
-    $GLOBALS['db']->Execute("UPDATE `".DB_PREFIX."_admins` SET `email` = ? WHERE `aid` = ?", array($email, $aid));
+    $GLOBALS['PDO']->query("UPDATE `:prefix_admins` SET `email` = ? WHERE `aid` = ?")->execute(array($email, $aid));
     $objResponse->addScript(
         "ShowBox('E-mail address changed', 'Your E-mail address has been changed successfully.', 'green', 'index.php?p=account', true);"
     );
@@ -427,8 +378,8 @@ function AddGroup($name, $type, $bitmask, $srvflags)
     }
 
     $error = 0;
-    $query = $GLOBALS['db']->GetRow("SELECT `gid` FROM `" . DB_PREFIX . "_groups` WHERE `name` = ?", array($name));
-    $query2 = $GLOBALS['db']->GetRow("SELECT `id` FROM `" . DB_PREFIX . "_srvgroups` WHERE `name` = ?", array($name));
+    $query = $GLOBALS['PDO']->query("SELECT `gid` FROM `:prefix_groups` WHERE `name` = ?")->single(array($name));
+    $query2 = $GLOBALS['PDO']->query("SELECT `id` FROM `:prefix_srvgroups` WHERE `name` = ?")->single(array($name));
     if (strlen($name) == 0 || count($query) > 0 || count($query2) > 0) {
         if (strlen($name) == 0) {
             $objResponse->addScript("$('name.msg').setStyle('display', 'block');");
@@ -459,14 +410,12 @@ function AddGroup($name, $type, $bitmask, $srvflags)
         return $objResponse;
     }
 
-    $query = $GLOBALS['db']->GetRow("SELECT MAX(gid) AS next_gid FROM `" . DB_PREFIX . "_groups`");
+    $query = $GLOBALS['PDO']->query("SELECT MAX(gid) AS next_gid FROM `:prefix_groups`")->single();
     if ($type == "1") {
         // add the web group
-        $query1 = $GLOBALS['db']->Execute(
-            "INSERT INTO `" . DB_PREFIX
-            . "_groups` (`gid`, `type`, `name`, `flags`) 
-            VALUES (" . (int)($query['next_gid'] + 1) . ", '" . (int)$type . "', ?, '" . (int)$bitmask . "')",
-            array($name)
+        $query1 = $GLOBALS['PDO']->query(
+            "INSERT INTO `:prefix_groups` (`gid`, `type`, `name`, `flags`) 
+            VALUES (" . (int)($query['next_gid'] + 1) . ", '" . (int)$type . "', ?, '" . (int)$bitmask . "')")->execute(array($name)
         );
     } elseif ($type == "2") {
         if (strstr($srvflags, "#")) {
@@ -475,17 +424,14 @@ function AddGroup($name, $type, $bitmask, $srvflags)
             $srvflags = substr($srvflags, 0, strlen($srvflags) - strlen($immunity) - 1);
         }
         $immunity = (isset($immunity) && $immunity > 0) ? $immunity : 0;
-        $add_group = $GLOBALS['db']->Prepare(
-            "INSERT INTO " . DB_PREFIX . "_srvgroups(immunity,flags,name,groups_immune)
+        $GLOBALS['PDO']->query(
+            "INSERT INTO `:prefix_srvgroups`(immunity,flags,name,groups_immune)
     VALUES (?,?,?,?)"
-        );
-        $GLOBALS['db']->Execute($add_group, array($immunity, $srvflags, $name, " "));
+        )->execute([$immunity, $srvflags, $name, " "]);
     } elseif ($type == "3") {
         // We need to add the server into the table
-        $query1 = $GLOBALS['db']->Execute(
-            "INSERT INTO `" . DB_PREFIX
-            . "_groups` (`gid`, `type`, `name`, `flags`) VALUES (" . ($query['next_gid'] + 1) . ", '3', ?, '0')",
-            array($name)
+        $query1 = $GLOBALS['PDO']->query(
+            "INSERT INTO `:prefix_groups` (`gid`, `type`, `name`, `flags`) VALUES (" . ($query['next_gid'] + 1) . ", '3', ?, '0')")->execute(array($name)
         );
     }
 
@@ -510,22 +456,20 @@ function RemoveGroup($gid, $type)
     $gid = (int)$gid;
 
     if ($type == "web") {
-        $query2 = $GLOBALS['db']->Execute("UPDATE `" . DB_PREFIX . "_admins` SET gid = -1 WHERE gid = $gid");
-        $query1 = $GLOBALS['db']->Execute("DELETE FROM `" . DB_PREFIX . "_groups` WHERE gid = $gid");
+        $query2 = $GLOBALS['PDO']->query("UPDATE `:prefix_admins` SET gid = -1 WHERE gid = $gid")->execute();
+        $query1 = $GLOBALS['PDO']->query("DELETE FROM `:prefix_groups` WHERE gid = $gid")->execute();
     } elseif ($type == "server") {
-        $query2 = $GLOBALS['db']->Execute("DELETE FROM `" . DB_PREFIX . "_servers_groups` WHERE group_id = $gid");
-        $query1 = $GLOBALS['db']->Execute("DELETE FROM `" . DB_PREFIX . "_groups` WHERE gid = $gid");
+        $query2 = $GLOBALS['PDO']->query("DELETE FROM `:prefix_servers_groups` WHERE group_id = $gid")->execute();
+        $query1 = $GLOBALS['PDO']->query("DELETE FROM `:prefix_groups` WHERE gid = $gid")->execute();
     } else {
-        $query2 = $GLOBALS['db']->Execute(
-            "UPDATE `" . DB_PREFIX . "_admins` SET srv_group = NULL WHERE srv_group = (SELECT name FROM `" . DB_PREFIX . "_srvgroups` WHERE id = $gid)"
-        );
-        $query1 = $GLOBALS['db']->Execute("DELETE FROM `" . DB_PREFIX . "_srvgroups` WHERE id = $gid");
-        $query0 = $GLOBALS['db']->Execute("DELETE FROM `" . DB_PREFIX . "_srvgroups_overrides` WHERE group_id = $gid");
+        $query2 = $GLOBALS['PDO']->query("UPDATE `:prefix_admins` SET srv_group = NULL WHERE srv_group = (SELECT name FROM `:prefix_srvgroups` WHERE id = $gid)")->execute();
+        $query1 = $GLOBALS['PDO']->query("DELETE FROM `:prefix_srvgroups` WHERE id = $gid")->execute();
+        $query0 = $GLOBALS['PDO']->query("DELETE FROM `:prefix_srvgroups_overrides` WHERE group_id = $gid")->execute();
     }
 
     if (Config::getBool('config.enableadminrehashing')) {
         // rehash the settings out of the database on all servers
-        $serveraccessq = $GLOBALS['db']->GetAll("SELECT sid FROM " . DB_PREFIX . "_servers WHERE enabled = 1;");
+        $serveraccessq = $GLOBALS['PDO']->query("SELECT sid FROM `:prefix_servers` WHERE enabled = 1;")->resultset();
         $allservers = [];
         foreach ($serveraccessq as $access) {
             if (!in_array($access['sid'], $allservers)) {
@@ -573,12 +517,8 @@ function RemoveSubmission($sid, $archiv)
     }
     $sid = (int)$sid;
     if($archiv == "1") { // move submission to archiv
-        $query1 = $GLOBALS['db']->Execute(
-            "UPDATE `" . DB_PREFIX . "_submissions` SET archiv = '1', archivedby = '" . $userbank->GetAid() . "' WHERE subid = $sid"
-        );
-        $query = $GLOBALS['db']->GetRow(
-            "SELECT count(subid) AS cnt FROM `" . DB_PREFIX . "_submissions` WHERE archiv = '0'"
-        );
+        $query1 = $GLOBALS['PDO']->query("UPDATE `:prefix_submissions` SET archiv = '1', archivedby = '" . $userbank->GetAid() . "' WHERE subid = $sid")->execute();
+        $query = $GLOBALS['PDO']->query("SELECT count(subid) AS cnt FROM `:prefix_submissions` WHERE archiv = '0'")->single();
         $objResponse->addScript("$('subcount').setHTML('" . $query['cnt'] . "');");
 
         $objResponse->addScript("SlideUp('sid_$sid');");
@@ -595,13 +535,9 @@ function RemoveSubmission($sid, $archiv)
             );
         }
     } else if($archiv == "0") { // delete submission
-        $query1 = $GLOBALS['db']->Execute("DELETE FROM `" . DB_PREFIX . "_submissions` WHERE subid = $sid");
-        $GLOBALS['db']->Execute(
-            "DELETE FROM `" . DB_PREFIX . "_demos` WHERE demid = '" . $sid . "' AND demtype = 'S'"
-        );
-        $query = $GLOBALS['db']->GetRow(
-            "SELECT count(subid) AS cnt FROM `" . DB_PREFIX . "_submissions` WHERE archiv = '1'"
-        );
+        $query1 = $GLOBALS['PDO']->query("DELETE FROM `:prefix_submissions` WHERE subid = $sid")->execute();
+        $GLOBALS['PDO']->query("DELETE FROM `:prefix_demos` WHERE demid = '" . $sid . "' AND demtype = 'S'")->execute();
+        $query = $GLOBALS['PDO']->query("SELECT count(subid) AS cnt FROM `:prefix_submissions` WHERE archiv = '1'")->single();
         $objResponse->addScript("$('subcountarchiv').setHTML('" . $query['cnt'] . "');");
 
         $objResponse->addScript("SlideUp('asid_$sid');");
@@ -614,8 +550,8 @@ function RemoveSubmission($sid, $archiv)
             $objResponse->addScript("ShowBox('Error', 'There was a problem deleting the submission from the database. Check the logs for more info', 'red', 'index.php?p=admin&c=bans', true);");
         }
     } else if($archiv == "2") { // restore the submission
-        $query1 = $GLOBALS['db']->Execute("UPDATE `" . DB_PREFIX . "_submissions` SET archiv = '0', archivedby = NULL WHERE subid = $sid");
-        $query = $GLOBALS['db']->GetRow("SELECT count(subid) AS cnt FROM `" . DB_PREFIX . "_submissions` WHERE archiv = '0'");
+        $query1 = $GLOBALS['PDO']->query("UPDATE `:prefix_submissions` SET archiv = '0', archivedby = NULL WHERE subid = $sid")->execute();
+        $query = $GLOBALS['PDO']->query("SELECT count(subid) AS cnt FROM `:prefix_submissions` WHERE archiv = '0'")->single();
         $objResponse->addScript("$('subcountarchiv').setHTML('" . $query['cnt'] . "');");
 
         $objResponse->addScript("SlideUp('asid_$sid');");
@@ -642,9 +578,9 @@ function RemoveProtest($pid, $archiv)
     }
     $pid = (int)$pid;
     if($archiv == '0') { // delete protest
-        $query1 = $GLOBALS['db']->Execute("DELETE FROM `" . DB_PREFIX . "_protests` WHERE pid = $pid");
-        $GLOBALS['db']->Execute("DELETE FROM `" . DB_PREFIX . "_comments` WHERE type = 'P' AND bid = $pid;");
-        $query = $GLOBALS['db']->GetRow("SELECT count(pid) AS cnt FROM `" . DB_PREFIX . "_protests` WHERE archiv = '1'");
+        $query1 = $GLOBALS['PDO']->query("DELETE FROM `:prefix_protests` WHERE pid = $pid")->execute();
+        $GLOBALS['PDO']->query("DELETE FROM `:prefix_comments` WHERE type = 'P' AND bid = $pid;")->execute();
+        $query = $GLOBALS['PDO']->query("SELECT count(pid) AS cnt FROM `:prefix_protests` WHERE archiv = '1'")->single();
         $objResponse->addScript("$('protcountarchiv').setHTML('" . $query['cnt'] . "');");
         $objResponse->addScript("SlideUp('apid_$pid');");
         $objResponse->addScript("SlideUp('apid_" . $pid . "a');");
@@ -660,12 +596,8 @@ function RemoveProtest($pid, $archiv)
             );
         }
     } else if($archiv == '1') { // move protest to archiv
-        $query1 = $GLOBALS['db']->Execute(
-            "UPDATE `" . DB_PREFIX . "_protests` SET archiv = '1', archivedby = '" . $userbank->GetAid() . "' WHERE pid = $pid"
-        );
-        $query = $GLOBALS['db']->GetRow(
-            "SELECT count(pid) AS cnt FROM `" . DB_PREFIX . "_protests` WHERE archiv = '0'"
-        );
+        $query1 = $GLOBALS['PDO']->query("UPDATE `:prefix_protests` SET archiv = '1', archivedby = '" . $userbank->GetAid() . "' WHERE pid = $pid")->execute();
+        $query = $GLOBALS['PDO']->query("SELECT count(pid) AS cnt FROM `:prefix_protests` WHERE archiv = '0'")->single();
         $objResponse->addScript("$('protcount').setHTML('" . $query['cnt'] . "');");
         $objResponse->addScript("SlideUp('pid_$pid');");
         $objResponse->addScript("SlideUp('pid_" . $pid . "a');");
@@ -681,12 +613,8 @@ function RemoveProtest($pid, $archiv)
             );
         }
     } else if($archiv == '2') { // restore protest
-        $query1 = $GLOBALS['db']->Execute(
-            "UPDATE `" . DB_PREFIX . "_protests` SET archiv = '0', archivedby = NULL WHERE pid = $pid"
-        );
-        $query = $GLOBALS['db']->GetRow(
-            "SELECT count(pid) AS cnt FROM `" . DB_PREFIX . "_protests` WHERE archiv = '1'"
-        );
+        $query1 = $GLOBALS['PDO']->query("UPDATE `:prefix_protests` SET archiv = '0', archivedby = NULL WHERE pid = $pid")->execute();
+        $query = $GLOBALS['PDO']->query("SELECT count(pid) AS cnt FROM `:prefix_protests` WHERE archiv = '1'")->single();
         $objResponse->addScript("$('protcountarchiv').setHTML('" . $query['cnt'] . "');");
         $objResponse->addScript("SlideUp('apid_$pid');");
         $objResponse->addScript("SlideUp('apid_" . $pid . "a');");
@@ -720,14 +648,12 @@ function RemoveServer($sid)
     }
     $sid = (int)$sid;
     $objResponse->addScript("SlideUp('sid_$sid');");
-    $servinfo = $GLOBALS['db']->GetRow("SELECT ip, port FROM `" . DB_PREFIX . "_servers` WHERE sid = $sid");
-    $query1 = $GLOBALS['db']->Execute("DELETE FROM `" . DB_PREFIX . "_servers` WHERE sid = $sid");
-    $GLOBALS['db']->Execute("DELETE FROM `" . DB_PREFIX . "_servers_groups` WHERE server_id = $sid");
-    $GLOBALS['db']->Execute(
-        "UPDATE `" . DB_PREFIX . "_admins_servers_groups` SET server_id = -1 WHERE server_id = $sid"
-    );
+    $servinfo = $GLOBALS['PDO']->query("SELECT ip, port FROM `:prefix_servers` WHERE sid = $sid")->single();
+    $query1 = $GLOBALS['PDO']->query("DELETE FROM `:prefix_servers` WHERE sid = $sid")->execute();
+    $GLOBALS['PDO']->query("DELETE FROM `:prefix_servers_groups` WHERE server_id = $sid")->execute();
+    $GLOBALS['PDO']->query("UPDATE `:prefix_admins_servers_groups` SET server_id = -1 WHERE server_id = $sid")->execute();
 
-    $query = $GLOBALS['db']->GetRow("SELECT count(sid) AS cnt FROM `" . DB_PREFIX . "_servers`");
+    $query = $GLOBALS['PDO']->query("SELECT count(sid) AS cnt FROM `:prefix_servers`")->single();
     $objResponse->addScript("$('srvcount').setHTML('" . $query['cnt'] . "');");
 
 
@@ -757,10 +683,10 @@ function RemoveMod($mid)
     $mid = (int)$mid;
     $objResponse->addScript("SlideUp('mid_$mid');");
 
-    $modicon = $GLOBALS['db']->GetRow("SELECT icon, name FROM `" . DB_PREFIX . "_mods` WHERE mid = '" . $mid . "';");
+    $modicon = $GLOBALS['PDO']->query("SELECT icon, name FROM `:prefix_mods` WHERE mid = '" . $mid . "';")->single();
     @unlink(SB_ICONS."/".$modicon['icon']);
 
-    $query1 = $GLOBALS['db']->Execute("DELETE FROM `" . DB_PREFIX . "_mods` WHERE mid = '" . $mid . "'");
+    $query1 = $GLOBALS['PDO']->query("DELETE FROM `:prefix_mods` WHERE mid = '" . $mid . "'")->execute();
 
     if($query1) {
         $objResponse->addScript(
@@ -790,26 +716,22 @@ function RemoveAdmin($aid)
         return $objResponse;
     }
     $aid = (int)$aid;
-    $gid = $GLOBALS['db']->GetRow(
-        "SELECT gid, authid, extraflags, user FROM `" . DB_PREFIX . "_admins` WHERE aid = $aid"
-    );
+    $gid = $GLOBALS['PDO']->query("SELECT gid, authid, extraflags, user FROM `:prefix_admins` WHERE aid = $aid")->single();
     if((intval($gid[2]) & ADMIN_OWNER) != 0) {
         $objResponse->addAlert("Error: You cannot delete the owner.");
         return $objResponse;
     }
 
-    $delquery = $GLOBALS['db']->Execute(sprintf("DELETE FROM `%s_admins` WHERE aid = %d LIMIT 1", DB_PREFIX, $aid));
+    $delquery = $GLOBALS['PDO']->query("DELETE FROM `:prefix_admins` WHERE aid = $aid LIMIT 1")->execute();
     if($delquery) {
         if (Config::getBool('config.enableadminrehashing')) {
             // rehash the admins for the servers where this admin was on
-            $serveraccessq = $GLOBALS['db']->GetAll(
-                "SELECT s.sid FROM `" . DB_PREFIX . "_servers` s
-    LEFT JOIN `" . DB_PREFIX . "_admins_servers_groups` asg ON asg.admin_id = '" . (int)$aid . "'
-    LEFT JOIN `" . DB_PREFIX . "_servers_groups` sg ON sg.group_id = asg.srv_group_id
+            $serveraccessq = $GLOBALS['PDO']->query("SELECT s.sid FROM `:prefix_servers` s
+    LEFT JOIN `:prefix_admins_servers_groups` asg ON asg.admin_id = '" . (int)$aid . "'
+    LEFT JOIN `:prefix_servers_groups` sg ON sg.group_id = asg.srv_group_id
     WHERE ((asg.server_id != '-1' AND asg.srv_group_id = '-1')
     OR (asg.srv_group_id != '-1' AND asg.server_id = '-1'))
-    AND (s.sid IN(asg.server_id) OR s.sid IN(sg.server_id)) AND s.enabled = 1"
-            );
+    AND (s.sid IN(asg.server_id) OR s.sid IN(sg.server_id)) AND s.enabled = 1")->resultset();
             $allservers = [];
             foreach ($serveraccessq as $access) {
                 if (!in_array($access['sid'], $allservers)) {
@@ -819,10 +741,10 @@ function RemoveAdmin($aid)
             $rehashing = true;
         }
 
-        $GLOBALS['db']->Execute(sprintf("DELETE FROM `%s_admins_servers_groups` WHERE admin_id = %d", DB_PREFIX, $aid));
+        $GLOBALS['PDO']->query("DELETE FROM `:prefix_admins_servers_groups` WHERE admin_id = $aid")->execute();
     }
 
-    $query = $GLOBALS['db']->GetRow("SELECT count(aid) AS cnt FROM `" . DB_PREFIX . "_admins`");
+    $query = $GLOBALS['PDO']->query("SELECT count(aid) AS cnt FROM `:prefix_admins`")->single();
     $objResponse->addScript("SlideUp('aid_$aid');");
     $objResponse->addScript("$('admincount').setHTML('" . $query['cnt'] . "');");
     if($delquery) {
@@ -934,9 +856,8 @@ function AddServer($ip, $port, $rcon, $rcon2, $mod, $enabled, $group, $group_nam
     }
 
     // Check for dublicates afterwards
-    $chk = $GLOBALS['db']->GetRow(
-        'SELECT sid FROM `'.DB_PREFIX.'_servers` WHERE ip = ? AND port = ?;',
-        array($ip, (int)$port)
+    $chk = $GLOBALS['PDO']->query(
+        'SELECT sid FROM `:prefix_servers` WHERE ip = ? AND port = ?;')->single(array($ip, (int)$port)
     );
     if($chk) {
         $objResponse->addScript("ShowBox('Error', 'There already is a server with that IP:Port combination.', 'red');");
@@ -953,20 +874,18 @@ function AddServer($ip, $port, $rcon, $rcon2, $mod, $enabled, $group, $group_nam
     $enable = ($enabled=="true"?1:0);
 
     // Add the server
-    $addserver = $GLOBALS['db']->Prepare(
-        "INSERT INTO ".DB_PREFIX."_servers (`sid`, `ip`, `port`, `rcon`, `modid`, `enabled`)
+    $GLOBALS['PDO']->query(
+        "INSERT INTO `:prefix_servers` (`sid`, `ip`, `port`, `rcon`, `modid`, `enabled`)
       VALUES (?,?,?,?,?,?)"
-    );
-    $GLOBALS['db']->Execute($addserver, array($sid, $ip, (int)$port, $rcon, $mod, $enable));
+    )->execute([$sid, $ip, (int)$port, $rcon, $mod, $enable]);
 
     // Add server to each group specified
     $groups = explode(",", $group);
-    $addtogrp = $GLOBALS['db']->Prepare(
-        "INSERT INTO ".DB_PREFIX."_servers_groups (`server_id`, `group_id`) VALUES (?,?)"
-    );
     foreach($groups AS $g) {
         if ($g) {
-            $GLOBALS['db']->Execute($addtogrp, array($sid, $g));
+            $GLOBALS['PDO']->query(
+                "INSERT INTO `:prefix_servers_groups` (`server_id`, `group_id`) VALUES (?,?)"
+            )->execute([$sid, $g]);
         }
     }
 
@@ -1382,11 +1301,11 @@ function AddAdmin(
     // Handle Webpermissions
     // Chose to create a new webgroup
     if ($a_wg == 'n') {
-        $add_webgroup = $GLOBALS['db']->Execute(
-            "INSERT INTO ".DB_PREFIX."_groups(type, name, flags)
-        VALUES (?,?,?)", array(1, $a_webname, $mask)
+        $add_webgroup = $GLOBALS['PDO']->query(
+            "INSERT INTO `:prefix_groups`(type, name, flags)
+        VALUES (?,?,?)")->execute(array(1, $a_webname, $mask)
         );
-        $web_group = (int)$GLOBALS['db']->Insert_ID();
+        $web_group = (int)$GLOBALS['PDO']->lastInsertId();
 
         // We added those permissons to the group, so don't add them as custom permissions again
         $mask = 0;
@@ -1401,22 +1320,23 @@ function AddAdmin(
     // Handle Serverpermissions
     // Chose to create a new server admin group
     if($a_sg == 'n') {
-        $add_servergroup = $GLOBALS['db']->Execute(
-            "INSERT INTO " . DB_PREFIX . "_srvgroups(immunity, flags, name, groups_immune)
-    VALUES (?,?,?,?)", array($immunity, $srv_mask, $a_servername, " ")
+        $add_servergroup = $GLOBALS['PDO']->query(
+            "INSERT INTO `:prefix_srvgroups`(immunity, flags, name, groups_immune)
+    VALUES (?,?,?,?)")->execute(array($immunity, $srv_mask, $a_servername, " ")
         );
 
         $server_admin_group = $a_servername;
-        $server_admin_group_int = (int)$GLOBALS['db']->Insert_ID();
+        $server_admin_group_int = (int)$GLOBALS['PDO']->lastInsertId();
 
         // We added those permissons to the group, so don't add them as custom permissions again
         $srv_mask = "";
     }
     // Chose an existing group
     else if($a_sg != 'c' && $a_sg > 0) {
-        $server_admin_group = $GLOBALS['db']->GetOne(
-            "SELECT `name` FROM " . DB_PREFIX . "_srvgroups WHERE id = '" . (int)$a_sg . "'"
-        );
+        $GLOBALS['PDO']->query("SELECT `name` FROM `:prefix_srvgroups` WHERE id = :id");
+        $GLOBALS['PDO']->bind(':id', (int)$a_sg);
+        $row = $GLOBALS['PDO']->single();
+        $server_admin_group = $row['name'] ?? null;
         $server_admin_group_int = (int)$a_sg;
     }
     // Custom permissions -> no group
@@ -1433,38 +1353,31 @@ function AddAdmin(
     if($aid > -1) {
         // Grant permissions to the selected server groups
         $srv_groups = explode(",", $server);
-        $addtosrvgrp = $GLOBALS['db']->Prepare(
-            "INSERT INTO " . DB_PREFIX . "_admins_servers_groups(admin_id,group_id,srv_group_id,server_id) VALUES (?,?,?,?)"
-        );
         foreach ($srv_groups AS $srv_group) {
             if (!empty($srv_group)) {
-                $GLOBALS['db']->Execute(
-                    $addtosrvgrp,
-                    array($aid, $server_admin_group_int, substr($srv_group, 1), '-1')
-                );
+                $GLOBALS['PDO']->query(
+                    "INSERT INTO `:prefix_admins_servers_groups`(admin_id,group_id,srv_group_id,server_id) VALUES (?,?,?,?)"
+                )->execute([$aid, $server_admin_group_int, substr($srv_group, 1), '-1']);
             }
         }
 
         // Grant permissions to individual servers
         $srv_arr = explode(",", $singlesrv);
-        $addtosrv = $GLOBALS['db']->Prepare(
-            "INSERT INTO " . DB_PREFIX . "_admins_servers_groups(admin_id,group_id,srv_group_id,server_id) VALUES (?,?,?,?)"
-        );
         foreach ($srv_arr AS $server) {
             if (!empty($server)) {
-                $GLOBALS['db']->Execute($addtosrv, array($aid, $server_admin_group_int, '-1', substr($server, 1)));
+                $GLOBALS['PDO']->query(
+                    "INSERT INTO `:prefix_admins_servers_groups`(admin_id,group_id,srv_group_id,server_id) VALUES (?,?,?,?)"
+                )->execute([$aid, $server_admin_group_int, '-1', substr($server, 1)]);
             }
         }
         if (Config::getBool('config.enableadminrehashing')) {
             // rehash the admins on the servers
-            $serveraccessq = $GLOBALS['db']->GetAll(
-                "SELECT s.sid FROM `" . DB_PREFIX . "_servers` s
-    LEFT JOIN `" . DB_PREFIX . "_admins_servers_groups` asg ON asg.admin_id = '" . (int)$aid . "'
-    LEFT JOIN `" . DB_PREFIX . "_servers_groups` sg ON sg.group_id = asg.srv_group_id
+            $serveraccessq = $GLOBALS['PDO']->query("SELECT s.sid FROM `:prefix_servers` s
+    LEFT JOIN `:prefix_admins_servers_groups` asg ON asg.admin_id = '" . (int)$aid . "'
+    LEFT JOIN `:prefix_servers_groups` sg ON sg.group_id = asg.srv_group_id
     WHERE ((asg.server_id != '-1' AND asg.srv_group_id = '-1')
     OR (asg.srv_group_id != '-1' AND asg.server_id = '-1'))
-    AND (s.sid IN(asg.server_id) OR s.sid IN(sg.server_id)) AND s.enabled = 1"
-            );
+    AND (s.sid IN(asg.server_id) OR s.sid IN(sg.server_id)) AND s.enabled = 1")->resultset();
             $allservers = [];
             foreach ($serveraccessq as $access) {
                 if (!in_array($access['sid'], $allservers)) {
@@ -2046,14 +1959,13 @@ function AddBan($nickname, $type, $steam, $ip, $length, $dfile, $dname, $reason,
     PruneBans();
     if ((int)$type==0) {
         // Check if the new steamid is already banned
-        $chk = $GLOBALS['db']->GetRow(
+        $chk = $GLOBALS['PDO']->query(
             "SELECT count(bid) AS count
-            FROM ".DB_PREFIX."_bans
+            FROM `:prefix_bans`
             WHERE authid = ?
             AND (length = 0 OR ends > UNIX_TIMESTAMP())
             AND RemovedBy IS NULL
-            AND type = '0'",
-            array($steam)
+            AND type = '0'")->single(array($steam)
         );
 
         if (intval($chk[0]) > 0) {
@@ -2073,9 +1985,8 @@ function AddBan($nickname, $type, $steam, $ip, $length, $dfile, $dname, $reason,
         }
     }
     if ((int)$type==1) {
-        $chk = $GLOBALS['db']->GetRow(
-            "SELECT count(bid) AS count FROM ".DB_PREFIX."_bans WHERE ip = ? AND (length = 0 OR ends > UNIX_TIMESTAMP()) AND RemovedBy IS NULL AND type = '1'",
-            array($ip)
+        $chk = $GLOBALS['PDO']->query(
+            "SELECT count(bid) AS count FROM `:prefix_bans` WHERE ip = ? AND (length = 0 OR ends > UNIX_TIMESTAMP()) AND RemovedBy IS NULL AND type = '1'")->single(array($ip)
         );
 
         if (intval($chk[0]) > 0) {
@@ -2084,12 +1995,11 @@ function AddBan($nickname, $type, $steam, $ip, $length, $dfile, $dname, $reason,
         }
     }
 
-    $pre = $GLOBALS['db']->Prepare(
-        "INSERT INTO " . DB_PREFIX . "_bans(created,type,ip,authid,name,ends,length,reason,aid,adminIp ) VALUES
+    $GLOBALS['PDO']->query(
+        "INSERT INTO `:prefix_bans`(created,type,ip,authid,name,ends,length,reason,aid,adminIp ) VALUES
     (UNIX_TIMESTAMP(),?,?,?,?,(UNIX_TIMESTAMP() + ?),?,?,?,?)"
-    );
-    $GLOBALS['db']->Execute(
-        $pre, array($type,
+    )->execute([
+        $type,
         $ip,
         $steam,
         $nickname,
@@ -2097,36 +2007,33 @@ function AddBan($nickname, $type, $steam, $ip, $length, $dfile, $dname, $reason,
         $len,
         $reason,
         $userbank->GetAid(),
-        $_SERVER['REMOTE_ADDR'])
-    );
-    $subid = $GLOBALS['db']->Insert_ID();
+        $_SERVER['REMOTE_ADDR'],
+    ]);
+    $subid = $GLOBALS['PDO']->lastInsertId();
 
     if ($dname && $dfile && preg_match('/^[a-z0-9]*$/i', $dfile)) {
         //Thanks jsifuentes: http://jacobsifuentes.com/sourcebans-1-4-lfi-exploit/
         //Official Fix: https://code.google.com/p/sourcebans/source/detail?r=165
 
-        $GLOBALS['db']->Execute(
-            "INSERT INTO ".DB_PREFIX."_demos(demid,demtype,filename,origname)
-         VALUES(?,'B', ?, ?)", array((int)$subid, $dfile, $dname)
+        $GLOBALS['PDO']->query(
+            "INSERT INTO `:prefix_demos`(demid,demtype,filename,origname)
+         VALUES(?,'B', ?, ?)")->execute(array((int)$subid, $dfile, $dname)
         );
     }
     if ($fromsub) {
-        $submail = $GLOBALS['db']->Execute(
-            "SELECT name, email FROM ".DB_PREFIX."_submissions WHERE subid = '" . (int)$fromsub . "'"
-        );
+        $GLOBALS['PDO']->query("SELECT name, email FROM `:prefix_submissions` WHERE subid = :subid");
+        $GLOBALS['PDO']->bind(':subid', (int)$fromsub);
+        $submail = $GLOBALS['PDO']->single();
 
-        Mail::send($submail->fields['email'], EmailType::BanAdded, [
+        Mail::send($submail['email'], EmailType::BanAdded, [
             '{home}' => Host::complete(true)
         ]);
 
-        $GLOBALS['db']->Execute(
-            "UPDATE `" . DB_PREFIX . "_submissions` SET archiv = '2', archivedby = '".$userbank->GetAid()."' WHERE subid = '" . (int)$fromsub . "'"
-        );
+        $GLOBALS['PDO']->query("UPDATE `:prefix_submissions` SET archiv = '2', archivedby = '".$userbank->GetAid()."' WHERE subid = '" . (int)$fromsub . "'")->execute();
     }
 
-    $GLOBALS['db']->Execute(
-        "UPDATE `".DB_PREFIX."_submissions` SET archiv = '3', archivedby = '".$userbank->GetAid()."' WHERE SteamId = ?;",
-        array($steam)
+    $GLOBALS['PDO']->query(
+        "UPDATE `:prefix_submissions` SET archiv = '3', archivedby = '".$userbank->GetAid()."' WHERE SteamId = ?;")->execute(array($steam)
     );
 
     $kickit = Config::getBool('config.enablekickit');
@@ -2192,10 +2099,8 @@ function PrepareReban($bid)
     $objResponse = new xajaxResponse();
     $bid = (int)$bid;
 
-    $ban = $GLOBALS['db']->GetRow(
-        "SELECT type, ip, authid, name, length, reason FROM ".DB_PREFIX."_bans WHERE bid = '".$bid."';"
-    );
-    $demo = $GLOBALS['db']->GetRow("SELECT * FROM ".DB_PREFIX."_demos WHERE demid = '".$bid."' AND demtype = \"B\";");
+    $ban = $GLOBALS['PDO']->query("SELECT type, ip, authid, name, length, reason FROM `:prefix_bans` WHERE bid = '".$bid."';")->single();
+    $demo = $GLOBALS['PDO']->query("SELECT * FROM `:prefix_demos` WHERE demid = '".$bid."' AND demtype = \"B\";")->single();
     // clear any old stuff
     $objResponse->addScript("$('nickname').value = ''");
     $objResponse->addScript("$('ip').value = ''");
@@ -2236,7 +2141,7 @@ function SetupEditServer($sid)
         return $objResponse;
     }
 
-    $server = $GLOBALS['db']->GetRow("SELECT * FROM ".DB_PREFIX."_servers WHERE sid = $sid");
+    $server = $GLOBALS['PDO']->query("SELECT * FROM `:prefix_servers` WHERE sid = $sid")->single();
 
     // clear any old stuff
     $objResponse->addScript("$('address').value = ''");
@@ -2348,8 +2253,8 @@ function AddMod($name, $folder, $icon, $steam_universe, $enabled)
     $enabled = (int)(bool)$enabled;
 
     // Already there?
-    $check = $GLOBALS['db']->GetRow(
-        "SELECT * FROM `" . DB_PREFIX . "_mods` WHERE modfolder = ? OR name = ?;", array($folder, $name)
+    $check = $GLOBALS['PDO']->query(
+        "SELECT * FROM `:prefix_mods` WHERE modfolder = ? OR name = ?;")->single(array($folder, $name)
     );
     if(!empty($check)) {
         $objResponse->addScript(
@@ -2358,10 +2263,9 @@ function AddMod($name, $folder, $icon, $steam_universe, $enabled)
         return $objResponse;
     }
 
-    $pre = $GLOBALS['db']->Prepare(
-        "INSERT INTO ".DB_PREFIX."_mods(name,icon,modfolder,steam_universe,enabled) VALUES (?,?,?,?,?)"
-    );
-    $GLOBALS['db']->Execute($pre, array($name, $icon, $folder, $steam_universe, $enabled));
+    $GLOBALS['PDO']->query(
+        "INSERT INTO `:prefix_mods`(name,icon,modfolder,steam_universe,enabled) VALUES (?,?,?,?,?)"
+    )->execute([$name, $icon, $folder, $steam_universe, $enabled]);
 
     $objResponse->addScript(
         "ShowBox('Mod Added', 'The game mod has been successfully added', 'green', 'index.php?p=admin&c=mods');"
@@ -2410,7 +2314,7 @@ function EditAdminPerms($aid, $web_flags, $srv_flags)
     }
 
     // Update web stuff
-    $GLOBALS['db']->Execute("UPDATE `".DB_PREFIX."_admins` SET `extraflags` = $web_flags WHERE `aid` = $aid");
+    $GLOBALS['PDO']->query("UPDATE `:prefix_admins` SET `extraflags` = $web_flags WHERE `aid` = $aid")->execute();
 
 
     if(strstr($srv_flags, "#")) {
@@ -2420,21 +2324,18 @@ function EditAdminPerms($aid, $web_flags, $srv_flags)
     }
     $immunity = ($immunity>0) ? $immunity : 0;
     // Update server stuff
-    $GLOBALS['db']->Execute(
-        "UPDATE `".DB_PREFIX."_admins` SET `srv_flags` = ?, `immunity` = ? WHERE `aid` = $aid",
-        array($srv_flags, $immunity)
+    $GLOBALS['PDO']->query(
+        "UPDATE `:prefix_admins` SET `srv_flags` = ?, `immunity` = ? WHERE `aid` = $aid")->execute(array($srv_flags, $immunity)
     );
 
     if(Config::getBool('config.enableadminrehashing')) {
         // rehash the admins on the servers
-        $serveraccessq = $GLOBALS['db']->GetAll(
-            "SELECT s.sid FROM `" . DB_PREFIX . "_servers` s
-    LEFT JOIN `" . DB_PREFIX . "_admins_servers_groups` asg ON asg.admin_id = '" . (int)$aid . "'
-    LEFT JOIN `" . DB_PREFIX . "_servers_groups` sg ON sg.group_id = asg.srv_group_id
+        $serveraccessq = $GLOBALS['PDO']->query("SELECT s.sid FROM `:prefix_servers` s
+    LEFT JOIN `:prefix_admins_servers_groups` asg ON asg.admin_id = '" . (int)$aid . "'
+    LEFT JOIN `:prefix_servers_groups` sg ON sg.group_id = asg.srv_group_id
     WHERE ((asg.server_id != '-1' AND asg.srv_group_id = '-1')
     OR (asg.srv_group_id != '-1' AND asg.server_id = '-1'))
-    AND (s.sid IN(asg.server_id) OR s.sid IN(sg.server_id)) AND s.enabled = 1"
-        );
+    AND (s.sid IN(asg.server_id) OR s.sid IN(sg.server_id)) AND s.enabled = 1")->resultset();
         $allservers = [];
         foreach ($serveraccessq as $access) {
             if (!in_array($access['sid'], $allservers)) {
@@ -2449,7 +2350,7 @@ function EditAdminPerms($aid, $web_flags, $srv_flags)
             "ShowBox('Permissions updated', 'The user`s permissions have been updated successfully', 'green', 'index.php?p=admin&c=admins');TabToReload();"
         );
     }
-    $admname = $GLOBALS['db']->GetRow("SELECT user FROM `".DB_PREFIX."_admins` WHERE aid = ?", array((int)$aid));
+    $admname = $GLOBALS['PDO']->query("SELECT user FROM `:prefix_admins` WHERE aid = ?")->single(array((int)$aid));
     Log::add("m", "Permissions Changed", "Permissions have been changed for ($admname[user])");
     return $objResponse;
 }
@@ -2476,14 +2377,13 @@ function EditGroup($gid, $web_flags, $srv_flags, $type, $name, $overrides, $newO
     $web_flags = (int)$web_flags;
     if ($type == "web" || $type == "server") {
         // Update web stuff
-        $GLOBALS['db']->Execute(
-            "UPDATE `" . DB_PREFIX . "_groups` SET `flags` = ?, `name` = ? WHERE `gid` = $gid",
-            array($web_flags, $name)
+        $GLOBALS['PDO']->query(
+            "UPDATE `:prefix_groups` SET `flags` = ?, `name` = ? WHERE `gid` = $gid")->execute(array($web_flags, $name)
         );
     }
 
     if($type == "srv") {
-        $gname = $GLOBALS['db']->GetRow("SELECT name FROM " . DB_PREFIX . "_srvgroups WHERE id = $gid");
+        $gname = $GLOBALS['PDO']->query("SELECT name FROM `:prefix_srvgroups` WHERE id = $gid")->single();
 
         if (strstr($srv_flags, "#")) {
             $immunity = 0;
@@ -2493,19 +2393,16 @@ function EditGroup($gid, $web_flags, $srv_flags, $type, $name, $overrides, $newO
         $immunity = ($immunity > 0) ? $immunity : 0;
 
         // Update server stuff
-        $GLOBALS['db']->Execute(
-            "UPDATE `" . DB_PREFIX . "_srvgroups` SET `flags` = ?, `name` = ?, `immunity` = ? WHERE `id` = $gid",
-            array($srv_flags, $name, $immunity)
+        $GLOBALS['PDO']->query(
+            "UPDATE `:prefix_srvgroups` SET `flags` = ?, `name` = ?, `immunity` = ? WHERE `id` = $gid")->execute(array($srv_flags, $name, $immunity)
         );
 
-        $oldname = $GLOBALS['db']->GetAll(
-            "SELECT aid FROM " . DB_PREFIX . "_admins WHERE srv_group = ?",
-            array($gname['name'])
+        $oldname = $GLOBALS['PDO']->query(
+            "SELECT aid FROM `:prefix_admins` WHERE srv_group = ?")->resultset(array($gname['name'])
         );
         foreach ($oldname as $o) {
-            $GLOBALS['db']->Execute(
-                "UPDATE `" . DB_PREFIX . "_admins` SET `srv_group` = ? WHERE `aid` = '" . (int)$o['aid'] . "'",
-                array($name)
+            $GLOBALS['PDO']->query(
+                "UPDATE `:prefix_admins` SET `srv_group` = ? WHERE `aid` = '" . (int)$o['aid'] . "'")->execute(array($name)
             );
         }
 
@@ -2523,15 +2420,13 @@ function EditGroup($gid, $web_flags, $srv_flags, $type, $name, $overrides, $newO
                 $id = (int)$override['id'];
                 // Wants to delete this override?
                 if (empty($override['name'])) {
-                    $GLOBALS['db']->Execute("DELETE FROM `" . DB_PREFIX . "_srvgroups_overrides` WHERE id = ?;",
-                        array($id));
+                    $GLOBALS['PDO']->query("DELETE FROM `:prefix_srvgroups_overrides` WHERE id = ?;")->execute(array($id));
                     continue;
                 }
 
                 // Check for duplicates
-                $chk = $GLOBALS['db']->GetAll(
-                    "SELECT * FROM `" . DB_PREFIX . "_srvgroups_overrides` WHERE name = ? AND type = ? AND group_id = ? AND id != ?",
-                    array($override['name'], $override['type'], $gid, $id));
+                $chk = $GLOBALS['PDO']->query(
+                    "SELECT * FROM `:prefix_srvgroups_overrides` WHERE name = ? AND type = ? AND group_id = ? AND id != ?")->resultset(array($override['name'], $override['type'], $gid, $id));
                 if (!empty($chk)) {
                     $objResponse->addScript(
                         "ShowBox('Error', 'There already is an override with name \\\"" . htmlspecialchars(addslashes($override['name'])) . "\\\" from the selected type..', 'red', '', true);"
@@ -2540,9 +2435,8 @@ function EditGroup($gid, $web_flags, $srv_flags, $type, $name, $overrides, $newO
                 }
 
                 // Edit the override
-                $GLOBALS['db']->Execute(
-                    "UPDATE `" . DB_PREFIX . "_srvgroups_overrides` SET name = ?, type = ?, access = ? WHERE id = ?;",
-                    array($override['name'], $override['type'], $override['access'], $id)
+                $GLOBALS['PDO']->query(
+                    "UPDATE `:prefix_srvgroups_overrides` SET name = ?, type = ?, access = ? WHERE id = ?;")->execute(array($override['name'], $override['type'], $override['access'], $id)
                 );
             }
         }
@@ -2554,9 +2448,8 @@ function EditGroup($gid, $web_flags, $srv_flags, $type, $name, $overrides, $newO
                 && !empty($newOverride['name'])
             ) {
                 // Check for duplicates
-                $chk = $GLOBALS['db']->GetAll(
-                    "SELECT * FROM `" . DB_PREFIX . "_srvgroups_overrides` WHERE name = ? AND type = ? AND group_id = ?",
-                    array($newOverride['name'], $newOverride['type'], $gid)
+                $chk = $GLOBALS['PDO']->query(
+                    "SELECT * FROM `:prefix_srvgroups_overrides` WHERE name = ? AND type = ? AND group_id = ?")->resultset(array($newOverride['name'], $newOverride['type'], $gid)
                 );
                 if (!empty($chk)) {
                     $objResponse->addScript(
@@ -2566,16 +2459,15 @@ function EditGroup($gid, $web_flags, $srv_flags, $type, $name, $overrides, $newO
                 }
 
                 // Insert the new override
-                $GLOBALS['db']->Execute(
-                    "INSERT INTO `" . DB_PREFIX . "_srvgroups_overrides` (group_id, type, name, access) VALUES (?, ?, ?, ?);",
-                    array($gid, $newOverride['type'], $newOverride['name'], $newOverride['access'])
+                $GLOBALS['PDO']->query(
+                    "INSERT INTO `:prefix_srvgroups_overrides` (group_id, type, name, access) VALUES (?, ?, ?, ?);")->execute(array($gid, $newOverride['type'], $newOverride['name'], $newOverride['access'])
                 );
             }
         }
 
         if (Config::getBool('config.enableadminrehashing')) {
             // rehash the settings out of the database on all servers
-            $serveraccessq = $GLOBALS['db']->GetAll("SELECT sid FROM " . DB_PREFIX . "_servers WHERE enabled = 1;");
+            $serveraccessq = $GLOBALS['PDO']->query("SELECT sid FROM `:prefix_servers` WHERE enabled = 1;")->resultset();
             $allservers = [];
             foreach ($serveraccessq as $access) {
                 if (!in_array($access['sid'], $allservers)) {
@@ -2680,13 +2572,17 @@ function SendMail($subject, $message, $type, $id)
     // Submission
     $email = "";
     if($type == 's') {
-        $email = $GLOBALS['db']->GetOne(
-            'SELECT email FROM `' . DB_PREFIX . '_submissions` WHERE subid = ?',
-            array($id));
+        $GLOBALS['PDO']->query('SELECT email FROM `:prefix_submissions` WHERE subid = :id');
+        $GLOBALS['PDO']->bind(':id', $id);
+        $row = $GLOBALS['PDO']->single();
+        $email = $row['email'] ?? "";
     }
     // Protest
     else if($type == 'p') {
-        $email = $GLOBALS['db']->GetOne('SELECT email FROM `' . DB_PREFIX . '_protests` WHERE pid = ?', array($id));
+        $GLOBALS['PDO']->query('SELECT email FROM `:prefix_protests` WHERE pid = :id');
+        $GLOBALS['PDO']->bind(':id', $id);
+        $row = $GLOBALS['PDO']->single();
+        $email = $row['email'] ?? "";
     }
 
     if(empty($email)) {
@@ -2830,9 +2726,8 @@ function ApplyTheme($theme)
         return $objResponse;
     }
 
-    $GLOBALS['db']->Execute(
-        "UPDATE `" . DB_PREFIX . "_settings` SET `value` = ? WHERE `setting` = 'config.theme'",
-        array($theme)
+    $GLOBALS['PDO']->query(
+        "UPDATE `:prefix_settings` SET `value` = ? WHERE `setting` = 'config.theme'")->execute(array($theme)
     );
     $objResponse->addScript('window.location.reload( false );');
     return $objResponse;
@@ -2878,15 +2773,9 @@ function AddComment($bid, $ctype, $ctext, $page)
 
     $ctext = trim($ctext);
 
-    $pre = $GLOBALS['db']->Prepare(
-        "INSERT INTO " . DB_PREFIX . "_comments(bid,type,aid,commenttxt,added) VALUES (?,?,?,?,UNIX_TIMESTAMP())"
-    );
-    $GLOBALS['db']->Execute(
-        $pre, array($bid,
-        $ctype,
-        $userbank->GetAid(),
-        $ctext)
-    );
+    $GLOBALS['PDO']->query(
+        "INSERT INTO `:prefix_comments`(bid,type,aid,commenttxt,added) VALUES (?,?,?,?,UNIX_TIMESTAMP())"
+    )->execute([$bid, $ctype, $userbank->GetAid(), $ctext]);
 
     $objResponse->addScript(
         "ShowBox('Comment Added', 'The comment has been successfully published', 'green', 'index.php$redir');"
@@ -2929,14 +2818,9 @@ function EditComment($cid, $ctype, $ctext, $page)
 
     $ctext = trim($ctext);
 
-    $pre = $GLOBALS['db']->Prepare(
-        "UPDATE " . DB_PREFIX . "_comments SET `commenttxt` = ?, `editaid` = ?, `edittime`= UNIX_TIMESTAMP() WHERE cid = ?"
-    );
-    $GLOBALS['db']->Execute(
-        $pre, array($ctext,
-        $userbank->GetAid(),
-        $cid)
-    );
+    $GLOBALS['PDO']->query(
+        "UPDATE `:prefix_comments` SET `commenttxt` = ?, `editaid` = ?, `edittime`= UNIX_TIMESTAMP() WHERE cid = ?"
+    )->execute([$ctext, $userbank->GetAid(), $cid]);
 
     $objResponse->addScript(
         "ShowBox('Comment Edited', 'The comment #".$cid." has been successfully edited', 'green', 'index.php$redir');"
@@ -2964,9 +2848,8 @@ function RemoveComment($cid, $ctype, $page)
         $pagelink = "&page=" . $page;
     }
 
-    $res = $GLOBALS['db']->Execute(
-        "DELETE FROM `" . DB_PREFIX . "_comments` WHERE `cid` = ?",
-        array($cid)
+    $res = $GLOBALS['PDO']->query(
+        "DELETE FROM `:prefix_comments` WHERE `cid` = ?")->execute(array($cid)
     );
     if($ctype=="B") {
         $redir = "?p=banlist" . $pagelink;
@@ -3018,7 +2901,7 @@ function RefreshServer($sid)
 {
     $objResponse = new xajaxResponse();
     $sid = (int)$sid;
-    $data = $GLOBALS['db']->GetRow("SELECT ip, port FROM `".DB_PREFIX."_servers` WHERE sid = ?;", array($sid));
+    $data = $GLOBALS['PDO']->query("SELECT ip, port FROM `:prefix_servers` WHERE sid = ?;")->single(array($sid));
 
     $objResponse->addScript("xajax_ServerHostPlayers('".$sid."');");
     return $objResponse;
@@ -3555,9 +3438,8 @@ function AddBlock($nickname, $type, $steam, $length, $reason)
     }
 
     // Check if the new steamid is already banned
-    $chk = $GLOBALS['db']->GetRow(
-        "SELECT count(bid) AS count FROM ".DB_PREFIX."_comms WHERE authid = ? AND (length = 0 OR ends > UNIX_TIMESTAMP()) AND RemovedBy IS NULL AND ".$typeW,
-        array($steam)
+    $chk = $GLOBALS['PDO']->query(
+        "SELECT count(bid) AS count FROM `:prefix_comms` WHERE authid = ? AND (length = 0 OR ends > UNIX_TIMESTAMP()) AND RemovedBy IS NULL AND ".$typeW)->single(array($steam)
     );
 
     if (intval($chk[0]) > 0) {
@@ -3577,34 +3459,32 @@ function AddBlock($nickname, $type, $steam, $length, $reason)
     }
 
     if ((int)$type == 1 || (int)$type == 3) {
-        $pre = $GLOBALS['db']->Prepare(
-            "INSERT INTO " . DB_PREFIX . "_comms(created,type,authid,name,ends,length,reason,aid,adminIp ) VALUES
+        $GLOBALS['PDO']->query(
+            "INSERT INTO `:prefix_comms`(created,type,authid,name,ends,length,reason,aid,adminIp ) VALUES
       (UNIX_TIMESTAMP(),1,?,?,(UNIX_TIMESTAMP() + ?),?,?,?,?)"
-        );
-        $GLOBALS['db']->Execute(
-            $pre, array($steam,
+        )->execute([
+            $steam,
             $nickname,
             $length * 60,
             $len,
             $reason,
             $userbank->GetAid(),
-            $_SERVER['REMOTE_ADDR'])
-        );
+            $_SERVER['REMOTE_ADDR'],
+        ]);
     }
     if ((int)$type == 2 || (int)$type ==3) {
-        $pre = $GLOBALS['db']->Prepare(
-            "INSERT INTO " . DB_PREFIX . "_comms(created,type,authid,name,ends,length,reason,aid,adminIp ) VALUES
+        $GLOBALS['PDO']->query(
+            "INSERT INTO `:prefix_comms`(created,type,authid,name,ends,length,reason,aid,adminIp ) VALUES
       (UNIX_TIMESTAMP(),2,?,?,(UNIX_TIMESTAMP() + ?),?,?,?,?)"
-        );
-        $GLOBALS['db']->Execute(
-            $pre, array($steam,
+        )->execute([
+            $steam,
             $nickname,
             $length * 60,
             $len,
             $reason,
             $userbank->GetAid(),
-            $_SERVER['REMOTE_ADDR'])
-        );
+            $_SERVER['REMOTE_ADDR'],
+        ]);
     }
 
     $objResponse->addScript("ShowBlockBox('".$steam."', '".(int)$type."', '".(int)$len."');");
@@ -3622,9 +3502,8 @@ function PrepareReblock($bid)
     $objResponse = new xajaxResponse();
     $bid = (int)$bid;
 
-    $ban = $GLOBALS['db']->GetRow(
-        "SELECT name, authid, type, length, reason FROM ".DB_PREFIX."_comms WHERE bid = ?;",
-        array($bid)
+    $ban = $GLOBALS['PDO']->query(
+        "SELECT name, authid, type, length, reason FROM `:prefix_comms` WHERE bid = ?;")->single(array($bid)
     );
 
     // clear any old stuff
@@ -3669,7 +3548,7 @@ function PrepareBlockFromBan($bid)
     $objResponse->addScript("$('txtReason').value = ''");
     $objResponse->addAssign("txtReason", "innerHTML",  "");
 
-    $ban = $GLOBALS['db']->GetRow("SELECT name, authid FROM ".DB_PREFIX."_bans WHERE bid = ?;", array($bid));
+    $ban = $GLOBALS['PDO']->query("SELECT name, authid FROM `:prefix_bans` WHERE bid = ?;")->single(array($bid));
 
     // add new stuff
     $objResponse->addScript("$('nickname').value = '" . $ban['name'] . "'");

--- a/web/includes/system-functions.php
+++ b/web/includes/system-functions.php
@@ -94,7 +94,7 @@ function SmFlagsToSb($flagstring)
  */
 function NextSid()
 {
-    $sid = $GLOBALS['db']->GetRow("SELECT MAX(sid) AS next_sid FROM `" . DB_PREFIX . "_servers`");
+    $sid = $GLOBALS['PDO']->query("SELECT MAX(sid) AS next_sid FROM `:prefix_servers`")->single();
     return ($sid['next_sid'] + 1);
 }
 
@@ -103,7 +103,7 @@ function NextSid()
  */
 function NextAid()
 {
-    $aid = $GLOBALS['db']->GetRow("SELECT MAX(aid) AS next_aid FROM `" . DB_PREFIX . "_admins`");
+    $aid = $GLOBALS['PDO']->query("SELECT MAX(aid) AS next_aid FROM `:prefix_admins`")->single();
     return ($aid['next_aid'] + 1);
 }
 

--- a/web/init.php
+++ b/web/init.php
@@ -110,17 +110,8 @@ if (!defined('SB_EMAIL')) {
     define('SB_EMAIL', '');
 }
 
-//include_once(INCLUDES_PATH . "/adodb/adodb.inc.php");
-//include_once(INCLUDES_PATH . "/adodb/adodb-errorhandler.inc.php");
 require_once(INCLUDES_PATH.'/Database.php');
-$GLOBALS['db'] =  ADONewConnection("mysqli://".DB_USER.':'.urlencode(DB_PASS).'@'.DB_HOST.':'.DB_PORT.'/'.DB_NAME);
 $GLOBALS['PDO'] = new Database(DB_HOST, DB_PORT, DB_NAME, DB_USER, DB_PASS, DB_PREFIX, DB_CHARSET);
-
-if (!is_object($GLOBALS['db'])) {
-    die();
-}
-
-$GLOBALS['db']->Execute("SET NAMES ".DB_CHARSET.";");
 
 require_once(INCLUDES_PATH.'/SteamID/bootstrap.php');
 \SteamID\SteamID::init($GLOBALS['PDO']);

--- a/web/pages/admin.admins.php
+++ b/web/pages/admin.admins.php
@@ -33,35 +33,42 @@ $AdminsPerPage = SB_BANS_PER_PAGE;
 $page = 1;
 $join = "";
 $where = "";
+$whereParams = [];
 $advSearchString = "";
 if (isset($_GET['page']) && $_GET['page'] > 0) {
     $page = intval($_GET['page']);
 }
 if (isset($_GET['advSearch'])) {
-    // Escape the value, but strip the leading and trailing quote
-    $value = substr($GLOBALS['db']->qstr($_GET['advSearch']), 1, -1);
+    $value = $_GET['advSearch'];
     $type = $_GET['advType'];
     switch ($type) {
         case "name":
-            $where = " AND ADM.user LIKE '%" . $value . "%'";
+            $where = " AND ADM.user LIKE ?";
+            $whereParams[] = '%' . $value . '%';
             break;
         case "steamid":
-            $where = " AND ADM.authid = '" . $value . "'";
+            $where = " AND ADM.authid = ?";
+            $whereParams[] = $value;
             break;
         case "steam":
-            $where = " AND ADM.authid LIKE '%" . $value . "%'";
+            $where = " AND ADM.authid LIKE ?";
+            $whereParams[] = '%' . $value . '%';
             break;
         case "admemail":
-            $where = " AND ADM.email LIKE '%" . $value . "%'";
+            $where = " AND ADM.email LIKE ?";
+            $whereParams[] = '%' . $value . '%';
             break;
         case "webgroup":
-            $where = " AND ADM.gid = '" . $value . "'";
+            $where = " AND ADM.gid = ?";
+            $whereParams[] = $value;
             break;
         case "srvadmgroup":
-            $where = " AND ADM.srv_group = '" . $value . "'";
+            $where = " AND ADM.srv_group = ?";
+            $whereParams[] = $value;
             break;
         case "srvgroup":
-            $where = " AND SG.srv_group_id = '" . $value . "'";
+            $where = " AND SG.srv_group_id = ?";
+            $whereParams[] = $value;
             $join = " LEFT JOIN `" . DB_PREFIX . "_admins_servers_groups` AS SG ON SG.admin_id = ADM.aid";
             break;
         case "admwebflag":
@@ -70,45 +77,55 @@ if (isset($_GET['advSearch'])) {
                 $flags[] = constant($flag);
             }
             $flagstring = implode('|', $flags);
-            $alladmins = $GLOBALS['db']->Execute("SELECT aid FROM `" . DB_PREFIX . "_admins` WHERE aid > 0");
-            while (!$alladmins->EOF) {
-                if ($userbank->HasAccess($flagstring, $alladmins->fields["aid"])) {
-                    if (!isset($accessaid)) {
-                        $accessaid = $alladmins->fields["aid"];
-                    }
-                    $accessaid .= ",".$alladmins->fields["aid"];
+            $alladmins = $GLOBALS['PDO']->query("SELECT aid FROM `:prefix_admins` WHERE aid > 0")->resultset();
+            $accessAids = [];
+            foreach ($alladmins as $row) {
+                if ($userbank->HasAccess($flagstring, $row['aid'])) {
+                    $accessAids[] = (int) $row['aid'];
                 }
-                $alladmins->MoveNext();
             }
-            $where = " AND ADM.aid IN(".$accessaid.")";
+            if (empty($accessAids)) {
+                $where = " AND 0";
+            } else {
+                $placeholders = implode(',', array_fill(0, count($accessAids), '?'));
+                $where = " AND ADM.aid IN($placeholders)";
+                $whereParams = array_merge($whereParams, $accessAids);
+            }
             break;
         case "admsrvflag":
             $findflags = explode(",", $value);
             foreach ($findflags as $flag) {
                 $flags[] = constant($flag);
             }
-            $alladmins = $GLOBALS['db']->Execute("SELECT aid, authid FROM `" . DB_PREFIX . "_admins` WHERE aid > 0");
-            while (!$alladmins->EOF) {
+            $alladmins = $GLOBALS['PDO']->query("SELECT aid, authid FROM `:prefix_admins` WHERE aid > 0")->resultset();
+            $accessAids = [];
+            foreach ($alladmins as $row) {
+                $matched = false;
                 foreach ($flags as $fla) {
-                    if ($userbank->HasAccess($fla, $alladmins->fields["authid"])) {
-                        if (!isset($accessaid)) {
-                            $accessaid = $alladmins->fields["aid"];
-                        }
-                        $accessaid .= ",".$alladmins->fields["aid"];
+                    if ($userbank->HasAccess($fla, $row['authid'])) {
+                        $matched = true;
+                        break;
                     }
                 }
-                if ($userbank->HasAccess(SM_ROOT, $alladmins->fields["authid"])) {
-                    if (!isset($accessaid)) {
-                        $accessaid = $alladmins->fields["aid"];
-                    }
-                    $accessaid .= ",".$alladmins->fields["aid"];
+                if (!$matched && $userbank->HasAccess(SM_ROOT, $row['authid'])) {
+                    $matched = true;
                 }
-                $alladmins->MoveNext();
+                if ($matched) {
+                    $accessAids[] = (int) $row['aid'];
+                }
             }
-            $where = " AND ADM.aid IN(".$accessaid.")";
+            if (empty($accessAids)) {
+                $where = " AND 0";
+            } else {
+                $placeholders = implode(',', array_fill(0, count($accessAids), '?'));
+                $where = " AND ADM.aid IN($placeholders)";
+                $whereParams = array_merge($whereParams, $accessAids);
+            }
             break;
         case "server":
-            $where = " AND (ASG.server_id = '" . $value . "' OR SG.server_id = '" . $value . "')";
+            $where = " AND (ASG.server_id = ? OR SG.server_id = ?)";
+            $whereParams[] = $value;
+            $whereParams[] = $value;
             $join = " LEFT JOIN `" . DB_PREFIX . "_admins_servers_groups` AS ASG ON ASG.admin_id = ADM.aid LEFT JOIN `" . DB_PREFIX . "_servers_groups` AS SG ON SG.group_id = ASG.srv_group_id";
             break;
         default:
@@ -119,7 +136,7 @@ if (isset($_GET['advSearch'])) {
     }
         $advSearchString = "&advSearch=".$_GET['advSearch']."&advType=".$_GET['advType'];
 }
-$admins = $GLOBALS['db']->GetAll("SELECT * FROM `" . DB_PREFIX . "_admins` AS ADM".$join." WHERE ADM.aid > 0".$where." ORDER BY user LIMIT " . intval(($page-1) * $AdminsPerPage) . "," . intval($AdminsPerPage));
+$admins = $GLOBALS['PDO']->query("SELECT * FROM `:prefix_admins` AS ADM".$join." WHERE ADM.aid > 0".$where." ORDER BY user LIMIT " . intval(($page-1) * $AdminsPerPage) . "," . intval($AdminsPerPage))->resultset($whereParams);
 // quick fix for the server search showing admins mulitple times.
 if (isset($_GET['advSearch']) && isset($_GET['advType']) && $_GET['advType'] == 'server') {
     $aadm = [];
@@ -134,7 +151,7 @@ if (isset($_GET['advSearch']) && isset($_GET['advType']) && $_GET['advType'] == 
     }
 }
 
-$query = $GLOBALS['db']->GetRow("SELECT COUNT(ADM.aid) AS cnt FROM `" . DB_PREFIX . "_admins` AS ADM".$join." WHERE ADM.aid > 0".$where);
+$query = $GLOBALS['PDO']->query("SELECT COUNT(ADM.aid) AS cnt FROM `:prefix_admins` AS ADM".$join." WHERE ADM.aid > 0".$where)->single($whereParams);
 $admin_count = $query['cnt'];
 
 if (isset($_GET['page']) && $_GET['page'] > 0) {
@@ -159,10 +176,14 @@ foreach ($admins as $admin) {
     if (empty($admin['server_group']) || $admin['server_group'] == " ") {
         $admin['server_group'] = "No Group/Individual Permissions";
     }
-    $num               = $GLOBALS['db']->GetRow("SELECT count(authid) AS num FROM `" . DB_PREFIX . "_bans` WHERE aid = '" . $admin['aid'] . "'");
+    $GLOBALS['PDO']->query("SELECT count(authid) AS num FROM `:prefix_bans` WHERE aid = :aid");
+    $GLOBALS['PDO']->bind(':aid', $admin['aid']);
+    $num               = $GLOBALS['PDO']->single();
     $admin['bancount'] = $num['num'];
 
-    $nodem                = $GLOBALS['db']->GetRow("SELECT count(B.bid) AS num FROM `" . DB_PREFIX . "_bans` AS B WHERE aid = '" . $admin['aid'] . "' AND NOT EXISTS (SELECT D.demid FROM `" . DB_PREFIX . "_demos` AS D WHERE D.demid = B.bid)");
+    $GLOBALS['PDO']->query("SELECT count(B.bid) AS num FROM `:prefix_bans` AS B WHERE aid = :aid AND NOT EXISTS (SELECT D.demid FROM `:prefix_demos` AS D WHERE D.demid = B.bid)");
+    $GLOBALS['PDO']->bind(':aid', $admin['aid']);
+    $nodem                = $GLOBALS['PDO']->single();
     $admin['aid']         = $admin['aid'];
     $admin['nodemocount'] = $nodem['num'];
 
@@ -222,10 +243,10 @@ $theme->assign('admins', $admin_list);
 $theme->display('page_admin_admins_list.tpl');
 
 // Add Page
-$group_list              = $GLOBALS['db']->GetAll("SELECT * FROM `" . DB_PREFIX . "_groups` WHERE type = '3'");
-$servers                 = $GLOBALS['db']->GetAll("SELECT * FROM `" . DB_PREFIX . "_servers`");
-$server_admin_group_list = $GLOBALS['db']->GetAll("SELECT * FROM `" . DB_PREFIX . "_srvgroups`");
-$server_group_list       = $GLOBALS['db']->GetAll("SELECT * FROM `" . DB_PREFIX . "_groups` WHERE type != 3");
+$group_list              = $GLOBALS['PDO']->query("SELECT * FROM `:prefix_groups` WHERE type = '3'")->resultset();
+$servers                 = $GLOBALS['PDO']->query("SELECT * FROM `:prefix_servers`")->resultset();
+$server_admin_group_list = $GLOBALS['PDO']->query("SELECT * FROM `:prefix_srvgroups`")->resultset();
+$server_group_list       = $GLOBALS['PDO']->query("SELECT * FROM `:prefix_groups` WHERE type != 3")->resultset();
 $server_list             = [];
 $serverscript            = "<script type=\"text/javascript\">";
 foreach ($servers as $server) {
@@ -264,30 +285,30 @@ try {
                 $id = (int) $id;
                 // Wants to delete this override?
                 if (empty($_POST['override_name'][$index])) {
-                    $GLOBALS['db']->Execute("DELETE FROM `" . DB_PREFIX . "_overrides` WHERE id = ?;", array(
-                        $id
-                    ));
+                    $GLOBALS['PDO']->query("DELETE FROM `:prefix_overrides` WHERE id = :id");
+                    $GLOBALS['PDO']->bind(':id', $id);
+                    $GLOBALS['PDO']->execute();
                     continue;
                 }
 
                 // Check for duplicates
-                $chk = $GLOBALS['db']->GetAll("SELECT * FROM `" . DB_PREFIX . "_overrides` WHERE name = ? AND type = ? AND id != ?", array(
+                $chk = $GLOBALS['PDO']->query("SELECT * FROM `:prefix_overrides` WHERE name = ? AND type = ? AND id != ?")->resultset([
                     $_POST['override_name'][$index],
                     $_POST['override_type'][$index],
-                    $id
-                ));
+                    $id,
+                ]);
                 if (!empty($chk)) {
                     $edit_errors .= "&bull; There already is an override with name \\\"" . htmlspecialchars(addslashes($_POST['override_name'][$index])) . "\\\" from the selected type.<br />";
                     continue;
                 }
 
                 // Edit the override
-                $GLOBALS['db']->Execute("UPDATE `" . DB_PREFIX . "_overrides` SET name = ?, type = ?, flags = ? WHERE id = ?;", array(
+                $GLOBALS['PDO']->query("UPDATE `:prefix_overrides` SET name = ?, type = ?, flags = ? WHERE id = ?")->execute([
                     $_POST['override_name'][$index],
                     $_POST['override_type'][$index],
                     trim($_POST['override_flags'][$index]),
-                    $id
-                ));
+                    $id,
+                ]);
             }
 
             if (!empty($edit_errors)) {
@@ -302,20 +323,20 @@ try {
             }
 
             // Check for duplicates
-            $chk = $GLOBALS['db']->GetAll("SELECT * FROM `" . DB_PREFIX . "_overrides` WHERE name = ? AND type = ?", array(
+            $chk = $GLOBALS['PDO']->query("SELECT * FROM `:prefix_overrides` WHERE name = ? AND type = ?")->resultset([
                 $_POST['new_override_name'],
-                $_POST['new_override_type']
-            ));
+                $_POST['new_override_type'],
+            ]);
             if (!empty($chk)) {
                 throw new Exception("There already is an override with that name from the selected type.");
             }
 
             // Insert the new override
-            $GLOBALS['db']->Execute("INSERT INTO `" . DB_PREFIX . "_overrides` (type, name, flags) VALUES (?, ?, ?);", array(
+            $GLOBALS['PDO']->query("INSERT INTO `:prefix_overrides` (type, name, flags) VALUES (?, ?, ?)")->execute([
                 $_POST['new_override_type'],
                 $_POST['new_override_name'],
-                trim($_POST['new_override_flags'])
-            ));
+                trim($_POST['new_override_flags']),
+            ]);
         }
 
         $overrides_save_success = true;
@@ -324,7 +345,7 @@ try {
     $overrides_error = $e->getMessage();
 }
 
-$overrides_list = $GLOBALS['db']->GetAll("SELECT * FROM `" . DB_PREFIX . "_overrides`;");
+$overrides_list = $GLOBALS['PDO']->query("SELECT * FROM `:prefix_overrides`")->resultset();
 
 $theme->assign('overrides_list', $overrides_list);
 $theme->assign('overrides_error', $overrides_error);

--- a/web/pages/admin.admins.search.php
+++ b/web/pages/admin.admins.search.php
@@ -20,53 +20,49 @@ Page: <http://www.sourcebans.net/> - <http://www.gameconnect.net/>
 global $userbank, $theme;
 
 //serverlist
-$server_list  = $GLOBALS['db']->Execute("SELECT sid, ip, port FROM `" . DB_PREFIX . "_servers` WHERE enabled = 1");
+$server_list  = $GLOBALS['PDO']->query("SELECT sid, ip, port FROM `:prefix_servers` WHERE enabled = 1")->resultset();
 $servers      = [];
 $serverscript = "<script type=\"text/javascript\">";
-while (!$server_list->EOF) {
+foreach ($server_list as $row) {
     $info = [];
-    $serverscript .= "xajax_ServerHostPlayers('" . $server_list->fields[0] . "', 'id', 'ss" . $server_list->fields[0] . "', '', '', false, 200);";
-    $info['sid']  = $server_list->fields[0];
-    $info['ip']   = $server_list->fields[1];
-    $info['port'] = $server_list->fields[2];
+    $serverscript .= "xajax_ServerHostPlayers('" . $row['sid'] . "', 'id', 'ss" . $row['sid'] . "', '', '', false, 200);";
+    $info['sid']  = $row['sid'];
+    $info['ip']   = $row['ip'];
+    $info['port'] = $row['port'];
     array_push($servers, $info);
-    $server_list->MoveNext();
 }
 $serverscript .= "</script>";
 
 //webgrouplist
-$webgroup_list = $GLOBALS['db']->Execute("SELECT gid, name FROM " . DB_PREFIX . "_groups WHERE type = '1'");
+$webgroup_list = $GLOBALS['PDO']->query("SELECT gid, name FROM `:prefix_groups` WHERE type = '1'")->resultset();
 $webgroups     = [];
-while (!$webgroup_list->EOF) {
+foreach ($webgroup_list as $row) {
     $data         = [];
-    $data['gid']  = $webgroup_list->fields['gid'];
-    $data['name'] = $webgroup_list->fields['name'];
+    $data['gid']  = $row['gid'];
+    $data['name'] = $row['name'];
 
     array_push($webgroups, $data);
-    $webgroup_list->MoveNext();
 }
 
 //serveradmingrouplist
-$srvadmgroup_list = $GLOBALS['db']->Execute("SELECT name FROM " . DB_PREFIX . "_srvgroups ORDER BY name ASC");
+$srvadmgroup_list = $GLOBALS['PDO']->query("SELECT name FROM `:prefix_srvgroups` ORDER BY name ASC")->resultset();
 $srvadmgroups     = [];
-while (!$srvadmgroup_list->EOF) {
+foreach ($srvadmgroup_list as $row) {
     $data         = [];
-    $data['name'] = $srvadmgroup_list->fields['name'];
+    $data['name'] = $row['name'];
 
     array_push($srvadmgroups, $data);
-    $srvadmgroup_list->MoveNext();
 }
 
 //servergroup
-$srvgroup_list = $GLOBALS['db']->Execute("SELECT gid, name FROM " . DB_PREFIX . "_groups WHERE type = '3'");
+$srvgroup_list = $GLOBALS['PDO']->query("SELECT gid, name FROM `:prefix_groups` WHERE type = '3'")->resultset();
 $srvgroups     = [];
-while (!$srvgroup_list->EOF) {
+foreach ($srvgroup_list as $row) {
     $data         = [];
-    $data['gid']  = $srvgroup_list->fields['gid'];
-    $data['name'] = $srvgroup_list->fields['name'];
+    $data['gid']  = $row['gid'];
+    $data['name'] = $row['name'];
 
     array_push($srvgroups, $data);
-    $srvgroup_list->MoveNext();
 }
 
 //webpermissions

--- a/web/pages/admin.bans.php
+++ b/web/pages/admin.bans.php
@@ -139,8 +139,8 @@ $page         = 1;
 if (isset($_GET['ppage']) && $_GET['ppage'] > 0) {
     $page = intval($_GET['ppage']);
 }
-$protests       = $GLOBALS['db']->GetAll("SELECT * FROM `" . DB_PREFIX . "_protests` WHERE archiv = '0' ORDER BY pid DESC LIMIT " . intval(($page - 1) * $ItemsPerPage) . "," . intval($ItemsPerPage));
-$protests_count = $GLOBALS['db']->GetRow("SELECT count(pid) AS count FROM `" . DB_PREFIX . "_protests` WHERE archiv = '0' ORDER BY pid DESC");
+$protests       = $GLOBALS['PDO']->query("SELECT * FROM `:prefix_protests` WHERE archiv = '0' ORDER BY pid DESC LIMIT " . intval(($page - 1) * $ItemsPerPage) . "," . intval($ItemsPerPage))->resultset();
+$protests_count = $GLOBALS['PDO']->query("SELECT count(pid) AS count FROM `:prefix_protests` WHERE archiv = '0' ORDER BY pid DESC")->single();
 $page_count     = $protests_count['count'];
 $PageStart      = intval(($page - 1) * $ItemsPerPage);
 $PageEnd        = intval($PageStart + $ItemsPerPage);
@@ -184,18 +184,20 @@ $delete       = [];
 $protest_list = [];
 foreach ($protests as $prot) {
     $prot['reason'] = wordwrap(htmlspecialchars($prot['reason']), 55, "<br />\n", true);
-    $protestb       = $GLOBALS['db']->GetRow("SELECT bid, ba.ip, ba.authid, ba.name, created, ends, length, reason, ba.aid, ba.sid, email,ad.user, CONCAT(se.ip,':',se.port), se.sid
-							    				FROM " . DB_PREFIX . "_bans AS ba
-							    				LEFT JOIN " . DB_PREFIX . "_admins AS ad ON ba.aid = ad.aid
-							    				LEFT JOIN " . DB_PREFIX . "_servers AS se ON se.sid = ba.sid
-							    				WHERE bid = \"" . (int) $prot['bid'] . "\"");
+    $GLOBALS['PDO']->query("SELECT bid, ba.ip, ba.authid, ba.name, created, ends, length, reason, ba.aid, ba.sid AS ba_sid, email, ad.user, CONCAT(se.ip,':',se.port) AS server_addr, se.sid AS se_sid
+							    				FROM `:prefix_bans` AS ba
+							    				LEFT JOIN `:prefix_admins` AS ad ON ba.aid = ad.aid
+							    				LEFT JOIN `:prefix_servers` AS se ON se.sid = ba.sid
+							    				WHERE bid = :bid");
+    $GLOBALS['PDO']->bind(':bid', (int) $prot['bid']);
+    $protestb = $GLOBALS['PDO']->single();
     if (!$protestb) {
         $delete[] = $prot['bid'];
         continue;
     }
 
-    $prot['name']   = $protestb[3];
-    $prot['authid'] = $protestb[2];
+    $prot['name']   = $protestb['name'];
+    $prot['authid'] = $protestb['authid'];
     $prot['ip']     = $protestb['ip'];
 
     $prot['date'] = Config::time($protestb['created']);
@@ -206,48 +208,50 @@ foreach ($protests as $prot) {
     }
     $prot['ban_reason'] = htmlspecialchars($protestb['reason']);
 
-    $prot['admin'] = $protestb[11];
-    if (!$protestb[12]) {
+    $prot['admin'] = $protestb['user'];
+    if (!$protestb['server_addr']) {
         $prot['server'] = "Web Ban";
     } else {
-        $prot['server'] = $protestb[12];
+        $prot['server'] = $protestb['server_addr'];
     }
     $prot['datesubmitted'] = Config::time($prot['datesubmitted']);
     //COMMENT STUFF
     //-----------------------------------
     $view_comments         = true;
-    $commentres            = $GLOBALS['db']->Execute("SELECT cid, aid, commenttxt, added, edittime,
-												(SELECT user FROM `" . DB_PREFIX . "_admins` WHERE aid = C.aid) AS comname,
-												(SELECT user FROM `" . DB_PREFIX . "_admins` WHERE aid = C.editaid) AS editname
-												FROM `" . DB_PREFIX . "_comments` AS C
-												WHERE type = 'P' AND bid = '" . (int) $prot['pid'] . "' ORDER BY added desc");
+    $GLOBALS['PDO']->query("SELECT cid, aid, commenttxt, added, edittime,
+												(SELECT user FROM `:prefix_admins` WHERE aid = C.aid) AS comname,
+												(SELECT user FROM `:prefix_admins` WHERE aid = C.editaid) AS editname
+												FROM `:prefix_comments` AS C
+												WHERE type = 'P' AND bid = :bid ORDER BY added desc");
+    $GLOBALS['PDO']->bind(':bid', (int) $prot['pid']);
+    $commentres            = $GLOBALS['PDO']->resultset();
 
-    if ($commentres->RecordCount() > 0) {
+    if (count($commentres) > 0) {
         $comment = [];
         $morecom = 0;
-        while (!$commentres->EOF) {
+        foreach ($commentres as $crow) {
             $cdata            = [];
             $cdata['morecom'] = ($morecom == 1 ? true : false);
-            if ($commentres->fields['aid'] == $userbank->GetAid() || $userbank->HasAccess(ADMIN_OWNER)) {
-                $cdata['editcomlink'] = CreateLinkR('<i class="fas fa-edit fa-lg"></i>', 'index.php?p=banlist&comment=' . (int) $prot['pid'] . '&ctype=P&cid=' . $commentres->fields['cid'], 'Edit Comment');
+            if ($crow['aid'] == $userbank->GetAid() || $userbank->HasAccess(ADMIN_OWNER)) {
+                $cdata['editcomlink'] = CreateLinkR('<i class="fas fa-edit fa-lg"></i>', 'index.php?p=banlist&comment=' . (int) $prot['pid'] . '&ctype=P&cid=' . $crow['cid'], 'Edit Comment');
                 if ($userbank->HasAccess(ADMIN_OWNER)) {
-                    $cdata['delcomlink'] = "<a href=\"#\" class=\"tip\" title=\"Delete Comment\" target=\"_self\" onclick=\"RemoveComment(" . $commentres->fields['cid'] . ",'P',-1);\"><i class='fas fa-trash fa-lg'></i></a>";
+                    $cdata['delcomlink'] = "<a href=\"#\" class=\"tip\" title=\"Delete Comment\" target=\"_self\" onclick=\"RemoveComment(" . $crow['cid'] . ",'P',-1);\"><i class='fas fa-trash fa-lg'></i></a>";
                 }
             } else {
                 $cdata['editcomlink'] = "";
                 $cdata['delcomlink']  = "";
             }
 
-            $cdata['comname']    = $commentres->fields['comname'];
-            $cdata['added']      = Config::time($commentres->fields['added']);
-            $commentText         = html_entity_decode($commentres->fields['commenttxt'], ENT_QUOTES | ENT_HTML5, 'UTF-8');
+            $cdata['comname']    = $crow['comname'];
+            $cdata['added']      = Config::time($crow['added']);
+            $commentText         = html_entity_decode($crow['commenttxt'], ENT_QUOTES | ENT_HTML5, 'UTF-8');
             $commentText         = encodePreservingBr($commentText);
             $commentText         = preg_replace('@(https?://([-\w\.]+)+(:\d+)?(/([\w/_\.]*(\?\S+)?)?)?)@', '<a href="$1" target="_blank">$1</a>', $commentText);
             $cdata['commenttxt'] = $commentText;
 
-            if (!empty($commentres->fields['edittime'])) {
-                $cdata['edittime'] = Config::time($commentres->fields['edittime']);
-                $cdata['editname'] = $commentres->fields['editname'];
+            if (!empty($crow['edittime'])) {
+                $cdata['edittime'] = Config::time($crow['edittime']);
+                $cdata['editname'] = $crow['editname'];
             } else {
                 $cdata['edittime'] = "";
                 $cdata['editname'] = "";
@@ -255,7 +259,6 @@ foreach ($protests as $prot) {
 
             $morecom = 1;
             array_push($comment, $cdata);
-            $commentres->MoveNext();
         }
     } else {
         $comment = "None";
@@ -268,9 +271,9 @@ foreach ($protests as $prot) {
     array_push($protest_list, $prot);
 }
 if (count($delete) > 0) { //time for protest cleanup
-    $ids = rtrim(implode(',', $delete), ',');
     $cnt = count($delete);
-    $GLOBALS['db']->Execute("UPDATE " . DB_PREFIX . "_protests SET archiv = '2' WHERE bid IN($ids) limit $cnt");
+    $placeholders = implode(',', array_fill(0, $cnt, '?'));
+    $GLOBALS['PDO']->query("UPDATE `:prefix_protests` SET archiv = '2' WHERE bid IN($placeholders) LIMIT $cnt")->execute($delete);
 }
 
 $theme->assign('permission_protests', $userbank->HasAccess(ADMIN_OWNER | ADMIN_BAN_PROTESTS));
@@ -281,7 +284,6 @@ $theme->assign('protest_count', $page_count - (isset($cnt) ? $cnt : 0));
 $theme->display('page_admin_bans_protests.tpl');
 echo '</div>';
 
-$protestsarchiv = $GLOBALS['db']->GetAll("SELECT * FROM `" . DB_PREFIX . "_protests` WHERE archiv > '0' ORDER BY pid DESC");
 // archived protests
 echo '<div id="p1" style="display:none;">';
 
@@ -290,8 +292,8 @@ $page         = 1;
 if (isset($_GET['papage']) && $_GET['papage'] > 0) {
     $page = intval($_GET['papage']);
 }
-$protestsarchiv       = $GLOBALS['db']->GetAll("SELECT p.*, (SELECT user FROM `" . DB_PREFIX . "_admins` WHERE aid = p.archivedby) AS archivedby FROM `" . DB_PREFIX . "_protests` p WHERE archiv > '0' ORDER BY pid DESC LIMIT " . intval(($page - 1) * $ItemsPerPage) . "," . intval($ItemsPerPage));
-$protestsarchiv_count = $GLOBALS['db']->GetRow("SELECT count(pid) AS count FROM `" . DB_PREFIX . "_protests` WHERE archiv > '0' ORDER BY pid DESC");
+$protestsarchiv       = $GLOBALS['PDO']->query("SELECT p.*, (SELECT user FROM `:prefix_admins` WHERE aid = p.archivedby) AS archivedby FROM `:prefix_protests` p WHERE archiv > '0' ORDER BY pid DESC LIMIT " . intval(($page - 1) * $ItemsPerPage) . "," . intval($ItemsPerPage))->resultset();
+$protestsarchiv_count = $GLOBALS['PDO']->query("SELECT count(pid) AS count FROM `:prefix_protests` WHERE archiv > '0' ORDER BY pid DESC")->single();
 $page_count           = $protestsarchiv_count['count'];
 $PageStart            = intval(($page - 1) * $ItemsPerPage);
 $PageEnd              = intval($PageStart + $ItemsPerPage);
@@ -337,18 +339,22 @@ foreach ($protestsarchiv as $prot) {
     $prot['reason'] = wordwrap(htmlspecialchars($prot['reason']), 55, "<br />\n", true);
 
     if ($prot['archiv'] != "2") {
-        $protestb = $GLOBALS['db']->GetRow("SELECT bid, ba.ip, ba.authid, ba.name, created, ends, length, reason, ba.aid, ba.sid, email,ad.user, CONCAT(se.ip,':',se.port), se.sid
-								    				FROM " . DB_PREFIX . "_bans AS ba
-								    				LEFT JOIN " . DB_PREFIX . "_admins AS ad ON ba.aid = ad.aid
-								    				LEFT JOIN " . DB_PREFIX . "_servers AS se ON se.sid = ba.sid
-								    				WHERE bid = \"" . (int) $prot['bid'] . "\"");
+        $GLOBALS['PDO']->query("SELECT bid, ba.ip, ba.authid, ba.name, created, ends, length, reason, ba.aid, ba.sid AS ba_sid, email, ad.user, CONCAT(se.ip,':',se.port) AS server_addr, se.sid AS se_sid
+								    				FROM `:prefix_bans` AS ba
+								    				LEFT JOIN `:prefix_admins` AS ad ON ba.aid = ad.aid
+								    				LEFT JOIN `:prefix_servers` AS se ON se.sid = ba.sid
+								    				WHERE bid = :bid");
+        $GLOBALS['PDO']->bind(':bid', (int) $prot['bid']);
+        $protestb = $GLOBALS['PDO']->single();
         if (!$protestb) {
-            $GLOBALS['db']->Execute("UPDATE `" . DB_PREFIX . "_protests` SET archiv = '2' WHERE pid = '" . (int) $prot['pid'] . "';");
+            $GLOBALS['PDO']->query("UPDATE `:prefix_protests` SET archiv = '2' WHERE pid = :pid");
+            $GLOBALS['PDO']->bind(':pid', (int) $prot['pid']);
+            $GLOBALS['PDO']->execute();
             $prot['archiv']  = "2";
             $prot['archive'] = "ban has been deleted.";
         } else {
-            $prot['name']   = $protestb[3];
-            $prot['authid'] = $protestb[2];
+            $prot['name']   = $protestb['name'];
+            $prot['authid'] = $protestb['authid'];
             $prot['ip']     = $protestb['ip'];
 
             $prot['date'] = Config::time($protestb['created']);
@@ -358,11 +364,11 @@ foreach ($protestsarchiv as $prot) {
                 $prot['ends'] = Config::time($protestb['ends']);
             }
             $prot['ban_reason'] = htmlspecialchars($protestb['reason']);
-            $prot['admin']      = $protestb[11];
-            if (!$protestb[12]) {
+            $prot['admin']      = $protestb['user'];
+            if (!$protestb['server_addr']) {
                 $prot['server'] = "Web Ban";
             } else {
-                $prot['server'] = $protestb[12];
+                $prot['server'] = $protestb['server_addr'];
             }
             if ($prot['archiv'] == "1") {
                 $prot['archive'] = "protest has been archived.";
@@ -379,38 +385,40 @@ foreach ($protestsarchiv as $prot) {
     //COMMENT STUFF
     //-----------------------------------
     $view_comments         = true;
-    $commentres            = $GLOBALS['db']->Execute("SELECT cid, aid, commenttxt, added, edittime,
-												(SELECT user FROM `" . DB_PREFIX . "_admins` WHERE aid = C.aid) AS comname,
-												(SELECT user FROM `" . DB_PREFIX . "_admins` WHERE aid = C.editaid) AS editname
-												FROM `" . DB_PREFIX . "_comments` AS C
-												WHERE type = 'P' AND bid = '" . (int) $prot['pid'] . "' ORDER BY added desc");
+    $GLOBALS['PDO']->query("SELECT cid, aid, commenttxt, added, edittime,
+												(SELECT user FROM `:prefix_admins` WHERE aid = C.aid) AS comname,
+												(SELECT user FROM `:prefix_admins` WHERE aid = C.editaid) AS editname
+												FROM `:prefix_comments` AS C
+												WHERE type = 'P' AND bid = :bid ORDER BY added desc");
+    $GLOBALS['PDO']->bind(':bid', (int) $prot['pid']);
+    $commentres            = $GLOBALS['PDO']->resultset();
 
-    if ($commentres->RecordCount() > 0) {
+    if (count($commentres) > 0) {
         $comment = [];
         $morecom = 0;
-        while (!$commentres->EOF) {
+        foreach ($commentres as $crow) {
             $cdata            = [];
             $cdata['morecom'] = ($morecom == 1 ? true : false);
-            if ($commentres->fields['aid'] == $userbank->GetAid() || $userbank->HasAccess(ADMIN_OWNER)) {
-                $cdata['editcomlink'] = CreateLinkR('<i class="fas fa-edit fa-lg"></i>', 'index.php?p=banlist&comment=' . (int) $prot['pid'] . '&ctype=P&cid=' . $commentres->fields['cid'], 'Edit Comment');
+            if ($crow['aid'] == $userbank->GetAid() || $userbank->HasAccess(ADMIN_OWNER)) {
+                $cdata['editcomlink'] = CreateLinkR('<i class="fas fa-edit fa-lg"></i>', 'index.php?p=banlist&comment=' . (int) $prot['pid'] . '&ctype=P&cid=' . $crow['cid'], 'Edit Comment');
                 if ($userbank->HasAccess(ADMIN_OWNER)) {
-                    $cdata['delcomlink'] = "<a href=\"#\" class=\"tip\" title=\"Delete Comment\" target=\"_self\" onclick=\"RemoveComment(" . $commentres->fields['cid'] . ",'P',-1);\"><i class='fas fa-trash fa-lg'></i></a>";
+                    $cdata['delcomlink'] = "<a href=\"#\" class=\"tip\" title=\"Delete Comment\" target=\"_self\" onclick=\"RemoveComment(" . $crow['cid'] . ",'P',-1);\"><i class='fas fa-trash fa-lg'></i></a>";
                 }
             } else {
                 $cdata['editcomlink'] = "";
                 $cdata['delcomlink']  = "";
             }
 
-            $cdata['comname']    = $commentres->fields['comname'];
-            $cdata['added']      = Config::time($commentres->fields['added']);
-            $commentText         = html_entity_decode($commentres->fields['commenttxt'], ENT_QUOTES | ENT_HTML5, 'UTF-8');
+            $cdata['comname']    = $crow['comname'];
+            $cdata['added']      = Config::time($crow['added']);
+            $commentText         = html_entity_decode($crow['commenttxt'], ENT_QUOTES | ENT_HTML5, 'UTF-8');
             $commentText         = encodePreservingBr($commentText);
             $commentText         = preg_replace('@(https?://([-\w\.]+)+(:\d+)?(/([\w/_\.]*(\?\S+)?)?)?)@', '<a href="$1" target="_blank">$1</a>', $commentText);
             $cdata['commenttxt'] = $commentText;
 
-            if (!empty($commentres->fields['edittime'])) {
-                $cdata['edittime'] = Config::time($commentres->fields['edittime']);
-                $cdata['editname'] = $commentres->fields['editname'];
+            if (!empty($crow['edittime'])) {
+                $cdata['edittime'] = Config::time($crow['edittime']);
+                $cdata['editname'] = $crow['editname'];
             } else {
                 $cdata['edittime'] = "";
                 $cdata['editname'] = "";
@@ -418,7 +426,6 @@ foreach ($protestsarchiv as $prot) {
 
             $morecom = 1;
             array_push($comment, $cdata);
-            $commentres->MoveNext();
         }
     } else {
         $comment = "None";
@@ -462,8 +469,8 @@ $page         = 1;
 if (isset($_GET['spage']) && $_GET['spage'] > 0) {
     $page = intval($_GET['spage']);
 }
-$submissions       = $GLOBALS['db']->GetAll("SELECT * FROM `" . DB_PREFIX . "_submissions` WHERE archiv = '0' ORDER BY subid DESC LIMIT " . intval(($page - 1) * $ItemsPerPage) . "," . intval($ItemsPerPage));
-$submissions_count = $GLOBALS['db']->GetRow("SELECT count(subid) AS count FROM `" . DB_PREFIX . "_submissions` WHERE archiv = '0' ORDER BY subid DESC");
+$submissions       = $GLOBALS['PDO']->query("SELECT * FROM `:prefix_submissions` WHERE archiv = '0' ORDER BY subid DESC LIMIT " . intval(($page - 1) * $ItemsPerPage) . "," . intval($ItemsPerPage))->resultset();
+$submissions_count = $GLOBALS['PDO']->query("SELECT count(subid) AS count FROM `:prefix_submissions` WHERE archiv = '0' ORDER BY subid DESC")->single();
 $page_count        = $submissions_count['count'];
 $PageStart         = intval(($page - 1) * $ItemsPerPage);
 $PageEnd           = intval($PageStart + $ItemsPerPage);
@@ -511,8 +518,9 @@ foreach ($submissions as $sub) {
     $sub['name']   = wordwrap(htmlspecialchars($sub['name']), 55, "<br />", true);
     $sub['reason'] = wordwrap(htmlspecialchars($sub['reason']), 55, "<br />", true);
 
-    $dem = $GLOBALS['db']->GetRow("SELECT filename FROM " . DB_PREFIX . "_demos
-												WHERE demtype = \"S\" AND demid = " . (int) $sub['subid']);
+    $GLOBALS['PDO']->query("SELECT filename FROM `:prefix_demos` WHERE demtype = 'S' AND demid = :subid");
+    $GLOBALS['PDO']->bind(':subid', (int) $sub['subid']);
+    $dem = $GLOBALS['PDO']->single();
 
     if ($dem && !empty($dem['filename']) && @file_exists(SB_DEMOS . "/" . $dem['filename'])) {
         $sub['demo'] = '<a href="getdemo.php?id=' . urlencode($sub['subid']) . '&type=S"><i class=\'fas fa-video fa-lg\'></i> Get Demo</a>';
@@ -522,9 +530,9 @@ foreach ($submissions as $sub) {
 
     $sub['submitted'] = Config::time($sub['submitted']);
 
-    $mod        = $GLOBALS['db']->GetRow("SELECT m.name FROM `" . DB_PREFIX . "_submissions` AS s
-												LEFT JOIN `" . DB_PREFIX . "_mods` AS m ON m.mid = s.ModID
-												WHERE s.subid = " . (int) $sub['subid']);
+    $GLOBALS['PDO']->query("SELECT m.name FROM `:prefix_submissions` AS s LEFT JOIN `:prefix_mods` AS m ON m.mid = s.ModID WHERE s.subid = :subid");
+    $GLOBALS['PDO']->bind(':subid', (int) $sub['subid']);
+    $mod        = $GLOBALS['PDO']->single();
     $sub['mod'] = $mod['name'];
 
     if (empty($sub['server'])) {
@@ -535,39 +543,41 @@ foreach ($submissions as $sub) {
     //COMMENT STUFF
     //-----------------------------------
     $view_comments = true;
-    $commentres    = $GLOBALS['db']->Execute("SELECT cid, aid, commenttxt, added, edittime,
-														(SELECT user FROM `" . DB_PREFIX . "_admins` WHERE aid = C.aid) AS comname,
-														(SELECT user FROM `" . DB_PREFIX . "_admins` WHERE aid = C.editaid) AS editname
-														FROM `" . DB_PREFIX . "_comments` AS C
-														WHERE type = 'S' AND bid = '" . (int) $sub['subid'] . "' ORDER BY added desc");
+    $GLOBALS['PDO']->query("SELECT cid, aid, commenttxt, added, edittime,
+														(SELECT user FROM `:prefix_admins` WHERE aid = C.aid) AS comname,
+														(SELECT user FROM `:prefix_admins` WHERE aid = C.editaid) AS editname
+														FROM `:prefix_comments` AS C
+														WHERE type = 'S' AND bid = :bid ORDER BY added desc");
+    $GLOBALS['PDO']->bind(':bid', (int) $sub['subid']);
+    $commentres    = $GLOBALS['PDO']->resultset();
 
-    if ($commentres->RecordCount() > 0) {
+    if (count($commentres) > 0) {
         $comment = [];
         $morecom = 0;
-        while (!$commentres->EOF) {
+        foreach ($commentres as $crow) {
             $cdata            = [];
             $cdata['morecom'] = ($morecom == 1 ? true : false);
-            if ($commentres->fields['aid'] == $userbank->GetAid() || $userbank->HasAccess(ADMIN_OWNER)) {
-                $cdata['editcomlink'] = CreateLinkR('<i class="fas fa-edit fa-lg"></i>', 'index.php?p=banlist&comment=' . (int) $sub['subid'] . '&ctype=S&cid=' . $commentres->fields['cid'], 'Edit Comment');
+            if ($crow['aid'] == $userbank->GetAid() || $userbank->HasAccess(ADMIN_OWNER)) {
+                $cdata['editcomlink'] = CreateLinkR('<i class="fas fa-edit fa-lg"></i>', 'index.php?p=banlist&comment=' . (int) $sub['subid'] . '&ctype=S&cid=' . $crow['cid'], 'Edit Comment');
                 if ($userbank->HasAccess(ADMIN_OWNER)) {
-                    $cdata['delcomlink'] = "<a href=\"#\" class=\"tip\" title=\"Delete Comment\" target=\"_self\" onclick=\"RemoveComment(" . $commentres->fields['cid'] . ",'S',-1);\"><i class='fas fa-trash fa-lg'></i></a>";
+                    $cdata['delcomlink'] = "<a href=\"#\" class=\"tip\" title=\"Delete Comment\" target=\"_self\" onclick=\"RemoveComment(" . $crow['cid'] . ",'S',-1);\"><i class='fas fa-trash fa-lg'></i></a>";
                 }
             } else {
                 $cdata['editcomlink'] = "";
                 $cdata['delcomlink']  = "";
             }
 
-            $cdata['comname']    = $commentres->fields['comname'];
-            $cdata['added']      = Config::time($commentres->fields['added']);
-            $commentText         = html_entity_decode($commentres->fields['commenttxt'], ENT_QUOTES | ENT_HTML5, 'UTF-8');
+            $cdata['comname']    = $crow['comname'];
+            $cdata['added']      = Config::time($crow['added']);
+            $commentText         = html_entity_decode($crow['commenttxt'], ENT_QUOTES | ENT_HTML5, 'UTF-8');
             $commentText         = encodePreservingBr($commentText);
             // Parse links and wrap them in a <a href=""></a> tag to be easily clickable
             $commentText         = preg_replace('@(https?://([-\w\.]+)+(:\d+)?(/([\w/_\.]*(\?\S+)?)?)?)@', '<a href="$1" target="_blank">$1</a>', $commentText);
             $cdata['commenttxt'] = $commentText;
 
-            if (!empty($commentres->fields['edittime'])) {
-                $cdata['edittime'] = Config::time($commentres->fields['edittime']);
-                $cdata['editname'] = $commentres->fields['editname'];
+            if (!empty($crow['edittime'])) {
+                $cdata['edittime'] = Config::time($crow['edittime']);
+                $cdata['editname'] = $crow['editname'];
             } else {
                 $cdata['edittime'] = "";
                 $cdata['editname'] = "";
@@ -575,7 +585,6 @@ foreach ($submissions as $sub) {
 
             $morecom = 1;
             array_push($comment, $cdata);
-            $commentres->MoveNext();
         }
     } else {
         $comment = "None";
@@ -599,8 +608,8 @@ $page         = 1;
 if (isset($_GET['sapage']) && $_GET['sapage'] > 0) {
     $page = intval($_GET['sapage']);
 }
-$submissionsarchiv       = $GLOBALS['db']->GetAll("SELECT s.*, (SELECT user FROM `" . DB_PREFIX . "_admins` WHERE aid = s.archivedby) AS archivedby FROM `" . DB_PREFIX . "_submissions` s WHERE archiv > '0' ORDER BY subid DESC LIMIT " . intval(($page - 1) * $ItemsPerPage) . "," . intval($ItemsPerPage));
-$submissionsarchiv_count = $GLOBALS['db']->GetRow("SELECT count(subid) AS count FROM `" . DB_PREFIX . "_submissions` WHERE archiv > '0' ORDER BY subid DESC");
+$submissionsarchiv       = $GLOBALS['PDO']->query("SELECT s.*, (SELECT user FROM `:prefix_admins` WHERE aid = s.archivedby) AS archivedby FROM `:prefix_submissions` s WHERE archiv > '0' ORDER BY subid DESC LIMIT " . intval(($page - 1) * $ItemsPerPage) . "," . intval($ItemsPerPage))->resultset();
+$submissionsarchiv_count = $GLOBALS['PDO']->query("SELECT count(subid) AS count FROM `:prefix_submissions` WHERE archiv > '0' ORDER BY subid DESC")->single();
 $page_count              = $submissionsarchiv_count['count'];
 $PageStart               = intval(($page - 1) * $ItemsPerPage);
 $PageEnd                 = intval($PageStart + $ItemsPerPage);
@@ -648,8 +657,9 @@ foreach ($submissionsarchiv as $sub) {
     $sub['name']   = wordwrap(htmlspecialchars($sub['name']), 55, "<br />", true);
     $sub['reason'] = wordwrap(htmlspecialchars($sub['reason']), 55, "<br />", true);
 
-    $dem = $GLOBALS['db']->GetRow("SELECT filename FROM " . DB_PREFIX . "_demos
-												WHERE demtype = \"S\" AND demid = " . (int) $sub['subid']);
+    $GLOBALS['PDO']->query("SELECT filename FROM `:prefix_demos` WHERE demtype = 'S' AND demid = :subid");
+    $GLOBALS['PDO']->bind(':subid', (int) $sub['subid']);
+    $dem = $GLOBALS['PDO']->single();
 
     if ($dem && !empty($dem['filename']) && @file_exists(SB_DEMOS . "/" . $dem['filename'])) {
         $sub['demo'] = '<a href="getdemo.php?id=' . urlencode($sub['subid']) . '&type=S"><i class=\'fas fa-video fa-lg\'></i> Get Demo</a>';
@@ -659,9 +669,9 @@ foreach ($submissionsarchiv as $sub) {
 
     $sub['submitted'] = Config::time($sub['submitted']);
 
-    $mod        = $GLOBALS['db']->GetRow("SELECT m.name FROM `" . DB_PREFIX . "_submissions` AS s
-												LEFT JOIN `" . DB_PREFIX . "_mods` AS m ON m.mid = s.ModID
-												WHERE s.subid = " . (int) $sub['subid']);
+    $GLOBALS['PDO']->query("SELECT m.name FROM `:prefix_submissions` AS s LEFT JOIN `:prefix_mods` AS m ON m.mid = s.ModID WHERE s.subid = :subid");
+    $GLOBALS['PDO']->bind(':subid', (int) $sub['subid']);
+    $mod        = $GLOBALS['PDO']->single();
     $sub['mod'] = $mod['name'];
     if (empty($sub['server'])) {
         $sub['hostname'] = '<i><font color="#677882">Other server...</font></i>';
@@ -678,39 +688,41 @@ foreach ($submissionsarchiv as $sub) {
     //COMMENT STUFF
     //-----------------------------------
     $view_comments = true;
-    $commentres    = $GLOBALS['db']->Execute("SELECT cid, aid, commenttxt, added, edittime,
-														(SELECT user FROM `" . DB_PREFIX . "_admins` WHERE aid = C.aid) AS comname,
-														(SELECT user FROM `" . DB_PREFIX . "_admins` WHERE aid = C.editaid) AS editname
-														FROM `" . DB_PREFIX . "_comments` AS C
-														WHERE type = 'S' AND bid = '" . (int) $sub['subid'] . "' ORDER BY added desc");
+    $GLOBALS['PDO']->query("SELECT cid, aid, commenttxt, added, edittime,
+														(SELECT user FROM `:prefix_admins` WHERE aid = C.aid) AS comname,
+														(SELECT user FROM `:prefix_admins` WHERE aid = C.editaid) AS editname
+														FROM `:prefix_comments` AS C
+														WHERE type = 'S' AND bid = :bid ORDER BY added desc");
+    $GLOBALS['PDO']->bind(':bid', (int) $sub['subid']);
+    $commentres    = $GLOBALS['PDO']->resultset();
 
-    if ($commentres->RecordCount() > 0) {
+    if (count($commentres) > 0) {
         $comment = [];
         $morecom = 0;
-        while (!$commentres->EOF) {
+        foreach ($commentres as $crow) {
             $cdata            = [];
             $cdata['morecom'] = ($morecom == 1 ? true : false);
-            if ($commentres->fields['aid'] == $userbank->GetAid() || $userbank->HasAccess(ADMIN_OWNER)) {
-                $cdata['editcomlink'] = CreateLinkR('<i class="fas fa-edit fa-lg"></i>', 'index.php?p=banlist&comment=' . (int) $sub['subid'] . '&ctype=S&cid=' . $commentres->fields['cid'], 'Edit Comment');
+            if ($crow['aid'] == $userbank->GetAid() || $userbank->HasAccess(ADMIN_OWNER)) {
+                $cdata['editcomlink'] = CreateLinkR('<i class="fas fa-edit fa-lg"></i>', 'index.php?p=banlist&comment=' . (int) $sub['subid'] . '&ctype=S&cid=' . $crow['cid'], 'Edit Comment');
                 if ($userbank->HasAccess(ADMIN_OWNER)) {
-                    $cdata['delcomlink'] = "<a href=\"#\" class=\"tip\" title=\"Delete Comment\" target=\"_self\" onclick=\"RemoveComment(" . $commentres->fields['cid'] . ",'S',-1);\"><i class='fas fa-trash fa-lg'></i></a>";
+                    $cdata['delcomlink'] = "<a href=\"#\" class=\"tip\" title=\"Delete Comment\" target=\"_self\" onclick=\"RemoveComment(" . $crow['cid'] . ",'S',-1);\"><i class='fas fa-trash fa-lg'></i></a>";
                 }
             } else {
                 $cdata['editcomlink'] = "";
                 $cdata['delcomlink']  = "";
             }
 
-            $cdata['comname']    = $commentres->fields['comname'];
-            $cdata['added']      = Config::time($commentres->fields['added']);
-            $commentText         = html_entity_decode($commentres->fields['commenttxt'], ENT_QUOTES | ENT_HTML5, 'UTF-8');
+            $cdata['comname']    = $crow['comname'];
+            $cdata['added']      = Config::time($crow['added']);
+            $commentText         = html_entity_decode($crow['commenttxt'], ENT_QUOTES | ENT_HTML5, 'UTF-8');
             $commentText         = encodePreservingBr($commentText);
             // Parse links and wrap them in a <a href=""></a> tag to be easily clickable
             $commentText         = preg_replace('@(https?://([-\w\.]+)+(:\d+)?(/([\w/_\.]*(\?\S+)?)?)?)@', '<a href="$1" target="_blank">$1</a>', $commentText);
             $cdata['commenttxt'] = $commentText;
 
-            if (!empty($commentres->fields['edittime'])) {
-                $cdata['edittime'] = Config::time($commentres->fields['edittime']);
-                $cdata['editname'] = $commentres->fields['editname'];
+            if (!empty($crow['edittime'])) {
+                $cdata['edittime'] = Config::time($crow['edittime']);
+                $cdata['editname'] = $crow['editname'];
             } else {
                 $cdata['edittime'] = "";
                 $cdata['editname'] = "";
@@ -718,7 +730,6 @@ foreach ($submissionsarchiv as $sub) {
 
             $morecom = 1;
             array_push($comment, $cdata);
-            $commentres->MoveNext();
         }
     } else {
         $comment = "None";

--- a/web/pages/admin.blockit.php
+++ b/web/pages/admin.blockit.php
@@ -42,19 +42,18 @@ function LoadServers2($check, $type, $length)
         return $objResponse;
     }
     $id      = 0;
-    $servers = $GLOBALS['db']->Execute("SELECT sid, rcon FROM " . DB_PREFIX . "_servers WHERE enabled = 1 ORDER BY modid, sid;");
-    while (!$servers->EOF) {
+    $servers = $GLOBALS['PDO']->query("SELECT sid, rcon FROM `:prefix_servers` WHERE enabled = 1 ORDER BY modid, sid")->resultset();
+    foreach ($servers as $server) {
         //search for player
-        if (!empty($servers->fields["rcon"])) {
+        if (!empty($server["rcon"])) {
             $text = '<font size="1">Searching...</font>';
-            $objResponse->addScript("xajax_BlockPlayer('" . $check . "', '" . $servers->fields["sid"] . "', '" . $id . "', '" . $type . "', '" . $length . "');");
+            $objResponse->addScript("xajax_BlockPlayer('" . $check . "', '" . $server["sid"] . "', '" . $id . "', '" . $type . "', '" . $length . "');");
         } else { //no rcon = servercount + 1 ;)
             $text = '<font size="1">No rcon password.</font>';
             $objResponse->addScript('set_counter(1);');
         }
         $objResponse->addAssign("srv_" . $id, "innerHTML", $text);
         $id++;
-        $servers->MoveNext();
     }
     return $objResponse;
 }
@@ -109,18 +108,17 @@ function BlockPlayer($check, int $sid, $num, $type, int $length)
     $objResponse->addScript('set_counter(1);');
     return $objResponse;
 }
-$servers = $GLOBALS['db']->Execute("SELECT ip, port, rcon FROM " . DB_PREFIX . "_servers WHERE enabled = 1 ORDER BY modid, sid;");
-$theme->assign('total', $servers->RecordCount());
+$servers = $GLOBALS['PDO']->query("SELECT ip, port, rcon FROM `:prefix_servers` WHERE enabled = 1 ORDER BY modid, sid")->resultset();
+$theme->assign('total', count($servers));
 $serverlinks = [];
 $num         = 0;
-while (!$servers->EOF) {
+foreach ($servers as $server) {
     $info         = [];
     $info['num']  = $num;
-    $info['ip']   = $servers->fields["ip"];
-    $info['port'] = $servers->fields["port"];
+    $info['ip']   = $server["ip"];
+    $info['port'] = $server["port"];
     array_push($serverlinks, $info);
     $num++;
-    $servers->MoveNext();
 }
 $theme->assign('servers', $serverlinks);
 $theme->assign('xajax_functions', $xajax->printJavascript("../scripts", "xajax.js"));

--- a/web/pages/admin.edit.admindetails.php
+++ b/web/pages/admin.edit.admindetails.php
@@ -195,52 +195,54 @@ if (isset($_POST['adminname'])) {
     // Only proceed, if there are no errors in the form
     if ($error == 0) {
         // set the basic fields
-        $edit = $GLOBALS['db']->Execute(
-            "UPDATE " . DB_PREFIX . "_admins SET
-            `user` = ?, `authid` = ?, `email` = ?
-            WHERE `aid` = ?",
-            array(
-                $a_name,
-                $a_steam,
-                $a_email,
-                $_GET['id']
-            )
+        $GLOBALS['PDO']->query(
+            "UPDATE `:prefix_admins` SET
+            `user` = :user, `authid` = :authid, `email` = :email
+            WHERE `aid` = :aid"
         );
+        $GLOBALS['PDO']->bindMultiple([
+            ':user'   => $a_name,
+            ':authid' => $a_steam,
+            ':email'  => $a_email,
+            ':aid'    => $_GET['id'],
+        ]);
+        $GLOBALS['PDO']->execute();
 
         // Password changed?
         if ($pw_changed) {
-            $edit = $GLOBALS['db']->Execute(
-                "UPDATE " . DB_PREFIX . "_admins SET
-                `password` = ?
-                WHERE `aid` = ?",
-                array(
-                    password_hash($_POST['password'], PASSWORD_BCRYPT),
-                    $_GET['id']
-                )
+            $GLOBALS['PDO']->query(
+                "UPDATE `:prefix_admins` SET
+                `password` = :password
+                WHERE `aid` = :aid"
             );
+            $GLOBALS['PDO']->bindMultiple([
+                ':password' => password_hash($_POST['password'], PASSWORD_BCRYPT),
+                ':aid'      => $_GET['id'],
+            ]);
+            $GLOBALS['PDO']->execute();
         }
 
         // Server Admin Password changed?
         if ($serverpw_changed) {
-            $edit = $GLOBALS['db']->Execute(
-                "UPDATE " . DB_PREFIX . "_admins SET
-                `srv_password` = ?
-                WHERE `aid` = ?",
-                array(
-                    $_POST['a_serverpass'],
-                    $_GET['id']
-                )
+            $GLOBALS['PDO']->query(
+                "UPDATE `:prefix_admins` SET
+                `srv_password` = :srv_password
+                WHERE `aid` = :aid"
             );
+            $GLOBALS['PDO']->bindMultiple([
+                ':srv_password' => $_POST['a_serverpass'],
+                ':aid'          => $_GET['id'],
+            ]);
+            $GLOBALS['PDO']->execute();
         } elseif (isset($_POST['a_useserverpass']) && $_POST['a_useserverpass'] != "on") {
             // Remove the server password
-            $edit = $GLOBALS['db']->Execute(
-                "UPDATE " . DB_PREFIX . "_admins SET
+            $GLOBALS['PDO']->query(
+                "UPDATE `:prefix_admins` SET
                 `srv_password` = NULL
-                WHERE `aid` = ?",
-                array(
-                    $_GET['id']
-                )
+                WHERE `aid` = :aid"
             );
+            $GLOBALS['PDO']->bind(':aid', $_GET['id']);
+            $GLOBALS['PDO']->execute();
         }
 
         // to prevent rehash window to error with "no access", cause pw doesn't match
@@ -251,12 +253,14 @@ if (isset($_POST['adminname'])) {
 
         if (Config::getBool('config.enableadminrehashing')) {
             // rehash the admins on the servers
-            $serveraccessq = $GLOBALS['db']->GetAll("SELECT s.sid FROM `" . DB_PREFIX . "_servers` s
-                LEFT JOIN `" . DB_PREFIX . "_admins_servers_groups` asg ON asg.admin_id = '" . (int) $_GET['id'] . "'
-                LEFT JOIN `" . DB_PREFIX . "_servers_groups` sg ON sg.group_id = asg.srv_group_id
+            $GLOBALS['PDO']->query("SELECT s.sid FROM `:prefix_servers` s
+                LEFT JOIN `:prefix_admins_servers_groups` asg ON asg.admin_id = :aid
+                LEFT JOIN `:prefix_servers_groups` sg ON sg.group_id = asg.srv_group_id
                 WHERE ((asg.server_id != '-1' AND asg.srv_group_id = '-1')
                 OR (asg.srv_group_id != '-1' AND asg.server_id = '-1'))
                 AND (s.sid IN(asg.server_id) OR s.sid IN(sg.server_id)) AND s.enabled = 1");
+            $GLOBALS['PDO']->bind(':aid', (int) $_GET['id']);
+            $serveraccessq = $GLOBALS['PDO']->resultset();
             $allservers    = [];
             foreach ($serveraccessq as $access) {
                 if (!in_array($access['sid'], $allservers)) {
@@ -266,9 +270,9 @@ if (isset($_POST['adminname'])) {
             $rehashing = true;
         }
 
-        $admname = $GLOBALS['db']->GetRow("SELECT user FROM `" . DB_PREFIX . "_admins` WHERE aid = ?", array(
-            (int) $_GET['id']
-        ));
+        $GLOBALS['PDO']->query("SELECT user FROM `:prefix_admins` WHERE aid = :aid");
+        $GLOBALS['PDO']->bind(':aid', (int) $_GET['id']);
+        $admname = $GLOBALS['PDO']->single();
         Log::add("m", "Admin Details Updated", "Admin ($admname[user]) details has been changed.");
         if ($ownpwchanged) {
             echo '<script>ShowBox("Admin details updated", "The admin details has been updated successfully", "green", "index.php?p=login");TabToReload();</script>';

--- a/web/pages/admin.edit.admingroup.php
+++ b/web/pages/admin.edit.admingroup.php
@@ -80,57 +80,62 @@ if (isset($_POST['wg']) || isset($_GET['wg']) || isset($_GET['sg'])) {
                 $_POST['wg'] = 0;
             }
             // Edit the web group
-            $edit = $GLOBALS['db']->Execute(
-                "UPDATE " . DB_PREFIX . "_admins SET
-                `gid` = ?
-                WHERE `aid` = ?;",
-                array(
-                    $_POST['wg'],
-                    $_GET['id']
-                )
+            $GLOBALS['PDO']->query(
+                "UPDATE `:prefix_admins` SET
+                `gid` = :gid
+                WHERE `aid` = :aid"
             );
+            $GLOBALS['PDO']->bindMultiple([
+                ':gid' => $_POST['wg'],
+                ':aid' => $_GET['id'],
+            ]);
+            $GLOBALS['PDO']->execute();
         }
 
         if (isset($_POST['sg']) && $_POST['sg'] != "-2") {
             // Edit the server admin group
             $group = "";
             if ($_POST['sg'] != -1) {
-                $grps = $GLOBALS['db']->GetRow("SELECT name FROM " . DB_PREFIX . "_srvgroups WHERE id = ?;", array(
-                    $_POST['sg']
-                ));
+                $GLOBALS['PDO']->query("SELECT name FROM `:prefix_srvgroups` WHERE id = :id");
+                $GLOBALS['PDO']->bind(':id', $_POST['sg']);
+                $grps = $GLOBALS['PDO']->single();
                 if ($grps) {
                     $group = $grps['name'];
                 }
             }
 
-            $edit = $GLOBALS['db']->Execute(
-                "UPDATE " . DB_PREFIX . "_admins SET
-                `srv_group` = ?
-                WHERE aid = ?",
-                array(
-                    $group,
-                    $_GET['id']
-                )
+            $GLOBALS['PDO']->query(
+                "UPDATE `:prefix_admins` SET
+                `srv_group` = :srv_group
+                WHERE aid = :aid"
             );
+            $GLOBALS['PDO']->bindMultiple([
+                ':srv_group' => $group,
+                ':aid'       => $_GET['id'],
+            ]);
+            $GLOBALS['PDO']->execute();
 
-            $edit = $GLOBALS['db']->Execute(
-                "UPDATE " . DB_PREFIX . "_admins_servers_groups SET
-                `group_id` = ?
-                WHERE admin_id = ?;",
-                array(
-                    $_POST['sg'],
-                    $_GET['id']
-                )
+            $GLOBALS['PDO']->query(
+                "UPDATE `:prefix_admins_servers_groups` SET
+                `group_id` = :group_id
+                WHERE admin_id = :aid"
             );
+            $GLOBALS['PDO']->bindMultiple([
+                ':group_id' => $_POST['sg'],
+                ':aid'      => $_GET['id'],
+            ]);
+            $GLOBALS['PDO']->execute();
         }
         if (Config::getBool('config.enableadminrehashing')) {
             // rehash the admins on the servers
-            $serveraccessq = $GLOBALS['db']->GetAll("SELECT s.sid FROM `" . DB_PREFIX . "_servers` s
-                LEFT JOIN `" . DB_PREFIX . "_admins_servers_groups` asg ON asg.admin_id = '" . (int) $_GET['id'] . "'
-                LEFT JOIN `" . DB_PREFIX . "_servers_groups` sg ON sg.group_id = asg.srv_group_id
+            $GLOBALS['PDO']->query("SELECT s.sid FROM `:prefix_servers` s
+                LEFT JOIN `:prefix_admins_servers_groups` asg ON asg.admin_id = :aid
+                LEFT JOIN `:prefix_servers_groups` sg ON sg.group_id = asg.srv_group_id
                 WHERE ((asg.server_id != '-1' AND asg.srv_group_id = '-1')
                 OR (asg.srv_group_id != '-1' AND asg.server_id = '-1'))
                 AND (s.sid IN(asg.server_id) OR s.sid IN(sg.server_id)) AND s.enabled = 1");
+            $GLOBALS['PDO']->bind(':aid', (int) $_GET['id']);
+            $serveraccessq = $GLOBALS['PDO']->resultset();
             $allservers    = [];
             foreach ($serveraccessq as $access) {
                 if (!in_array($access['sid'], $allservers)) {
@@ -142,15 +147,15 @@ if (isset($_POST['wg']) || isset($_GET['wg']) || isset($_GET['sg'])) {
             echo '<script>ShowBox("Admin updated", "The admin has been updated successfully", "green", "index.php?p=admin&c=admins");TabToReload();</script>';
         }
 
-        $admname = $GLOBALS['db']->GetRow("SELECT user FROM `" . DB_PREFIX . "_admins` WHERE aid = ?", array(
-            (int) $_GET['id']
-        ));
+        $GLOBALS['PDO']->query("SELECT user FROM `:prefix_admins` WHERE aid = :aid");
+        $GLOBALS['PDO']->bind(':aid', (int) $_GET['id']);
+        $admname = $GLOBALS['PDO']->single();
         Log::add("m", "Admin's Groups Updated", "Admin ($admname[user]) groups has been updated.");
     }
 }
 
-$wgroups = $GLOBALS['db']->GetAll("SELECT gid, name FROM " . DB_PREFIX . "_groups WHERE type != 3");
-$sgroups = $GLOBALS['db']->GetAll("SELECT id, name FROM " . DB_PREFIX . "_srvgroups");
+$wgroups = $GLOBALS['PDO']->query("SELECT gid, name FROM `:prefix_groups` WHERE type != 3")->resultset();
+$sgroups = $GLOBALS['PDO']->query("SELECT id, name FROM `:prefix_srvgroups`")->resultset();
 
 $server_admin_group = $userbank->GetProperty('srv_groups', $_GET['id']);
 foreach ($sgroups as $sg) {

--- a/web/pages/admin.edit.adminservers.php
+++ b/web/pages/admin.edit.adminservers.php
@@ -58,47 +58,56 @@ if (!$userbank->HasAccess(ADMIN_OWNER | ADMIN_EDIT_ADMINS)) {
     PageDie();
 }
 
-$servers    = $GLOBALS['db']->GetAll("SELECT `server_id`, `srv_group_id` FROM " . DB_PREFIX . "_admins_servers_groups WHERE admin_id = " . (int) $aid);
-$adminGroup = $GLOBALS['db']->GetAll('SELECT id FROM ' . DB_PREFIX . '_srvgroups sg, ' . DB_PREFIX . '_admins a WHERE sg.name = a.srv_group and a.aid = ? limit 1', array(
-    $aid
-));
+$GLOBALS['PDO']->query("SELECT `server_id`, `srv_group_id` FROM `:prefix_admins_servers_groups` WHERE admin_id = :aid");
+$GLOBALS['PDO']->bind(':aid', (int) $aid);
+$servers    = $GLOBALS['PDO']->resultset();
+
+$GLOBALS['PDO']->query("SELECT id FROM `:prefix_srvgroups` sg, `:prefix_admins` a WHERE sg.name = a.srv_group AND a.aid = :aid LIMIT 1");
+$GLOBALS['PDO']->bind(':aid', $aid);
+$adminGroup = $GLOBALS['PDO']->resultset();
 
 $server_grp = isset($adminGroup[0]['id']) ? $adminGroup[0]['id'] : 0;
 
 
 if (isset($_POST['editadminserver'])) {
     // clear old stuffs
-    $GLOBALS['db']->Execute("DELETE FROM " . DB_PREFIX . "_admins_servers_groups WHERE admin_id = {$aid}");
+    $GLOBALS['PDO']->query("DELETE FROM `:prefix_admins_servers_groups` WHERE admin_id = :aid");
+    $GLOBALS['PDO']->bind(':aid', $aid);
+    $GLOBALS['PDO']->execute();
     if (isset($_POST['servers']) && is_array($_POST['servers']) && count($_POST['servers']) > 0) {
         foreach ($_POST['servers'] as $s) {
-            $pre = $GLOBALS['db']->Prepare("INSERT INTO " . DB_PREFIX . "_admins_servers_groups(admin_id,group_id,srv_group_id,server_id) VALUES (?,?,?,?)");
-            $GLOBALS['db']->Execute($pre, array(
-                $aid,
-                $server_grp,
-                -1,
-                (int) substr($s, 1)
-            ));
+            $GLOBALS['PDO']->query("INSERT INTO `:prefix_admins_servers_groups`(admin_id,group_id,srv_group_id,server_id) VALUES (:aid,:gid,:srv_group_id,:server_id)");
+            $GLOBALS['PDO']->bindMultiple([
+                ':aid'          => $aid,
+                ':gid'          => $server_grp,
+                ':srv_group_id' => -1,
+                ':server_id'    => (int) substr($s, 1),
+            ]);
+            $GLOBALS['PDO']->execute();
         }
     }
     if (isset($_POST['group']) && is_array($_POST['group']) && count($_POST['group']) > 0) {
         foreach ($_POST['group'] as $g) {
-            $pre = $GLOBALS['db']->Prepare("INSERT INTO " . DB_PREFIX . "_admins_servers_groups(admin_id,group_id,srv_group_id,server_id) VALUES (?,?,?,?)");
-            $GLOBALS['db']->Execute($pre, array(
-                $aid,
-                $server_grp,
-                (int) substr($g, 1),
-                -1
-            ));
+            $GLOBALS['PDO']->query("INSERT INTO `:prefix_admins_servers_groups`(admin_id,group_id,srv_group_id,server_id) VALUES (:aid,:gid,:srv_group_id,:server_id)");
+            $GLOBALS['PDO']->bindMultiple([
+                ':aid'          => $aid,
+                ':gid'          => $server_grp,
+                ':srv_group_id' => (int) substr($g, 1),
+                ':server_id'    => -1,
+            ]);
+            $GLOBALS['PDO']->execute();
         }
     }
     if (Config::getBool('config.enableadminrehashing')) {
         // rehash the admins on the servers
-        $serveraccessq = $GLOBALS['db']->GetAll("SELECT s.sid FROM `" . DB_PREFIX . "_servers` s
-												LEFT JOIN `" . DB_PREFIX . "_admins_servers_groups` asg ON asg.admin_id = '" . (int) $aid . "'
-												LEFT JOIN `" . DB_PREFIX . "_servers_groups` sg ON sg.group_id = asg.srv_group_id
+        $GLOBALS['PDO']->query("SELECT s.sid FROM `:prefix_servers` s
+												LEFT JOIN `:prefix_admins_servers_groups` asg ON asg.admin_id = :aid
+												LEFT JOIN `:prefix_servers_groups` sg ON sg.group_id = asg.srv_group_id
 												WHERE ((asg.server_id != '-1' AND asg.srv_group_id = '-1')
 												OR (asg.srv_group_id != '-1' AND asg.server_id = '-1'))
 												AND (s.sid IN(asg.server_id) OR s.sid IN(sg.server_id)) AND s.enabled = 1");
+        $GLOBALS['PDO']->bind(':aid', (int) $aid);
+        $serveraccessq = $GLOBALS['PDO']->resultset();
 
         $allservers = [];
         foreach ($serveraccessq as $access) {
@@ -114,9 +123,9 @@ if (isset($_POST['editadminserver'])) {
             }
 
             // old server groups
-            $serv_in_grp = $GLOBALS['db']->GetAll('SELECT server_id FROM `' . DB_PREFIX . '_servers_groups` WHERE group_id = ?;', array(
-                (int) $server['srv_group_id']
-            ));
+            $GLOBALS['PDO']->query('SELECT server_id FROM `:prefix_servers_groups` WHERE group_id = :gid');
+            $GLOBALS['PDO']->bind(':gid', (int) $server['srv_group_id']);
+            $serv_in_grp = $GLOBALS['PDO']->resultset();
             foreach ($serv_in_grp as $srg) {
                 if ($srg['server_id'] != "-1" && !in_array((int) $srg['server_id'], $allservers)) {
                     $allservers[] = (int) $srg['server_id'];
@@ -129,15 +138,15 @@ if (isset($_POST['editadminserver'])) {
         echo '<script>ShowBox("Admin server access updated", "The admin server access has been updated successfully", "green", "index.php?p=admin&c=admins");TabToReload();</script>';
     }
 
-    $admname = $GLOBALS['db']->GetRow("SELECT user FROM `" . DB_PREFIX . "_admins` WHERE aid = ?", array(
-        (int) $aid
-    ));
+    $GLOBALS['PDO']->query("SELECT user FROM `:prefix_admins` WHERE aid = :aid");
+    $GLOBALS['PDO']->bind(':aid', (int) $aid);
+    $admname = $GLOBALS['PDO']->single();
     Log::add("m", "Admin Servers Updated", "Admin ($admname[user]) server access has been changed.");
 }
 
 
-$server_list = $GLOBALS['db']->GetAll("SELECT * FROM `" . DB_PREFIX . "_servers`");
-$group_list  = $GLOBALS['db']->GetAll("SELECT * FROM `" . DB_PREFIX . "_groups` WHERE type = '3'");
+$server_list = $GLOBALS['PDO']->query("SELECT * FROM `:prefix_servers`")->resultset();
+$group_list  = $GLOBALS['PDO']->query("SELECT * FROM `:prefix_groups` WHERE type = '3'")->resultset();
 $rowcount    = (count($server_list) + count($group_list));
 
 $theme->assign('row_count', $rowcount);

--- a/web/pages/admin.edit.ban.php
+++ b/web/pages/admin.edit.ban.php
@@ -36,15 +36,17 @@ if (!isset($_GET['id']) || !is_numeric($_GET['id'])) {
 }
 $_GET['id'] = (int) $_GET['id'];
 
-$res = $GLOBALS['db']->GetRow("
-    				SELECT bid, ba.ip, ba.type, ba.authid, ba.name, created, ends, length, reason, ba.aid, ba.sid, ad.user, ad.gid, CONCAT(se.ip,':',se.port), se.sid, mo.icon, (SELECT origname FROM " . DB_PREFIX . "_demos WHERE demtype = 'b' AND demid = ?)
-    				FROM " . DB_PREFIX . "_bans AS ba
-    				LEFT JOIN " . DB_PREFIX . "_admins AS ad ON ba.aid = ad.aid
-    				LEFT JOIN " . DB_PREFIX . "_servers AS se ON se.sid = ba.sid
-    				LEFT JOIN " . DB_PREFIX . "_mods AS mo ON mo.mid = se.modid
-    				WHERE bid = ?", array($_GET['id'], $_GET['id']));
+$GLOBALS['PDO']->query("
+    				SELECT bid, ba.ip, ba.type, ba.authid, ba.name, created, ends, length, reason, ba.aid, ba.sid AS ba_sid, ad.user, ad.gid, CONCAT(se.ip,':',se.port) AS server_addr, se.sid AS se_sid, mo.icon, (SELECT origname FROM `:prefix_demos` WHERE demtype = 'b' AND demid = :id) AS dname
+    				FROM `:prefix_bans` AS ba
+    				LEFT JOIN `:prefix_admins` AS ad ON ba.aid = ad.aid
+    				LEFT JOIN `:prefix_servers` AS se ON se.sid = ba.sid
+    				LEFT JOIN `:prefix_mods` AS mo ON mo.mid = se.modid
+    				WHERE bid = :id");
+$GLOBALS['PDO']->bind(':id', $_GET['id']);
+$res = $GLOBALS['PDO']->single();
 
-if (!$userbank->HasAccess(ADMIN_OWNER | ADMIN_EDIT_ALL_BANS) && (!$userbank->HasAccess(ADMIN_EDIT_OWN_BANS) && $res[8] != $userbank->GetAid()) && (!$userbank->HasAccess(ADMIN_EDIT_GROUP_BANS) && $res->fields['gid'] != $userbank->GetProperty('gid'))) {
+if (!$userbank->HasAccess(ADMIN_OWNER | ADMIN_EDIT_ALL_BANS) && (!$userbank->HasAccess(ADMIN_EDIT_OWN_BANS) && $res['aid'] != $userbank->GetAid()) && (!$userbank->HasAccess(ADMIN_EDIT_GROUP_BANS) && $res['gid'] != $userbank->GetProperty('gid'))) {
     echo '<script>ShowBox("Error", "You don\'t have access to this!", "red", "index.php?p=admin&c=bans");</script>';
     PageDie();
 }
@@ -92,12 +94,14 @@ if (isset($_POST['name'])) {
     if ($error == 0) {
         // Check if the new steamid is already banned
         if ($_POST['type'] == 0) {
-            $chk = $GLOBALS['db']->GetRow("SELECT count(bid) AS count FROM " . DB_PREFIX . "_bans WHERE authid = ? AND (length = 0 OR ends > UNIX_TIMESTAMP()) AND RemovedBy IS NULL AND type = '0' AND bid != ?", array(
-                $_POST['steam'],
-                (int) $_GET['id']
-            ));
+            $GLOBALS['PDO']->query("SELECT count(bid) AS count FROM `:prefix_bans` WHERE authid = :authid AND (length = 0 OR ends > UNIX_TIMESTAMP()) AND RemovedBy IS NULL AND type = '0' AND bid != :bid");
+            $GLOBALS['PDO']->bindMultiple([
+                ':authid' => $_POST['steam'],
+                ':bid'    => (int) $_GET['id'],
+            ]);
+            $chk = $GLOBALS['PDO']->single();
 
-            if ((int) $chk[0] > 0) {
+            if ((int) $chk['count'] > 0) {
                 $error++;
                 $errorScript .= "$('steam.msg').innerHTML = 'This SteamID is already banned';";
                 $errorScript .= "$('steam.msg').setStyle('display', 'block');";
@@ -115,12 +119,14 @@ if (isset($_POST['name'])) {
             }
         } elseif ($_POST['type'] == 1) {
             // Check if the ip is already banned
-            $chk = $GLOBALS['db']->GetRow("SELECT count(bid) AS count FROM " . DB_PREFIX . "_bans WHERE ip = ? AND (length = 0 OR ends > UNIX_TIMESTAMP()) AND RemovedBy IS NULL AND type = '1' AND bid != ?", array(
-                $_POST['ip'],
-                (int) $_GET['id']
-            ));
+            $GLOBALS['PDO']->query("SELECT count(bid) AS count FROM `:prefix_bans` WHERE ip = :ip AND (length = 0 OR ends > UNIX_TIMESTAMP()) AND RemovedBy IS NULL AND type = '1' AND bid != :bid");
+            $GLOBALS['PDO']->bindMultiple([
+                ':ip'  => $_POST['ip'],
+                ':bid' => (int) $_GET['id'],
+            ]);
+            $chk = $GLOBALS['PDO']->single();
 
-            if ((int) $chk[0] > 0) {
+            if ((int) $chk['count'] > 0) {
                 $error++;
                 $errorScript .= "$('ip.msg').innerHTML = 'This IP is already banned';";
                 $errorScript .= "$('ip.msg').setStyle('display', 'block');";
@@ -147,57 +153,65 @@ if (isset($_POST['name'])) {
 
     // Only process if there are still no errors
     if ($error == 0) {
-        $lengthrev = $GLOBALS['db']->Execute("SELECT length, authid FROM " . DB_PREFIX . "_bans WHERE bid = ?", array($_GET['id']));
+        $GLOBALS['PDO']->query("SELECT length, authid FROM `:prefix_bans` WHERE bid = :bid");
+        $GLOBALS['PDO']->bind(':bid', $_GET['id']);
+        $lengthrev = $GLOBALS['PDO']->single();
 
-
-        $edit = $GLOBALS['db']->Execute(
-            "UPDATE " . DB_PREFIX . "_bans SET
-            `name` = ?, `type` = ?, `reason` = ?, `authid` = ?,
-            `length` = ?,
-            `ip` = ?,
+        $GLOBALS['PDO']->query(
+            "UPDATE `:prefix_bans` SET
+            `name` = :name, `type` = :type, `reason` = :reason, `authid` = :authid,
+            `length` = :length,
+            `ip` = :ip,
             `country` = '',
-            `ends` 	 =  `created` + ?
-            WHERE bid = ?",
-            array(
-                $_POST['name'],
-                $_POST['type'],
-                $reason,
-                $_POST['steam'],
-                $_POST['banlength'],
-                $_POST['ip'],
-                $_POST['banlength'],
-                (int) $_GET['id']
-            )
+            `ends` 	 =  `created` + :ends
+            WHERE bid = :bid"
         );
+        $GLOBALS['PDO']->bindMultiple([
+            ':name'   => $_POST['name'],
+            ':type'   => $_POST['type'],
+            ':reason' => $reason,
+            ':authid' => $_POST['steam'],
+            ':length' => $_POST['banlength'],
+            ':ip'     => $_POST['ip'],
+            ':ends'   => $_POST['banlength'],
+            ':bid'    => (int) $_GET['id'],
+        ]);
+        $GLOBALS['PDO']->execute();
 
         // Set all submissions to archived for that steamid
-        $GLOBALS['db']->Execute("UPDATE `" . DB_PREFIX . "_submissions` SET archiv = '3', archivedby = '" . $userbank->GetAid() . "' WHERE SteamId = ?;", array(
-            $_POST['steam']
-        ));
+        $GLOBALS['PDO']->query("UPDATE `:prefix_submissions` SET archiv = '3', archivedby = :aid WHERE SteamId = :steam");
+        $GLOBALS['PDO']->bindMultiple([
+            ':aid'   => $userbank->GetAid(),
+            ':steam' => $_POST['steam'],
+        ]);
+        $GLOBALS['PDO']->execute();
 
         if (!empty($_POST['dname'])) {
-            $demoid = $GLOBALS['db']->GetRow("SELECT filename FROM `" . DB_PREFIX . "_demos` WHERE demid = ?;", array($_GET['id']));
+            $GLOBALS['PDO']->query("SELECT filename FROM `:prefix_demos` WHERE demid = :id");
+            $GLOBALS['PDO']->bind(':id', $_GET['id']);
+            $demoid = $GLOBALS['PDO']->single();
             @unlink(SB_DEMOS . "/" . $demoid['filename']);
-            $edit         = $GLOBALS['db']->Execute(
-                "REPLACE INTO " . DB_PREFIX . "_demos
+            $GLOBALS['PDO']->query(
+                "REPLACE INTO `:prefix_demos`
                 (`demid`, `demtype`, `filename`, `origname`)
                 VALUES
-                (?,
+                (:demid,
                 'b',
-                ?,
-                ?)",
-                array(
-                    (int) $_GET['id'],
-                    $_POST['did'],
-                    $_POST['dname']
-                )
+                :filename,
+                :origname)"
             );
+            $GLOBALS['PDO']->bindMultiple([
+                ':demid'    => (int) $_GET['id'],
+                ':filename' => $_POST['did'],
+                ':origname' => $_POST['dname'],
+            ]);
+            $GLOBALS['PDO']->execute();
             $res['dname'] = $_POST['dname'];
         }
 
-        if ($_POST['banlength'] != $lengthrev->fields['length']) {
-            Log::add("m", "Ban length edited", "Ban length for ({$lengthrev->fields['authid']}) has been updated."
-                . " Before: {$lengthrev->fields['length']}; Now: {$_POST['banlength']}.");
+        if ($_POST['banlength'] != $lengthrev['length']) {
+            Log::add("m", "Ban length edited", "Ban length for ({$lengthrev['authid']}) has been updated."
+                . " Before: {$lengthrev['length']}; Now: {$_POST['banlength']}.");
         }
         echo '<script>ShowBox("Ban updated", "The ban has been updated successfully", "green", "index.php?p=banlist' . $pagelink . '");</script>';
     }

--- a/web/pages/admin.edit.comms.php
+++ b/web/pages/admin.edit.comms.php
@@ -36,12 +36,14 @@ if (!isset($_GET['id']) || !is_numeric($_GET['id'])) {
 }
 $_GET['id'] = (int) $_GET['id'];
 
-$res = $GLOBALS['db']->GetRow("SELECT bid, ba.type, ba.authid, ba.name, created, ends, length, reason, ba.aid, ba.sid, ad.user, ad.gid
-    FROM " . DB_PREFIX . "_comms AS ba
-    LEFT JOIN " . DB_PREFIX . "_admins AS ad ON ba.aid = ad.aid
-    WHERE bid = ?", array($_GET['id']));
+$GLOBALS['PDO']->query("SELECT bid, ba.type, ba.authid, ba.name, created, ends, length, reason, ba.aid, ba.sid, ad.user, ad.gid
+    FROM `:prefix_comms` AS ba
+    LEFT JOIN `:prefix_admins` AS ad ON ba.aid = ad.aid
+    WHERE bid = :bid");
+$GLOBALS['PDO']->bind(':bid', $_GET['id']);
+$res = $GLOBALS['PDO']->single();
 
-if (!$userbank->HasAccess(ADMIN_OWNER | ADMIN_EDIT_ALL_BANS) && (!$userbank->HasAccess(ADMIN_EDIT_OWN_BANS) && $res[8] != $userbank->GetAid()) && (!$userbank->HasAccess(ADMIN_EDIT_GROUP_BANS) && $res->fields['gid'] != $userbank->GetProperty('gid'))) {
+if (!$userbank->HasAccess(ADMIN_OWNER | ADMIN_EDIT_ALL_BANS) && (!$userbank->HasAccess(ADMIN_EDIT_OWN_BANS) && $res['aid'] != $userbank->GetAid()) && (!$userbank->HasAccess(ADMIN_EDIT_GROUP_BANS) && $res['gid'] != $userbank->GetProperty('gid'))) {
     echo '<script>ShowBox("Error", "You don\'t have access to this!", "red", "index.php?p=admin&c=comms");</script>';
     PageDie();
 }
@@ -79,12 +81,14 @@ if (isset($_POST['name'])) {
 
     if ($error == 0) {
         // Check if the new steamid is already banned
-        $chk = $GLOBALS['db']->GetRow("SELECT count(bid) AS count FROM " . DB_PREFIX . "_comms WHERE authid = ? AND RemovedBy IS NULL AND type = ? AND bid != ? AND (length = 0 OR ends > UNIX_TIMESTAMP())", array(
-            $_POST['steam'],
-            (int) $_POST['type'],
-            (int) $_GET['id']
-        ));
-        if ((int) $chk[0] > 0) {
+        $GLOBALS['PDO']->query("SELECT count(bid) AS count FROM `:prefix_comms` WHERE authid = :authid AND RemovedBy IS NULL AND type = :type AND bid != :bid AND (length = 0 OR ends > UNIX_TIMESTAMP())");
+        $GLOBALS['PDO']->bindMultiple([
+            ':authid' => $_POST['steam'],
+            ':type'   => (int) $_POST['type'],
+            ':bid'    => (int) $_GET['id'],
+        ]);
+        $chk = $GLOBALS['PDO']->single();
+        if ((int) $chk['count'] > 0) {
             $error++;
             $errorScript .= "$('steam.msg').innerHTML = 'This SteamID is already blocked';";
             $errorScript .= "$('steam.msg').setStyle('display', 'block');";
@@ -119,26 +123,31 @@ if (isset($_POST['name'])) {
 
     // Only process if there are still no errors
     if ($error == 0) {
-        $lengthrev = $GLOBALS['db']->Execute("SELECT length, authid, type FROM " . DB_PREFIX . "_comms WHERE bid = ?", array($_GET['id']));
-        $edit = $GLOBALS['db']->Execute(
-            "UPDATE " . DB_PREFIX . "_comms SET
-            `name` = ?, `type` = ?, `reason` = ?, `authid` = ?,
-            `length` = ?,
-            `ends` 	 =  `created` + ?
-            WHERE bid = ?",
-            array(
-                $_POST['name'],
-                $_POST['type'],
-                $reason,
-                $_POST['steam'],
-                $_POST['banlength'],
-                $_POST['banlength'],
-                (int) $_GET['id']
-            )
+        $GLOBALS['PDO']->query("SELECT length, authid, type FROM `:prefix_comms` WHERE bid = :bid");
+        $GLOBALS['PDO']->bind(':bid', $_GET['id']);
+        $lengthrev = $GLOBALS['PDO']->single();
+
+        $GLOBALS['PDO']->query(
+            "UPDATE `:prefix_comms` SET
+            `name` = :name, `type` = :type, `reason` = :reason, `authid` = :authid,
+            `length` = :length,
+            `ends` 	 =  `created` + :ends
+            WHERE bid = :bid"
         );
-        if ($_POST['banlength'] != $lengthrev->fields['length']) {
-            Log::add("m", "Block edited", "Block for ({$lengthrev->fields['authid']}) has been updated."
-                . " Before: length ({$lengthrev->fields['length']}), type ({$lengthrev->fields['type']});"
+        $GLOBALS['PDO']->bindMultiple([
+            ':name'   => $_POST['name'],
+            ':type'   => $_POST['type'],
+            ':reason' => $reason,
+            ':authid' => $_POST['steam'],
+            ':length' => $_POST['banlength'],
+            ':ends'   => $_POST['banlength'],
+            ':bid'    => (int) $_GET['id'],
+        ]);
+        $GLOBALS['PDO']->execute();
+
+        if ($_POST['banlength'] != $lengthrev['length']) {
+            Log::add("m", "Block edited", "Block for ({$lengthrev['authid']}) has been updated."
+                . " Before: length ({$lengthrev['length']}), type ({$lengthrev['type']});"
                 . " Now: length ({$_POST['banlength']}), type ({$_POST['type']}).");
         }
         echo '<script>ShowBox("Block updated", "The block has been updated successfully", "green", "index.php?p=commslist' . $pagelink . '");</script>';

--- a/web/pages/admin.edit.group.php
+++ b/web/pages/admin.edit.group.php
@@ -46,11 +46,16 @@ if (!isset($_GET['type']) || ($_GET['type'] != 'web' && $_GET['type'] != 'srv' &
 
 $_GET['id'] = (int) $_GET['id'];
 
-$web_group = $GLOBALS['db']->GetRow("SELECT flags, name FROM " . DB_PREFIX . "_groups WHERE gid = {$_GET['id']}");
-$srv_group = $GLOBALS['db']->GetRow("SELECT flags, name, immunity FROM " . DB_PREFIX . "_srvgroups WHERE id = {$_GET['id']}");
+$GLOBALS['PDO']->query("SELECT flags, name FROM `:prefix_groups` WHERE gid = :id");
+$GLOBALS['PDO']->bind(':id', $_GET['id']);
+$web_group = $GLOBALS['PDO']->single();
 
-$web_flags = intval($web_group[0] ?? null);
-$srv_flags = isset($srv_group[0]) ? $srv_group[0] : '';
+$GLOBALS['PDO']->query("SELECT flags, name, immunity FROM `:prefix_srvgroups` WHERE id = :id");
+$GLOBALS['PDO']->bind(':id', $_GET['id']);
+$srv_group = $GLOBALS['PDO']->single();
+
+$web_flags = intval($web_group['flags'] ?? null);
+$srv_flags = $srv_group['flags'] ?? '';
 
 $name = $userbank->GetProperty("user", $_GET['id'])?>
 <div id="admin-page-content">
@@ -82,9 +87,9 @@ if ($_GET['type'] == "web") {
     // Group overrides
     // ALERT >>> GROSS CODE MIX <<<
     // I'm far to lazy to rewrite this to use smarty right now.
-    $overrides_list = $GLOBALS['db']->GetAll("SELECT * FROM `" . DB_PREFIX . "_srvgroups_overrides` WHERE group_id = ?", array(
-        $_GET['id']
-    ));
+    $GLOBALS['PDO']->query("SELECT * FROM `:prefix_srvgroups_overrides` WHERE group_id = :gid");
+    $GLOBALS['PDO']->bind(':gid', $_GET['id']);
+    $overrides_list = $GLOBALS['PDO']->resultset();
 ?>
 <br />
 <form action="" method="post" name="group_overrides_form">

--- a/web/pages/admin.edit.mod.php
+++ b/web/pages/admin.edit.mod.php
@@ -41,12 +41,12 @@ if (!$userbank->HasAccess(ADMIN_OWNER | ADMIN_EDIT_MODS)) {
 }
 
 $_GET['id'] = (int) $_GET['id'];
-$res        = $GLOBALS['db']->GetRow("
+$GLOBALS['PDO']->query("
     				SELECT name, modfolder, icon, enabled, steam_universe
-    				FROM " . DB_PREFIX . "_mods
-    				WHERE mid = ?", array(
-    $_GET['id']
-));
+    				FROM `:prefix_mods`
+    				WHERE mid = :mid");
+$GLOBALS['PDO']->bind(':mid', $_GET['id']);
+$res = $GLOBALS['PDO']->single();
 
 $errorScript = "";
 
@@ -60,10 +60,12 @@ if (isset($_POST['name'])) {
         $errorScript .= "$('name.msg').setStyle('display', 'block');";
     } else {
         // Already there?
-        $check = $GLOBALS['db']->GetRow("SELECT * FROM `" . DB_PREFIX . "_mods` WHERE name = ? AND mid != ?;", array(
-            $_POST['name'],
-            $_GET['id']
-        ));
+        $GLOBALS['PDO']->query("SELECT * FROM `:prefix_mods` WHERE name = :name AND mid != :mid");
+        $GLOBALS['PDO']->bindMultiple([
+            ':name' => $_POST['name'],
+            ':mid'  => $_GET['id'],
+        ]);
+        $check = $GLOBALS['PDO']->single();
         if (!empty($check)) {
             $error++;
             $errorScript .= "$('name.msg').innerHTML = 'A mod with that name already exists.';";
@@ -76,10 +78,12 @@ if (isset($_POST['name'])) {
         $errorScript .= "$('folder.msg').setStyle('display', 'block');";
     } else {
         // Already there?
-        $check = $GLOBALS['db']->GetRow("SELECT * FROM `" . DB_PREFIX . "_mods` WHERE modfolder = ? AND mid != ?;", array(
-            $_POST['folder'],
-            $_GET['id']
-        ));
+        $GLOBALS['PDO']->query("SELECT * FROM `:prefix_mods` WHERE modfolder = :folder AND mid != :mid");
+        $GLOBALS['PDO']->bindMultiple([
+            ':folder' => $_POST['folder'],
+            ':mid'    => $_GET['id'],
+        ]);
+        $check = $GLOBALS['PDO']->single();
         if (!empty($check)) {
             $error++;
             $errorScript .= "$('folder.msg').innerHTML = 'A mod using that folder already exists.';";
@@ -98,19 +102,20 @@ if (isset($_POST['name'])) {
             @unlink(SB_ICONS . "/" . $res['icon']);
         }
 
-        $edit = $GLOBALS['db']->Execute(
-            "UPDATE " . DB_PREFIX . "_mods SET
-            `name` = ?, `modfolder` = ?, `icon` = ?, `enabled` = ?, `steam_universe` = ?
-            WHERE `mid` = ?",
-            array(
-                $name,
-                $folder,
-                $icon,
-                $enabled,
-                $steam_universe,
-                $_GET['id']
-            )
+        $GLOBALS['PDO']->query(
+            "UPDATE `:prefix_mods` SET
+            `name` = :name, `modfolder` = :folder, `icon` = :icon, `enabled` = :enabled, `steam_universe` = :steam_universe
+            WHERE `mid` = :mid"
         );
+        $GLOBALS['PDO']->bindMultiple([
+            ':name'           => $name,
+            ':folder'         => $folder,
+            ':icon'           => $icon,
+            ':enabled'        => $enabled,
+            ':steam_universe' => $steam_universe,
+            ':mid'            => $_GET['id'],
+        ]);
+        $GLOBALS['PDO']->execute();
         echo '<script>ShowBox("Mod updated", "The mod has been updated successfully", "green", "index.php?p=admin&c=mods");</script>';
     }
     // put into array to display new values after submit

--- a/web/pages/admin.edit.server.php
+++ b/web/pages/admin.edit.server.php
@@ -36,7 +36,9 @@ if (!isset($_GET['id'])) {
 }
 $_GET['id'] = (int) $_GET['id'];
 
-$server = $GLOBALS['db']->GetRow("SELECT * FROM " . DB_PREFIX . "_servers WHERE sid = {$_GET['id']}");
+$GLOBALS['PDO']->query("SELECT * FROM `:prefix_servers` WHERE sid = :sid");
+$GLOBALS['PDO']->bind(':sid', $_GET['id']);
+$server = $GLOBALS['PDO']->single();
 if (!$server) {
     Log::add("e", "Getting server data failed", "Can't find data for server with id $_GET[id].");
     echo '<div id="msg-red" >
@@ -91,11 +93,13 @@ if (isset($_POST['address'])) {
 
     // Check for dublicates afterwards
     if ($error == 0) {
-        $chk = $GLOBALS['db']->GetRow('SELECT sid FROM `' . DB_PREFIX . '_servers` WHERE ip = ? AND port = ? AND sid != ?;', array(
-            $ip,
-            (int) $_POST['port'],
-            $_GET['id']
-        ));
+        $GLOBALS['PDO']->query('SELECT sid FROM `:prefix_servers` WHERE ip = :ip AND port = :port AND sid != :sid');
+        $GLOBALS['PDO']->bindMultiple([
+            ':ip'   => $ip,
+            ':port' => (int) $_POST['port'],
+            ':sid'  => $_GET['id'],
+        ]);
+        $chk = $GLOBALS['PDO']->single();
         if ($chk) {
             $error++;
             $errorScript .= "ShowBox('Error', 'There already is a server with that IP:Port combination.', 'red');";
@@ -111,56 +115,66 @@ if (isset($_POST['address'])) {
 
     if ($error == 0) {
         $grps = "";
-        $sg   = $GLOBALS['db']->GetAll("SELECT * FROM " . DB_PREFIX . "_servers_groups WHERE server_id = {$_GET['id']}");
+        $GLOBALS['PDO']->query("SELECT * FROM `:prefix_servers_groups` WHERE server_id = :sid");
+        $GLOBALS['PDO']->bind(':sid', $_GET['id']);
+        $sg = $GLOBALS['PDO']->resultset();
         foreach ($sg as $s) {
-            $GLOBALS['db']->Execute("DELETE FROM " . DB_PREFIX . "_servers_groups WHERE server_id = " . (int) $s['server_id'] . " AND group_id = " . (int) $s['group_id']);
+            $GLOBALS['PDO']->query("DELETE FROM `:prefix_servers_groups` WHERE server_id = :sid AND group_id = :gid");
+            $GLOBALS['PDO']->bindMultiple([
+                ':sid' => (int) $s['server_id'],
+                ':gid' => (int) $s['group_id'],
+            ]);
+            $GLOBALS['PDO']->execute();
         }
         if (!empty($_POST['groups'])) {
             foreach ($_POST['groups'] as $t) {
-                $addtogrp = $GLOBALS['db']->Prepare("INSERT INTO " . DB_PREFIX . "_servers_groups (`server_id`, `group_id`) VALUES (?,?)");
-                $GLOBALS['db']->Execute($addtogrp, array(
-                    $_GET['id'],
-                    (int) $t
-                ));
+                $GLOBALS['PDO']->query("INSERT INTO `:prefix_servers_groups` (`server_id`, `group_id`) VALUES (:sid, :gid)");
+                $GLOBALS['PDO']->bindMultiple([
+                    ':sid' => $_GET['id'],
+                    ':gid' => (int) $t,
+                ]);
+                $GLOBALS['PDO']->execute();
             }
         }
         $enabled = (isset($_POST['enabled']) && $_POST['enabled'] == "on" ? 1 : 0);
 
-        $edit = $GLOBALS['db']->Execute(
-            "UPDATE " . DB_PREFIX . "_servers SET
-            `ip` = ?,
-            `port` = ?,
-            `modid` = ?,
-            `enabled` = ?
-            WHERE `sid` = ?",
-            array(
-                $ip,
-                (int) $_POST['port'],
-                (int) $_POST['mod'],
-                $enabled,
-                (int) $_GET['id']
-            )
+        $GLOBALS['PDO']->query(
+            "UPDATE `:prefix_servers` SET
+            `ip` = :ip,
+            `port` = :port,
+            `modid` = :modid,
+            `enabled` = :enabled
+            WHERE `sid` = :sid"
         );
+        $GLOBALS['PDO']->bindMultiple([
+            ':ip'      => $ip,
+            ':port'    => (int) $_POST['port'],
+            ':modid'   => (int) $_POST['mod'],
+            ':enabled' => $enabled,
+            ':sid'     => (int) $_GET['id'],
+        ]);
+        $GLOBALS['PDO']->execute();
 
         // don't change rcon password if not changed
         if ($_POST['rcon'] != '+-#*_') {
-            $edit = $GLOBALS['db']->Execute(
-                "UPDATE " . DB_PREFIX . "_servers SET
-                `rcon` = ?
-                WHERE `sid` = ?",
-                array(
-                    $_POST['rcon'],
-                    (int) $_GET['id']
-                )
+            $GLOBALS['PDO']->query(
+                "UPDATE `:prefix_servers` SET
+                `rcon` = :rcon
+                WHERE `sid` = :sid"
             );
+            $GLOBALS['PDO']->bindMultiple([
+                ':rcon' => $_POST['rcon'],
+                ':sid'  => (int) $_GET['id'],
+            ]);
+            $GLOBALS['PDO']->execute();
         }
 
         echo "<script>ShowBox('Server updated', 'The server has been updated successfully', 'green', 'index.php?p=admin&c=servers');TabToReload();</script>";
     }
 }
 
-$modlist   = $GLOBALS['db']->GetAll("SELECT mid, name FROM `" . DB_PREFIX . "_mods` WHERE `mid` > 0 AND `enabled` = 1 ORDER BY name ASC");
-$grouplist = $GLOBALS['db']->GetAll("SELECT gid, name FROM `" . DB_PREFIX . "_groups` WHERE type = 3 ORDER BY name ASC");
+$modlist   = $GLOBALS['PDO']->query("SELECT mid, name FROM `:prefix_mods` WHERE `mid` > 0 AND `enabled` = 1 ORDER BY name ASC")->resultset();
+$grouplist = $GLOBALS['PDO']->query("SELECT gid, name FROM `:prefix_groups` WHERE type = 3 ORDER BY name ASC")->resultset();
 
 $theme->assign('ip', $server['ip']);
 $theme->assign('port', $server['port']);
@@ -182,12 +196,14 @@ $theme->assign('submit_text', "Update Server");
 <script>
 <?php
 if (!isset($_POST['address'])) {
-    $groups = $GLOBALS['db']->GetAll("SELECT group_id FROM `" . DB_PREFIX . "_servers_groups` WHERE server_id = {$_GET['id']}");
+    $GLOBALS['PDO']->query("SELECT group_id FROM `:prefix_servers_groups` WHERE server_id = :sid");
+    $GLOBALS['PDO']->bind(':sid', $_GET['id']);
+    $groups = $GLOBALS['PDO']->resultset();
 } else {
     if (isset($_POST['groups']) && is_array($_POST['groups'])) {
         $groups = $_POST['groups'];
         foreach ($groups as $k => $g) {
-            $groups[$k] = array($g);
+            $groups[$k] = ['group_id' => $g];
         }
     } else {
         $groups = [];
@@ -195,7 +211,7 @@ if (!isset($_POST['address'])) {
 }
 foreach ($groups as $g) {
     if ($g) {
-        echo "if($('g_" . $g[0] . "')) $('g_" . $g[0] . "').checked = true;";
+        echo "if($('g_" . $g['group_id'] . "')) $('g_" . $g['group_id'] . "').checked = true;";
     }
 }
 echo $errorScript;

--- a/web/pages/admin.groups.php
+++ b/web/pages/admin.groups.php
@@ -33,34 +33,45 @@ new AdminTabs([
 <?php
 // web groups
 $web_group_admins = [];
-$web_group_list = $GLOBALS['db']->GetAll("SELECT * FROM `" . DB_PREFIX . "_groups` WHERE type != '3'");
+$web_group_list = $GLOBALS['PDO']->query("SELECT * FROM `:prefix_groups` WHERE type != '3'")->resultset();
 for ($i = 0; $i < count($web_group_list); $i++) {
     $web_group_list[$i]['permissions'] = BitToString($web_group_list[$i]['flags'], $web_group_list[$i]['type']);
-    $query                             = $GLOBALS['db']->GetRow("SELECT COUNT(gid) AS cnt FROM `" . DB_PREFIX . "_admins` WHERE gid = '" . $web_group_list[$i]['gid'] . "'");
+    $GLOBALS['PDO']->query("SELECT COUNT(gid) AS cnt FROM `:prefix_admins` WHERE gid = :gid");
+    $GLOBALS['PDO']->bind(':gid', $web_group_list[$i]['gid']);
+    $query                             = $GLOBALS['PDO']->single();
     $web_group_count[$i]               = $query['cnt'];
-    $web_group_admins[$i]              = $GLOBALS['db']->GetAll("SELECT aid, user, authid FROM `" . DB_PREFIX . "_admins` WHERE gid = '" . $web_group_list[$i]['gid'] . "'");
+    $GLOBALS['PDO']->query("SELECT aid, user, authid FROM `:prefix_admins` WHERE gid = :gid");
+    $GLOBALS['PDO']->bind(':gid', $web_group_list[$i]['gid']);
+    $web_group_admins[$i]              = $GLOBALS['PDO']->resultset();
 }
 
 // Server admin groups
 $server_admin_group_overrides = [];
 $server_admin_group_admins = [];
-$server_admin_group_list = $GLOBALS['db']->GetAll("SELECT * FROM `" . DB_PREFIX . "_srvgroups`");
+$server_admin_group_list = $GLOBALS['PDO']->query("SELECT * FROM `:prefix_srvgroups`")->resultset();
 for ($i = 0; $i < count($server_admin_group_list); $i++) {
     $server_admin_group_list[$i]['permissions'] = SmFlagsToSb($server_admin_group_list[$i]['flags']);
-    $srvGroup                                   = $GLOBALS['db']->qstr($server_admin_group_list[$i]['name']);
-    $query                                      = $GLOBALS['db']->GetRow("SELECT COUNT(aid) AS cnt FROM `" . DB_PREFIX . "_admins` WHERE srv_group = $srvGroup;");
+    $GLOBALS['PDO']->query("SELECT COUNT(aid) AS cnt FROM `:prefix_admins` WHERE srv_group = :srv_group");
+    $GLOBALS['PDO']->bind(':srv_group', $server_admin_group_list[$i]['name']);
+    $query                                      = $GLOBALS['PDO']->single();
     $server_admin_group_count[$i]               = $query['cnt'];
-    $server_admin_group_admins[$i]              = $GLOBALS['db']->GetAll("SELECT aid, user, authid FROM `" . DB_PREFIX . "_admins` WHERE srv_group = $srvGroup;");
-    $server_admin_group_overrides[$i]           = $GLOBALS['db']->GetAll("SELECT type, name, access FROM `" . DB_PREFIX . "_srvgroups_overrides` WHERE group_id = ?", array(
-        $server_admin_group_list[$i]['id']
-    ));
+    $GLOBALS['PDO']->query("SELECT aid, user, authid FROM `:prefix_admins` WHERE srv_group = :srv_group");
+    $GLOBALS['PDO']->bind(':srv_group', $server_admin_group_list[$i]['name']);
+    $server_admin_group_admins[$i]              = $GLOBALS['PDO']->resultset();
+    $GLOBALS['PDO']->query("SELECT type, name, access FROM `:prefix_srvgroups_overrides` WHERE group_id = :gid");
+    $GLOBALS['PDO']->bind(':gid', $server_admin_group_list[$i]['id']);
+    $server_admin_group_overrides[$i]           = $GLOBALS['PDO']->resultset();
 }
 // server groups
-$server_group_list = $GLOBALS['db']->GetAll("SELECT * FROM `" . DB_PREFIX . "_groups` WHERE type = '3'");
+$server_group_list = $GLOBALS['PDO']->query("SELECT * FROM `:prefix_groups` WHERE type = '3'")->resultset();
 for ($i = 0; $i < count($server_group_list); $i++) {
-    $query                  = $GLOBALS['db']->GetRow("SELECT COUNT(server_id) AS cnt FROM `" . DB_PREFIX . "_servers_groups` WHERE `group_id` = " . $server_group_list[$i]['gid']);
+    $GLOBALS['PDO']->query("SELECT COUNT(server_id) AS cnt FROM `:prefix_servers_groups` WHERE `group_id` = :gid");
+    $GLOBALS['PDO']->bind(':gid', $server_group_list[$i]['gid']);
+    $query                  = $GLOBALS['PDO']->single();
     $server_group_count[$i] = $query['cnt'];
-    $servers_in_group       = $GLOBALS['db']->GetAll("SELECT server_id FROM `" . DB_PREFIX . "_servers_groups` WHERE group_id = " . $server_group_list[$i]['gid']);
+    $GLOBALS['PDO']->query("SELECT server_id FROM `:prefix_servers_groups` WHERE group_id = :gid");
+    $GLOBALS['PDO']->bind(':gid', $server_group_list[$i]['gid']);
+    $servers_in_group       = $GLOBALS['PDO']->resultset();
     $server_arr             = "";
     foreach ($servers_in_group as $server) {
         $server_arr .= $server['server_id'] . ";";

--- a/web/pages/admin.kickit.php
+++ b/web/pages/admin.kickit.php
@@ -42,19 +42,18 @@ function LoadServers($check, $type)
         return $objResponse;
     }
     $id      = 0;
-    $servers = $GLOBALS['db']->Execute("SELECT sid, rcon FROM " . DB_PREFIX . "_servers WHERE enabled = 1 ORDER BY modid, sid;");
-    while (!$servers->EOF) {
+    $servers = $GLOBALS['PDO']->query("SELECT sid, rcon FROM `:prefix_servers` WHERE enabled = 1 ORDER BY modid, sid")->resultset();
+    foreach ($servers as $server) {
         //search for player
-        if (!empty($servers->fields["rcon"])) {
+        if (!empty($server["rcon"])) {
             $text = '<font size="1">Searching...</font>';
-            $objResponse->addScript("xajax_KickPlayer('" . $check . "', '" . $servers->fields["sid"] . "', '" . $id . "', '" . $type . "');");
+            $objResponse->addScript("xajax_KickPlayer('" . $check . "', '" . $server["sid"] . "', '" . $id . "', '" . $type . "');");
         } else { //no rcon = servercount + 1 ;)
             $text = '<font size="1">No rcon password.</font>';
             $objResponse->addScript('set_counter(1);');
         }
         $objResponse->addAssign("srv_" . $id, "innerHTML", $text);
         $id++;
-        $servers->MoveNext();
     }
     return $objResponse;
 }
@@ -128,18 +127,17 @@ function KickPlayer($check, int $sid, $num, $type)
     return $objResponse;
 }
 
-$servers = $GLOBALS['db']->Execute("SELECT ip, port, rcon FROM " . DB_PREFIX . "_servers WHERE enabled = 1 ORDER BY modid, sid;");
-$theme->assign('total', $servers->RecordCount());
+$servers = $GLOBALS['PDO']->query("SELECT ip, port, rcon FROM `:prefix_servers` WHERE enabled = 1 ORDER BY modid, sid")->resultset();
+$theme->assign('total', count($servers));
 $serverlinks = [];
 $num         = 0;
-while (!$servers->EOF) {
+foreach ($servers as $server) {
     $info         = [];
     $info['num']  = $num;
-    $info['ip']   = $servers->fields["ip"];
-    $info['port'] = $servers->fields["port"];
+    $info['ip']   = $server["ip"];
+    $info['port'] = $server["port"];
     array_push($serverlinks, $info);
     $num++;
-    $servers->MoveNext();
 }
 $theme->assign('servers', $serverlinks);
 $theme->assign('xajax_functions', $xajax->printJavascript("../scripts", "xajax.js"));

--- a/web/pages/admin.rcon.php
+++ b/web/pages/admin.rcon.php
@@ -29,7 +29,9 @@ new AdminTabs([], $userbank, $theme);
 $sid = (int) $_GET['id'];
 
 // Access on that server?
-$servers = $GLOBALS['db']->GetAll("SELECT `server_id`, `srv_group_id` FROM " . DB_PREFIX . "_admins_servers_groups WHERE admin_id = " . $userbank->GetAid());
+$GLOBALS['PDO']->query("SELECT `server_id`, `srv_group_id` FROM `:prefix_admins_servers_groups` WHERE admin_id = :aid");
+$GLOBALS['PDO']->bind(':aid', $userbank->GetAid());
+$servers = $GLOBALS['PDO']->resultset();
 $access  = false;
 foreach ($servers as $server) {
     if ($server['server_id'] == $sid) {
@@ -37,7 +39,9 @@ foreach ($servers as $server) {
         break;
     }
     if ($server['srv_group_id'] > 0) {
-        $servers_in_group = $GLOBALS['db']->GetAll("SELECT `server_id` FROM " . DB_PREFIX . "_servers_groups WHERE group_id = " . (int) $server['srv_group_id']);
+        $GLOBALS['PDO']->query("SELECT `server_id` FROM `:prefix_servers_groups` WHERE group_id = :gid");
+        $GLOBALS['PDO']->bind(':gid', (int) $server['srv_group_id']);
+        $servers_in_group = $GLOBALS['PDO']->resultset();
         foreach ($servers_in_group as $servig) {
             if ($servig['server_id'] == $sid) {
                 $access = true;

--- a/web/pages/admin.servers.php
+++ b/web/pages/admin.servers.php
@@ -10,19 +10,23 @@ new AdminTabs([
     ['name' => 'Add new server', 'permission' => ADMIN_OWNER|ADMIN_ADD_SERVER]
 ], $userbank, $theme);
 
-$servers = $GLOBALS['db']->GetAll("SELECT srv.ip ip, srv.port port, srv.sid sid, mo.icon icon, srv.enabled enabled FROM `" . DB_PREFIX . "_servers` AS srv
-   LEFT JOIN `" . DB_PREFIX . "_mods` AS mo ON mo.mid = srv.modid
-   ORDER BY modid, sid");
-$server_count = $GLOBALS['db']->GetRow("SELECT COUNT(sid) AS cnt FROM `" . DB_PREFIX . "_servers`");
+$servers = $GLOBALS['PDO']->query("SELECT srv.ip ip, srv.port port, srv.sid sid, mo.icon icon, srv.enabled enabled FROM `:prefix_servers` AS srv
+   LEFT JOIN `:prefix_mods` AS mo ON mo.mid = srv.modid
+   ORDER BY modid, sid")->resultset();
+$server_count = $GLOBALS['PDO']->query("SELECT COUNT(sid) AS cnt FROM `:prefix_servers`")->single();
 
 $server_access = [];
 if ($userbank->HasAccess(SM_RCON . SM_ROOT)) {
     // Get all servers the admin has access to
-    $servers2 = $GLOBALS['db']->GetAll("SELECT `server_id`, `srv_group_id` FROM " . DB_PREFIX . "_admins_servers_groups WHERE admin_id = " . $userbank->GetAid());
+    $GLOBALS['PDO']->query("SELECT `server_id`, `srv_group_id` FROM `:prefix_admins_servers_groups` WHERE admin_id = :aid");
+    $GLOBALS['PDO']->bind(':aid', $userbank->GetAid());
+    $servers2 = $GLOBALS['PDO']->resultset();
     foreach ($servers2 as $server) {
         $server_access[] = $server['server_id'];
         if ($server['srv_group_id'] > 0) {
-            $servers_in_group = $GLOBALS['db']->GetAll("SELECT `server_id` FROM " . DB_PREFIX . "_servers_groups WHERE group_id = " . (int) $server['srv_group_id']);
+            $GLOBALS['PDO']->query("SELECT `server_id` FROM `:prefix_servers_groups` WHERE group_id = :gid");
+            $GLOBALS['PDO']->bind(':gid', (int) $server['srv_group_id']);
+            $servers_in_group = $GLOBALS['PDO']->resultset();
             foreach ($servers_in_group as $servig) {
                 $server_access[] = $servig['server_id'];
             }
@@ -40,9 +44,9 @@ foreach ($servers as &$server) {
 }
 
 // List mods
-$modlist = $GLOBALS['db']->GetAll("SELECT mid, name FROM `" . DB_PREFIX . "_mods` WHERE `mid` > 0 AND `enabled` = 1 ORDER BY name ASC");
+$modlist = $GLOBALS['PDO']->query("SELECT mid, name FROM `:prefix_mods` WHERE `mid` > 0 AND `enabled` = 1 ORDER BY name ASC")->resultset();
 // List groups
-$grouplist = $GLOBALS['db']->GetAll("SELECT gid, name FROM `" . DB_PREFIX . "_groups` WHERE type = 3 ORDER BY name ASC");
+$grouplist = $GLOBALS['PDO']->query("SELECT gid, name FROM `:prefix_groups` WHERE type = 3 ORDER BY name ASC")->resultset();
 
 // Vars for server list
 $theme->assign('permission_list', $userbank->HasAccess(ADMIN_OWNER | ADMIN_LIST_SERVERS));

--- a/web/pages/admin.settings.php
+++ b/web/pages/admin.settings.php
@@ -37,7 +37,7 @@ if (isset($_GET['page']) && $_GET['page'] > 0) {
 
 if (isset($_GET['log_clear']) && $_GET['log_clear'] == "true") {
     if ($userbank->HasAccess(ADMIN_OWNER)) {
-        $result = $GLOBALS['db']->Execute("TRUNCATE TABLE `" . DB_PREFIX . "_log`");
+        $GLOBALS['PDO']->query("TRUNCATE TABLE `:prefix_log`")->execute();
     } else {
         Log::add("w", "Hacking Attempt", $userbank->GetProperty('user')." tried to clear the logs, but doesn't have access.");
     }
@@ -46,9 +46,6 @@ if (isset($_GET['log_clear']) && $_GET['log_clear'] == "true") {
 // search
 $where = "";
 if (isset($_GET['advSearch'])) {
-    // Escape the value, but strip the leading and trailing quote
-    $value = substr($GLOBALS['db']->qstr($_GET['advSearch']), 1, -1);
-    $type  = $_GET['advType'];
 //    switch ($type) {
 //        case "admin":
 //            $where = " WHERE l.aid = '" . $value . "'";
@@ -220,7 +217,7 @@ if (!$userbank->HasAccess(ADMIN_OWNER | ADMIN_WEB_SETTINGS)) {
                     $smtpConfig []= $_POST['mail_pass'];
                 }
 
-                $edit = $GLOBALS['db']->Execute("REPLACE INTO " . DB_PREFIX . "_settings (`value`, `setting`) VALUES
+                $GLOBALS['PDO']->query("REPLACE INTO `:prefix_settings` (`value`, `setting`) VALUES
                     (?, 'template.title'),
                     (?,'template.logo'),
                     (" . (int) $_POST['config_password_minlength'] . ", 'config.password.minlength'),
@@ -242,10 +239,7 @@ if (!$userbank->HasAccess(ADMIN_OWNER | ADMIN_WEB_SETTINGS)) {
                     (?, 'auth.maxlife.remember'),
                     (?, 'auth.maxlife.steam'),
                     (" . (int) $_POST['default_page'] . ", 'config.defaultpage')"
-                    . $smtpConfigSql,
-
-                    // Values
-                    [
+                    . $smtpConfigSql)->execute([
                         $_POST['template_title'],
                         $_POST['template_logo'],
                         $_POST['config_dateformat'],
@@ -256,7 +250,7 @@ if (!$userbank->HasAccess(ADMIN_OWNER | ADMIN_WEB_SETTINGS)) {
                         $_POST['auth_maxlife_remember'],
                         $_POST['auth_maxlife_steam'],
                         ...$smtpConfig,
-                ]);
+                    ]);
 
 ?>
 <script>ShowBox('Settings updated', 'The changes have been successfully updated', 'green', 'index.php?p=admin&c=settings');</script>
@@ -281,14 +275,14 @@ if (!$userbank->HasAccess(ADMIN_OWNER | ADMIN_WEB_SETTINGS)) {
 
             $publiccomments = (isset($_POST['enable_publiccomments']) && $_POST['enable_publiccomments'] == "on" ? 1 : 0);
 
-            $edit = $GLOBALS['db']->Execute("REPLACE INTO " . DB_PREFIX . "_settings (`value`, `setting`) VALUES
+            $GLOBALS['PDO']->query("REPLACE INTO `:prefix_settings` (`value`, `setting`) VALUES
 											(" . (int) $exportpub . ", 'config.exportpublic'),
 											(" . (int) $kickit . ", 'config.enablekickit'),
 											(" . (int) $groupban . ", 'config.enablegroupbanning'),
 											(" . (int) $friendsban . ", 'config.enablefriendsbanning'),
 											(" . (int) $adminrehash . ", 'config.enableadminrehashing'),
 											(" . (int) $publiccomments . ", 'config.enablepubliccomments'),
-											(" . (int) $steamloginopt . ", 'config.enablesteamlogin')");
+											(" . (int) $steamloginopt . ", 'config.enablesteamlogin')")->execute();
 
 
 ?>

--- a/web/pages/admin.srvadmins.php
+++ b/web/pages/admin.srvadmins.php
@@ -24,16 +24,18 @@ new AdminTabs([], $userbank, $theme);
 $admsteam = [];
 $admins = [];
 
-$srv_admins = $GLOBALS['db']->GetAll("SELECT authid, user
-    FROM " . DB_PREFIX . "_admins_servers_groups AS asg
-    LEFT JOIN " . DB_PREFIX . "_admins AS a ON a.aid = asg.admin_id
-    WHERE (server_id = " . (int) $_GET['id'] . " OR srv_group_id = ANY
+$GLOBALS['PDO']->query("SELECT authid, user
+    FROM `:prefix_admins_servers_groups` AS asg
+    LEFT JOIN `:prefix_admins` AS a ON a.aid = asg.admin_id
+    WHERE (server_id = :sid OR srv_group_id = ANY
     (
             SELECT group_id
-            FROM " . DB_PREFIX . "_servers_groups
-            WHERE server_id = " . (int) $_GET['id'] . ")
+            FROM `:prefix_servers_groups`
+            WHERE server_id = :sid)
     )
     GROUP BY aid, authid, srv_password, srv_group, srv_flags, user ");
+$GLOBALS['PDO']->bind(':sid', (int) $_GET['id']);
+$srv_admins = $GLOBALS['PDO']->resultset();
 $i = 0;
 foreach ($srv_admins as $admin) {
     if (!is_null($admin['authid'])) {

--- a/web/pages/page.banlist.php
+++ b/web/pages/page.banlist.php
@@ -65,8 +65,10 @@ if (isset($_GET['a']) && $_GET['a'] == "unban" && isset($_GET['id'])) {
     $fail   = 0;
     foreach ($bids as $bid) {
         $bid = intval($bid);
-        $res = $GLOBALS['db']->Execute("SELECT a.aid, a.gid FROM `" . DB_PREFIX . "_bans` b INNER JOIN " . DB_PREFIX . "_admins a ON a.aid = b.aid WHERE bid = '" . $bid . "';");
-        if (!$userbank->HasAccess(ADMIN_OWNER | ADMIN_UNBAN) && !($userbank->HasAccess(ADMIN_UNBAN_OWN_BANS) && $res->fields['aid'] == $userbank->GetAid()) && !($userbank->HasAccess(ADMIN_UNBAN_GROUP_BANS) && $res->fields['gid'] == $userbank->GetProperty('gid'))) {
+        $GLOBALS['PDO']->query("SELECT a.aid, a.gid FROM `:prefix_bans` b INNER JOIN `:prefix_admins` a ON a.aid = b.aid WHERE bid = :bid");
+        $GLOBALS['PDO']->bind(':bid', $bid);
+        $res = $GLOBALS['PDO']->single();
+        if (!$userbank->HasAccess(ADMIN_OWNER | ADMIN_UNBAN) && !($userbank->HasAccess(ADMIN_UNBAN_OWN_BANS) && $res['aid'] == $userbank->GetAid()) && !($userbank->HasAccess(ADMIN_UNBAN_GROUP_BANS) && $res['gid'] == $userbank->GetProperty('gid'))) {
             $fail++;
             if (!isset($_GET['bulk'])) {
                 die("You don't have access to this");
@@ -74,14 +76,14 @@ if (isset($_GET['a']) && $_GET['a'] == "unban" && isset($_GET['id'])) {
             continue;
         }
 
-        $row = $GLOBALS['db']->GetRow("SELECT b.ip, b.authid,
+        $GLOBALS['PDO']->query("SELECT b.ip, b.authid,
 										b.name, b.created, b.sid, b.type, m.steam_universe, UNIX_TIMESTAMP() as now
-										FROM " . DB_PREFIX . "_bans b
-										LEFT JOIN " . DB_PREFIX . "_servers s ON s.sid = b.sid
-										LEFT JOIN " . DB_PREFIX . "_mods m ON m.mid = s.modid
-										WHERE b.bid = ? AND (b.length = '0' OR b.ends > UNIX_TIMESTAMP()) AND b.RemoveType IS NULL", array(
-            $bid
-        ));
+										FROM `:prefix_bans` b
+										LEFT JOIN `:prefix_servers` s ON s.sid = b.sid
+										LEFT JOIN `:prefix_mods` m ON m.mid = s.modid
+										WHERE b.bid = :bid AND (b.length = '0' OR b.ends > UNIX_TIMESTAMP()) AND b.RemoveType IS NULL");
+        $GLOBALS['PDO']->bind(':bid', $bid);
+        $row = $GLOBALS['PDO']->single();
         if (empty($row) || !$row) {
             $fail++;
             if (!isset($_GET['bulk'])) {
@@ -91,22 +93,26 @@ if (isset($_GET['a']) && $_GET['a'] == "unban" && isset($_GET['id'])) {
             continue;
         }
         $unbanReason = htmlspecialchars(trim($_GET['ureason']));
-        $ins         = $GLOBALS['db']->Execute("UPDATE `" . DB_PREFIX . "_bans` SET
-										`RemovedBy` = ?,
+        $GLOBALS['PDO']->query("UPDATE `:prefix_bans` SET
+										`RemovedBy` = :removedby,
 										`RemoveType` = 'U',
 										`RemovedOn` = UNIX_TIMESTAMP(),
-										`ureason` = ?
-										WHERE `bid` = ?;", array(
-            $userbank->GetAid(),
-            $unbanReason,
-            $bid
-        ));
+										`ureason` = :ureason
+										WHERE `bid` = :bid");
+        $GLOBALS['PDO']->bindMultiple([
+            ':removedby' => $userbank->GetAid(),
+            ':ureason'   => $unbanReason,
+            ':bid'       => $bid,
+        ]);
+        $GLOBALS['PDO']->execute();
 
-        $protestsunban = $GLOBALS['db']->Execute("UPDATE `" . DB_PREFIX . "_protests` SET archiv = '4' WHERE bid = '" . $bid . "';");
+        $GLOBALS['PDO']->query("UPDATE `:prefix_protests` SET archiv = '4' WHERE bid = :bid");
+        $GLOBALS['PDO']->bind(':bid', $bid);
+        $GLOBALS['PDO']->execute();
 
-        $blocked = $GLOBALS['db']->GetAll("SELECT s.sid, m.steam_universe FROM `" . DB_PREFIX . "_banlog` bl INNER JOIN " . DB_PREFIX . "_servers s ON s.sid = bl.sid INNER JOIN " . DB_PREFIX . "_mods m ON m.mid = s.modid WHERE bl.bid=? AND (UNIX_TIMESTAMP() - bl.time <= 300)", array(
-            $bid
-        ));
+        $GLOBALS['PDO']->query("SELECT s.sid, m.steam_universe FROM `:prefix_banlog` bl INNER JOIN `:prefix_servers` s ON s.sid = bl.sid INNER JOIN `:prefix_mods` m ON m.mid = s.modid WHERE bl.bid = :bid AND (UNIX_TIMESTAMP() - bl.time <= 300)");
+        $GLOBALS['PDO']->bind(':bid', $bid);
+        $blocked = $GLOBALS['PDO']->resultset();
         foreach ($blocked as $tempban) {
             rcon(($row['type'] == 0 ? "removeid STEAM_" . $tempban['steam_universe'] . substr($row['authid'], 7) : "removeip " . $row['ip']), $tempban['sid']);
         }
@@ -152,26 +158,28 @@ if (isset($_GET['a']) && $_GET['a'] == "unban" && isset($_GET['id'])) {
     $fail   = 0;
     foreach ($bids as $bid) {
         $bid    = intval($bid);
-        $demres = $GLOBALS['db']->Execute("SELECT filename FROM `" . DB_PREFIX . "_demos` WHERE `demid` = ?", array(
-            $bid
-        ));
-        @unlink(SB_DEMOS . "/" . $demres->fields["filename"]);
-        $blocked = $GLOBALS['db']->GetAll("SELECT s.sid, m.steam_universe FROM `" . DB_PREFIX . "_banlog` bl INNER JOIN " . DB_PREFIX . "_servers s ON s.sid = bl.sid INNER JOIN " . DB_PREFIX . "_mods m ON m.mid = s.modid WHERE bl.bid=? AND (UNIX_TIMESTAMP() - bl.time <= 300)", array(
-            $bid
-        ));
-        $steam   = $GLOBALS['db']->GetRow("SELECT b.name, b.authid, b.created, b.sid, b.RemoveType, b.ip, b.type, m.steam_universe, UNIX_TIMESTAMP() AS now
-										FROM " . DB_PREFIX . "_bans b
-										LEFT JOIN " . DB_PREFIX . "_servers s ON s.sid = b.sid
-										LEFT JOIN " . DB_PREFIX . "_mods m ON m.mid = s.modid
-										WHERE b.bid=?", array(
-            $bid
-        ));
-        $block   = $GLOBALS['db']->Execute("DELETE FROM `" . DB_PREFIX . "_banlog` WHERE bid = ?", array(
-            $bid
-        ));
-        $res     = $GLOBALS['db']->Execute("DELETE FROM `" . DB_PREFIX . "_bans` WHERE `bid` = ?", array(
-            $bid
-        ));
+        $GLOBALS['PDO']->query("SELECT filename FROM `:prefix_demos` WHERE `demid` = :bid");
+        $GLOBALS['PDO']->bind(':bid', $bid);
+        $demres = $GLOBALS['PDO']->single();
+        if ($demres) {
+            @unlink(SB_DEMOS . "/" . $demres["filename"]);
+        }
+        $GLOBALS['PDO']->query("SELECT s.sid, m.steam_universe FROM `:prefix_banlog` bl INNER JOIN `:prefix_servers` s ON s.sid = bl.sid INNER JOIN `:prefix_mods` m ON m.mid = s.modid WHERE bl.bid = :bid AND (UNIX_TIMESTAMP() - bl.time <= 300)");
+        $GLOBALS['PDO']->bind(':bid', $bid);
+        $blocked = $GLOBALS['PDO']->resultset();
+        $GLOBALS['PDO']->query("SELECT b.name, b.authid, b.created, b.sid, b.RemoveType, b.ip, b.type, m.steam_universe, UNIX_TIMESTAMP() AS now
+										FROM `:prefix_bans` b
+										LEFT JOIN `:prefix_servers` s ON s.sid = b.sid
+										LEFT JOIN `:prefix_mods` m ON m.mid = s.modid
+										WHERE b.bid = :bid");
+        $GLOBALS['PDO']->bind(':bid', $bid);
+        $steam = $GLOBALS['PDO']->single();
+        $GLOBALS['PDO']->query("DELETE FROM `:prefix_banlog` WHERE bid = :bid");
+        $GLOBALS['PDO']->bind(':bid', $bid);
+        $GLOBALS['PDO']->execute();
+        $GLOBALS['PDO']->query("DELETE FROM `:prefix_bans` WHERE `bid` = :bid");
+        $GLOBALS['PDO']->bind(':bid', $bid);
+        $res = $GLOBALS['PDO']->execute();
         if (empty($steam['RemoveType'])) {
             foreach ($blocked as $tempban) {
                 rcon(($steam['type'] == 0 ? "removeid STEAM_" . $tempban['steam_universe'] . substr($steam['authid'], 7) : "removeip " . $steam['ip']), $tempban['sid']);
@@ -246,50 +254,50 @@ if (isset($_GET['searchText'])) {
         $search_array[] = $search;
     }
 
-    $res = $GLOBALS['db']->Execute("SELECT BA.bid ban_id, BA.type, BA.ip ban_ip, BA.authid, BA.name player_name, created ban_created, ends ban_ends, length ban_length, reason ban_reason, BA.ureason unban_reason, BA.aid, AD.gid AS gid, adminIp, BA.sid ban_server, country ban_country, RemovedOn, RemovedBy, RemoveType row_type,
+    $res = $GLOBALS['PDO']->query("SELECT BA.bid ban_id, BA.type, BA.ip ban_ip, BA.authid, BA.name player_name, created ban_created, ends ban_ends, length ban_length, reason ban_reason, BA.ureason unban_reason, BA.aid, AD.gid AS gid, adminIp, BA.sid ban_server, country ban_country, RemovedOn, RemovedBy, RemoveType row_type,
 			SE.ip server_ip, AD.user admin_name, AD.gid, MO.icon as mod_icon,
 			CAST(MID(BA.authid, 9, 1) AS UNSIGNED) + CAST('76561197960265728' AS UNSIGNED) + CAST(MID(BA.authid, 11, 10) * 2 AS UNSIGNED) AS community_id,
-			(SELECT count(*) FROM " . DB_PREFIX . "_demos as DM WHERE DM.demtype='B' and DM.demid = BA.bid) as demo_count,
-            (SELECT (SELECT count(*) FROM " . DB_PREFIX . "_bans as BH WHERE (BH.type = BA.type AND BH.type = 0 AND BH.authid = BA.authid AND BH.authid != '' AND BH.authid IS NOT NULL)) + (SELECT count(*) FROM " . DB_PREFIX . "_bans as BH WHERE (BH.type = BA.type AND BH.type = 1 AND BH.ip = BA.ip AND BH.ip != '' AND BH.ip IS NOT NULL))) as history_count
-	   FROM " . DB_PREFIX . "_bans AS BA
-  LEFT JOIN " . DB_PREFIX . "_servers AS SE ON SE.sid = BA.sid
-  LEFT JOIN " . DB_PREFIX . "_mods AS MO on SE.modid = MO.mid
-  LEFT JOIN " . DB_PREFIX . "_admins AS AD ON BA.aid = AD.aid
+			(SELECT count(*) FROM `:prefix_demos` as DM WHERE DM.demtype='B' and DM.demid = BA.bid) as demo_count,
+            (SELECT (SELECT count(*) FROM `:prefix_bans` as BH WHERE (BH.type = BA.type AND BH.type = 0 AND BH.authid = BA.authid AND BH.authid != '' AND BH.authid IS NOT NULL)) + (SELECT count(*) FROM `:prefix_bans` as BH WHERE (BH.type = BA.type AND BH.type = 1 AND BH.ip = BA.ip AND BH.ip != '' AND BH.ip IS NOT NULL))) as history_count
+	   FROM `:prefix_bans` AS BA
+  LEFT JOIN `:prefix_servers` AS SE ON SE.sid = BA.sid
+  LEFT JOIN `:prefix_mods` AS MO on SE.modid = MO.mid
+  LEFT JOIN `:prefix_admins` AS AD ON BA.aid = AD.aid
       WHERE " . $search_ips . "BA.authid LIKE ? or BA.name LIKE ? or BA.reason LIKE ?" . $hideinactive . "
    ORDER BY BA.created DESC
-   LIMIT ?,?", array_merge($search_array, array(
+   LIMIT ?,?")->resultset(array_merge($search_array, [
         $search,
         $search,
         $search,
         intval($BansStart),
-        intval($BansPerPage)
-    )));
+        intval($BansPerPage),
+    ]));
 
 
-    $res_count  = $GLOBALS['db']->Execute("SELECT count(BA.bid) FROM " . DB_PREFIX . "_bans AS BA WHERE " . $search_ips . "BA.authid LIKE ? OR BA.name LIKE ? OR BA.reason LIKE ?" . $hideinactive, array_merge($search_array, array(
+    $res_count  = $GLOBALS['PDO']->query("SELECT count(BA.bid) AS cnt FROM `:prefix_bans` AS BA WHERE " . $search_ips . "BA.authid LIKE ? OR BA.name LIKE ? OR BA.reason LIKE ?" . $hideinactive)->resultset(array_merge($search_array, [
         $search,
         $search,
-        $search
-    )));
+        $search,
+    ]));
     $searchlink = "&searchText=" . urlencode($_GET["searchText"]);
 } elseif (!isset($_GET['advSearch'])) {
-    $res = $GLOBALS['db']->Execute("SELECT bid ban_id, BA.type, BA.ip ban_ip, BA.authid, BA.name player_name, created ban_created, ends ban_ends, length ban_length, reason ban_reason, BA.ureason unban_reason, BA.aid, AD.gid AS gid, adminIp, BA.sid ban_server, country ban_country, RemovedOn, RemovedBy, RemoveType row_type,
+    $res = $GLOBALS['PDO']->query("SELECT bid ban_id, BA.type, BA.ip ban_ip, BA.authid, BA.name player_name, created ban_created, ends ban_ends, length ban_length, reason ban_reason, BA.ureason unban_reason, BA.aid, AD.gid AS gid, adminIp, BA.sid ban_server, country ban_country, RemovedOn, RemovedBy, RemoveType row_type,
 			SE.ip server_ip, AD.user admin_name, AD.gid, MO.icon as mod_icon,
 			CAST(MID(BA.authid, 9, 1) AS UNSIGNED) + CAST('76561197960265728' AS UNSIGNED) + CAST(MID(BA.authid, 11, 10) * 2 AS UNSIGNED) AS community_id,
-			(SELECT count(*) FROM " . DB_PREFIX . "_demos as DM WHERE DM.demtype='B' and DM.demid = BA.bid) as demo_count,
-			(SELECT (SELECT count(*) FROM " . DB_PREFIX . "_bans as BH WHERE (BH.type = BA.type AND BH.type = 0 AND BH.authid = BA.authid AND BH.authid != '' AND BH.authid IS NOT NULL)) + (SELECT count(*) FROM " . DB_PREFIX . "_bans as BH WHERE (BH.type = BA.type AND BH.type = 1 AND BH.ip = BA.ip AND BH.ip != '' AND BH.ip IS NOT NULL))) as history_count
-	   FROM " . DB_PREFIX . "_bans AS BA
-  LEFT JOIN " . DB_PREFIX . "_servers AS SE ON SE.sid = BA.sid
-  LEFT JOIN " . DB_PREFIX . "_mods AS MO on SE.modid = MO.mid
-  LEFT JOIN " . DB_PREFIX . "_admins AS AD ON BA.aid = AD.aid
+			(SELECT count(*) FROM `:prefix_demos` as DM WHERE DM.demtype='B' and DM.demid = BA.bid) as demo_count,
+			(SELECT (SELECT count(*) FROM `:prefix_bans` as BH WHERE (BH.type = BA.type AND BH.type = 0 AND BH.authid = BA.authid AND BH.authid != '' AND BH.authid IS NOT NULL)) + (SELECT count(*) FROM `:prefix_bans` as BH WHERE (BH.type = BA.type AND BH.type = 1 AND BH.ip = BA.ip AND BH.ip != '' AND BH.ip IS NOT NULL))) as history_count
+	   FROM `:prefix_bans` AS BA
+  LEFT JOIN `:prefix_servers` AS SE ON SE.sid = BA.sid
+  LEFT JOIN `:prefix_mods` AS MO on SE.modid = MO.mid
+  LEFT JOIN `:prefix_admins` AS AD ON BA.aid = AD.aid
   " . $hideinactiven . "
    ORDER BY created DESC
-   LIMIT ?,?", array(
+   LIMIT ?,?")->resultset([
         intval($BansStart),
-        intval($BansPerPage)
-    ));
+        intval($BansPerPage),
+    ]);
 
-    $res_count  = $GLOBALS['db']->Execute("SELECT count(bid) FROM " . DB_PREFIX . "_bans" . $hideinactiven);
+    $res_count  = $GLOBALS['PDO']->query("SELECT count(bid) AS cnt FROM `:prefix_bans`" . $hideinactiven)->resultset();
     $searchlink = "";
 }
 
@@ -448,29 +456,29 @@ if (isset($_GET['advSearch'])) {
         $hideinactive = $hideinactiven;
     }
 
-    $res = $GLOBALS['db']->Execute("SELECT BA.bid ban_id, BA.type, BA.ip ban_ip, BA.authid, BA.name player_name, created ban_created, ends ban_ends, length ban_length, reason ban_reason, BA.ureason unban_reason, BA.aid, AD.gid AS gid, adminIp, BA.sid ban_server, country ban_country, RemovedOn, RemovedBy, RemoveType row_type,
+    $res = $GLOBALS['PDO']->query("SELECT BA.bid ban_id, BA.type, BA.ip ban_ip, BA.authid, BA.name player_name, created ban_created, ends ban_ends, length ban_length, reason ban_reason, BA.ureason unban_reason, BA.aid, AD.gid AS gid, adminIp, BA.sid ban_server, country ban_country, RemovedOn, RemovedBy, RemoveType row_type,
 			SE.ip server_ip, AD.user admin_name, AD.gid, MO.icon as mod_icon,
 			CAST(MID(BA.authid, 9, 1) AS UNSIGNED) + CAST('76561197960265728' AS UNSIGNED) + CAST(MID(BA.authid, 11, 10) * 2 AS UNSIGNED) AS community_id,
-			(SELECT count(*) FROM " . DB_PREFIX . "_demos as DM WHERE DM.demtype='B' and DM.demid = BA.bid) as demo_count,
-            (SELECT (SELECT count(*) FROM " . DB_PREFIX . "_bans as BH WHERE (BH.type = BA.type AND BH.type = 0 AND BH.authid = BA.authid AND BH.authid != '' AND BH.authid IS NOT NULL)) + (SELECT count(*) FROM " . DB_PREFIX . "_bans as BH WHERE (BH.type = BA.type AND BH.type = 1 AND BH.ip = BA.ip AND BH.ip != '' AND BH.ip IS NOT NULL))) as history_count
-	   FROM " . DB_PREFIX . "_bans AS BA
-  LEFT JOIN " . DB_PREFIX . "_servers AS SE ON SE.sid = BA.sid
-  LEFT JOIN " . DB_PREFIX . "_mods AS MO on SE.modid = MO.mid
-  LEFT JOIN " . DB_PREFIX . "_admins AS AD ON BA.aid = AD.aid
-  " . ($type == "comment" && $userbank->is_admin() ? "LEFT JOIN " . DB_PREFIX . "_comments AS CO ON BA.bid = CO.bid" : "") . "
+			(SELECT count(*) FROM `:prefix_demos` as DM WHERE DM.demtype='B' and DM.demid = BA.bid) as demo_count,
+            (SELECT (SELECT count(*) FROM `:prefix_bans` as BH WHERE (BH.type = BA.type AND BH.type = 0 AND BH.authid = BA.authid AND BH.authid != '' AND BH.authid IS NOT NULL)) + (SELECT count(*) FROM `:prefix_bans` as BH WHERE (BH.type = BA.type AND BH.type = 1 AND BH.ip = BA.ip AND BH.ip != '' AND BH.ip IS NOT NULL))) as history_count
+	   FROM `:prefix_bans` AS BA
+  LEFT JOIN `:prefix_servers` AS SE ON SE.sid = BA.sid
+  LEFT JOIN `:prefix_mods` AS MO on SE.modid = MO.mid
+  LEFT JOIN `:prefix_admins` AS AD ON BA.aid = AD.aid
+  " . ($type == "comment" && $userbank->is_admin() ? "LEFT JOIN `:prefix_comments` AS CO ON BA.bid = CO.bid" : "") . "
       " . $where . $hideinactive . "
    ORDER BY BA.created DESC
-   LIMIT ?,?", array_merge($advcrit, array(
+   LIMIT ?,?")->resultset(array_merge($advcrit, [
         intval($BansStart),
-        intval($BansPerPage)
-    )));
+        intval($BansPerPage),
+    ]));
 
-    $res_count  = $GLOBALS['db']->Execute("SELECT count(BA.bid) FROM " . DB_PREFIX . "_bans AS BA
-										  " . ($type == "comment" && $userbank->is_admin() ? "LEFT JOIN " . DB_PREFIX . "_comments AS CO ON BA.bid = CO.bid" : "") . " " . $where . $hideinactive, $advcrit);
+    $res_count  = $GLOBALS['PDO']->query("SELECT count(BA.bid) AS cnt FROM `:prefix_bans` AS BA
+										  " . ($type == "comment" && $userbank->is_admin() ? "LEFT JOIN `:prefix_comments` AS CO ON BA.bid = CO.bid" : "") . " " . $where . $hideinactive)->resultset($advcrit);
     $searchlink = "&advSearch=" . urlencode($_GET['advSearch']) . "&advType=" . urlencode($_GET['advType']);
 }
 
-$BanCount = $res_count->fields[0];
+$BanCount = isset($res_count[0]['cnt']) ? (int) $res_count[0]['cnt'] : 0;
 if ($BansEnd > $BanCount) {
     $BansEnd = $BanCount;
 }
@@ -482,21 +490,21 @@ if (!$res) {
 $canEditComment = false;
 $view_comments = false;
 $bans          = [];
-while (!$res->EOF) {
+foreach ($res as $row) {
     $data = [];
 
-    $data['ban_id'] = $res->fields['ban_id'];
+    $data['ban_id'] = $row['ban_id'];
 
-    if (!empty($res->fields['ban_ip']) && !Config::getBool('banlist.nocountryfetch')) {
-        if (!empty($res->fields['ban_country']) && $res->fields['ban_country'] != ' ') {
-            $data['country'] = '<img src="images/country/' . strtolower($res->fields['ban_country']) . '.png" alt="' . $res->fields['ban_country'] . '" border="0" align="absmiddle" />';
+    if (!empty($row['ban_ip']) && !Config::getBool('banlist.nocountryfetch')) {
+        if (!empty($row['ban_country']) && $row['ban_country'] != ' ') {
+            $data['country'] = '<img src="images/country/' . strtolower($row['ban_country']) . '.png" alt="' . $row['ban_country'] . '" border="0" align="absmiddle" />';
         } elseif (!Config::getBool('banlist.nocountryfetch')) {
-            $country = FetchIp($res->fields['ban_ip']);
-            $edit    = $GLOBALS['db']->Execute("UPDATE " . DB_PREFIX . "_bans SET country = ?
-				                            WHERE bid = ?", array(
+            $country = FetchIp($row['ban_ip']);
+            $GLOBALS['PDO']->query("UPDATE `:prefix_bans` SET country = ?
+				                            WHERE bid = ?")->execute([
                 $country,
-                $res->fields['ban_id']
-            ));
+                $row['ban_id'],
+            ]);
 
             $countryFlag = empty($country) ? 'zz' : strtolower($country);
             $data['country'] = '<img src="images/country/' . $countryFlag . '.png" alt="' . $country . '" border="0" align="absmiddle" />';
@@ -507,10 +515,10 @@ while (!$res->EOF) {
         $data['country'] = '<img src="images/country/zz.png" alt="Unknown Country" border="0" align="absmiddle" />';
     }
 
-    $data['ban_date']    = Config::time($res->fields['ban_created']);
+    $data['ban_date']    = Config::time($row['ban_created']);
 
     // Fix #1008 - bug: Player Names Contain Unwanted Non-Standard Characters
-    $raw_name = $res->fields['player_name'];
+    $raw_name = $row['player_name'];
     $cleaned_name = mb_convert_encoding($raw_name, 'UTF-8', 'UTF-8');
     $unwanted_sequences = ["\xF3\xA0\x80\xA1"];
     foreach ($unwanted_sequences as $sequence) {
@@ -519,56 +527,58 @@ while (!$res->EOF) {
     $cleaned_name = trim($cleaned_name);
 
     $data['player'] = addslashes($cleaned_name);
-    $data['type']        = $res->fields['type'];
-    $data['steamid']     = $res->fields['authid'];
+    $data['type']        = $row['type'];
+    $data['steamid']     = $row['authid'];
     // Fix #900 - Bad SteamID Format broke the page view, so give them an null SteamID.
 	if (isset($data['steamid']) && !empty($data['steamid']) && !\SteamID\SteamID::isValidID($data['steamid'])) {
 		$data['steamid'] = 'STEAM_0:0:00000000';
 	}
-    $data['communityid'] = $res->fields['community_id'];
+    $data['communityid'] = $row['community_id'];
     $data['steamid3']    = \SteamID\SteamID::toSteam3($data['steamid']);
 
     if (Config::getBool('banlist.hideadminname') && !$userbank->is_admin()) {
         $data['admin'] = false;
     } else {
-        $data['admin'] = stripslashes($res->fields['admin_name']);
+        $data['admin'] = stripslashes($row['admin_name']);
     }
-    $data['reason']     = stripslashes($res->fields['ban_reason']);
-    $data['ban_length'] = $res->fields['ban_length'] == 0 ? 'Permanent' : SecondsToString(intval($res->fields['ban_length']));
+    $data['reason']     = stripslashes($row['ban_reason']);
+    $data['ban_length'] = $row['ban_length'] == 0 ? 'Permanent' : SecondsToString(intval($row['ban_length']));
 
     // Custom "listtable_1_banned" & "listtable_1_permanent" addition entries
     // Comment the 14 lines below out if they cause issues
-    if ($res->fields['ban_length'] == 0) {
+    if ($row['ban_length'] == 0) {
         $data['expires']   = 'never';
         $data['class']     = "listtable_1_permanent";
         $data['ub_reason'] = "";
         $data['unbanned']  = false;
     } else {
-        $data['expires']   = Config::time($res->fields['ban_ends']);
+        $data['expires']   = Config::time($row['ban_ends']);
         $data['class']     = "listtable_1_banned";
         $data['ub_reason'] = "";
         $data['unbanned']  = false;
     }
     // End custom entries
 
-    if ($res->fields['row_type'] == 'D' || $res->fields['row_type'] == 'U' || $res->fields['row_type'] == 'E' || ($res->fields['ban_length'] && $res->fields['ban_ends'] < time())) {
+    if ($row['row_type'] == 'D' || $row['row_type'] == 'U' || $row['row_type'] == 'E' || ($row['ban_length'] && $row['ban_ends'] < time())) {
         $data['unbanned'] = true;
         $data['class']    = "listtable_1_unbanned";
 
-        if ($res->fields['row_type'] == "D") {
+        if ($row['row_type'] == "D") {
             $data['ub_reason'] = "(Deleted)";
-        } elseif ($res->fields['row_type'] == "U") {
+        } elseif ($row['row_type'] == "U") {
             $data['ub_reason'] = "(Unbanned)";
         } else {
             $data['ub_reason'] = "(Expired)";
         }
 
-        $data['ureason'] = stripslashes($res->fields['unban_reason'] ?? '');
+        $data['ureason'] = stripslashes($row['unban_reason'] ?? '');
 
-        $removedby         = $GLOBALS['db']->GetRow("SELECT user FROM `" . DB_PREFIX . "_admins` WHERE aid = '" . $res->fields['RemovedBy'] . "'");
+        $GLOBALS['PDO']->query("SELECT user FROM `:prefix_admins` WHERE aid = :aid");
+        $GLOBALS['PDO']->bind(':aid', $row['RemovedBy']);
+        $removedby         = $GLOBALS['PDO']->single();
         $data['removedby'] = "";
-        if (isset($removedby[0]) && $data['admin']) {
-            $data['removedby'] = $removedby[0];
+        if (!empty($removedby['user']) && $data['admin']) {
+            $data['removedby'] = $removedby['user'];
         }
     }
     // Don't need this stuff.
@@ -580,59 +590,63 @@ while (!$res->EOF) {
     //		$data['ub_reason'] = "";
     //	}
 
-    $data['layer_id'] = 'layer_' . $res->fields['ban_id'];
+    $data['layer_id'] = 'layer_' . $row['ban_id'];
     if ($data['type'] == "0") {
-        $alrdybnd = $GLOBALS['db']->Execute("SELECT count(bid) as count FROM `" . DB_PREFIX . "_bans` WHERE authid = '" . $data['steamid'] . "' AND (length = 0 OR ends > UNIX_TIMESTAMP()) AND RemovedBy IS NULL AND type = '0';");
+        $GLOBALS['PDO']->query("SELECT count(bid) as count FROM `:prefix_bans` WHERE authid = :authid AND (length = 0 OR ends > UNIX_TIMESTAMP()) AND RemovedBy IS NULL AND type = '0'");
+        $GLOBALS['PDO']->bind(':authid', $data['steamid']);
+        $alrdybnd = $GLOBALS['PDO']->single();
     } else {
-        $alrdybnd = $GLOBALS['db']->Execute("SELECT count(bid) as count FROM `" . DB_PREFIX . "_bans` WHERE ip = '" . $res->fields['ban_ip'] . "' AND (length = 0 OR ends > UNIX_TIMESTAMP()) AND RemovedBy IS NULL AND type = '1';");
+        $GLOBALS['PDO']->query("SELECT count(bid) as count FROM `:prefix_bans` WHERE ip = :ip AND (length = 0 OR ends > UNIX_TIMESTAMP()) AND RemovedBy IS NULL AND type = '1'");
+        $GLOBALS['PDO']->bind(':ip', $row['ban_ip']);
+        $alrdybnd = $GLOBALS['PDO']->single();
     }
-    if ($alrdybnd->fields['count'] == 0) {
-        $data['reban_link'] = CreateLinkR('<i class="fas fa-redo fa-lg"></i> Reban', "index.php?p=admin&c=bans" . $pagelink . "&rebanid=" . $res->fields['ban_id'] . "&key=" . $_SESSION['banlist_postkey'] . "#^0");
+    if ($alrdybnd['count'] == 0) {
+        $data['reban_link'] = CreateLinkR('<i class="fas fa-redo fa-lg"></i> Reban', "index.php?p=admin&c=bans" . $pagelink . "&rebanid=" . $row['ban_id'] . "&key=" . $_SESSION['banlist_postkey'] . "#^0");
     } else {
         $data['reban_link'] = false;
     }
-    $data['blockcomm_link']  = CreateLinkR('<i class="fas fa-ban fa-lg"></i> Block Comms', "index.php?p=admin&c=comms" . $pagelink . "&blockfromban=" . $res->fields['ban_id'] . "&key=" . $_SESSION['banlist_postkey'] . "#^0");
-    $data['details_link']    = CreateLinkR('click', 'getdemo.php?type=B&id=' . urlencode($res->fields['ban_id']));
+    $data['blockcomm_link']  = CreateLinkR('<i class="fas fa-ban fa-lg"></i> Block Comms', "index.php?p=admin&c=comms" . $pagelink . "&blockfromban=" . $row['ban_id'] . "&key=" . $_SESSION['banlist_postkey'] . "#^0");
+    $data['details_link']    = CreateLinkR('click', 'getdemo.php?type=B&id=' . urlencode($row['ban_id']));
     $data['groups_link']     = CreateLinkR('<i class="fas fa-users fa-lg"></i> Show Groups', "index.php?p=admin&c=bans&fid=" . urlencode($data['communityid']) . "#^4");
     $data['friend_ban_link'] = CreateLinkR('<i class="fas fa-trash fa-lg"></i> Ban Friends', '#', '', '_self', false, "BanFriendsProcess('" . $data['communityid'] . "','" . $data['player'] . "');return false;");
-    $data['edit_link']       = CreateLinkR('<i class="fas fa-edit fa-lg"></i> Edit Details', "index.php?p=admin&c=bans&o=edit" . $pagelink . "&id=" . $res->fields['ban_id'] . "&key=" . $_SESSION['banlist_postkey']);
+    $data['edit_link']       = CreateLinkR('<i class="fas fa-edit fa-lg"></i> Edit Details', "index.php?p=admin&c=bans&o=edit" . $pagelink . "&id=" . $row['ban_id'] . "&key=" . $_SESSION['banlist_postkey']);
 
-    $data['unban_link']  = CreateLinkR('<i class="fas fa-undo fa-lg"></i> Unban', "#", "", "_self", false, "UnbanBan('" . $res->fields['ban_id'] . "', '" . $_SESSION['banlist_postkey'] . "', '" . $pagelink . "', '" . $data['player'] . "', 1, false);return false;");
-    $data['delete_link'] = CreateLinkR('<i class="fas fa-trash fa-lg"></i> Delete Ban', "#", "", "_self", false, "RemoveBan('" . $res->fields['ban_id'] . "', '" . $_SESSION['banlist_postkey'] . "', '" . $pagelink . "', '" . $data['player'] . "', 0, false);return false;");
+    $data['unban_link']  = CreateLinkR('<i class="fas fa-undo fa-lg"></i> Unban', "#", "", "_self", false, "UnbanBan('" . $row['ban_id'] . "', '" . $_SESSION['banlist_postkey'] . "', '" . $pagelink . "', '" . $data['player'] . "', 1, false);return false;");
+    $data['delete_link'] = CreateLinkR('<i class="fas fa-trash fa-lg"></i> Delete Ban', "#", "", "_self", false, "RemoveBan('" . $row['ban_id'] . "', '" . $_SESSION['banlist_postkey'] . "', '" . $pagelink . "', '" . $data['player'] . "', 0, false);return false;");
 
 
-    $data['server_id'] = $res->fields['ban_server'];
+    $data['server_id'] = $row['ban_server'];
 
-    if (empty($res->fields['mod_icon'])) {
+    if (empty($row['mod_icon'])) {
         $modicon = "web.png";
     } else {
-        $modicon = $res->fields['mod_icon'];
+        $modicon = $row['mod_icon'];
     }
 
     $data['mod_icon'] = '<img src="images/games/' . $modicon . '" alt="MOD" border="0" align="absmiddle" />&nbsp;' . $data['country'];
 
-    if ($res->fields['history_count'] > 1) {
-        $data['prevoff_link'] = $res->fields['history_count'] . " " . CreateLinkR("&nbsp;(search)", "index.php?p=banlist&searchText=" . urlencode($data['type'] == 0 ? $data['steamid'] : $res->fields['ban_ip']) . "&Submit");
+    if ($row['history_count'] > 1) {
+        $data['prevoff_link'] = $row['history_count'] . " " . CreateLinkR("&nbsp;(search)", "index.php?p=banlist&searchText=" . urlencode($data['type'] == 0 ? $data['steamid'] : $row['ban_ip']) . "&Submit");
     } else {
         $data['prevoff_link'] = "No previous bans";
     }
 
 
 
-    if (strlen($res->fields['ban_ip']) < 7) {
+    if (strlen($row['ban_ip']) < 7) {
         $data['ip'] = 'none';
     } else {
-        $data['ip'] = $data['country'] . '&nbsp;' . $res->fields['ban_ip'];
+        $data['ip'] = $data['country'] . '&nbsp;' . $row['ban_ip'];
     }
 
-    if ($res->fields['ban_length'] == 0) {
+    if ($row['ban_length'] == 0) {
         $data['expires'] = 'never';
     } else {
-        $data['expires'] = Config::time($res->fields['ban_ends']);
+        $data['expires'] = Config::time($row['ban_ends']);
     }
 
 
-    if ($res->fields['demo_count'] == 0) {
+    if ($row['demo_count'] == 0) {
         $data['demo_available'] = false;
         $data['demo_quick']     = 'N/A';
         $data['demo_link']      = CreateLinkR('<i class="fas fa-video-slash fa-lg"></i> No Demos', "#");
@@ -644,9 +658,11 @@ while (!$res->EOF) {
 
 
 
-    $data['server_id'] = $res->fields['ban_server'];
+    $data['server_id'] = $row['ban_server'];
 
-    $banlog             = $GLOBALS['db']->GetAll("SELECT bl.time, bl.name, s.ip, s.port FROM `" . DB_PREFIX . "_banlog` AS bl LEFT JOIN `" . DB_PREFIX . "_servers` AS s ON s.sid = bl.sid WHERE bid = '" . $data['ban_id'] . "'");
+    $GLOBALS['PDO']->query("SELECT bl.time, bl.name, s.ip, s.port FROM `:prefix_banlog` AS bl LEFT JOIN `:prefix_servers` AS s ON s.sid = bl.sid WHERE bid = :bid");
+    $GLOBALS['PDO']->bind(':bid', $data['ban_id']);
+    $banlog             = $GLOBALS['PDO']->resultset();
     $data['blockcount'] = sizeof($banlog);
     $logstring          = "";
     foreach ($banlog as $logged) {
@@ -661,39 +677,41 @@ while (!$res->EOF) {
     //-----------------------------------
     if (Config::getBool('config.enablepubliccomments') || $userbank->is_admin()) {
         $view_comments = true;
-        $commentres    = $GLOBALS['db']->Execute("SELECT cid, aid, commenttxt, added, edittime,
-											(SELECT user FROM `" . DB_PREFIX . "_admins` WHERE aid = C.aid) AS comname,
-											(SELECT user FROM `" . DB_PREFIX . "_admins` WHERE aid = C.editaid) AS editname
-											FROM `" . DB_PREFIX . "_comments` AS C
-											WHERE type = 'B' AND bid = '" . $data['ban_id'] . "' ORDER BY added desc");
+        $GLOBALS['PDO']->query("SELECT cid, aid, commenttxt, added, edittime,
+											(SELECT user FROM `:prefix_admins` WHERE aid = C.aid) AS comname,
+											(SELECT user FROM `:prefix_admins` WHERE aid = C.editaid) AS editname
+											FROM `:prefix_comments` AS C
+											WHERE type = 'B' AND bid = :bid ORDER BY added desc");
+        $GLOBALS['PDO']->bind(':bid', $data['ban_id']);
+        $commentres    = $GLOBALS['PDO']->resultset();
 
-        if ($commentres->RecordCount() > 0) {
+        if (count($commentres) > 0) {
             $comment = [];
             $morecom = 0;
-            while (!$commentres->EOF) {
+            foreach ($commentres as $crow) {
                 $cdata            = [];
                 $cdata['morecom'] = ($morecom == 1 ? true : false);
-                if ($commentres->fields['aid'] == $userbank->GetAid() || $userbank->HasAccess(ADMIN_OWNER)) {
-                    $cdata['editcomlink'] = CreateLinkR('<i class="fas fa-edit fa-lg"></i>', 'index.php?p=banlist&comment=' . $data['ban_id'] . '&ctype=B&cid=' . $commentres->fields['cid'] . $pagelink, 'Edit Comment');
+                if ($crow['aid'] == $userbank->GetAid() || $userbank->HasAccess(ADMIN_OWNER)) {
+                    $cdata['editcomlink'] = CreateLinkR('<i class="fas fa-edit fa-lg"></i>', 'index.php?p=banlist&comment=' . $data['ban_id'] . '&ctype=B&cid=' . $crow['cid'] . $pagelink, 'Edit Comment');
                     if ($userbank->HasAccess(ADMIN_OWNER)) {
-                        $cdata['delcomlink'] = "<a href=\"#\" class=\"tip\" title=\"Delete Comment\" target=\"_self\" onclick=\"RemoveComment(" . $commentres->fields['cid'] . ",'B'," . (isset($_GET["page"]) ? $page : -1) . ");\"><i class='fas fa-trash fa-lg'></i></a>";
+                        $cdata['delcomlink'] = "<a href=\"#\" class=\"tip\" title=\"Delete Comment\" target=\"_self\" onclick=\"RemoveComment(" . $crow['cid'] . ",'B'," . (isset($_GET["page"]) ? $page : -1) . ");\"><i class='fas fa-trash fa-lg'></i></a>";
                     }
                 } else {
                     $cdata['editcomlink'] = "";
                     $cdata['delcomlink']  = "";
                 }
 
-                $cdata['comname']    = $commentres->fields['comname'];
-                $cdata['added']      = Config::time($commentres->fields['added']);
-                $commentText         = html_entity_decode($commentres->fields['commenttxt'], ENT_QUOTES | ENT_HTML5, 'UTF-8');
+                $cdata['comname']    = $crow['comname'];
+                $cdata['added']      = Config::time($crow['added']);
+                $commentText         = html_entity_decode($crow['commenttxt'], ENT_QUOTES | ENT_HTML5, 'UTF-8');
                 $commentText         = encodePreservingBr($commentText);
                 // Parse links and wrap them in a <a href=""></a> tag to be easily clickable
                 $commentText         = preg_replace('@(https?://([-\w\.]+)+(:\d+)?(/([\w/_\.]*(\?\S+)?)?)?)@', '<a href="$1" target="_blank">$1</a>', $commentText);
                 $cdata['commenttxt'] = $commentText;
 
-                if (!empty($commentres->fields['edittime'])) {
-                    $cdata['edittime'] = Config::time($commentres->fields['edittime']);
-                    $cdata['editname'] = $commentres->fields['editname'];
+                if (!empty($crow['edittime'])) {
+                    $cdata['edittime'] = Config::time($crow['edittime']);
+                    $cdata['editname'] = $crow['editname'];
                 } else {
                     $cdata['edittime'] = "";
                     $cdata['editname'] = "";
@@ -701,7 +719,6 @@ while (!$res->EOF) {
 
                 $morecom = 1;
                 array_push($comment, $cdata);
-                $commentres->MoveNext();
             }
         } else {
             $comment = "None";
@@ -716,11 +733,10 @@ while (!$res->EOF) {
 
     $data['ub_reason']   = (isset($data['ub_reason']) ? $data['ub_reason'] : "");
     $data['banlength']   = $data['ban_length'] . " " . $data['ub_reason'];
-    $data['view_edit']   = ($userbank->HasAccess(ADMIN_OWNER | ADMIN_EDIT_ALL_BANS) || ($userbank->HasAccess(ADMIN_EDIT_OWN_BANS) && $res->fields['aid'] == $userbank->GetAid()) || ($userbank->HasAccess(ADMIN_EDIT_GROUP_BANS) && $res->fields['gid'] == $userbank->GetProperty('gid')));
-    $data['view_unban']  = ($userbank->HasAccess(ADMIN_OWNER | ADMIN_UNBAN) || ($userbank->HasAccess(ADMIN_UNBAN_OWN_BANS) && $res->fields['aid'] == $userbank->GetAid()) || ($userbank->HasAccess(ADMIN_UNBAN_GROUP_BANS) && $res->fields['gid'] == $userbank->GetProperty('gid')));
+    $data['view_edit']   = ($userbank->HasAccess(ADMIN_OWNER | ADMIN_EDIT_ALL_BANS) || ($userbank->HasAccess(ADMIN_EDIT_OWN_BANS) && $row['aid'] == $userbank->GetAid()) || ($userbank->HasAccess(ADMIN_EDIT_GROUP_BANS) && $row['gid'] == $userbank->GetProperty('gid')));
+    $data['view_unban']  = ($userbank->HasAccess(ADMIN_OWNER | ADMIN_UNBAN) || ($userbank->HasAccess(ADMIN_UNBAN_OWN_BANS) && $row['aid'] == $userbank->GetAid()) || ($userbank->HasAccess(ADMIN_UNBAN_GROUP_BANS) && $row['gid'] == $userbank->GetProperty('gid')));
     $data['view_delete'] = ($userbank->HasAccess(ADMIN_OWNER | ADMIN_DELETE_BAN));
     array_push($bans, $data);
-    $res->MoveNext();
 }
 
 if (isset($_GET['advSearch'])) {
@@ -780,7 +796,9 @@ if (isset($_GET["comment"])) {
     $theme->assign('commenttype', (isset($_GET["cid"]) ? "Edit" : "Add"));
     if (isset($_GET["cid"])) {
         $_GET["cid"]    = (int) $_GET["cid"];
-        $ceditdata      = $GLOBALS['db']->GetRow("SELECT * FROM " . DB_PREFIX . "_comments WHERE cid = '" . $_GET["cid"] . "'");
+        $GLOBALS['PDO']->query("SELECT * FROM `:prefix_comments` WHERE cid = :cid");
+        $GLOBALS['PDO']->bind(':cid', $_GET["cid"]);
+        $ceditdata      = $GLOBALS['PDO']->single();
         $ctext          = html_entity_decode($ceditdata['commenttxt'], ENT_QUOTES | ENT_HTML5, 'UTF-8');
         $cotherdataedit = " AND cid != '" . $_GET["cid"] . "'";
     } else {
@@ -790,35 +808,34 @@ if (isset($_GET["comment"])) {
 
     $_GET["ctype"] = substr($_GET["ctype"], 0, 1);
 
-    $cotherdata = $GLOBALS['db']->Execute("SELECT cid, aid, commenttxt, added, edittime,
-											(SELECT user FROM `" . DB_PREFIX . "_admins` WHERE aid = C.aid) AS comname,
-											(SELECT user FROM `" . DB_PREFIX . "_admins` WHERE aid = C.editaid) AS editname
-											FROM `" . DB_PREFIX . "_comments` AS C
-											WHERE type = ? AND bid = ?" . $cotherdataedit . " ORDER BY added desc", array(
+    $cotherdata = $GLOBALS['PDO']->query("SELECT cid, aid, commenttxt, added, edittime,
+											(SELECT user FROM `:prefix_admins` WHERE aid = C.aid) AS comname,
+											(SELECT user FROM `:prefix_admins` WHERE aid = C.editaid) AS editname
+											FROM `:prefix_comments` AS C
+											WHERE type = ? AND bid = ?" . $cotherdataedit . " ORDER BY added desc")->resultset([
         $_GET["ctype"],
-        $_GET["comment"]
-    ));
+        $_GET["comment"],
+    ]);
 
     $ocomments = [];
-    while (!$cotherdata->EOF) {
+    foreach ($cotherdata as $cdrow) {
         $coment               = [];
-        $coment['comname']    = $cotherdata->fields['comname'];
-        $coment['added']      = Config::time($cotherdata->fields['added']);
-        $commentText          = html_entity_decode($cotherdata->fields['commenttxt'], ENT_QUOTES | ENT_HTML5, 'UTF-8');
+        $coment['comname']    = $cdrow['comname'];
+        $coment['added']      = Config::time($cdrow['added']);
+        $commentText          = html_entity_decode($cdrow['commenttxt'], ENT_QUOTES | ENT_HTML5, 'UTF-8');
         $commentText          = encodePreservingBr($commentText);
         // Parse links and wrap them in a <a href=""></a> tag to be easily clickable
         $commentText         = preg_replace('@(https?://([-\w\.]+)+(:\d+)?(/([\w/_\.]*(\?\S+)?)?)?)@', '<a href="$1" target="_blank">$1</a>', $commentText);
         $coment['commenttxt'] = $commentText;
 
-        if ($cotherdata->fields['editname'] != "") {
-            $coment['edittime'] = Config::time($cotherdata->fields['edittime']);
-            $coment['editname'] = $cotherdata->fields['editname'];
+        if ($cdrow['editname'] != "") {
+            $coment['edittime'] = Config::time($cdrow['edittime']);
+            $coment['editname'] = $cdrow['editname'];
         } else {
             $coment['editname'] = "";
             $coment['edittime'] = "";
         }
         array_push($ocomments, $coment);
-        $cotherdata->MoveNext();
     }
 
     $theme->assign('page', (isset($_GET["page"]) ? $page : -1));

--- a/web/pages/page.commslist.php
+++ b/web/pages/page.commslist.php
@@ -291,7 +291,7 @@ if (isset($_GET['searchText'])) {
         intval($BansPerPage)
     ));
 
-    $res_count  = $GLOBALS['PDO']->query("SELECT count(bid) AS cnt FROM `:prefix_comms`" . $hideinactiven);
+    $res_count  = $GLOBALS['PDO']->query("SELECT count(bid) AS cnt FROM `:prefix_comms`" . $hideinactiven)->resultset();
     $searchlink = "";
 }
 

--- a/web/pages/page.commslist.php
+++ b/web/pages/page.commslist.php
@@ -65,35 +65,39 @@ if (isset($_GET['a']) && $_GET['a'] == "ungag" && isset($_GET['id'])) {
     }
     //we have a multiple unban asking
     $bid = intval($_GET['id']);
-    $res = $GLOBALS['db']->Execute("SELECT a.aid, a.gid FROM `" . DB_PREFIX . "_comms` c INNER JOIN " . DB_PREFIX . "_admins a ON a.aid = c.aid WHERE bid = '" . $bid . "' AND c.type = 2;");
-    if (!$userbank->HasAccess(ADMIN_OWNER | ADMIN_UNBAN) && !($userbank->HasAccess(ADMIN_UNBAN_OWN_BANS) && $res->fields['aid'] == $userbank->GetAid()) && !($userbank->HasAccess(ADMIN_UNBAN_GROUP_BANS) && $res->fields['gid'] == $userbank->GetProperty('gid'))) {
+    $GLOBALS['PDO']->query("SELECT a.aid, a.gid FROM `:prefix_comms` c INNER JOIN `:prefix_admins` a ON a.aid = c.aid WHERE bid = :bid AND c.type = 2");
+    $GLOBALS['PDO']->bind(':bid', $bid);
+    $res = $GLOBALS['PDO']->single();
+    if (!$userbank->HasAccess(ADMIN_OWNER | ADMIN_UNBAN) && !($userbank->HasAccess(ADMIN_UNBAN_OWN_BANS) && $res['aid'] == $userbank->GetAid()) && !($userbank->HasAccess(ADMIN_UNBAN_GROUP_BANS) && $res['gid'] == $userbank->GetProperty('gid'))) {
         die("You don't have access to this");
     }
 
-    $row = $GLOBALS['db']->GetRow("SELECT b.authid, b.name, b.created, b.sid, UNIX_TIMESTAMP() as now
-										FROM " . DB_PREFIX . "_comms b
-										LEFT JOIN " . DB_PREFIX . "_servers s ON s.sid = b.sid
-										WHERE b.bid = ? AND b.RemoveType IS NULL AND b.type = 2 AND (b.length = '0' OR b.ends > UNIX_TIMESTAMP())", array(
-        $bid
-    ));
+    $GLOBALS['PDO']->query("SELECT b.authid, b.name, b.created, b.sid, UNIX_TIMESTAMP() as now
+										FROM `:prefix_comms` b
+										LEFT JOIN `:prefix_servers` s ON s.sid = b.sid
+										WHERE b.bid = :bid AND b.RemoveType IS NULL AND b.type = 2 AND (b.length = '0' OR b.ends > UNIX_TIMESTAMP())");
+    $GLOBALS['PDO']->bind(':bid', $bid);
+    $row = $GLOBALS['PDO']->single();
     if (empty($row) || !$row) {
         echo "<script>ShowBox('Player Not UnGagged', 'The player was not ungagged, either already ungagged or not a valid block.', 'red', 'index.php?p=commslist$pagelink');</script>";
         PageDie();
     }
 
     $unbanReason = htmlspecialchars(trim($_GET['ureason']));
-    $ins         = $GLOBALS['db']->Execute("UPDATE `" . DB_PREFIX . "_comms` SET
-										`RemovedBy` = ?,
+    $GLOBALS['PDO']->query("UPDATE `:prefix_comms` SET
+										`RemovedBy` = :removedby,
 										`RemoveType` = 'U',
 										`RemovedOn` = UNIX_TIMESTAMP(),
-										`ureason` = ?
-										WHERE `bid` = ?;", array(
-        $userbank->GetAid(),
-        $unbanReason,
-        $bid
-    ));
+										`ureason` = :ureason
+										WHERE `bid` = :bid");
+    $GLOBALS['PDO']->bindMultiple([
+        ':removedby' => $userbank->GetAid(),
+        ':ureason'   => $unbanReason,
+        ':bid'       => $bid,
+    ]);
+    $GLOBALS['PDO']->execute();
 
-    $blocked = $GLOBALS['db']->GetAll("SELECT sid FROM `" . DB_PREFIX . "_servers` WHERE `enabled`=1");
+    $blocked = $GLOBALS['PDO']->query("SELECT sid FROM `:prefix_servers` WHERE `enabled`=1")->resultset();
     foreach ($blocked as $tempban) {
         rcon(("sc_fw_ungag " . $row['authid']), $tempban['sid']);
     }
@@ -110,35 +114,39 @@ if (isset($_GET['a']) && $_GET['a'] == "ungag" && isset($_GET['id'])) {
     }
     //we have a multiple unban asking
     $bid = intval($_GET['id']);
-    $res = $GLOBALS['db']->Execute("SELECT a.aid, a.gid FROM `" . DB_PREFIX . "_comms` c INNER JOIN " . DB_PREFIX . "_admins a ON a.aid = c.aid WHERE bid = '" . $bid . "' AND c.type = 1;");
-    if (!$userbank->HasAccess(ADMIN_OWNER | ADMIN_UNBAN) && !($userbank->HasAccess(ADMIN_UNBAN_OWN_BANS) && $res->fields['aid'] == $userbank->GetAid()) && !($userbank->HasAccess(ADMIN_UNBAN_GROUP_BANS) && $res->fields['gid'] == $userbank->GetProperty('gid'))) {
+    $GLOBALS['PDO']->query("SELECT a.aid, a.gid FROM `:prefix_comms` c INNER JOIN `:prefix_admins` a ON a.aid = c.aid WHERE bid = :bid AND c.type = 1");
+    $GLOBALS['PDO']->bind(':bid', $bid);
+    $res = $GLOBALS['PDO']->single();
+    if (!$userbank->HasAccess(ADMIN_OWNER | ADMIN_UNBAN) && !($userbank->HasAccess(ADMIN_UNBAN_OWN_BANS) && $res['aid'] == $userbank->GetAid()) && !($userbank->HasAccess(ADMIN_UNBAN_GROUP_BANS) && $res['gid'] == $userbank->GetProperty('gid'))) {
         die("You don't have access to this");
     }
 
-    $row = $GLOBALS['db']->GetRow("SELECT b.authid, b.name, b.created, b.sid, UNIX_TIMESTAMP() as now
-										FROM " . DB_PREFIX . "_comms b
-										LEFT JOIN " . DB_PREFIX . "_servers s ON s.sid = b.sid
-										WHERE b.bid = ? AND b.RemoveType IS NULL AND b.type = 1 AND (b.length = '0' OR b.ends > UNIX_TIMESTAMP())", array(
-        $bid
-    ));
+    $GLOBALS['PDO']->query("SELECT b.authid, b.name, b.created, b.sid, UNIX_TIMESTAMP() as now
+										FROM `:prefix_comms` b
+										LEFT JOIN `:prefix_servers` s ON s.sid = b.sid
+										WHERE b.bid = :bid AND b.RemoveType IS NULL AND b.type = 1 AND (b.length = '0' OR b.ends > UNIX_TIMESTAMP())");
+    $GLOBALS['PDO']->bind(':bid', $bid);
+    $row = $GLOBALS['PDO']->single();
     if (empty($row) || !$row) {
         echo "<script>ShowBox('Player Not UnGagged', 'The player was not unmuted, either already unmuted or not a valid block.', 'red', 'index.php?p=commslist$pagelink');</script>";
         PageDie();
     }
 
     $unbanReason = htmlspecialchars(trim($_GET['ureason']));
-    $ins         = $GLOBALS['db']->Execute("UPDATE `" . DB_PREFIX . "_comms` SET
-										`RemovedBy` = ?,
+    $GLOBALS['PDO']->query("UPDATE `:prefix_comms` SET
+										`RemovedBy` = :removedby,
 										`RemoveType` = 'U',
 										`RemovedOn` = UNIX_TIMESTAMP(),
-										`ureason` = ?
-										WHERE `bid` = ?;", array(
-        $userbank->GetAid(),
-        $unbanReason,
-        $bid
-    ));
+										`ureason` = :ureason
+										WHERE `bid` = :bid");
+    $GLOBALS['PDO']->bindMultiple([
+        ':removedby' => $userbank->GetAid(),
+        ':ureason'   => $unbanReason,
+        ':bid'       => $bid,
+    ]);
+    $GLOBALS['PDO']->execute();
 
-    $blocked = $GLOBALS['db']->GetAll("SELECT sid FROM `" . DB_PREFIX . "_servers` WHERE `enabled`=1");
+    $blocked = $GLOBALS['PDO']->query("SELECT sid FROM `:prefix_servers` WHERE `enabled`=1")->resultset();
     foreach ($blocked as $tempban) {
         rcon(("sc_fw_unmute " . $row['authid']), $tempban['sid']);
     }
@@ -161,10 +169,10 @@ if (isset($_GET['a']) && $_GET['a'] == "ungag" && isset($_GET['id'])) {
 
     $bid = intval($_GET['id']);
 
-    $steam  = $GLOBALS['db']->GetRow("SELECT name, authid, ends, length, RemoveType, type, UNIX_TIMESTAMP() AS now
-									FROM " . DB_PREFIX . "_comms WHERE bid=?", array(
-        $bid
-    ));
+    $GLOBALS['PDO']->query("SELECT name, authid, ends, length, RemoveType, type, UNIX_TIMESTAMP() AS now
+									FROM `:prefix_comms` WHERE bid = :bid");
+    $GLOBALS['PDO']->bind(':bid', $bid);
+    $steam = $GLOBALS['PDO']->single();
     $end    = (int) $steam['ends'];
     $length = (int) $steam['length'];
     $now    = (int) $steam['now'];
@@ -182,12 +190,12 @@ if (isset($_GET['a']) && $_GET['a'] == "ungag" && isset($_GET['id'])) {
             break;
     }
 
-    $res = $GLOBALS['db']->Execute("DELETE FROM `" . DB_PREFIX . "_comms` WHERE `bid` = ?", array(
-        $bid
-    ));
+    $GLOBALS['PDO']->query("DELETE FROM `:prefix_comms` WHERE `bid` = :bid");
+    $GLOBALS['PDO']->bind(':bid', $bid);
+    $res = $GLOBALS['PDO']->execute();
 
     if (empty($steam['RemoveType']) && ($length == 0 || $end > $now)) {
-        $blocked = $GLOBALS['db']->GetAll("SELECT sid FROM `" . DB_PREFIX . "_servers` WHERE `enabled`=1");
+        $blocked = $GLOBALS['PDO']->query("SELECT sid FROM `:prefix_servers` WHERE `enabled`=1")->resultset();
         foreach ($blocked as $tempban) {
             rcon(($cmd . " " . $steam['authid']), $tempban['sid']);
         }
@@ -239,18 +247,18 @@ if (isset($_GET['searchText'])) {
 
     $search = "%{$searchText}%";
 
-    $res = $GLOBALS['db']->Execute("SELECT bid ban_id, CO.type, CO.authid, CO.name player_name, created ban_created, ends ban_ends, length ban_length, reason ban_reason, CO.ureason unban_reason, CO.aid, AD.gid AS gid, adminIp, CO.sid ban_server, RemovedOn, RemovedBy, RemoveType row_type,
+    $res = $GLOBALS['PDO']->query("SELECT bid ban_id, CO.type, CO.authid, CO.name player_name, created ban_created, ends ban_ends, length ban_length, reason ban_reason, CO.ureason unban_reason, CO.aid, AD.gid AS gid, adminIp, CO.sid ban_server, RemovedOn, RemovedBy, RemoveType row_type,
 		SE.ip server_ip, AD.user admin_name, MO.icon as mod_icon,
 		CAST(MID(CO.authid, 9, 1) AS UNSIGNED) + CAST('76561197960265728' AS UNSIGNED) + CAST(MID(CO.authid, 11, 10) * 2 AS UNSIGNED) AS community_id,
-		(SELECT count(*) FROM " . DB_PREFIX . "_comms as BH WHERE (BH.authid = CO.authid AND BH.authid != '' AND BH.authid IS NOT NULL AND BH.type = 1)) as mute_count,
-		(SELECT count(*) FROM " . DB_PREFIX . "_comms as BH WHERE (BH.authid = CO.authid AND BH.authid != '' AND BH.authid IS NOT NULL AND BH.type = 2)) as gag_count,
+		(SELECT count(*) FROM `:prefix_comms` as BH WHERE (BH.authid = CO.authid AND BH.authid != '' AND BH.authid IS NOT NULL AND BH.type = 1)) as mute_count,
+		(SELECT count(*) FROM `:prefix_comms` as BH WHERE (BH.authid = CO.authid AND BH.authid != '' AND BH.authid IS NOT NULL AND BH.type = 2)) as gag_count,
 		UNIX_TIMESTAMP() as c_time
-		FROM " . DB_PREFIX . "_comms AS CO FORCE INDEX (created)
-		LEFT JOIN " . DB_PREFIX . "_servers AS SE ON SE.sid = CO.sid
-		LEFT JOIN " . DB_PREFIX . "_mods AS MO on SE.modid = MO.mid
-		LEFT JOIN " . DB_PREFIX . "_admins AS AD ON CO.aid = AD.aid
+		FROM `:prefix_comms` AS CO FORCE INDEX (created)
+		LEFT JOIN `:prefix_servers` AS SE ON SE.sid = CO.sid
+		LEFT JOIN `:prefix_mods` AS MO on SE.modid = MO.mid
+		LEFT JOIN `:prefix_admins` AS AD ON CO.aid = AD.aid
       	WHERE CO.authid LIKE ? or CO.name LIKE ? or CO.reason LIKE ?" . $hideinactive . "
-   		ORDER BY CO.created DESC LIMIT ?,?", array(
+   		ORDER BY CO.created DESC LIMIT ?,?")->resultset(array(
         $search,
         $search,
         $search,
@@ -259,31 +267,31 @@ if (isset($_GET['searchText'])) {
     ));
 
 
-    $res_count  = $GLOBALS['db']->Execute("SELECT count(CO.bid) FROM " . DB_PREFIX . "_comms AS CO WHERE CO.authid LIKE ? OR CO.name LIKE ? OR CO.reason LIKE ?" . $hideinactive, array(
+    $res_count  = $GLOBALS['PDO']->query("SELECT count(CO.bid) AS cnt FROM `:prefix_comms` AS CO WHERE CO.authid LIKE ? OR CO.name LIKE ? OR CO.reason LIKE ?" . $hideinactive)->resultset(array(
         $search,
         $search,
         $search
     ));
     $searchlink = "&searchText=" . urlencode($_GET["searchText"]);
 } elseif (!isset($_GET['advSearch'])) {
-    $res = $GLOBALS['db']->Execute("SELECT bid ban_id, CO.type, CO.authid, CO.name player_name, created ban_created, ends ban_ends, length ban_length, reason ban_reason, CO.ureason unban_reason, CO.aid, AD.gid AS gid, adminIp, CO.sid ban_server, RemovedOn, RemovedBy, RemoveType row_type,
+    $res = $GLOBALS['PDO']->query("SELECT bid ban_id, CO.type, CO.authid, CO.name player_name, created ban_created, ends ban_ends, length ban_length, reason ban_reason, CO.ureason unban_reason, CO.aid, AD.gid AS gid, adminIp, CO.sid ban_server, RemovedOn, RemovedBy, RemoveType row_type,
 		SE.ip server_ip, AD.user admin_name, MO.icon as mod_icon,
 		CAST(MID(CO.authid, 9, 1) AS UNSIGNED) + CAST('76561197960265728' AS UNSIGNED) + CAST(MID(CO.authid, 11, 10) * 2 AS UNSIGNED) AS community_id,
-		(SELECT count(*) FROM " . DB_PREFIX . "_comms as BH WHERE (BH.authid = CO.authid AND BH.authid != '' AND BH.authid IS NOT NULL AND BH.type = 1)) as mute_count,
-		(SELECT count(*) FROM " . DB_PREFIX . "_comms as BH WHERE (BH.authid = CO.authid AND BH.authid != '' AND BH.authid IS NOT NULL AND BH.type = 2)) as gag_count,
+		(SELECT count(*) FROM `:prefix_comms` as BH WHERE (BH.authid = CO.authid AND BH.authid != '' AND BH.authid IS NOT NULL AND BH.type = 1)) as mute_count,
+		(SELECT count(*) FROM `:prefix_comms` as BH WHERE (BH.authid = CO.authid AND BH.authid != '' AND BH.authid IS NOT NULL AND BH.type = 2)) as gag_count,
 		UNIX_TIMESTAMP() as c_time
-		FROM " . DB_PREFIX . "_comms AS CO FORCE INDEX (created)
-		LEFT JOIN " . DB_PREFIX . "_servers AS SE ON SE.sid = CO.sid
-		LEFT JOIN " . DB_PREFIX . "_mods AS MO on SE.modid = MO.mid
-		LEFT JOIN " . DB_PREFIX . "_admins AS AD ON CO.aid = AD.aid
+		FROM `:prefix_comms` AS CO FORCE INDEX (created)
+		LEFT JOIN `:prefix_servers` AS SE ON SE.sid = CO.sid
+		LEFT JOIN `:prefix_mods` AS MO on SE.modid = MO.mid
+		LEFT JOIN `:prefix_admins` AS AD ON CO.aid = AD.aid
 		" . $hideinactiven . "
 		ORDER BY created DESC
-		LIMIT ?,?", array(
+		LIMIT ?,?")->resultset(array(
         intval($BansStart),
         intval($BansPerPage)
     ));
 
-    $res_count  = $GLOBALS['db']->Execute("SELECT count(bid) FROM " . DB_PREFIX . "_comms" . $hideinactiven);
+    $res_count  = $GLOBALS['PDO']->query("SELECT count(bid) AS cnt FROM `:prefix_comms`" . $hideinactiven);
     $searchlink = "";
 }
 
@@ -419,30 +427,30 @@ if (isset($_GET['advSearch'])) {
             break;
     }
 
-    $res = $GLOBALS['db']->Execute("SELECT CO.bid ban_id, CO.type, CO.authid, CO.name player_name, created ban_created, ends ban_ends, length ban_length, reason ban_reason, CO.ureason unban_reason, CO.aid, AD.gid AS gid, adminIp, CO.sid ban_server, RemovedOn, RemovedBy, RemoveType row_type,
+    $res = $GLOBALS['PDO']->query("SELECT CO.bid ban_id, CO.type, CO.authid, CO.name player_name, created ban_created, ends ban_ends, length ban_length, reason ban_reason, CO.ureason unban_reason, CO.aid, AD.gid AS gid, adminIp, CO.sid ban_server, RemovedOn, RemovedBy, RemoveType row_type,
 			SE.ip server_ip, AD.user admin_name, MO.icon as mod_icon,
 			CAST(MID(CO.authid, 9, 1) AS UNSIGNED) + CAST('76561197960265728' AS UNSIGNED) + CAST(MID(CO.authid, 11, 10) * 2 AS UNSIGNED) AS community_id,
-			(SELECT count(*) FROM " . DB_PREFIX . "_comms as BH WHERE (BH.authid = CO.authid AND BH.authid != '' AND BH.authid IS NOT NULL AND BH.type = 1)) as mute_count,
-			(SELECT count(*) FROM " . DB_PREFIX . "_comms as BH WHERE (BH.authid = CO.authid AND BH.authid != '' AND BH.authid IS NOT NULL AND BH.type = 2)) as gag_count,
+			(SELECT count(*) FROM `:prefix_comms` as BH WHERE (BH.authid = CO.authid AND BH.authid != '' AND BH.authid IS NOT NULL AND BH.type = 1)) as mute_count,
+			(SELECT count(*) FROM `:prefix_comms` as BH WHERE (BH.authid = CO.authid AND BH.authid != '' AND BH.authid IS NOT NULL AND BH.type = 2)) as gag_count,
 			UNIX_TIMESTAMP() as c_time
-			FROM " . DB_PREFIX . "_comms AS CO FORCE INDEX (created)
-			LEFT JOIN " . DB_PREFIX . "_servers AS SE ON SE.sid = CO.sid
-			LEFT JOIN " . DB_PREFIX . "_mods AS MO on SE.modid = MO.mid
-			LEFT JOIN " . DB_PREFIX . "_admins AS AD ON CO.aid = AD.aid
-  			" . ($type == "comment" && $userbank->is_admin() ? "LEFT JOIN " . DB_PREFIX . "_comments AS CM ON CO.bid = CM.bid" : "") . "
+			FROM `:prefix_comms` AS CO FORCE INDEX (created)
+			LEFT JOIN `:prefix_servers` AS SE ON SE.sid = CO.sid
+			LEFT JOIN `:prefix_mods` AS MO on SE.modid = MO.mid
+			LEFT JOIN `:prefix_admins` AS AD ON CO.aid = AD.aid
+  			" . ($type == "comment" && $userbank->is_admin() ? "LEFT JOIN `:prefix_comments` AS CM ON CO.bid = CM.bid" : "") . "
       " . $where . $hideinactive . "
    ORDER BY CO.created DESC
-   LIMIT ?,?", array_merge($advcrit, array(
+   LIMIT ?,?")->resultset(array_merge($advcrit, array(
         intval($BansStart),
         intval($BansPerPage)
     )));
 
-    $res_count  = $GLOBALS['db']->Execute("SELECT count(CO.bid) FROM " . DB_PREFIX . "_comms AS CO
-										  " . ($type == "comment" && $userbank->is_admin() ? "LEFT JOIN " . DB_PREFIX . "_comments AS CM ON CO.bid = CM.bid" : "") . " " . $where . $hideinactive, $advcrit);
+    $res_count  = $GLOBALS['PDO']->query("SELECT count(CO.bid) AS cnt FROM `:prefix_comms` AS CO
+										  " . ($type == "comment" && $userbank->is_admin() ? "LEFT JOIN `:prefix_comments` AS CM ON CO.bid = CM.bid" : "") . " " . $where . $hideinactive)->resultset($advcrit);
     $searchlink = "&advSearch=" . urlencode($_GET['advSearch']) . "&advType=" . urlencode($_GET['advType']);
 }
 
-$BanCount = $res_count->fields[0];
+$BanCount = isset($res_count[0]['cnt']) ? (int) $res_count[0]['cnt'] : 0;
 if ($BansEnd > $BanCount) {
     $BansEnd = $BanCount;
 }
@@ -453,15 +461,15 @@ if (!$res) {
 
 $view_comments = false;
 $bans          = [];
-while (!$res->EOF) {
+foreach ($res as $row) {
     $data = [];
 
-    $data['ban_id'] = $res->fields['ban_id'];
-    $data['type']   = $res->fields['type'];
-    $data['c_time'] = $res->fields['c_time'];
+    $data['ban_id'] = $row['ban_id'];
+    $data['type']   = $row['type'];
+    $data['c_time'] = $row['c_time'];
 
-    $mute_count    = (int) $res->fields['mute_count'];
-    $gag_count     = (int) $res->fields['gag_count'];
+    $mute_count    = (int) $row['mute_count'];
+    $gag_count     = (int) $row['gag_count'];
     $history_count = $mute_count + $gag_count;
 
     $delimiter = "";
@@ -480,10 +488,10 @@ while (!$res->EOF) {
             break;
     }
 
-    $data['ban_date']    = Config::time($res->fields['ban_created']);
+    $data['ban_date']    = Config::time($row['ban_created']);
 
     // Fix #1008 - bug: Player Names Contain Unwanted Non-Standard Characters
-    $raw_name = $res->fields['player_name'];
+    $raw_name = $row['player_name'];
     $cleaned_name = mb_convert_encoding($raw_name, 'UTF-8', 'UTF-8');
     $unwanted_sequences = ["\xF3\xA0\x80\xA1"];
     foreach ($unwanted_sequences as $sequence) {
@@ -492,12 +500,12 @@ while (!$res->EOF) {
     $cleaned_name = trim($cleaned_name);
 
     $data['player']      = addslashes($cleaned_name);
-    $data['steamid']     = $res->fields['authid'];
+    $data['steamid']     = $row['authid'];
     // Fix #906 - Bad SteamID Format broke the page view, so give them an null SteamID.
     if (!\SteamID\SteamID::isValidID($data['steamid'])) {
 		$data['steamid'] = 'STEAM_0:0:00000000';
 	}
-    $data['communityid'] = $res->fields['community_id'];
+    $data['communityid'] = $row['community_id'];
     $steam2id            = $data['steamid'];
     $steam3parts         = explode(':', $steam2id);
     $data['steamid3']    = \SteamID\SteamID::toSteam3($data['steamid']);
@@ -505,14 +513,14 @@ while (!$res->EOF) {
     if (Config::getBool('banlist.hideadminname') && !$userbank->is_admin()) {
         $data['admin'] = false;
     } else {
-        $data['admin'] = stripslashes($res->fields['admin_name']);
+        $data['admin'] = stripslashes($row['admin_name']);
     }
-    $data['reason'] = stripslashes($res->fields['ban_reason']);
+    $data['reason'] = stripslashes($row['ban_reason']);
 
-    if ($res->fields['ban_length'] > 0) {
-        $data['ban_length'] = SecondsToString(intval($res->fields['ban_length']));
-        $data['expires']    = Config::time($res->fields['ban_ends']);
-    } else if ($res->fields['ban_length'] == 0) {
+    if ($row['ban_length'] > 0) {
+        $data['ban_length'] = SecondsToString(intval($row['ban_length']));
+        $data['expires']    = Config::time($row['ban_ends']);
+    } else if ($row['ban_length'] == 0) {
         $data['ban_length'] = 'Permanent';
         $data['expires']    = 'never';
     } else {
@@ -521,25 +529,27 @@ while (!$res->EOF) {
     }
 
     // Что за тип разбана - D? Я такой не видел, но оставлю так и быть.. for feature use...
-    if ($res->fields['row_type'] == 'D' || $res->fields['row_type'] == 'U' || $res->fields['row_type'] == 'E' || ($res->fields['ban_length'] && $res->fields['ban_ends'] < $data['c_time'])) {
+    if ($row['row_type'] == 'D' || $row['row_type'] == 'U' || $row['row_type'] == 'E' || ($row['ban_length'] && $row['ban_ends'] < $data['c_time'])) {
         $data['unbanned'] = true;
         $data['class']    = "listtable_1_unbanned";
 
-        if ($res->fields['row_type'] == "D") {
+        if ($row['row_type'] == "D") {
             $data['ub_reason'] = "(Deleted)";
-        } elseif ($res->fields['row_type'] == "U") {
+        } elseif ($row['row_type'] == "U") {
             $data['ub_reason'] = "(Unbanned)";
         } else {
             $data['ub_reason'] = "(Expired)";
         }
 
-        if (isset($res->fields['unban_reason']))
-            $data['ureason'] = stripslashes($res->fields['unban_reason']);
+        if (isset($row['unban_reason']))
+            $data['ureason'] = stripslashes($row['unban_reason']);
 
-        $removedby         = $GLOBALS['db']->GetRow("SELECT user FROM `" . DB_PREFIX . "_admins` WHERE aid = '" . $res->fields['RemovedBy'] . "'");
+        $GLOBALS['PDO']->query("SELECT user FROM `:prefix_admins` WHERE aid = :aid");
+        $GLOBALS['PDO']->bind(':aid', $row['RemovedBy']);
+        $removedby         = $GLOBALS['PDO']->single();
         $data['removedby'] = "";
-        if (isset($removedby[0]) && $data['admin']) {
-            $data['removedby'] = $removedby[0];
+        if (!empty($removedby['user']) && $data['admin']) {
+            $data['removedby'] = $removedby['user'];
         }
     } else if ($data['ban_length'] == 'Permanent') {
         $data['class'] = "listtable_1_permanent";
@@ -549,16 +559,21 @@ while (!$res->EOF) {
         $data['ub_reason'] = "";
     }
 
-    $data['layer_id'] = 'layer_' . $res->fields['ban_id'];
+    $data['layer_id'] = 'layer_' . $row['ban_id'];
     // Запрос текущего статуса игрока для рисования ссылки на мьют или гаг
-    $alrdybnd         = $GLOBALS['db']->Execute("SELECT count(bid) as count FROM `" . DB_PREFIX . "_comms` WHERE authid = '" . $data['steamid'] . "' AND RemovedBy IS NULL AND type = '" . $data['type'] . "' AND (length = 0 OR ends > UNIX_TIMESTAMP());");
-    if ($alrdybnd->fields['count'] == 0) {
+    $GLOBALS['PDO']->query("SELECT count(bid) as count FROM `:prefix_comms` WHERE authid = :authid AND RemovedBy IS NULL AND type = :type AND (length = 0 OR ends > UNIX_TIMESTAMP())");
+    $GLOBALS['PDO']->bindMultiple([
+        ':authid' => $data['steamid'],
+        ':type'   => $data['type'],
+    ]);
+    $alrdybnd         = $GLOBALS['PDO']->single();
+    if ($alrdybnd['count'] == 0) {
         switch ($data['type']) {
             case 1:
-                $data['reban_link'] = CreateLinkR('<i class="fas fa-redo fa-lg"></i> ReMute', "index.php?p=admin&c=comms" . $pagelink . "&rebanid=" . $res->fields['ban_id'] . "&key=" . $_SESSION['banlist_postkey'] . "#^0");
+                $data['reban_link'] = CreateLinkR('<i class="fas fa-redo fa-lg"></i> ReMute', "index.php?p=admin&c=comms" . $pagelink . "&rebanid=" . $row['ban_id'] . "&key=" . $_SESSION['banlist_postkey'] . "#^0");
                 break;
             case 2:
-                $data['reban_link'] = CreateLinkR('<i class="fas fa-redo fa-lg"></i> ReGag', "index.php?p=admin&c=comms" . $pagelink . "&rebanid=" . $res->fields['ban_id'] . "&key=" . $_SESSION['banlist_postkey'] . "#^0");
+                $data['reban_link'] = CreateLinkR('<i class="fas fa-redo fa-lg"></i> ReGag', "index.php?p=admin&c=comms" . $pagelink . "&rebanid=" . $row['ban_id'] . "&key=" . $_SESSION['banlist_postkey'] . "#^0");
                 break;
             default:
                 break;
@@ -568,27 +583,27 @@ while (!$res->EOF) {
     }
 
 
-    $data['edit_link'] = CreateLinkR('<i class="fas fa-edit fa-lg"></i> Edit Details', "index.php?p=admin&c=comms&o=edit" . $pagelink . "&id=" . $res->fields['ban_id'] . "&key=" . $_SESSION['banlist_postkey']);
+    $data['edit_link'] = CreateLinkR('<i class="fas fa-edit fa-lg"></i> Edit Details', "index.php?p=admin&c=comms&o=edit" . $pagelink . "&id=" . $row['ban_id'] . "&key=" . $_SESSION['banlist_postkey']);
 
     switch ($data['type']) {
         case 2:
-            $data['unban_link'] = CreateLinkR('<i class="fas fa-undo fa-lg"></i> UnGag', "#", "", "_self", false, "UnGag('" . $res->fields['ban_id'] . "', '" . $_SESSION['banlist_postkey'] . "', '" . $pagelink . "', '" . $data['player'] . "', 1);return false;");
+            $data['unban_link'] = CreateLinkR('<i class="fas fa-undo fa-lg"></i> UnGag', "#", "", "_self", false, "UnGag('" . $row['ban_id'] . "', '" . $_SESSION['banlist_postkey'] . "', '" . $pagelink . "', '" . $data['player'] . "', 1);return false;");
             break;
         case 1:
-            $data['unban_link'] = CreateLinkR('<i class="fas fa-undo fa-lg"></i> UnMute', "#", "", "_self", false, "UnMute('" . $res->fields['ban_id'] . "', '" . $_SESSION['banlist_postkey'] . "', '" . $pagelink . "', '" . $data['player'] . "', 1);return false;");
+            $data['unban_link'] = CreateLinkR('<i class="fas fa-undo fa-lg"></i> UnMute', "#", "", "_self", false, "UnMute('" . $row['ban_id'] . "', '" . $_SESSION['banlist_postkey'] . "', '" . $pagelink . "', '" . $data['player'] . "', 1);return false;");
             break;
         default:
             break;
     }
 
-    $data['delete_link'] = CreateLinkR('<i class="fas fa-trash fa-lg"></i> Delete Block', "#", "", "_self", false, "RemoveBlock('" . $res->fields['ban_id'] . "', '" . $_SESSION['banlist_postkey'] . "', '" . $pagelink . "', '" . $data['player'] . "', 0);return false;");
+    $data['delete_link'] = CreateLinkR('<i class="fas fa-trash fa-lg"></i> Delete Block', "#", "", "_self", false, "RemoveBlock('" . $row['ban_id'] . "', '" . $_SESSION['banlist_postkey'] . "', '" . $pagelink . "', '" . $data['player'] . "', 0);return false;");
 
-    $data['server_id'] = $res->fields['ban_server'];
+    $data['server_id'] = $row['ban_server'];
 
-    if (empty($res->fields['mod_icon'])) {
+    if (empty($row['mod_icon'])) {
         $modicon = "web.png";
     } else {
-        $modicon = $res->fields['mod_icon'];
+        $modicon = $row['mod_icon'];
     }
 
     $data['mod_icon'] = '<img src="images/games/' . $modicon . '" alt="MOD" border="0" align="absmiddle" />&nbsp;' . $data['type_icon'];
@@ -611,48 +626,50 @@ while (!$res->EOF) {
         $gags = $gag_count . '<i class="fas fa-comment-slash fa-lg"></i>';
     }
 
-    $data['server_id'] = $res->fields['ban_server'];
+    $data['server_id'] = $row['ban_server'];
 
     //COMMENT STUFF
     //-----------------------------------
     if (Config::getBool('config.enablepubliccomments') || $userbank->is_admin()) {
         $view_comments = true;
-        $commentres    = $GLOBALS['db']->Execute("SELECT cid, aid, commenttxt, added, edittime,
-											(SELECT user FROM `" . DB_PREFIX . "_admins` WHERE aid = C.aid) AS comname,
-											(SELECT user FROM `" . DB_PREFIX . "_admins` WHERE aid = C.editaid) AS editname
-											FROM `" . DB_PREFIX . "_comments` AS C
-											WHERE C.type = 'C' AND bid = '" . $data['ban_id'] . "' ORDER BY added desc");
+        $GLOBALS['PDO']->query("SELECT cid, aid, commenttxt, added, edittime,
+											(SELECT user FROM `:prefix_admins` WHERE aid = C.aid) AS comname,
+											(SELECT user FROM `:prefix_admins` WHERE aid = C.editaid) AS editname
+											FROM `:prefix_comments` AS C
+											WHERE C.type = 'C' AND bid = :bid ORDER BY added desc");
+        $GLOBALS['PDO']->bind(':bid', $data['ban_id']);
+        $commentres    = $GLOBALS['PDO']->resultset();
 
-        if ($commentres->RecordCount() > 0) {
+        if (count($commentres) > 0) {
             if ($mute_count > 0 || $gag_count > 0) {
                 $delimiter = "&ensp;";
             }
             $comment = [];
             $morecom = 0;
-            while (!$commentres->EOF) {
+            foreach ($commentres as $crow) {
                 $cdata            = [];
                 $cdata['morecom'] = ($morecom == 1 ? true : false);
-                if ($commentres->fields['aid'] == $userbank->GetAid() || $userbank->HasAccess(ADMIN_OWNER)) {
-                    $cdata['editcomlink'] = CreateLinkR('<i class="fas fa-edit fa-lg"></i>', 'index.php?p=commslist&comment=' . $data['ban_id'] . '&ctype=C&cid=' . $commentres->fields['cid'] . $pagelink, 'Edit Comment');
+                if ($crow['aid'] == $userbank->GetAid() || $userbank->HasAccess(ADMIN_OWNER)) {
+                    $cdata['editcomlink'] = CreateLinkR('<i class="fas fa-edit fa-lg"></i>', 'index.php?p=commslist&comment=' . $data['ban_id'] . '&ctype=C&cid=' . $crow['cid'] . $pagelink, 'Edit Comment');
                     if ($userbank->HasAccess(ADMIN_OWNER)) {
-                        $cdata['delcomlink'] = "<a href=\"#\" class=\"tip\" title=\"Delete Comment\" target=\"_self\" onclick=\"RemoveComment(" . $commentres->fields['cid'] . ",'C'," . (isset($_GET["page"]) ? $_GET["page"] : -1) . ");\"><i class='fas fa-trash fa-lg'></i></a>";
+                        $cdata['delcomlink'] = "<a href=\"#\" class=\"tip\" title=\"Delete Comment\" target=\"_self\" onclick=\"RemoveComment(" . $crow['cid'] . ",'C'," . (isset($_GET["page"]) ? $_GET["page"] : -1) . ");\"><i class='fas fa-trash fa-lg'></i></a>";
                     }
                 } else {
                     $cdata['editcomlink'] = "";
                     $cdata['delcomlink']  = "";
                 }
 
-                $cdata['comname']    = $commentres->fields['comname'];
-                $cdata['added']      = Config::time($commentres->fields['added']);
-                $commentText         = html_entity_decode($commentres->fields['commenttxt'], ENT_QUOTES | ENT_HTML5, 'UTF-8');
+                $cdata['comname']    = $crow['comname'];
+                $cdata['added']      = Config::time($crow['added']);
+                $commentText         = html_entity_decode($crow['commenttxt'], ENT_QUOTES | ENT_HTML5, 'UTF-8');
                 $commentText         = encodePreservingBr($commentText);
                 // Parse links and wrap them in a <a href=""></a> tag to be easily clickable
                 $commentText         = preg_replace('@(https?://([-\w\.]+)+(:\d+)?(/([\w/_\.]*(\?\S+)?)?)?)@', '<a href="$1" target="_blank">$1</a>', $commentText);
                 $cdata['commenttxt'] = $commentText;
 
-                if (!empty($commentres->fields['edittime'])) {
-                    $cdata['edittime'] = Config::time($commentres->fields['edittime']);
-                    $cdata['editname'] = $commentres->fields['editname'];
+                if (!empty($crow['edittime'])) {
+                    $cdata['edittime'] = Config::time($crow['edittime']);
+                    $cdata['editname'] = $crow['editname'];
                 } else {
                     $cdata['edittime'] = "";
                     $cdata['editname'] = "";
@@ -660,7 +677,6 @@ while (!$res->EOF) {
 
                 $morecom = 1;
                 array_push($comment, $cdata);
-                $commentres->MoveNext();
             }
         } else {
             $comment = "None";
@@ -675,11 +691,10 @@ while (!$res->EOF) {
 
     $data['ub_reason']   = (isset($data['ub_reason']) ? $data['ub_reason'] : "");
     $data['banlength']   = $data['ban_length'] . " " . $data['ub_reason'];
-    $data['view_edit']   = ($userbank->HasAccess(ADMIN_OWNER | ADMIN_EDIT_ALL_BANS) || ($userbank->HasAccess(ADMIN_EDIT_OWN_BANS) && $res->fields['aid'] == $userbank->GetAid()) || ($userbank->HasAccess(ADMIN_EDIT_GROUP_BANS) && $res->fields['gid'] == $userbank->GetProperty('gid')));
-    $data['view_unban']  = ($userbank->HasAccess(ADMIN_OWNER | ADMIN_UNBAN) || ($userbank->HasAccess(ADMIN_UNBAN_OWN_BANS) && $res->fields['aid'] == $userbank->GetAid()) || ($userbank->HasAccess(ADMIN_UNBAN_GROUP_BANS) && $res->fields['gid'] == $userbank->GetProperty('gid')));
+    $data['view_edit']   = ($userbank->HasAccess(ADMIN_OWNER | ADMIN_EDIT_ALL_BANS) || ($userbank->HasAccess(ADMIN_EDIT_OWN_BANS) && $row['aid'] == $userbank->GetAid()) || ($userbank->HasAccess(ADMIN_EDIT_GROUP_BANS) && $row['gid'] == $userbank->GetProperty('gid')));
+    $data['view_unban']  = ($userbank->HasAccess(ADMIN_OWNER | ADMIN_UNBAN) || ($userbank->HasAccess(ADMIN_UNBAN_OWN_BANS) && $row['aid'] == $userbank->GetAid()) || ($userbank->HasAccess(ADMIN_UNBAN_GROUP_BANS) && $row['gid'] == $userbank->GetProperty('gid')));
     $data['view_delete'] = ($userbank->HasAccess(ADMIN_OWNER | ADMIN_DELETE_BAN));
     array_push($bans, $data);
-    $res->MoveNext();
 }
 
 if (isset($_GET['advSearch'])) {
@@ -737,40 +752,41 @@ if ($pages > 1) {
 if (isset($_GET["comment"])) {
     $theme->assign('commenttype', (isset($_GET["cid"]) ? "Edit" : "Add"));
     if (isset($_GET["cid"])) {
-        $ceditdata      = $GLOBALS['db']->GetRow("SELECT * FROM " . DB_PREFIX . "_comments WHERE cid = '" . (int) $_GET["cid"] . "'");
+        $GLOBALS['PDO']->query("SELECT * FROM `:prefix_comments` WHERE cid = :cid");
+        $GLOBALS['PDO']->bind(':cid', (int) $_GET["cid"]);
+        $ceditdata      = $GLOBALS['PDO']->single();
         $ctext          = html_entity_decode($ceditdata['commenttxt'], ENT_QUOTES | ENT_HTML5, 'UTF-8');
         $cotherdataedit = " AND cid != '" . (int) $_GET["cid"] . "'";
     } else {
         $cotherdataedit = "";
         $ctext          = "";
     }
-    $cotherdata = $GLOBALS['db']->Execute("SELECT cid, aid, commenttxt, added, edittime,
-											(SELECT user FROM `" . DB_PREFIX . "_admins` WHERE aid = C.aid) AS comname,
-											(SELECT user FROM `" . DB_PREFIX . "_admins` WHERE aid = C.editaid) AS editname
-											FROM `" . DB_PREFIX . "_comments` AS C
-											WHERE type = ? AND bid = ?" . $cotherdataedit . " ORDER BY added desc", array(
+    $cotherdata = $GLOBALS['PDO']->query("SELECT cid, aid, commenttxt, added, edittime,
+											(SELECT user FROM `:prefix_admins` WHERE aid = C.aid) AS comname,
+											(SELECT user FROM `:prefix_admins` WHERE aid = C.editaid) AS editname
+											FROM `:prefix_comments` AS C
+											WHERE type = ? AND bid = ?" . $cotherdataedit . " ORDER BY added desc")->resultset(array(
         $_GET["ctype"],
         $_GET["comment"]
     ));
 
     $ocomments = [];
-    while (!$cotherdata->EOF) {
+    foreach ($cotherdata as $cdrow) {
         $coment               = [];
-        $coment['comname']    = $cotherdata->fields['comname'];
-        $coment['added']      = Config::time($cotherdata->fields['added']);
-        $commentText          = html_entity_decode($cotherdata->fields['commenttxt'], ENT_QUOTES | ENT_HTML5, 'UTF-8');
+        $coment['comname']    = $cdrow['comname'];
+        $coment['added']      = Config::time($cdrow['added']);
+        $commentText          = html_entity_decode($cdrow['commenttxt'], ENT_QUOTES | ENT_HTML5, 'UTF-8');
         $commentText          = encodePreservingBr($commentText);
         $commentText          = preg_replace('@(https?://([-\w\.]+)+(:\d+)?(/([\w/_\.]*(\?\S+)?)?)?)@', '<a href="$1" target="_blank">$1</a>', $commentText);
         $coment['commenttxt'] = $commentText;
-        if ($cotherdata->fields['editname'] != "") {
-            $coment['edittime'] = Config::time($cotherdata->fields['edittime']);
-            $coment['editname'] = $cotherdata->fields['editname'];
+        if ($cdrow['editname'] != "") {
+            $coment['edittime'] = Config::time($cdrow['edittime']);
+            $coment['editname'] = $cdrow['editname'];
         } else {
             $coment['editname'] = "";
             $coment['edittime'] = "";
         }
         array_push($ocomments, $coment);
-        $cotherdata->MoveNext();
     }
 
     $theme->assign('page', (isset($_GET["page"]) ? $_GET["page"] : -1));

--- a/web/pages/page.home.php
+++ b/web/pages/page.home.php
@@ -24,21 +24,20 @@ if (!defined("IN_SB")) {
 }
 define('IN_HOME', true);
 
-$res          = $GLOBALS['db']->Execute("SELECT count(name) FROM " . DB_PREFIX . "_banlog");
-$totalstopped = (int) $res->fields[0];
+$totalstopped = (int) $GLOBALS['PDO']->query("SELECT count(name) AS cnt FROM `:prefix_banlog`")->single()['cnt'];
 
-$res = $GLOBALS['db']->Execute("SELECT bl.name, time, bl.sid, bl.bid, b.type, b.authid, b.ip
-								FROM " . DB_PREFIX . "_banlog AS bl
-								LEFT JOIN " . DB_PREFIX . "_bans AS b ON b.bid = bl.bid
-								ORDER BY time DESC LIMIT 10");
+$rows = $GLOBALS['PDO']->query("SELECT bl.name, time, bl.sid, bl.bid, b.type, b.authid, b.ip
+								FROM `:prefix_banlog` AS bl
+								LEFT JOIN `:prefix_bans` AS b ON b.bid = bl.bid
+								ORDER BY time DESC LIMIT 10")->resultset();
 
 $GLOBALS['server_qry'] = "";
 $stopped               = [];
 $blcount               = 0;
-while (!$res->EOF) {
+foreach ($rows as $row) {
     $info               = [];
-    $info['date']       = Config::time($res->fields[1]);
-    $raw_name           = htmlspecialchars(stripslashes((string) $res->fields[0]), ENT_NOQUOTES, 'UTF-8');
+    $info['date']       = Config::time($row['time']);
+    $raw_name           = htmlspecialchars(stripslashes((string) $row['name']), ENT_NOQUOTES, 'UTF-8');
     $cleaned_name       = mb_convert_encoding($raw_name, 'UTF-8', 'UTF-8');
     $unwanted_sequences = ["\xF3\xA0\x80\xA1"];
     foreach ($unwanted_sequences as $sequence) {
@@ -47,11 +46,11 @@ while (!$res->EOF) {
     $cleaned_name = trim($cleaned_name);
     $info['name']       = htmlspecialchars(addslashes($cleaned_name), ENT_QUOTES, 'UTF-8');
     $info['short_name'] = trunc($cleaned_name, 40);
-    $info['auth']       = $res->fields['authid'];
-    $info['ip']         = $res->fields['ip'];
-    $info['server']     = "block_" . $res->fields['sid'] . "_$blcount";
+    $info['auth']       = $row['authid'];
+    $info['ip']         = $row['ip'];
+    $info['server']     = "block_" . $row['sid'] . "_$blcount";
 
-    if ($res->fields['type'] == 1) {
+    if ($row['type'] == 1) {
         if ($userbank->is_admin())
             $info['search_link'] = 'index.php?p=banlist&advSearch=' . urlencode($info['ip']) . '&advType=ip&Submit';
         else
@@ -67,36 +66,34 @@ while (!$res->EOF) {
     }
     $info['popup']    = "ShowBox('Blocked player: " . $cleaned_name . "', '" . $cleaned_name . " tried to enter<br />' + document.getElementById('" . $info['server'] . "').title + '<br />at " . $info['date'] . "<br /><div align=middle><a href=" . $info['search_link'] . ">Click here for ban details.</a></div>', 'red', '', true);";
 
-    $GLOBALS['server_qry'] .= "xajax_ServerHostProperty(" . $res->fields['sid'] . ", 'block_" . $res->fields['sid'] . "_$blcount', 'title', 100);";
+    $GLOBALS['server_qry'] .= "xajax_ServerHostProperty(" . $row['sid'] . ", 'block_" . $row['sid'] . "_$blcount', 'title', 100);";
 
     $stopped []= $info;
-    $res->MoveNext();
     ++$blcount;
 }
 
-$res      = $GLOBALS['db']->Execute("SELECT count(bid) FROM " . DB_PREFIX . "_bans");
-$BanCount = (int) $res->fields[0];
+$BanCount = (int) $GLOBALS['PDO']->query("SELECT count(bid) AS cnt FROM `:prefix_bans`")->single()['cnt'];
 
-$res  = $GLOBALS['db']->Execute("SELECT bid, ba.ip, ba.authid, ba.name, created, ends, length, reason, ba.aid, ba.sid, ad.user, CONCAT(se.ip,':',se.port), se.sid, mo.icon, ba.RemoveType, ba.type
-			    				FROM " . DB_PREFIX . "_bans AS ba
-			    				LEFT JOIN " . DB_PREFIX . "_admins AS ad ON ba.aid = ad.aid
-			    				LEFT JOIN " . DB_PREFIX . "_servers AS se ON se.sid = ba.sid
-			    				LEFT JOIN " . DB_PREFIX . "_mods AS mo ON mo.mid = se.modid
-			    				ORDER BY created DESC LIMIT 10");
+$rows = $GLOBALS['PDO']->query("SELECT bid, ba.ip, ba.authid, ba.name, created, ends, length, reason, ba.aid, ba.sid AS ba_sid, ad.user, CONCAT(se.ip,':',se.port) AS server_addr, se.sid AS se_sid, mo.icon, ba.RemoveType, ba.type
+			    				FROM `:prefix_bans` AS ba
+			    				LEFT JOIN `:prefix_admins` AS ad ON ba.aid = ad.aid
+			    				LEFT JOIN `:prefix_servers` AS se ON se.sid = ba.sid
+			    				LEFT JOIN `:prefix_mods` AS mo ON mo.mid = se.modid
+			    				ORDER BY created DESC LIMIT 10")->resultset();
 $bans = [];
-while (!$res->EOF) {
+foreach ($rows as $row) {
     $info = [];
     $info['temp']     = false;
     $info['perm']     = false;
     $info['unbanned'] = false;
-    if ($res->fields['length'] == 0) {
+    if ($row['length'] == 0) {
         $info['perm']     = true;
         $info['unbanned'] = false;
     } else {
         $info['temp']     = true;
         $info['unbanned'] = false;
     }
-    $raw_name         = stripslashes($res->fields[3]);
+    $raw_name         = stripslashes($row['name']);
     $cleaned_name     = mb_convert_encoding($raw_name, 'UTF-8', 'UTF-8');
     $unwanted_sequences = ["\xF3\xA0\x80\xA1"];
     foreach ($unwanted_sequences as $sequence) {
@@ -104,13 +101,13 @@ while (!$res->EOF) {
     }
     $cleaned_name = trim($cleaned_name);
     $info['name']    = htmlspecialchars(addslashes($cleaned_name), ENT_QUOTES, 'UTF-8');
-    $info['created'] = Config::time($res->fields['created']);
-    $ltemp           = explode(",", $res->fields[6] == 0 ? 'Permanent' : SecondsToString(intval($res->fields[6])));
+    $info['created'] = Config::time($row['created']);
+    $ltemp           = explode(",", $row['length'] == 0 ? 'Permanent' : SecondsToString(intval($row['length'])));
     $info['length']  = $ltemp[0];
-    $info['icon']    = empty($res->fields[13]) ? 'web.png' : $res->fields[13];
-    $info['authid']  = $res->fields[2];
-    $info['ip']      = $res->fields[1];
-    if ($res->fields[15] == 1) {
+    $info['icon']    = empty($row['icon']) ? 'web.png' : $row['icon'];
+    $info['authid']  = $row['authid'];
+    $info['ip']      = $row['ip'];
+    if ($row['type'] == 1) {
         if ($userbank->is_admin())
             $info['search_link'] = 'index.php?p=banlist&advSearch=' . urlencode($info['ip']) . '&advType=ip&Submit';
         else
@@ -121,12 +118,12 @@ while (!$res->EOF) {
     $info['link_url']   = "window.location = '" . $info['search_link'] . "';";
     $info['short_name'] = trunc($cleaned_name, 40);
 
-    if ($res->fields[14] == 'D' || $res->fields[14] == 'U' || $res->fields[14] == 'E' || ($res->fields[6] && $res->fields[5] < time())) {
+    if ($row['RemoveType'] == 'D' || $row['RemoveType'] == 'U' || $row['RemoveType'] == 'E' || ($row['length'] && $row['ends'] < time())) {
         $info['unbanned'] = true;
 
-        if ($res->fields[14] == 'D') {
+        if ($row['RemoveType'] == 'D') {
             $info['ub_reason'] = 'D';
-        } elseif ($res->fields[14] == 'U') {
+        } elseif ($row['RemoveType'] == 'U') {
             $info['ub_reason'] = 'U';
         } else {
             $info['ub_reason'] = 'E';
@@ -136,33 +133,31 @@ while (!$res->EOF) {
     }
 
     array_push($bans, $info);
-    $res->MoveNext();
 }
 
-$res       = $GLOBALS['db']->Execute("SELECT count(bid) FROM " . DB_PREFIX . "_comms");
-$CommCount = (int) $res->fields[0];
+$CommCount = (int) $GLOBALS['PDO']->query("SELECT count(bid) AS cnt FROM `:prefix_comms`")->single()['cnt'];
 
-$res   = $GLOBALS['db']->Execute("SELECT bid, ba.authid, ba.type, ba.name, created, ends, length, reason, ba.aid, ba.sid, ad.user, CONCAT(se.ip,':',se.port), se.sid, mo.icon, ba.RemoveType, ba.type
-				    				FROM " . DB_PREFIX . "_comms AS ba
-				    				LEFT JOIN " . DB_PREFIX . "_admins AS ad ON ba.aid = ad.aid
-				    				LEFT JOIN " . DB_PREFIX . "_servers AS se ON se.sid = ba.sid
-				    				LEFT JOIN " . DB_PREFIX . "_mods AS mo ON mo.mid = se.modid
-				    				ORDER BY created DESC LIMIT 10");
+$rows = $GLOBALS['PDO']->query("SELECT bid, ba.authid, ba.type, ba.name, created, ends, length, reason, ba.aid, ba.sid AS ba_sid, ad.user, CONCAT(se.ip,':',se.port) AS server_addr, se.sid AS se_sid, mo.icon, ba.RemoveType
+				    				FROM `:prefix_comms` AS ba
+				    				LEFT JOIN `:prefix_admins` AS ad ON ba.aid = ad.aid
+				    				LEFT JOIN `:prefix_servers` AS se ON se.sid = ba.sid
+				    				LEFT JOIN `:prefix_mods` AS mo ON mo.mid = se.modid
+				    				ORDER BY created DESC LIMIT 10")->resultset();
 $comms = [];
-while (!$res->EOF) {
+foreach ($rows as $row) {
     $info = [];
     $info['temp']     = false;
     $info['perm']     = false;
     $info['unbanned'] = false;
 
-    if ($res->fields['length'] == 0) {
+    if ($row['length'] == 0) {
         $info['perm']     = true;
         $info['unbanned'] = false;
     } else {
         $info['temp']     = true;
         $info['unbanned'] = false;
     }
-    $raw_name             = stripslashes($res->fields[3]);
+    $raw_name             = stripslashes($row['name']);
     $cleaned_name         = mb_convert_encoding($raw_name, 'UTF-8', 'UTF-8');
     $unwanted_sequences   = ["\xF3\xA0\x80\xA1"];
     foreach ($unwanted_sequences as $sequence) {
@@ -170,22 +165,22 @@ while (!$res->EOF) {
     }
     $cleaned_name = trim($cleaned_name);
     $info['name']        = htmlspecialchars(addslashes($cleaned_name), ENT_QUOTES, 'UTF-8');
-    $info['created']     = Config::time($res->fields['created']);
-    $ltemp               = explode(",", $res->fields[6] == 0 ? 'Permanent' : SecondsToString(intval($res->fields[6])));
+    $info['created']     = Config::time($row['created']);
+    $ltemp               = explode(",", $row['length'] == 0 ? 'Permanent' : SecondsToString(intval($row['length'])));
     $info['length']      = $ltemp[0];
-    $info['icon']        = empty($res->fields[13]) ? 'web.png' : $res->fields[13];
-    $info['authid']      = $res->fields['authid'];
+    $info['icon']        = empty($row['icon']) ? 'web.png' : $row['icon'];
+    $info['authid']      = $row['authid'];
     $info['search_link'] = 'index.php?p=commslist&advSearch=' . urlencode($info['authid']) . '&advType=steamid&Submit';
     $info['link_url']    = "window.location = '" . $info['search_link'] . "';";
     $info['short_name']  = trunc($cleaned_name, 40);
-    $info['type']        = $res->fields['type'] == 2 ? "fas fa-comment-slash fa-lg" : "fas fa-microphone-slash fa-lg";
+    $info['type']        = $row['type'] == 2 ? "fas fa-comment-slash fa-lg" : "fas fa-microphone-slash fa-lg";
 
-    if ($res->fields[14] == 'D' || $res->fields[14] == 'U' || $res->fields[14] == 'E' || ($res->fields[6] && $res->fields[5] < time())) {
+    if ($row['RemoveType'] == 'D' || $row['RemoveType'] == 'U' || $row['RemoveType'] == 'E' || ($row['length'] && $row['ends'] < time())) {
         $info['unbanned'] = true;
 
-        if ($res->fields[14] == 'D') {
+        if ($row['RemoveType'] == 'D') {
             $info['ub_reason'] = 'D';
-        } elseif ($res->fields[14] == 'U') {
+        } elseif ($row['RemoveType'] == 'U') {
             $info['ub_reason'] = 'U';
         } else {
             $info['ub_reason'] = 'E';
@@ -195,7 +190,6 @@ while (!$res->EOF) {
     }
 
     array_push($comms, $info);
-    $res->MoveNext();
 }
 
 

--- a/web/pages/page.protest.php
+++ b/web/pages/page.protest.php
@@ -53,17 +53,18 @@ if (!isset($_POST['subprotest']) || $_POST['subprotest'] != 1) {
         $errors .= '* Please type a valid STEAM ID.<br>';
         $validsubmit = false;
     } elseif ($Type == 0) {
-        $pre = $GLOBALS['db']->Prepare("SELECT bid FROM " . DB_PREFIX . "_bans WHERE authid=? AND RemovedBy IS NULL AND type=0;");
-        $res = $GLOBALS['db']->Execute($pre, array(
-            $SteamID
-        ));
-        if ($res->RecordCount() == 0) {
+        $GLOBALS['PDO']->query("SELECT bid FROM `:prefix_bans` WHERE authid = :authid AND RemovedBy IS NULL AND type = 0");
+        $GLOBALS['PDO']->bind(':authid', $SteamID);
+        $res = $GLOBALS['PDO']->resultset();
+        if (count($res) == 0) {
             $errors .= '* That Steam ID is not banned!<br>';
             $validsubmit = false;
         } else {
-            $BanId = (int) $res->fields[0];
-            $res   = $GLOBALS['db']->Execute("SELECT pid FROM " . DB_PREFIX . "_protests WHERE bid=$BanId");
-            if ($res->RecordCount() > 0) {
+            $BanId = (int) $res[0]['bid'];
+            $GLOBALS['PDO']->query("SELECT pid FROM `:prefix_protests` WHERE bid = :bid");
+            $GLOBALS['PDO']->bind(':bid', $BanId);
+            $res   = $GLOBALS['PDO']->resultset();
+            if (count($res) > 0) {
                 $errors .= '* A protest is already pending for this Steam ID.<br>';
                 $validsubmit = false;
             }
@@ -73,17 +74,18 @@ if (!isset($_POST['subprotest']) || $_POST['subprotest'] != 1) {
         $errors .= '* Please type a valid IP.<br>';
         $validsubmit = false;
     } elseif ($Type == 1) {
-        $pre = $GLOBALS['db']->Prepare("SELECT bid FROM " . DB_PREFIX . "_bans WHERE ip=? AND RemovedBy IS NULL AND type=1;");
-        $res = $GLOBALS['db']->Execute($pre, array(
-            $IP
-        ));
-        if ($res->RecordCount() == 0) {
+        $GLOBALS['PDO']->query("SELECT bid FROM `:prefix_bans` WHERE ip = :ip AND RemovedBy IS NULL AND type = 1");
+        $GLOBALS['PDO']->bind(':ip', $IP);
+        $res = $GLOBALS['PDO']->resultset();
+        if (count($res) == 0) {
             $errors .= '* That IP is not banned!<br>';
             $validsubmit = false;
         } else {
-            $BanId = (int) $res->fields[0];
-            $res   = $GLOBALS['db']->Execute("SELECT pid FROM " . DB_PREFIX . "_protests WHERE bid=$BanId");
-            if ($res->RecordCount() > 0) {
+            $BanId = (int) $res[0]['bid'];
+            $GLOBALS['PDO']->query("SELECT pid FROM `:prefix_protests` WHERE bid = :bid");
+            $GLOBALS['PDO']->bind(':bid', $BanId);
+            $res   = $GLOBALS['PDO']->resultset();
+            if (count($res) > 0) {
                 $errors .= '* A protest is already pending for this IP.<br>';
                 $validsubmit = false;
             }
@@ -108,15 +110,18 @@ if (!isset($_POST['subprotest']) || $_POST['subprotest'] != 1) {
 
     if ($validsubmit && $BanId != -1) {
         $UnbanReason = trim($UnbanReason);
-        $pre         = $GLOBALS['db']->Prepare("INSERT INTO " . DB_PREFIX . "_protests(bid,datesubmitted,reason,email,archiv,pip) VALUES (?,UNIX_TIMESTAMP(),?,?,0,?)");
-        $res         = $GLOBALS['db']->Execute($pre, array(
-            $BanId,
-            $UnbanReason,
-            $Email,
-            $_SERVER['REMOTE_ADDR']
-        ));
-        $protid      = $GLOBALS['db']->Insert_ID();
-        $protadmin   = $GLOBALS['db']->GetRow("SELECT ad.user FROM " . DB_PREFIX . "_protests p, " . DB_PREFIX . "_admins ad, " . DB_PREFIX . "_bans b WHERE p.pid = '" . $protid . "' AND b.bid = p.bid AND ad.aid = b.aid");
+        $GLOBALS['PDO']->query("INSERT INTO `:prefix_protests`(bid,datesubmitted,reason,email,archiv,pip) VALUES (:bid,UNIX_TIMESTAMP(),:reason,:email,0,:pip)");
+        $GLOBALS['PDO']->bindMultiple([
+            ':bid'    => $BanId,
+            ':reason' => $UnbanReason,
+            ':email'  => $Email,
+            ':pip'    => $_SERVER['REMOTE_ADDR'],
+        ]);
+        $GLOBALS['PDO']->execute();
+        $protid    = $GLOBALS['PDO']->lastInsertId();
+        $GLOBALS['PDO']->query("SELECT ad.user FROM `:prefix_protests` p, `:prefix_admins` ad, `:prefix_bans` b WHERE p.pid = :pid AND b.bid = p.bid AND ad.aid = b.aid");
+        $GLOBALS['PDO']->bind(':pid', $protid);
+        $protadmin = $GLOBALS['PDO']->single();
 
         $Type        = 0;
         $SteamID     = "";
@@ -128,14 +133,16 @@ if (!isset($_POST['subprotest']) || $_POST['subprotest'] != 1) {
         // Send an email when protest was posted
         $headers = 'From: ' . SB_EMAIL . "\n" . 'X-Mailer: PHP/' . phpversion();
 
-        $emailinfo = $GLOBALS['db']->Execute("SELECT aid, user, email FROM `" . DB_PREFIX . "_admins` WHERE aid = (SELECT aid FROM `" . DB_PREFIX . "_bans` WHERE bid = '" . (int) $BanId . "');");
+        $GLOBALS['PDO']->query("SELECT aid, user, email FROM `:prefix_admins` WHERE aid = (SELECT aid FROM `:prefix_bans` WHERE bid = :bid)");
+        $GLOBALS['PDO']->bind(':bid', (int) $BanId);
+        $emailinfo = $GLOBALS['PDO']->single();
         $requri    = substr($_SERVER['REQUEST_URI'], 0, strrpos($_SERVER['REQUEST_URI'], ".php") + 4);
-        if (Config::getBool('protest.emailonlyinvolved') && !empty($emailinfo->fields['email'])) {
+        if (Config::getBool('protest.emailonlyinvolved') && !empty($emailinfo['email'])) {
             $admins = array(
                 array(
-                    'aid' => $emailinfo->fields['aid'],
-                    'user' => $emailinfo->fields['user'],
-                    'email' => $emailinfo->fields['email']
+                    'aid' => $emailinfo['aid'],
+                    'user' => $emailinfo['user'],
+                    'email' => $emailinfo['email']
                 )
             );
         } else {

--- a/web/pages/page.submit.php
+++ b/web/pages/page.submit.php
@@ -80,11 +80,10 @@ if (!isset($_POST['subban']) || $_POST['subban'] != 1) {
             $validsubmit = false;
         }
     }
-    $checkres = $GLOBALS['db']->Execute("SELECT length FROM " . DB_PREFIX . "_bans WHERE authid = ? AND RemoveType IS NULL", array(
-        $SteamID
-    ));
-    $numcheck = $checkres->RecordCount();
-    if ($numcheck == 1 && $checkres->fields['length'] == 0) {
+    $GLOBALS['PDO']->query("SELECT length FROM `:prefix_bans` WHERE authid = :authid AND RemoveType IS NULL");
+    $GLOBALS['PDO']->bind(':authid', $SteamID);
+    $checkres = $GLOBALS['PDO']->resultset();
+    if (count($checkres) == 1 && $checkres[0]['length'] == 0) {
         $errors .= '* The player is already banned permanent.<br>';
         $validsubmit = false;
     }
@@ -130,8 +129,7 @@ if (!isset($_POST['subban']) || $_POST['subban'] != 1) {
             if ($SteamID == "STEAM_0:") {
                 $SteamID = "";
             }
-            $pre = $GLOBALS['db']->Prepare("INSERT INTO " . DB_PREFIX . "_submissions(submitted,SteamId,name,email,ModID,reason,ip,subname,sip,archiv,server) VALUES (UNIX_TIMESTAMP(),?,?,?,?,?,?,?,?,0,?)");
-            $GLOBALS['db']->Execute($pre, array(
+            $GLOBALS['PDO']->query("INSERT INTO `:prefix_submissions`(submitted,SteamId,name,email,ModID,reason,ip,subname,sip,archiv,server) VALUES (UNIX_TIMESTAMP(),?,?,?,?,?,?,?,?,0,?)")->execute([
                 $SteamID,
                 $PlayerName,
                 $Email,
@@ -140,16 +138,16 @@ if (!isset($_POST['subban']) || $_POST['subban'] != 1) {
                 $_SERVER['REMOTE_ADDR'],
                 $SubmitterName,
                 $BanIP,
-                $SID
-            ));
-            $subid = (int) $GLOBALS['db']->Insert_ID();
+                $SID,
+            ]);
+            $subid = (int) $GLOBALS['PDO']->lastInsertId();
 
             if (!empty($_FILES['demo_file']['name'])) {
-                $GLOBALS['db']->Execute("INSERT INTO " . DB_PREFIX . "_demos(demid,demtype,filename,origname) VALUES (?, 'S', ?, ?)", array(
+                $GLOBALS['PDO']->query("INSERT INTO `:prefix_demos`(demid,demtype,filename,origname) VALUES (?, 'S', ?, ?)")->execute([
                     $subid,
                     $filename,
-                    $_FILES['demo_file']['name']
-                ));
+                    $_FILES['demo_file']['name'],
+                ]);
             }
             $SteamID       = "";
             $BanIP         = "";

--- a/web/phpstan-baseline.neon
+++ b/web/phpstan-baseline.neon
@@ -715,12 +715,6 @@ parameters:
 			path: install/template/submenu.php
 
 		-
-			message: '#^Variable \$accessaid might not be defined\.$#'
-			identifier: variable.undefined
-			count: 2
-			path: pages/admin.admins.php
-
-		-
 			message: '#^Call to method addAssign\(\) on an unknown class xajaxResponse\.$#'
 			identifier: class.notFound
 			count: 5
@@ -1015,12 +1009,6 @@ parameters:
 			path: pages/page.banlist.php
 
 		-
-			message: '#^Variable \$res_count might not be defined\.$#'
-			identifier: variable.undefined
-			count: 1
-			path: pages/page.banlist.php
-
-		-
 			message: '#^Variable \$searchlink might not be defined\.$#'
 			identifier: variable.undefined
 			count: 1
@@ -1052,12 +1040,6 @@ parameters:
 
 		-
 			message: '#^Variable \$res might not be defined\.$#'
-			identifier: variable.undefined
-			count: 1
-			path: pages/page.commslist.php
-
-		-
-			message: '#^Variable \$res_count might not be defined\.$#'
 			identifier: variable.undefined
 			count: 1
 			path: pages/page.commslist.php


### PR DESCRIPTION
## Summary
- Completes the migration started in #1091 (refs #1078). Every remaining `\$GLOBALS['db']` call site — ~270 of them, including the 115 in `web/includes/sb-callback.php` — now goes through the PDO `Database` wrapper at `web/includes/Database.php`.
- Drops `adodb/adodb-php` from `web/composer.json` and removes the `\$GLOBALS['db']` / `SET NAMES` bootstrap from `web/init.php`. Composer lockfile and vendor tree refreshed.
- After this PR, `grep -r 'GLOBALS\[.db.\]' web/` returns nothing.

Notable changes beyond mechanical translation:
- `NormalAuthHandler::__construct` is now typed as `Database $dbs`, so its `Prepare`/`Execute` pattern is replaced with the same `query`/`bind`/`single`/`execute` calls used everywhere else.
- Search/filter clauses in `admin.admins.php`, `page.banlist.php`, and `page.commslist.php` build positional `?` placeholders into a `\$whereParams` array instead of going through ADOdb's `qstr()` + string concat. User input no longer lands in a SQL string literal.
- A handful of queries that relied on ADOdb's mixed numeric/assoc recordset (e.g. `\$row[12]` for `CONCAT(se.ip,':',se.port)`) were given explicit aliases so PDO `FETCH_ASSOC` keeps the same fields reachable.
- Three PHPStan baseline entries (`\$accessaid` in `admin.admins.php`, `\$res_count` in `page.banlist.php` / `page.commslist.php`) became unmatched once the conditional-init paths that produced them were rewritten — pruned from the baseline. PHPStan level 4 still green locally.

Closes #1078

## Test plan
- [ ] CI: PHPStan (already green locally via Docker)
- [ ] Login flow (normal + lockout), logout, lost password
- [ ] Admin home dashboard renders blocks/bans/comms counts and feeds
- [ ] Bans tab: list, search (free-text + each advSearch type), edit, unban, delete (single + bulk), reban, friends/group ban
- [ ] Comms tab: list, search (free-text + each advSearch type), edit, ungag, unmute, delete
- [ ] Admin management: list, search (each advSearch type incl. webflag/srvflag/server), add, edit details, edit groups, edit server access, edit permissions, delete
- [ ] Servers tab: list, add, edit, RCON, kickit, blockit
- [ ] Groups tab: list, add (web + srv-admin + server), edit
- [ ] MODs tab: list, add, edit
- [ ] Settings: main settings save, features save, theme list, system log + clear
- [ ] Submit form (logged out + logged in, with/without demo) and Protest form
- [ ] Public banlist + commslist
- [ ] `getdemo.php`, `exportbans.php?type=steam|ip`
- [ ] Comments add/edit/remove on bans, comms, submissions, protests