### PR TITLE
fix(web): stream exportbans rows instead of buffering full result

### DIFF
--- a/web/exportbans.php
+++ b/web/exportbans.php
@@ -10,7 +10,7 @@ if (!$userbank->HasAccess(ADMIN_OWNER) && !Config::getBool('config.exportpublic'
         header('Content-Disposition: attachment; filename="banned_user.cfg"');
         $bans = $GLOBALS['PDO']->query(
             "SELECT authid FROM `:prefix_bans` WHERE length = '0' AND RemoveType IS NULL AND type = '0'"
-        )->resultset();
+        )->iterate();
         foreach ($bans as $ban) {
             print("banid 0 " . $ban['authid'] . "\r\n");
         }
@@ -19,7 +19,7 @@ if (!$userbank->HasAccess(ADMIN_OWNER) && !Config::getBool('config.exportpublic'
         header('Content-Disposition: attachment; filename="banned_ip.cfg"');
         $bans = $GLOBALS['PDO']->query(
             "SELECT ip FROM `:prefix_bans` WHERE length = '0' AND RemoveType IS NULL AND type = '1'"
-        )->resultset();
+        )->iterate();
         foreach ($bans as $ban) {
             print("addip 0 " . $ban['ip'] . "\r\n");
         }

--- a/web/includes/Database.php
+++ b/web/includes/Database.php
@@ -133,6 +133,18 @@ class Database
     }
 
     /**
+     * Yields rows one at a time so callers can stream large result sets
+     * without materialising the full set in PHP memory like resultset() does.
+     */
+    public function iterate(?array $inputParams = null, $fetchType = PDO::FETCH_ASSOC): Generator
+    {
+        $this->execute($inputParams);
+        while (($row = $this->stmt->fetch($fetchType)) !== false) {
+            yield $row;
+        }
+    }
+
+    /**
      * @return int
      */
     public function rowCount()


### PR DESCRIPTION
## Summary
- Addresses both Copilot review comments on #1091 about a memory/runtime regression in `web/exportbans.php`. The migration replaced the ADOdb cursor loop (`Execute` + `MoveNext` + `->fields[…]`) with `resultset()`, which calls `fetchAll()` and materialises the entire permanent-ban list in PHP memory before any output is written. On larger installs that can OOM or time out where the previous row-at-a-time loop kept working.
- Adds an `iterate()` generator on the `Database` wrapper that yields rows one at a time via `fetch()`, and switches both branches of `exportbans.php` (`type=steam`, `type=ip`) to use it. The `foreach` bodies are unchanged — each row is printed and discarded — so the streaming semantics of the original loop are restored.
- No other PR #1091 file uses `resultset()` over a potentially large set; the rest are admin/server dropdowns or single-row lookups.

Refs review thread: https://github.com/sbpp/sourcebans-pp/pull/1091#pullrequestreview-4216537467

## Test plan
- [ ] PHPStan (CI) passes — `iterate()` is typed `: Generator` so the return path stays inferred.
- [ ] Manual: hit `exportbans.php?type=steam` while logged in as owner; confirm `banned_user.cfg` downloads with one `banid 0 <authid>` line per permanent Steam ban.
- [ ] Manual: hit `exportbans.php?type=ip` while logged in as owner; confirm `banned_ip.cfg` downloads with one `addip 0 <ip>` line per permanent IP ban.
- [ ] Manual: with a non-trivial ban set, confirm the response starts streaming (first bytes arrive before the query has fully drained) rather than waiting for the full list to buffer.