### PR TITLE
feat(migrator): idempotent schema migrator for 1.x → 2.0 upgrades (#1111)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,7 +23,7 @@ code change — never as a follow-up. CI doesn't gate this; it's on you.
 | Add/rename/remove a top-level subsystem in `web/includes/`  | `ARCHITECTURE.md` (Web panel → Directory layout, and the relevant subsystem section) |
 | Change a request lifecycle (page or JSON API)               | `ARCHITECTURE.md` (the lifecycle section + any diagrams) |
 | Add an API handler **topic file** (new file in `api/handlers/`) | `ARCHITECTURE.md` (handler list under "Handler registration") |
-| Add or rename a DB table, or change the schema substantively | `ARCHITECTURE.md` (Database schema table) + ensure `install/includes/sql/struc.sql` is the source of truth |
+| Add or rename a DB table, or change the schema substantively | `ARCHITECTURE.md` (Database schema table) + ensure `install/includes/sql/struc.sql` is the source of truth (the migrator at `web/includes/Migrator/` reads it directly to back-fill upgrading panels) |
 | Add or remove a quality gate / CI workflow                  | `ARCHITECTURE.md` (Quality gates) **and** `AGENTS.md` (Quality gates) |
 | Change a `./sbpp.sh` command surface                        | `AGENTS.md` (Dev commands) + `docker/README.md`       |
 | Introduce a new convention or pattern (e.g. View DTOs)      | `AGENTS.md` (Conventions) + `ARCHITECTURE.md` if it's an architectural shift |
@@ -142,6 +142,13 @@ API-contract specifics:
   `Database::query()` rewrites the placeholder. Never inline the prefix.
 - Pattern: `query` → `bind` → `execute` / `single` / `resultset`.
 - ADOdb was fully removed (commit `b9c812b2`). **Do not reintroduce it.**
+- Schema additions for 1.x → 2.0 go in `web/install/includes/sql/struc.sql`
+  (or `data.sql` for new `sb_settings` keys). The
+  `web/includes/Migrator/` runner reads those files as the source of
+  truth and back-fills any deployed panel through
+  `php web/bin/upgrade.php` (CLI) or `?p=admin&c=upgrade` (panel page,
+  `ADMIN_OWNER` only). Do **not** add new files under `web/install/` or
+  `web/updater/` for this work.
 
 ### JSON API
 
@@ -245,5 +252,6 @@ API-contract specifics:
 | Auth / JWT cookie                      | `web/includes/auth/`                                     |
 | CSRF                                   | `web/includes/security/CSRF.php`                         |
 | Schema                                 | `web/install/includes/sql/struc.sql`                     |
+| 1.x → 2.0 schema migrator              | `web/includes/Migrator/` + `web/bin/upgrade.php` + `?p=admin&c=upgrade` |
 | Test fixtures                          | `web/tests/Fixture.php`, `web/tests/ApiTestCase.php`     |
 | Local dev stack details                | `docker/README.md`                                       |

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -86,6 +86,7 @@ web/
 │   ├── system-functions.php  Legacy helpers shared across pages
 │   ├── SmartyCustomFunctions.php  {help_icon} / {csrf_field} / {load_template}
 │   ├── View/                 Typed Smarty view-model DTOs
+│   ├── Migrator/             1.x → 2.0 schema migrator (CLI + JSON API + panel page)
 │   ├── auth/                 JWT cookie auth + Steam OpenID + login handlers
 │   ├── security/             CSRF + Crypto helpers
 │   ├── Mail/                 Symfony Mailer wrapper + email templates
@@ -225,6 +226,9 @@ Api::register('admins.update_perms', 'api_admins_update_perms', 0, true);  // an
 
 Handler functions live in topic-grouped files
 (`api/handlers/{account,admins,auth,bans,blockit,comms,groups,kickit,mods,protests,servers,submissions,system}.php`).
+The `system` topic also hosts the schema-migrator actions
+(`system.upgrade_diff` / `system.upgrade_apply`); both are gated to
+`ADMIN_OWNER` and back the `?p=admin&c=upgrade` page.
 
 ### Auth (`includes/auth/`)
 
@@ -388,6 +392,45 @@ never raw strings.
 wraps `symfony/mailer`. SMTP creds + sender come from the `sb_settings`
 keys (`config.mail.*`). Email templates live in
 `themes/<name>/mails/*.html`.
+
+### Schema migrator (`includes/Migrator/`)
+
+The migrator brings a 1.x panel up to 2.0 by diffing the live database
+against `web/install/includes/sql/struc.sql` + `data.sql` and applying
+the additive deltas (missing tables, missing columns, missing settings
+rows). It deliberately does *not* extend `web/install/`: the installer is
+for greenfield deployments, the migrator is for upgrading panels.
+
+The same code path drives three surfaces:
+
+| Surface | Entry point |
+| ------- | ----------- |
+| CLI (operators on the host) | `php web/bin/upgrade.php [--apply]` |
+| JSON API (panel button) | `system.upgrade_diff` / `system.upgrade_apply` (gated to `ADMIN_OWNER`) |
+| Panel page | `?p=admin&c=upgrade` (rendered via `AdminUpgradeView`) |
+
+Pieces:
+
+- `Migrator` — façade. `plan(PDO)` returns a `MigrationPlan`;
+  `apply(PDO)` runs the plan and returns a `MigrationResult`.
+- `SchemaParser` — regex-based reader for `struc.sql` + `data.sql`;
+  preserves `{prefix}` / `{charset}` placeholders so one parsed value can
+  be diffed against any deployment.
+- `SchemaDiffer` — compares the parsed structure to a live PDO using
+  `information_schema` lookups. Additive only; never proposes a DROP.
+- `MigrationApplier` — runs the deltas. DDL statements (`CREATE TABLE`,
+  `ALTER TABLE … ADD COLUMN`) are executed one at a time fail-fast
+  (MariaDB implicitly commits around them, so wrapping them in a
+  transaction is a no-op). The settings INSERT IGNORE rows are wrapped
+  in a single transaction.
+- `CliRunner` / `CliPrinter` — argv parsing and ANSI-aware pretty-print
+  for the CLI; loaded by the one-line `web/bin/upgrade.php` shim.
+
+Idempotence comes from the diff itself: re-running `plan()` after
+`apply()` returns an empty plan because every delta type is recomputed
+from the current schema state. Test coverage lives in
+`web/tests/integration/UpgradeRunnerTest.php`, which knocks out one of
+each delta type and asserts the diff converges to zero.
 
 ### Logging (`includes/Log.php`)
 

--- a/web/api/handlers/_register.php
+++ b/web/api/handlers/_register.php
@@ -111,3 +111,9 @@ Api::register('system.check_version',         'api_system_check_version',       
 Api::register('system.sel_theme',             'api_system_sel_theme',             ADMIN_OWNER | ADMIN_WEB_SETTINGS);
 Api::register('system.apply_theme',           'api_system_apply_theme',           ADMIN_OWNER | ADMIN_WEB_SETTINGS);
 Api::register('system.clear_cache',           'api_system_clear_cache',           ADMIN_OWNER | ADMIN_WEB_SETTINGS);
+// Schema migrator: owner-only on both ends. The diff handler is read-only
+// but still gated to ADMIN_OWNER to keep the action surface symmetric
+// with apply (no point letting any admin scout the schema diff if they
+// can't do anything with it).
+Api::register('system.upgrade_diff',          'api_system_upgrade_diff',          ADMIN_OWNER);
+Api::register('system.upgrade_apply',         'api_system_upgrade_apply',         ADMIN_OWNER);

--- a/web/api/handlers/system.php
+++ b/web/api/handlers/system.php
@@ -190,3 +190,95 @@ function api_system_rehash_admins(array $params): array
     }
     return ['results' => $results];
 }
+
+/**
+ * Compute the schema-migrator dry-run plan against the live database.
+ *
+ * Backs the `?p=admin&c=upgrade` page's "Refresh dry-run" button. Read-only
+ * — never mutates the schema. Permission gating (`ADMIN_OWNER`) is enforced
+ * at the {@see Api::register()} call in `_register.php`.
+ *
+ * The exact response shape is documented on
+ * {@see \Sbpp\Migrator\MigrationPlan::toArray()}; we keep the @return tag
+ * loose here on purpose — the api-contract generator's JSDoc emitter
+ * trips on `?T`-followed-by-comma in nested array shapes, and the JS
+ * caller (`UpgradeRefresh()`) re-types the response inline anyway.
+ *
+ * @return array
+ */
+function api_system_upgrade_diff(array $params): array
+{
+    $migrator = api_system_make_migrator();
+    return $migrator->plan(api_system_raw_pdo())->toArray();
+}
+
+/**
+ * Apply the schema-migrator plan against the live database.
+ *
+ * Re-computes the plan inside the handler so the apply always reflects the
+ * live diff at the moment of click — staleness between a "Refresh" view
+ * and the "Apply" click would otherwise let an admin try to apply a
+ * change that's already been satisfied. Permission gating (`ADMIN_OWNER`)
+ * is enforced at the {@see Api::register()} call in `_register.php`.
+ *
+ * The exact response shape is documented on
+ * {@see \Sbpp\Migrator\MigrationResult::toArray()}; we keep the @return
+ * tag loose here on purpose — the api-contract generator's JSDoc emitter
+ * trips on `?T`-followed-by-comma in nested array shapes, and the JS
+ * caller (`UpgradeApply()`) re-types the response inline anyway.
+ *
+ * @return array
+ */
+function api_system_upgrade_apply(array $params): array
+{
+    $migrator = api_system_make_migrator();
+    $pdo      = api_system_raw_pdo();
+
+    $plan    = $migrator->plan($pdo);
+    $applier = new \Sbpp\Migrator\MigrationApplier($GLOBALS['PDO']->getPrefix());
+    $result  = $applier->apply($pdo, $plan);
+
+    Log::add(
+        $result->success ? 'm' : 'e',
+        $result->success ? 'Schema upgrade applied' : 'Schema upgrade failed',
+        sprintf(
+            '%d step(s); %s',
+            count($result->steps),
+            $result->error ?? 'ok'
+        ),
+    );
+
+    return $result->toArray();
+}
+
+/**
+ * Build the migrator façade pointed at the canonical SQL files shipped
+ * in `web/install/includes/sql/`. Helper kept inside the handler file
+ * because nothing else needs it.
+ */
+function api_system_make_migrator(): \Sbpp\Migrator\Migrator
+{
+    return \Sbpp\Migrator\Migrator::fromInstallSql(
+        ROOT,
+        $GLOBALS['PDO']->getPrefix(),
+        defined('DB_CHARSET') ? (string) DB_CHARSET : 'utf8mb4',
+    );
+}
+
+/**
+ * Open a fresh PDO connection for the migrator. The differ runs raw
+ * `information_schema` queries, which is awkward through `Database`
+ * (the `:prefix_` rewriter would mangle bound table names). A bare PDO
+ * sidesteps the whole issue.
+ */
+function api_system_raw_pdo(): \PDO
+{
+    $dsn = sprintf(
+        'mysql:host=%s;port=%d;dbname=%s;charset=%s',
+        DB_HOST,
+        defined('DB_PORT') ? (int) DB_PORT : 3306,
+        DB_NAME,
+        defined('DB_CHARSET') ? (string) DB_CHARSET : 'utf8mb4',
+    );
+    return new \PDO($dsn, DB_USER, DB_PASS, [\PDO::ATTR_ERRMODE => \PDO::ERRMODE_EXCEPTION]);
+}

--- a/web/bin/upgrade.php
+++ b/web/bin/upgrade.php
@@ -1,0 +1,54 @@
+<?php
+/*************************************************************************
+This file is part of SourceBans++
+
+SourceBans++ (c) 2014-2024 by SourceBans++ Dev Team
+
+The SourceBans++ Web panel is licensed under a
+Creative Commons Attribution-NonCommercial-ShareAlike 3.0 Unported License.
+
+You should have received a copy of the license along with this
+work.  If not, see <http://creativecommons.org/licenses/by-nc-sa/3.0/>.
+
+CLI front-end for the 1.x → 2.0 schema migrator.
+
+Reads the live database (using the credentials in `web/config.php`) and
+the canonical schema from `web/install/includes/sql/struc.sql`, prints a
+diff summary, and — with `--apply` — runs the missing changes inside a
+single transaction wherever the storage engine allows it.
+
+Usage:
+  php web/bin/upgrade.php             # dry run (default)
+  php web/bin/upgrade.php --apply     # actually apply the changes
+  php web/bin/upgrade.php --no-color  # suppress ANSI colour codes
+  php web/bin/upgrade.php --help      # this message
+
+Exit codes:
+  0  success — either nothing to do, or apply completed cleanly
+  1  apply failed (one of the steps threw); message printed to stderr
+  2  invalid invocation / missing config / unreadable SQL file
+
+The implementation lives in `web/includes/Migrator/` (autoloaded under
+the `Sbpp\Migrator` namespace) so the same code path also serves the
+`system.upgrade_diff` / `system.upgrade_apply` JSON API actions and the
+`?p=admin&c=upgrade` panel page.
+*************************************************************************/
+
+declare(strict_types=1);
+
+if (PHP_SAPI !== 'cli') {
+    fwrite(STDERR, "upgrade.php: must be run from the command line\n");
+    exit(2);
+}
+
+$autoload = __DIR__ . '/../includes/vendor/autoload.php';
+if (!is_file($autoload)) {
+    fwrite(STDERR,
+        "upgrade.php: composer autoload not found at $autoload.\n"
+        . "Run `composer install` from web/ first.\n",
+    );
+    exit(2);
+}
+require_once $autoload;
+
+exit(\Sbpp\Migrator\CliRunner::main($argv));

--- a/web/includes/Migrator/CliPrinter.php
+++ b/web/includes/Migrator/CliPrinter.php
@@ -1,0 +1,119 @@
+<?php
+/*************************************************************************
+This file is part of SourceBans++
+
+SourceBans++ (c) 2014-2024 by SourceBans++ Dev Team
+
+The SourceBans++ Web panel is licensed under a
+Creative Commons Attribution-NonCommercial-ShareAlike 3.0 Unported License.
+
+You should have received a copy of the license along with this
+work.  If not, see <http://creativecommons.org/licenses/by-nc-sa/3.0/>.
+*************************************************************************/
+
+declare(strict_types=1);
+
+namespace Sbpp\Migrator;
+
+/**
+ * Tiny ANSI-aware formatter the CLI pipes plan + result output through.
+ * Lives next to {@see CliRunner} because it's a presentation detail
+ * nothing outside the CLI surface uses.
+ *
+ * The colour codes are deliberately the 8-colour set so the output stays
+ * readable on terminals that don't support 256-colour escapes.
+ */
+final class CliPrinter
+{
+    /** @param resource $stream */
+    public function __construct(
+        private readonly bool $color,
+        private $stream,
+    ) {
+    }
+
+    public function printPlan(MigrationPlan $plan): void
+    {
+        $this->writeln($this->bold('SourceBans++ schema migrator'));
+        $this->writeln('');
+
+        if ($plan->isEmpty()) {
+            $this->writeln($this->ok('  ✓ Schema is up to date.'));
+            $this->writeln('');
+            return;
+        }
+
+        if ($plan->missingTables !== []) {
+            $this->writeln($this->bold(sprintf('Missing tables (%d):', count($plan->missingTables))));
+            foreach ($plan->missingTables as $delta) {
+                $this->writeln('  + :prefix_' . $delta->table);
+            }
+            $this->writeln('');
+        }
+
+        if ($plan->missingColumns !== []) {
+            $this->writeln($this->bold(sprintf('Missing columns (%d):', count($plan->missingColumns))));
+            foreach ($plan->missingColumns as $delta) {
+                $this->writeln(sprintf('  + :prefix_%s.%s', $delta->table, $delta->column));
+            }
+            $this->writeln('');
+        }
+
+        if ($plan->missingSettings !== []) {
+            $this->writeln($this->bold(sprintf('Missing settings keys (%d):', count($plan->missingSettings))));
+            foreach ($plan->missingSettings as $delta) {
+                $this->writeln(sprintf('  + %s = %s', $delta->key, $this->truncate($delta->value, 60)));
+            }
+            $this->writeln('');
+        }
+
+        $this->writeln($this->bold(sprintf('Total: %d change(s).', $plan->totalChanges())));
+        $this->writeln('');
+    }
+
+    public function printResult(MigrationResult $result): void
+    {
+        $this->writeln($this->bold('Apply results:'));
+        foreach ($result->steps as $step) {
+            $marker = $step->success ? $this->ok('  ✓') : $this->fail('  ✗');
+            $this->writeln(sprintf('%s  %s', $marker, $step->summary));
+            if (!$step->success && $step->error !== null) {
+                $this->writeln('     ' . $this->fail($step->error));
+            }
+        }
+        $this->writeln('');
+
+        if ($result->success) {
+            $this->writeln($this->ok('Apply completed.'));
+        } else {
+            $this->writeln($this->fail('Apply FAILED — re-run after addressing the error above.'));
+            if ($result->error !== null) {
+                $this->writeln($this->fail($result->error));
+            }
+        }
+        $this->writeln('');
+    }
+
+    public function infoLine(string $msg): void
+    {
+        $this->writeln($msg);
+        $this->writeln('');
+    }
+
+    private function writeln(string $msg): void
+    {
+        fwrite($this->stream, $msg . "\n");
+    }
+
+    private function bold(string $s): string  { return $this->color ? "\033[1m$s\033[0m"   : $s; }
+    private function ok(string $s): string    { return $this->color ? "\033[32m$s\033[0m"  : $s; }
+    private function fail(string $s): string  { return $this->color ? "\033[31m$s\033[0m"  : $s; }
+
+    private function truncate(string $s, int $max): string
+    {
+        if (strlen($s) <= $max) {
+            return $s;
+        }
+        return substr($s, 0, $max - 1) . '…';
+    }
+}

--- a/web/includes/Migrator/CliRunner.php
+++ b/web/includes/Migrator/CliRunner.php
@@ -1,0 +1,248 @@
+<?php
+/*************************************************************************
+This file is part of SourceBans++
+
+SourceBans++ (c) 2014-2024 by SourceBans++ Dev Team
+
+The SourceBans++ Web panel is licensed under a
+Creative Commons Attribution-NonCommercial-ShareAlike 3.0 Unported License.
+
+You should have received a copy of the license along with this
+work.  If not, see <http://creativecommons.org/licenses/by-nc-sa/3.0/>.
+*************************************************************************/
+
+declare(strict_types=1);
+
+namespace Sbpp\Migrator;
+
+use PDO;
+use Throwable;
+
+/**
+ * Argument parsing + pretty-printing for the upgrade CLI. Lives in the
+ * Migrator namespace so the autoloader picks it up; the actual entry
+ * point is `web/bin/upgrade.php`, which is a one-liner that delegates to
+ * {@see CliRunner::main()}.
+ *
+ * The runner deliberately doesn't include the panel's `init.php`. That
+ * file starts a session, builds Smarty, opens GeoIP, etc. — none of
+ * which the migrator needs and most of which would fail in a
+ * non-installed environment. We load `config.php` directly (after
+ * defining the `IN_SB` sentinel it guards on) and connect a bare PDO.
+ */
+final class CliRunner
+{
+    private const EXIT_OK         = 0;
+    private const EXIT_APPLY_FAIL = 1;
+    private const EXIT_INVOCATION = 2;
+
+    /** @param list<string> $argv */
+    public static function main(array $argv): int
+    {
+        $opts = self::parseArgv($argv);
+
+        if ($opts['help']) {
+            self::printUsage();
+            return self::EXIT_OK;
+        }
+
+        if ($opts['error'] !== null) {
+            fwrite(STDERR, "upgrade.php: " . $opts['error'] . "\n\n");
+            self::printUsage(STDERR);
+            return self::EXIT_INVOCATION;
+        }
+
+        $webRoot = realpath(__DIR__ . '/../..');
+        if ($webRoot === false) {
+            fwrite(STDERR, "upgrade.php: cannot resolve web/ root from " . __DIR__ . "\n");
+            return self::EXIT_INVOCATION;
+        }
+
+        $cfg = self::loadConfig($webRoot);
+        if ($cfg === null) {
+            return self::EXIT_INVOCATION;
+        }
+
+        try {
+            $pdo = self::connect($cfg);
+        } catch (Throwable $e) {
+            fwrite(STDERR, "upgrade.php: cannot connect to MariaDB: " . $e->getMessage() . "\n");
+            return self::EXIT_INVOCATION;
+        }
+
+        try {
+            $migrator = Migrator::fromInstallSql($webRoot, $cfg['prefix'], $cfg['charset']);
+            $plan     = $migrator->plan($pdo);
+        } catch (Throwable $e) {
+            fwrite(STDERR, "upgrade.php: failed to compute plan: " . $e->getMessage() . "\n");
+            return self::EXIT_INVOCATION;
+        }
+
+        $writer = new CliPrinter($opts['color'], STDOUT);
+        $writer->printPlan($plan);
+
+        if (!$opts['apply']) {
+            if ($plan->isEmpty()) {
+                $writer->infoLine('Nothing to do.');
+            } else {
+                $writer->infoLine(
+                    sprintf('Run with --apply to execute the %d change(s) above.', $plan->totalChanges()),
+                );
+            }
+            return self::EXIT_OK;
+        }
+
+        if ($plan->isEmpty()) {
+            $writer->infoLine('Nothing to do.');
+            return self::EXIT_OK;
+        }
+
+        $applier = new MigrationApplier($cfg['prefix']);
+        $result  = $applier->apply($pdo, $plan);
+
+        $writer->printResult($result);
+
+        return $result->success ? self::EXIT_OK : self::EXIT_APPLY_FAIL;
+    }
+
+    /**
+     * @param list<string> $argv
+     * @return array{apply: bool, color: bool, help: bool, error: ?string}
+     */
+    private static function parseArgv(array $argv): array
+    {
+        $opts = ['apply' => false, 'color' => true, 'help' => false, 'error' => null];
+
+        $args = array_slice($argv, 1);
+
+        // Auto-detect non-TTY stdout so piping the output to a file
+        // doesn't carry escape codes. Operators can still force colour
+        // off explicitly with --no-color.
+        if (function_exists('posix_isatty') && !@posix_isatty(STDOUT)) {
+            $opts['color'] = false;
+        } elseif (getenv('NO_COLOR') !== false) {
+            $opts['color'] = false;
+        }
+
+        foreach ($args as $a) {
+            switch ($a) {
+                case '--apply':
+                    $opts['apply'] = true;
+                    break;
+                case '--no-color':
+                    $opts['color'] = false;
+                    break;
+                case '--color':
+                    $opts['color'] = true;
+                    break;
+                case '-h':
+                case '--help':
+                    $opts['help'] = true;
+                    break;
+                default:
+                    $opts['error'] = "unknown argument '$a'";
+                    return $opts;
+            }
+        }
+
+        return $opts;
+    }
+
+    /**
+     * @param resource $stream
+     */
+    private static function printUsage($stream = STDOUT): void
+    {
+        $msg = <<<TXT
+Usage: php web/bin/upgrade.php [options]
+
+Diffs the live database against web/install/includes/sql/struc.sql + data.sql
+and either prints what it would change (default) or applies the changes.
+
+Options:
+  --apply       Run the missing CREATE TABLE / ADD COLUMN / INSERT IGNORE
+                statements. Without this flag the tool only prints the diff.
+  --no-color    Suppress ANSI colour codes (auto-disabled on non-TTY).
+  --color       Force ANSI colour codes even when stdout isn't a TTY.
+  -h, --help    Show this help message.
+
+Exit codes:
+  0  success (nothing to do, or apply completed)
+  1  apply failed (a step threw — error printed to stderr)
+  2  invalid invocation, missing config, or unreadable SQL file
+
+
+TXT;
+        fwrite($stream, $msg);
+    }
+
+    /**
+     * Resolve DB connection parameters. Environment variables win so the
+     * test harness can point the migrator at `sourcebans_test` without
+     * touching `web/config.php`. Falls back to including `config.php`
+     * (the production path).
+     *
+     * @return array{host:string, port:int, name:string, user:string, password:string, prefix:string, charset:string}|null
+     */
+    private static function loadConfig(string $webRoot): ?array
+    {
+        $envHost = getenv('DB_HOST');
+        if ($envHost !== false && $envHost !== '') {
+            return [
+                'host'     => $envHost,
+                'port'     => (int) (getenv('DB_PORT') ?: 3306),
+                'name'     => (string) (getenv('DB_NAME') ?: 'sourcebans'),
+                'user'     => (string) (getenv('DB_USER') ?: 'sourcebans'),
+                'password' => (string) (getenv('DB_PASS') ?: ''),
+                'prefix'   => (string) (getenv('DB_PREFIX') ?: 'sb'),
+                'charset'  => (string) (getenv('DB_CHARSET') ?: 'utf8mb4'),
+            ];
+        }
+
+        $configPath = $webRoot . '/config.php';
+        if (!is_file($configPath)) {
+            fwrite(STDERR,
+                "upgrade.php: $configPath not found.\n"
+                . "Either install SourceBans++ first, or pass DB_HOST/DB_NAME/etc. via env.\n",
+            );
+            return null;
+        }
+
+        // config.php guards on `IN_SB`; we satisfy that without dragging
+        // in init.php (which would also start a session and instantiate
+        // the global $userbank — overkill for a CLI).
+        if (!defined('IN_SB')) {
+            define('IN_SB', true);
+        }
+        require_once $configPath;
+
+        if (!defined('DB_HOST') || !defined('DB_NAME') || !defined('DB_USER') || !defined('DB_PASS')) {
+            fwrite(STDERR, "upgrade.php: $configPath is missing one of DB_HOST/DB_NAME/DB_USER/DB_PASS.\n");
+            return null;
+        }
+
+        return [
+            'host'     => (string) DB_HOST,
+            'port'     => defined('DB_PORT')    ? (int) DB_PORT : 3306,
+            'name'     => (string) DB_NAME,
+            'user'     => (string) DB_USER,
+            'password' => (string) DB_PASS,
+            'prefix'   => defined('DB_PREFIX')  ? (string) DB_PREFIX  : 'sb',
+            'charset'  => defined('DB_CHARSET') ? (string) DB_CHARSET : 'utf8mb4',
+        ];
+    }
+
+    /**
+     * @param array{host:string, port:int, name:string, user:string, password:string, prefix:string, charset:string} $cfg
+     */
+    private static function connect(array $cfg): PDO
+    {
+        $dsn = sprintf(
+            'mysql:host=%s;port=%d;dbname=%s;charset=%s',
+            $cfg['host'], $cfg['port'], $cfg['name'], $cfg['charset'],
+        );
+        return new PDO($dsn, $cfg['user'], $cfg['password'], [
+            PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
+        ]);
+    }
+}

--- a/web/includes/Migrator/ColumnDelta.php
+++ b/web/includes/Migrator/ColumnDelta.php
@@ -1,0 +1,34 @@
+<?php
+/*************************************************************************
+This file is part of SourceBans++
+
+SourceBans++ (c) 2014-2024 by SourceBans++ Dev Team
+
+The SourceBans++ Web panel is licensed under a
+Creative Commons Attribution-NonCommercial-ShareAlike 3.0 Unported License.
+
+You should have received a copy of the license along with this
+work.  If not, see <http://creativecommons.org/licenses/by-nc-sa/3.0/>.
+*************************************************************************/
+
+declare(strict_types=1);
+
+namespace Sbpp\Migrator;
+
+/**
+ * `ALTER TABLE … ADD COLUMN` statement for a column that exists in
+ * struc.sql but not in the live DB. `sql` is fully rendered.
+ *
+ * We never emit ADD COLUMN IF NOT EXISTS because the differ has already
+ * filtered to the genuinely-missing set; the bare ADD COLUMN keeps us
+ * portable to MySQL 5.6 (which doesn't support the IF NOT EXISTS suffix).
+ */
+final class ColumnDelta
+{
+    public function __construct(
+        public readonly string $table,
+        public readonly string $column,
+        public readonly string $sql,
+    ) {
+    }
+}

--- a/web/includes/Migrator/MigrationApplier.php
+++ b/web/includes/Migrator/MigrationApplier.php
@@ -1,0 +1,157 @@
+<?php
+/*************************************************************************
+This file is part of SourceBans++
+
+SourceBans++ (c) 2014-2024 by SourceBans++ Dev Team
+
+The SourceBans++ Web panel is licensed under a
+Creative Commons Attribution-NonCommercial-ShareAlike 3.0 Unported License.
+
+You should have received a copy of the license along with this
+work.  If not, see <http://creativecommons.org/licenses/by-nc-sa/3.0/>.
+*************************************************************************/
+
+declare(strict_types=1);
+
+namespace Sbpp\Migrator;
+
+use PDO;
+use PDOException;
+use Throwable;
+
+/**
+ * Applies a {@see MigrationPlan} against a live PDO connection and returns
+ * a per-step {@see MigrationResult} record so callers can pretty-print
+ * exactly what ran.
+ *
+ * ## Transaction model
+ *
+ * MariaDB/MySQL implicitly commit before *and* after every DDL statement,
+ * so wrapping CREATE TABLE / ALTER TABLE in a `BEGIN…COMMIT` is a no-op
+ * (worse: it silently truncates any preceding DML transaction). The
+ * applier therefore:
+ *
+ *   1. Runs DDL statements one at a time, top-down, fail-fast. Each is
+ *      already idempotent (`CREATE TABLE IF NOT EXISTS`) or filtered to
+ *      genuinely-missing columns by the differ, so a partial failure
+ *      leaves the DB in a state where re-running converges.
+ *   2. Wraps the settings INSERT IGNOREs in a single transaction so the
+ *      seed updates are atomic relative to themselves. They use INSERT
+ *      IGNORE on the `setting` UNIQUE KEY, so a re-run is a no-op even
+ *      after a partial DDL failure.
+ *
+ * Any thrown PDOException stops the apply immediately; the {@see MigrationResult}
+ * captures the step that failed and the message so the CLI/UI can surface
+ * a precise error rather than a generic "migration failed".
+ */
+final class MigrationApplier
+{
+    public function __construct(
+        private readonly string $prefix,
+    ) {
+    }
+
+    public function apply(PDO $pdo, MigrationPlan $plan): MigrationResult
+    {
+        $steps  = [];
+        $error  = null;
+
+        try {
+            foreach ($plan->missingTables as $delta) {
+                $pdo->exec($delta->sql);
+                $steps[] = new MigrationStep(
+                    kind:    'table',
+                    target:  $delta->table,
+                    summary: "CREATE TABLE :prefix_{$delta->table}",
+                    sql:     $delta->sql,
+                    success: true,
+                );
+            }
+
+            foreach ($plan->missingColumns as $delta) {
+                $pdo->exec($delta->sql);
+                $steps[] = new MigrationStep(
+                    kind:    'column',
+                    target:  "{$delta->table}.{$delta->column}",
+                    summary: "ALTER TABLE :prefix_{$delta->table} ADD COLUMN {$delta->column}",
+                    sql:     $delta->sql,
+                    success: true,
+                );
+            }
+
+            $this->applySettings($pdo, $plan->missingSettings, $steps);
+        } catch (Throwable $e) {
+            $error = $e instanceof PDOException
+                ? sprintf('PDO error: %s', $e->getMessage())
+                : sprintf('%s: %s', $e::class, $e->getMessage());
+            // Synthetic failed step so callers see *which* change was in
+            // flight when we tripped (the steps array up to here is the
+            // actual successful prefix).
+            $steps[] = new MigrationStep(
+                kind:    'error',
+                target:  '',
+                summary: 'Apply aborted',
+                sql:     '',
+                success: false,
+                error:   $error,
+            );
+        }
+
+        return new MigrationResult($steps, $error === null, $error);
+    }
+
+    /**
+     * @param list<SettingDelta>            $deltas
+     * @param list<MigrationStep>           $steps  Mutated in-place with one step per insert.
+     */
+    private function applySettings(PDO $pdo, array $deltas, array &$steps): void
+    {
+        if ($deltas === []) {
+            return;
+        }
+
+        $tableName = $this->prefix . '_settings';
+
+        // identifier interpolation: `$tableName` is built from the
+        // operator-controlled prefix constant plus a literal suffix, so
+        // there's no user input on this path. PDO can't bind identifiers
+        // anyway; the value placeholders below carry the user-provided
+        // bits.
+        $stmt = $pdo->prepare(sprintf(
+            'INSERT IGNORE INTO `%s` (`setting`, `value`) VALUES (:setting, :value)',
+            $tableName,
+        ));
+
+        $inTx = false;
+        try {
+            $pdo->beginTransaction();
+            $inTx = true;
+
+            foreach ($deltas as $delta) {
+                $stmt->execute([
+                    ':setting' => $delta->key,
+                    ':value'   => $delta->value,
+                ]);
+                $steps[] = new MigrationStep(
+                    kind:    'setting',
+                    target:  $delta->key,
+                    summary: "INSERT IGNORE :prefix_settings ({$delta->key})",
+                    sql:     sprintf("INSERT IGNORE INTO `%s` (setting, value) VALUES ('%s', '%s')",
+                        $tableName,
+                        addslashes($delta->key),
+                        addslashes($delta->value),
+                    ),
+                    success: true,
+                );
+            }
+
+            $pdo->commit();
+            $inTx = false;
+        } catch (Throwable $e) {
+            if ($inTx && $pdo->inTransaction()) {
+                $pdo->rollBack();
+            }
+            throw $e;
+        }
+    }
+}

--- a/web/includes/Migrator/MigrationPlan.php
+++ b/web/includes/Migrator/MigrationPlan.php
@@ -1,0 +1,92 @@
+<?php
+/*************************************************************************
+This file is part of SourceBans++
+
+SourceBans++ (c) 2014-2024 by SourceBans++ Dev Team
+
+The SourceBans++ Web panel is licensed under a
+Creative Commons Attribution-NonCommercial-ShareAlike 3.0 Unported License.
+
+You should have received a copy of the license along with this
+work.  If not, see <http://creativecommons.org/licenses/by-nc-sa/3.0/>.
+*************************************************************************/
+
+declare(strict_types=1);
+
+namespace Sbpp\Migrator;
+
+/**
+ * What the migrator wants to do, once.
+ *
+ * Produced by {@see SchemaDiffer::diff()} and consumed by
+ * {@see MigrationApplier::apply()}. The same value is also handed to the
+ * panel's dry-run preview verbatim — the UI shouldn't render any state
+ * the CLI doesn't see.
+ *
+ * All SQL strings inside the deltas are deployment-ready — `{prefix}` and
+ * `{charset}` have already been substituted — so the applier only has to
+ * `prepare()` and `execute()`.
+ */
+final class MigrationPlan
+{
+    /**
+     * @param list<TableDelta>   $missingTables
+     * @param list<ColumnDelta>  $missingColumns
+     * @param list<SettingDelta> $missingSettings
+     */
+    public function __construct(
+        public readonly array $missingTables,
+        public readonly array $missingColumns,
+        public readonly array $missingSettings,
+    ) {
+    }
+
+    public function isEmpty(): bool
+    {
+        return $this->missingTables === []
+            && $this->missingColumns === []
+            && $this->missingSettings === [];
+    }
+
+    public function totalChanges(): int
+    {
+        return count($this->missingTables)
+            + count($this->missingColumns)
+            + count($this->missingSettings);
+    }
+
+    /**
+     * Compact JSON-friendly shape suitable for the JSON API + UI.
+     *
+     * @return array{
+     *     ok: bool,
+     *     total: int,
+     *     tables: list<array{name: string, sql: string}>,
+     *     columns: list<array{table: string, column: string, sql: string}>,
+     *     settings: list<array{key: string, value: string}>,
+     * }
+     */
+    public function toArray(): array
+    {
+        return [
+            'ok'      => $this->isEmpty(),
+            'total'   => $this->totalChanges(),
+            'tables'  => array_map(
+                fn(TableDelta $t): array => ['name' => $t->table, 'sql' => $t->sql],
+                $this->missingTables,
+            ),
+            'columns' => array_map(
+                fn(ColumnDelta $c): array => [
+                    'table'  => $c->table,
+                    'column' => $c->column,
+                    'sql'    => $c->sql,
+                ],
+                $this->missingColumns,
+            ),
+            'settings' => array_map(
+                fn(SettingDelta $s): array => ['key' => $s->key, 'value' => $s->value],
+                $this->missingSettings,
+            ),
+        ];
+    }
+}

--- a/web/includes/Migrator/MigrationResult.php
+++ b/web/includes/Migrator/MigrationResult.php
@@ -1,0 +1,62 @@
+<?php
+/*************************************************************************
+This file is part of SourceBans++
+
+SourceBans++ (c) 2014-2024 by SourceBans++ Dev Team
+
+The SourceBans++ Web panel is licensed under a
+Creative Commons Attribution-NonCommercial-ShareAlike 3.0 Unported License.
+
+You should have received a copy of the license along with this
+work.  If not, see <http://creativecommons.org/licenses/by-nc-sa/3.0/>.
+*************************************************************************/
+
+declare(strict_types=1);
+
+namespace Sbpp\Migrator;
+
+/**
+ * Outcome of {@see MigrationApplier::apply()}. `success` is true exactly
+ * when every queued step executed; `error` carries the message the
+ * exception raised on the first failure.
+ */
+final class MigrationResult
+{
+    /** @param list<MigrationStep> $steps */
+    public function __construct(
+        public readonly array $steps,
+        public readonly bool $success,
+        public readonly ?string $error,
+    ) {
+    }
+
+    /**
+     * Compact JSON-friendly shape suitable for the JSON API + UI.
+     *
+     * @return array{
+     *     ok: bool,
+     *     error: ?string,
+     *     steps: list<array{
+     *         kind: string, target: string, summary: string,
+     *         success: bool, error: ?string
+     *     }>
+     * }
+     */
+    public function toArray(): array
+    {
+        return [
+            'ok'    => $this->success,
+            'error' => $this->error,
+            'steps' => array_map(
+                fn(MigrationStep $s): array => [
+                    'kind'    => $s->kind,
+                    'target'  => $s->target,
+                    'summary' => $s->summary,
+                    'success' => $s->success,
+                    'error'   => $s->error,
+                ],
+                $this->steps,
+            ),
+        ];
+    }
+}

--- a/web/includes/Migrator/MigrationStep.php
+++ b/web/includes/Migrator/MigrationStep.php
@@ -1,0 +1,36 @@
+<?php
+/*************************************************************************
+This file is part of SourceBans++
+
+SourceBans++ (c) 2014-2024 by SourceBans++ Dev Team
+
+The SourceBans++ Web panel is licensed under a
+Creative Commons Attribution-NonCommercial-ShareAlike 3.0 Unported License.
+
+You should have received a copy of the license along with this
+work.  If not, see <http://creativecommons.org/licenses/by-nc-sa/3.0/>.
+*************************************************************************/
+
+declare(strict_types=1);
+
+namespace Sbpp\Migrator;
+
+/**
+ * One executed (or attempted) step. `kind` is one of:
+ *   - `table`   — a missing CREATE TABLE that was applied
+ *   - `column`  — a missing ADD COLUMN that was applied
+ *   - `setting` — a missing INSERT IGNORE that was applied
+ *   - `error`   — synthetic, only emitted when the apply is aborted
+ */
+final class MigrationStep
+{
+    public function __construct(
+        public readonly string $kind,
+        public readonly string $target,
+        public readonly string $summary,
+        public readonly string $sql,
+        public readonly bool $success,
+        public readonly ?string $error = null,
+    ) {
+    }
+}

--- a/web/includes/Migrator/Migrator.php
+++ b/web/includes/Migrator/Migrator.php
@@ -1,0 +1,103 @@
+<?php
+/*************************************************************************
+This file is part of SourceBans++
+
+SourceBans++ (c) 2014-2024 by SourceBans++ Dev Team
+
+The SourceBans++ Web panel is licensed under a
+Creative Commons Attribution-NonCommercial-ShareAlike 3.0 Unported License.
+
+You should have received a copy of the license along with this
+work.  If not, see <http://creativecommons.org/licenses/by-nc-sa/3.0/>.
+*************************************************************************/
+
+declare(strict_types=1);
+
+namespace Sbpp\Migrator;
+
+use PDO;
+
+/**
+ * Public façade for the 1.x → 2.0 schema migrator.
+ *
+ * Orchestrates the three concrete pieces:
+ *   1. {@see SchemaParser}    — reads `struc.sql` + `data.sql`.
+ *   2. {@see SchemaDiffer}    — compares the parsed structure to a live PDO.
+ *   3. {@see MigrationApplier} — runs whatever the diff produced.
+ *
+ * Used by:
+ *   - `web/bin/upgrade.php`   — CLI (operator runs it from the host).
+ *   - `web/api/handlers/system.php` — JSON API (admin runs it from the panel).
+ *   - `web/tests/integration/UpgradeRunnerTest.php` — convergence test.
+ *
+ * The façade has no dependency on `init.php` so it can run unbootstrapped
+ * (the CLI) or under the panel's bootstrap (the API handler).
+ */
+final class Migrator
+{
+    public function __construct(
+        public readonly string $strucSqlPath,
+        public readonly string $dataSqlPath,
+        public readonly string $prefix,
+        public readonly string $charset,
+    ) {
+    }
+
+    /**
+     * Construct a migrator wired against the canonical files shipped in
+     * `web/install/includes/sql/`. `$prefix` and `$charset` come from the
+     * caller's environment (DB_PREFIX / DB_CHARSET).
+     */
+    public static function fromInstallSql(string $webRoot, string $prefix, string $charset): self
+    {
+        return new self(
+            strucSqlPath: rtrim($webRoot, '/') . '/install/includes/sql/struc.sql',
+            dataSqlPath:  rtrim($webRoot, '/') . '/install/includes/sql/data.sql',
+            prefix:       $prefix,
+            charset:      $charset,
+        );
+    }
+
+    /**
+     * Compute the diff between the on-disk SQL and the live database.
+     *
+     * Throws {@see \RuntimeException} when struc.sql or data.sql isn't
+     * readable — both are part of the release tarball, so a missing file
+     * means something is fundamentally wrong with the deployment.
+     */
+    public function plan(PDO $pdo): MigrationPlan
+    {
+        $struc = $this->readSqlFile($this->strucSqlPath);
+        $data  = $this->readSqlFile($this->dataSqlPath);
+
+        $schema = SchemaParser::parseStructure($struc);
+        $seeds  = SchemaParser::parseSettings($data);
+
+        $differ = new SchemaDiffer();
+        return $differ->diff($pdo, $schema, $seeds, $this->prefix, $this->charset);
+    }
+
+    /**
+     * Compute the plan and immediately apply it. Returns the same result
+     * shape the CLI/panel render — the `MigrationPlan` is preserved on the
+     * applier output via {@see MigrationApplier::apply()}'s step list.
+     */
+    public function apply(PDO $pdo): MigrationResult
+    {
+        $plan    = $this->plan($pdo);
+        $applier = new MigrationApplier($this->prefix);
+        return $applier->apply($pdo, $plan);
+    }
+
+    private function readSqlFile(string $path): string
+    {
+        if (!is_file($path) || !is_readable($path)) {
+            throw new \RuntimeException("Migrator: cannot read SQL file at $path");
+        }
+        $content = (string) file_get_contents($path);
+        if ($content === '') {
+            throw new \RuntimeException("Migrator: $path is empty");
+        }
+        return $content;
+    }
+}

--- a/web/includes/Migrator/ParsedColumn.php
+++ b/web/includes/Migrator/ParsedColumn.php
@@ -1,0 +1,33 @@
+<?php
+/*************************************************************************
+This file is part of SourceBans++
+
+SourceBans++ (c) 2014-2024 by SourceBans++ Dev Team
+
+The SourceBans++ Web panel is licensed under a
+Creative Commons Attribution-NonCommercial-ShareAlike 3.0 Unported License.
+
+You should have received a copy of the license along with this
+work.  If not, see <http://creativecommons.org/licenses/by-nc-sa/3.0/>.
+*************************************************************************/
+
+declare(strict_types=1);
+
+namespace Sbpp\Migrator;
+
+/**
+ * One column declaration from a CREATE TABLE body.
+ *
+ * `definition` is the everything-after-`name` substring with whitespace
+ * collapsed (e.g. `int(11) NOT NULL default '0'`). It still carries any
+ * `{charset}` placeholder so the differ can substitute it just before
+ * synthesising an ADD COLUMN statement.
+ */
+final class ParsedColumn
+{
+    public function __construct(
+        public readonly string $name,
+        public readonly string $definition,
+    ) {
+    }
+}

--- a/web/includes/Migrator/ParsedSchema.php
+++ b/web/includes/Migrator/ParsedSchema.php
@@ -1,0 +1,46 @@
+<?php
+/*************************************************************************
+This file is part of SourceBans++
+
+SourceBans++ (c) 2014-2024 by SourceBans++ Dev Team
+
+The SourceBans++ Web panel is licensed under a
+Creative Commons Attribution-NonCommercial-ShareAlike 3.0 Unported License.
+
+You should have received a copy of the license along with this
+work.  If not, see <http://creativecommons.org/licenses/by-nc-sa/3.0/>.
+*************************************************************************/
+
+declare(strict_types=1);
+
+namespace Sbpp\Migrator;
+
+/**
+ * Whole-schema view of `struc.sql` produced by {@see SchemaParser::parseStructure()}.
+ * Tables keep `{prefix}_` placeholders so the same parsed value can be
+ * compared against any deployment.
+ */
+final class ParsedSchema
+{
+    /** @param list<ParsedTable> $tables */
+    public function __construct(
+        public readonly array $tables,
+    ) {
+    }
+
+    /** @return list<string> Short (unprefixed) table names, e.g. `admins`. */
+    public function tableNames(): array
+    {
+        return array_map(fn(ParsedTable $t): string => $t->shortName, $this->tables);
+    }
+
+    public function table(string $shortName): ?ParsedTable
+    {
+        foreach ($this->tables as $t) {
+            if ($t->shortName === $shortName) {
+                return $t;
+            }
+        }
+        return null;
+    }
+}

--- a/web/includes/Migrator/ParsedTable.php
+++ b/web/includes/Migrator/ParsedTable.php
@@ -1,0 +1,43 @@
+<?php
+/*************************************************************************
+This file is part of SourceBans++
+
+SourceBans++ (c) 2014-2024 by SourceBans++ Dev Team
+
+The SourceBans++ Web panel is licensed under a
+Creative Commons Attribution-NonCommercial-ShareAlike 3.0 Unported License.
+
+You should have received a copy of the license along with this
+work.  If not, see <http://creativecommons.org/licenses/by-nc-sa/3.0/>.
+*************************************************************************/
+
+declare(strict_types=1);
+
+namespace Sbpp\Migrator;
+
+/**
+ * One CREATE TABLE block from struc.sql.
+ *
+ * `createSql` retains the literal `{prefix}` and `{charset}` placeholders
+ * so callers can substitute deployment-specific values without re-parsing.
+ */
+final class ParsedTable
+{
+    /** @param list<ParsedColumn> $columns */
+    public function __construct(
+        public readonly string $shortName,
+        public readonly string $createSql,
+        public readonly array $columns,
+    ) {
+    }
+
+    public function column(string $name): ?ParsedColumn
+    {
+        foreach ($this->columns as $c) {
+            if ($c->name === $name) {
+                return $c;
+            }
+        }
+        return null;
+    }
+}

--- a/web/includes/Migrator/SchemaDiffer.php
+++ b/web/includes/Migrator/SchemaDiffer.php
@@ -1,0 +1,221 @@
+<?php
+/*************************************************************************
+This file is part of SourceBans++
+
+SourceBans++ (c) 2014-2024 by SourceBans++ Dev Team
+
+The SourceBans++ Web panel is licensed under a
+Creative Commons Attribution-NonCommercial-ShareAlike 3.0 Unported License.
+
+You should have received a copy of the license along with this
+work.  If not, see <http://creativecommons.org/licenses/by-nc-sa/3.0/>.
+*************************************************************************/
+
+declare(strict_types=1);
+
+namespace Sbpp\Migrator;
+
+use PDO;
+
+/**
+ * Compares the live database against a {@see ParsedSchema} (from struc.sql)
+ * and a list of {@see SettingSeed} rows (from data.sql) and returns a
+ * {@see MigrationPlan}.
+ *
+ * The diff is intentionally additive-only:
+ *
+ *   - Missing tables → emit a `CREATE TABLE IF NOT EXISTS …` derived from
+ *     the canonical CREATE TABLE block.
+ *   - Missing columns on existing tables → emit `ALTER TABLE … ADD COLUMN …`.
+ *   - Missing settings keys → emit `INSERT IGNORE INTO :prefix_settings …`.
+ *
+ * Any extra tables/columns/keys in the live DB are *ignored*. We never drop
+ * anything: an admin who created a `sb_my_custom` audit column should not
+ * have it deleted by an upgrade. The migrator is for additive 1.x → 2.0
+ * changes; destructive migrations would belong to a different tool.
+ *
+ * The differ is also stateless — every method takes the live PDO + parsed
+ * inputs as arguments. That makes it trivial to test without booting
+ * `init.php`.
+ */
+final class SchemaDiffer
+{
+    /**
+     * Compute what the migrator would do against `$pdo`.
+     *
+     * `$prefix` and `$charset` are substituted into the canonical SQL
+     * before it lands in the plan, so the produced statements are ready
+     * for `prepare()`/`execute()`.
+     *
+     * @param list<SettingSeed> $settingSeeds
+     */
+    public function diff(
+        PDO $pdo,
+        ParsedSchema $schema,
+        array $settingSeeds,
+        string $prefix,
+        string $charset,
+    ): MigrationPlan {
+        $existingTables  = self::listExistingTables($pdo, $prefix);
+        $existingColumns = []; // table-short-name => map<columnName, true>
+        $missingTables   = [];
+        $missingColumns  = [];
+
+        foreach ($schema->tables as $table) {
+            $fullName = $prefix . '_' . $table->shortName;
+            if (!isset($existingTables[$fullName])) {
+                $missingTables[] = new TableDelta(
+                    table: $table->shortName,
+                    sql:   self::renderDdl($table->createSql, $prefix, $charset),
+                );
+                continue;
+            }
+
+            // Table exists — diff its column set. Cache the live columns so
+            // the next `column` lookup in the same loop iteration doesn't
+            // re-query.
+            if (!isset($existingColumns[$table->shortName])) {
+                $existingColumns[$table->shortName] = self::listExistingColumns($pdo, $fullName);
+            }
+            $live = $existingColumns[$table->shortName];
+
+            foreach ($table->columns as $col) {
+                if (isset($live[strtolower($col->name)])) {
+                    continue;
+                }
+                $rawDefinition = self::renderDdl($col->definition, $prefix, $charset);
+                $missingColumns[] = new ColumnDelta(
+                    table:  $table->shortName,
+                    column: $col->name,
+                    sql:    sprintf(
+                        'ALTER TABLE `%s` ADD COLUMN `%s` %s',
+                        $fullName,
+                        $col->name,
+                        $rawDefinition,
+                    ),
+                );
+            }
+        }
+
+        $missingSettings = self::diffSettings($pdo, $settingSeeds, $prefix);
+
+        return new MigrationPlan(
+            missingTables:   $missingTables,
+            missingColumns:  $missingColumns,
+            missingSettings: $missingSettings,
+        );
+    }
+
+    /**
+     * Substitute the `{prefix}` / `{charset}` placeholders inside a parsed
+     * SQL fragment. Kept private to the differ so the rendering rules live
+     * in one place. Both placeholders are common DDL idioms in this repo.
+     */
+    private static function renderDdl(string $sql, string $prefix, string $charset): string
+    {
+        return strtr($sql, [
+            '{prefix}'  => $prefix,
+            '{charset}' => $charset,
+        ]);
+    }
+
+    /**
+     * List every table whose name starts with `$prefix_`. Returns a map
+     * keyed by full table name for O(1) presence checks.
+     *
+     * We use `information_schema.tables` rather than `SHOW TABLES LIKE` so
+     * the LIKE wildcard escaping doesn't trip on a prefix that contains
+     * `_` (it does — DB_PREFIX is literally `sb`, and the rendered table
+     * names are `sb_admins`, `sb_bans`, etc.). information_schema also
+     * gives us a stable plan target across MySQL/MariaDB versions.
+     *
+     * @return array<string, true>
+     */
+    private static function listExistingTables(PDO $pdo, string $prefix): array
+    {
+        $stmt = $pdo->prepare(
+            'SELECT TABLE_NAME FROM information_schema.TABLES '
+            . 'WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME LIKE :pattern'
+        );
+        $stmt->bindValue(':pattern', addcslashes($prefix, '_%') . '\\_%');
+        $stmt->execute();
+
+        /** @var array<string, true> $tables */
+        $tables = [];
+        foreach ($stmt->fetchAll(PDO::FETCH_COLUMN) as $name) {
+            $tables[(string) $name] = true;
+        }
+        return $tables;
+    }
+
+    /**
+     * @return array<string, true> Lower-cased column names → true.
+     */
+    private static function listExistingColumns(PDO $pdo, string $fullTableName): array
+    {
+        // `SHOW COLUMNS FROM :ident` doesn't accept bound identifiers, but
+        // information_schema does. Going through there keeps us safe even
+        // if a deployment uses a weird prefix character set.
+        $stmt = $pdo->prepare(
+            'SELECT COLUMN_NAME FROM information_schema.COLUMNS '
+            . 'WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = :name'
+        );
+        $stmt->bindValue(':name', $fullTableName);
+        $stmt->execute();
+
+        /** @var array<string, true> $cols */
+        $cols = [];
+        foreach ($stmt->fetchAll(PDO::FETCH_COLUMN) as $col) {
+            $cols[strtolower((string) $col)] = true;
+        }
+        return $cols;
+    }
+
+    /**
+     * Compute which settings rows from data.sql are missing in `:prefix_settings`.
+     *
+     * If the table itself is missing we return *every* seed — the planner
+     * already queued the CREATE TABLE for it, and the applier will run the
+     * inserts after the DDL succeeds.
+     *
+     * @param list<SettingSeed> $seeds
+     * @return list<SettingDelta>
+     */
+    private static function diffSettings(PDO $pdo, array $seeds, string $prefix): array
+    {
+        $tableName = $prefix . '_settings';
+
+        // Quick existence check — avoids a `SELECT setting FROM nonexistent`
+        // throw before the CREATE TABLE has run.
+        $exists = $pdo->prepare(
+            'SELECT 1 FROM information_schema.TABLES '
+            . 'WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = :name'
+        );
+        $exists->bindValue(':name', $tableName);
+        $exists->execute();
+        $tableExists = (bool) $exists->fetchColumn();
+
+        $present = [];
+        if ($tableExists) {
+            // identifier interpolation is fine here: `$tableName` is built
+            // from the DB_PREFIX constant + literal `_settings`, both
+            // operator-controlled. PDO won't bind table names anyway.
+            // PDO is configured with ERRMODE_EXCEPTION upstream, so query()
+            // throws on failure rather than returning false (phpstan reads
+            // the typed signature; we don't need to re-check here).
+            $stmt = $pdo->query(sprintf('SELECT `setting` FROM `%s`', $tableName));
+            foreach ($stmt->fetchAll(PDO::FETCH_COLUMN) as $key) {
+                $present[(string) $key] = true;
+            }
+        }
+
+        $missing = [];
+        foreach ($seeds as $seed) {
+            if (isset($present[$seed->key])) {
+                continue;
+            }
+            $missing[] = new SettingDelta($seed->key, $seed->value);
+        }
+        return $missing;
+    }
+}

--- a/web/includes/Migrator/SchemaParser.php
+++ b/web/includes/Migrator/SchemaParser.php
@@ -1,0 +1,335 @@
+<?php
+/*************************************************************************
+This file is part of SourceBans++
+
+SourceBans++ (c) 2014-2024 by SourceBans++ Dev Team
+
+The SourceBans++ Web panel is licensed under a
+Creative Commons Attribution-NonCommercial-ShareAlike 3.0 Unported License.
+
+You should have received a copy of the license along with this
+work.  If not, see <http://creativecommons.org/licenses/by-nc-sa/3.0/>.
+*************************************************************************/
+
+declare(strict_types=1);
+
+namespace Sbpp\Migrator;
+
+/**
+ * Reads `web/install/includes/sql/struc.sql` and `data.sql` (with the
+ * `{prefix}` / `{charset}` placeholders preserved) and turns them into a
+ * structured representation the {@see SchemaDiffer} can compare against
+ * the live database without re-executing the SQL.
+ *
+ * The parser is intentionally regex-based rather than reaching for a full
+ * SQL parser:
+ *   - Both files are vanilla DDL/DML hand-edited by humans, never machine
+ *     generated; the grammar is tiny and stable (one CREATE TABLE block per
+ *     table, one INSERT INTO ... VALUES (...), (...) ... block per seed).
+ *   - The Fixture used by every PHPUnit test already executes the same
+ *     files on a real MariaDB before each test run, so any malformed SQL
+ *     would fail the gates loudly long before the parser cared.
+ *   - Anything fancier (nikic/php-sql-parser, pgsql-parser bindings, etc.)
+ *     would be a brand-new runtime dependency for a tool that's run a
+ *     handful of times per release.
+ *
+ * Callers must pass the source as the *raw* file contents — i.e. with
+ * `{prefix}` / `{charset}` still present. The parser strips the prefix so
+ * the resulting `ParsedSchema` is independent of the deploying installation
+ * and can be substituted late.
+ */
+final class SchemaParser
+{
+    /**
+     * Parse a struc.sql source string into a list of tables.
+     *
+     * The parser keeps the `{prefix}` / `{charset}` placeholders intact in
+     * the rendered SQL so the caller (typically {@see SchemaDiffer::renderDdl()})
+     * can substitute them with the deployment-specific values just before
+     * execution. That means the parsed representation is portable across
+     * deployments with different prefixes/charsets without re-parsing.
+     */
+    public static function parseStructure(string $sql): ParsedSchema
+    {
+        $tables = [];
+
+        $stripped = self::stripComments($sql);
+
+        $rx = '/CREATE\s+TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?'
+            . '`(\{prefix\}_[a-zA-Z0-9_]+)`\s*\(([\s\S]*?)\)\s*ENGINE\s*=\s*[a-zA-Z0-9]+'
+            . '[^;]*;/i';
+
+        if (preg_match_all($rx, $stripped, $matches, PREG_SET_ORDER) === false) {
+            throw new \RuntimeException('SchemaParser: regex failed against struc.sql');
+        }
+
+        foreach ($matches as $hit) {
+            $rawName  = $hit[1];                                                  // {prefix}_admins
+            $shortName = (string) preg_replace('/^\{prefix\}_/', '', $rawName);   // admins
+            $body     = $hit[2];
+
+            $columns = self::parseColumns($body);
+            $tables[] = new ParsedTable(
+                shortName: $shortName,
+                createSql: rtrim(trim($hit[0])),
+                columns:   $columns,
+            );
+        }
+
+        return new ParsedSchema($tables);
+    }
+
+    /**
+     * Parse the `INSERT INTO {prefix}_settings (`setting`, `value`) VALUES
+     * (...), (...);` block(s) out of data.sql and return the seed key/value
+     * pairs.
+     *
+     * Settings are the only piece of `data.sql` the migrator backfills —
+     * the `{prefix}_mods` rows and the seed `{prefix}_admins` row are
+     * deliberately left to the install/dev fixture flow because clobbering
+     * them on an upgrading panel would erase admin-edited rows.
+     *
+     * @return list<SettingSeed>
+     */
+    public static function parseSettings(string $sql): array
+    {
+        $stripped = self::stripComments($sql);
+
+        // Anchor on the literal table name in the INSERT to be robust to
+        // future seed inserts for other tables.
+        $rx = '/INSERT\s+(?:IGNORE\s+)?INTO\s+`\{prefix\}_settings`'
+            . '\s*\(\s*`setting`\s*,\s*`value`\s*\)\s*VALUES\s*([\s\S]*?);/i';
+
+        if (preg_match_all($rx, $stripped, $matches, PREG_SET_ORDER) === false) {
+            return [];
+        }
+
+        $seeds = [];
+        $seen  = [];
+        foreach ($matches as $hit) {
+            foreach (self::extractTuples($hit[1]) as [$key, $value]) {
+                if (isset($seen[$key])) {
+                    // data.sql is human-edited; flag a duplicate at parse
+                    // time so we don't silently shadow one row with another.
+                    throw new \RuntimeException(
+                        "SchemaParser: duplicate settings key '$key' in data.sql"
+                    );
+                }
+                $seen[$key] = true;
+                $seeds[]    = new SettingSeed($key, $value);
+            }
+        }
+
+        return $seeds;
+    }
+
+    /**
+     * Strip `--`-prefixed line comments and `/* ... *\/` block comments. We
+     * keep `#` literals alone — `data.sql` doesn't use them and stripping
+     * them naively would clobber `value` payloads that happen to contain a
+     * `#` (e.g. an HTML colour).
+     */
+    private static function stripComments(string $sql): string
+    {
+        $sql = (string) preg_replace('@/\*.*?\*/@s', '', $sql);
+        $sql = (string) preg_replace('/^\s*--[^\n]*\n/m', '', $sql);
+        return $sql;
+    }
+
+    /**
+     * Pull `\`name\` TYPE ...` column declarations out of a CREATE TABLE
+     * body. Index/constraint declarations (`PRIMARY KEY`, `UNIQUE KEY`,
+     * `KEY`, `FULLTEXT`, `INDEX`, `UNIQUE`, `CONSTRAINT`, `FOREIGN KEY`)
+     * are skipped.
+     *
+     * @return list<ParsedColumn>
+     */
+    private static function parseColumns(string $body): array
+    {
+        $columns = [];
+        $depth   = 0;
+        $buffer  = '';
+        $len     = strlen($body);
+
+        // Walk character by character so we can split on top-level commas
+        // without falling for ones inside `int(11)` / `enum('a','b')`.
+        for ($i = 0; $i < $len; $i++) {
+            $ch = $body[$i];
+            if ($ch === '(') {
+                $depth++;
+                $buffer .= $ch;
+                continue;
+            }
+            if ($ch === ')') {
+                $depth--;
+                $buffer .= $ch;
+                continue;
+            }
+            if ($ch === ',' && $depth === 0) {
+                $col = self::columnFromLine($buffer);
+                if ($col !== null) {
+                    $columns[] = $col;
+                }
+                $buffer = '';
+                continue;
+            }
+            $buffer .= $ch;
+        }
+
+        if (trim($buffer) !== '') {
+            $col = self::columnFromLine($buffer);
+            if ($col !== null) {
+                $columns[] = $col;
+            }
+        }
+
+        return $columns;
+    }
+
+    /**
+     * Convert a single column-or-index declaration into a {@see ParsedColumn}
+     * (or `null` if the line is an index/constraint, not a column).
+     */
+    private static function columnFromLine(string $line): ?ParsedColumn
+    {
+        $trimmed = trim($line);
+        if ($trimmed === '') {
+            return null;
+        }
+
+        $upper = strtoupper($trimmed);
+        // Order matters: FULLTEXT KEY / UNIQUE KEY share a tail with KEY.
+        $skipPrefixes = [
+            'PRIMARY KEY',
+            'UNIQUE KEY',
+            'UNIQUE INDEX',
+            'UNIQUE ',
+            'FULLTEXT KEY',
+            'FULLTEXT INDEX',
+            'FULLTEXT ',
+            'INDEX ',
+            'INDEX(',
+            'KEY ',
+            'KEY(',
+            'CONSTRAINT ',
+            'FOREIGN KEY',
+            'CHECK ',
+        ];
+        foreach ($skipPrefixes as $p) {
+            if (str_starts_with($upper, $p)) {
+                return null;
+            }
+        }
+
+        if (!preg_match('/^`([a-zA-Z0-9_]+)`\s+(.+)$/s', $trimmed, $m)) {
+            return null;
+        }
+
+        return new ParsedColumn(
+            name:       $m[1],
+            definition: self::collapseWhitespace((string) $m[2]),
+        );
+    }
+
+    private static function collapseWhitespace(string $s): string
+    {
+        return trim((string) preg_replace('/\s+/', ' ', $s));
+    }
+
+    /**
+     * Pull every `('key', 'value')` tuple out of an INSERT VALUES list. We
+     * accept single-quoted literals (the only ones used in data.sql) and
+     * tolerate escaped quotes via a doubled `''` SQL convention.
+     *
+     * @return list<array{0: string, 1: string}>
+     */
+    private static function extractTuples(string $valuesBody): array
+    {
+        $tuples = [];
+        $len    = strlen($valuesBody);
+        $i      = 0;
+
+        while ($i < $len) {
+            // Skip whitespace + commas between tuples.
+            while ($i < $len && ($valuesBody[$i] === ' ' || $valuesBody[$i] === "\t"
+                || $valuesBody[$i] === "\n" || $valuesBody[$i] === "\r"
+                || $valuesBody[$i] === ',')) {
+                $i++;
+            }
+            if ($i >= $len) {
+                break;
+            }
+            if ($valuesBody[$i] !== '(') {
+                // Stray char — most likely a trailing newline; bail rather
+                // than misparse half a tuple.
+                break;
+            }
+            $i++; // consume '('
+
+            $key = self::readQuoted($valuesBody, $i);
+            self::skipCommaWs($valuesBody, $i);
+            $val = self::readQuoted($valuesBody, $i);
+
+            // Skip until the matching close paren.
+            while ($i < $len && $valuesBody[$i] !== ')') {
+                $i++;
+            }
+            if ($i < $len && $valuesBody[$i] === ')') {
+                $i++;
+            }
+
+            $tuples[] = [$key, $val];
+        }
+
+        return $tuples;
+    }
+
+    /** Read a single-quoted SQL literal starting at `$pos`. Advances `$pos`. */
+    private static function readQuoted(string $s, int &$pos): string
+    {
+        // Skip leading whitespace.
+        while ($pos < strlen($s) && ($s[$pos] === ' ' || $s[$pos] === "\t" || $s[$pos] === "\n" || $s[$pos] === "\r")) {
+            $pos++;
+        }
+        if ($pos >= strlen($s) || $s[$pos] !== "'") {
+            throw new \RuntimeException(
+                "SchemaParser: expected single-quoted literal at offset $pos in INSERT body"
+            );
+        }
+        $pos++; // consume opening '
+
+        $buf = '';
+        $len = strlen($s);
+        while ($pos < $len) {
+            $ch = $s[$pos];
+            if ($ch === "\\" && $pos + 1 < $len) {
+                $buf .= $s[$pos + 1];
+                $pos += 2;
+                continue;
+            }
+            if ($ch === "'") {
+                if ($pos + 1 < $len && $s[$pos + 1] === "'") {
+                    $buf .= "'";
+                    $pos += 2;
+                    continue;
+                }
+                $pos++; // consume closing '
+                return $buf;
+            }
+            $buf .= $ch;
+            $pos++;
+        }
+
+        throw new \RuntimeException(
+            'SchemaParser: unterminated single-quoted literal in INSERT body'
+        );
+    }
+
+    private static function skipCommaWs(string $s, int &$pos): void
+    {
+        $len = strlen($s);
+        while ($pos < $len && ($s[$pos] === ' ' || $s[$pos] === "\t" || $s[$pos] === "\n" || $s[$pos] === "\r" || $s[$pos] === ',')) {
+            $pos++;
+        }
+    }
+}

--- a/web/includes/Migrator/SettingDelta.php
+++ b/web/includes/Migrator/SettingDelta.php
@@ -1,0 +1,30 @@
+<?php
+/*************************************************************************
+This file is part of SourceBans++
+
+SourceBans++ (c) 2014-2024 by SourceBans++ Dev Team
+
+The SourceBans++ Web panel is licensed under a
+Creative Commons Attribution-NonCommercial-ShareAlike 3.0 Unported License.
+
+You should have received a copy of the license along with this
+work.  If not, see <http://creativecommons.org/licenses/by-nc-sa/3.0/>.
+*************************************************************************/
+
+declare(strict_types=1);
+
+namespace Sbpp\Migrator;
+
+/**
+ * One missing `:prefix_settings` row that data.sql ships and the live DB
+ * is missing. The applier wraps these in a transaction together because
+ * they're plain DML and rolling back is cheap.
+ */
+final class SettingDelta
+{
+    public function __construct(
+        public readonly string $key,
+        public readonly string $value,
+    ) {
+    }
+}

--- a/web/includes/Migrator/SettingSeed.php
+++ b/web/includes/Migrator/SettingSeed.php
@@ -1,0 +1,29 @@
+<?php
+/*************************************************************************
+This file is part of SourceBans++
+
+SourceBans++ (c) 2014-2024 by SourceBans++ Dev Team
+
+The SourceBans++ Web panel is licensed under a
+Creative Commons Attribution-NonCommercial-ShareAlike 3.0 Unported License.
+
+You should have received a copy of the license along with this
+work.  If not, see <http://creativecommons.org/licenses/by-nc-sa/3.0/>.
+*************************************************************************/
+
+declare(strict_types=1);
+
+namespace Sbpp\Migrator;
+
+/**
+ * One row of `INSERT INTO :prefix_settings (`setting`, `value`) VALUES …`
+ * pulled out of data.sql.
+ */
+final class SettingSeed
+{
+    public function __construct(
+        public readonly string $key,
+        public readonly string $value,
+    ) {
+    }
+}

--- a/web/includes/Migrator/TableDelta.php
+++ b/web/includes/Migrator/TableDelta.php
@@ -1,0 +1,30 @@
+<?php
+/*************************************************************************
+This file is part of SourceBans++
+
+SourceBans++ (c) 2014-2024 by SourceBans++ Dev Team
+
+The SourceBans++ Web panel is licensed under a
+Creative Commons Attribution-NonCommercial-ShareAlike 3.0 Unported License.
+
+You should have received a copy of the license along with this
+work.  If not, see <http://creativecommons.org/licenses/by-nc-sa/3.0/>.
+*************************************************************************/
+
+declare(strict_types=1);
+
+namespace Sbpp\Migrator;
+
+/**
+ * `CREATE TABLE` statement for a table that exists in struc.sql but not in
+ * the live DB. `sql` is fully rendered (prefix + charset substituted) and
+ * idempotent (`CREATE TABLE IF NOT EXISTS …`).
+ */
+final class TableDelta
+{
+    public function __construct(
+        public readonly string $table,
+        public readonly string $sql,
+    ) {
+    }
+}

--- a/web/includes/View/AdminUpgradeView.php
+++ b/web/includes/View/AdminUpgradeView.php
@@ -1,0 +1,32 @@
+<?php
+declare(strict_types=1);
+
+namespace Sbpp\View;
+
+/**
+ * Admin → Upgrade page (`?p=admin&c=upgrade`).
+ *
+ * Wraps the same {@see \Sbpp\Migrator\Migrator} pipeline the CLI uses so
+ * an operator can preview the dry-run diff and apply it without shelling
+ * into the host. Gated to `ADMIN_OWNER` by the router.
+ */
+final class AdminUpgradeView extends View
+{
+    public const TEMPLATE = 'page_admin_upgrade.tpl';
+
+    /**
+     * @param array{
+     *     ok: bool,
+     *     total: int,
+     *     tables: list<array{name: string, sql: string}>,
+     *     columns: list<array{table: string, column: string, sql: string}>,
+     *     settings: list<array{key: string, value: string}>,
+     * } $plan
+     */
+    public function __construct(
+        public readonly bool $permission_owner,
+        public readonly array $plan,
+        public readonly ?string $plan_error,
+    ) {
+    }
+}

--- a/web/includes/page-builder.php
+++ b/web/includes/page-builder.php
@@ -110,6 +110,12 @@ function route($fallback)
                 case 'settings':
                     CheckAdminAccess(ADMIN_OWNER|ADMIN_WEB_SETTINGS);
                     return ['SourceBans++ Settings', '/admin.settings.php'];
+                case 'upgrade':
+                    // Owner-only because applying schema changes is a
+                    // root-of-trust action; even a permissive web settings
+                    // role shouldn't be able to alter the table layout.
+                    CheckAdminAccess(ADMIN_OWNER);
+                    return ['Schema Upgrade', '/admin.upgrade.php'];
                 default:
                     CheckAdminAccess(ALL_WEB);
                     return ['Administration', '/page.admin.php'];

--- a/web/pages/admin.upgrade.php
+++ b/web/pages/admin.upgrade.php
@@ -1,0 +1,66 @@
+<?php
+/*************************************************************************
+This file is part of SourceBans++
+
+SourceBans++ (c) 2014-2024 by SourceBans++ Dev Team
+
+The SourceBans++ Web panel is licensed under a
+Creative Commons Attribution-NonCommercial-ShareAlike 3.0 Unported License.
+
+You should have received a copy of the license along with this
+work.  If not, see <http://creativecommons.org/licenses/by-nc-sa/3.0/>.
+
+Admin → Upgrade page (`?p=admin&c=upgrade`).
+
+Renders the dry-run preview produced by the same {@see \Sbpp\Migrator\Migrator}
+that backs `web/bin/upgrade.php`. The "Apply changes" button posts to the
+`system.upgrade_apply` JSON action, which re-runs the planner inside the
+handler so the apply always reflects the live diff at the moment of click.
+
+Gated to `ADMIN_OWNER` by `route()` (page-builder.php) and again by the
+template — defence in depth, since the template is what an admin sees if
+they reach the page through any other path.
+*************************************************************************/
+
+if (!defined("IN_SB")) {
+    echo "You should not be here. Only follow links!";
+    die();
+}
+
+global $userbank, $theme;
+
+$planArr   = ['ok' => true, 'total' => 0, 'tables' => [], 'columns' => [], 'settings' => []];
+$planError = null;
+
+if ($userbank->HasAccess(ADMIN_OWNER)) {
+    try {
+        // Open a fresh PDO for the migrator: the differ runs raw
+        // information_schema queries, which is awkward through the
+        // `Database` wrapper (its `:prefix_` rewriter would mangle bound
+        // table names). A bare PDO opened from the same env sidesteps
+        // the whole issue and stays scoped to this page.
+        $dsn = sprintf(
+            'mysql:host=%s;port=%d;dbname=%s;charset=%s',
+            DB_HOST,
+            defined('DB_PORT') ? (int) DB_PORT : 3306,
+            DB_NAME,
+            defined('DB_CHARSET') ? (string) DB_CHARSET : 'utf8mb4',
+        );
+        $rawPdo = new \PDO($dsn, DB_USER, DB_PASS, [\PDO::ATTR_ERRMODE => \PDO::ERRMODE_EXCEPTION]);
+
+        $migrator = \Sbpp\Migrator\Migrator::fromInstallSql(
+            ROOT,
+            $GLOBALS['PDO']->getPrefix(),
+            defined('DB_CHARSET') ? (string) DB_CHARSET : 'utf8mb4',
+        );
+        $planArr = $migrator->plan($rawPdo)->toArray();
+    } catch (\Throwable $e) {
+        $planError = $e->getMessage();
+    }
+}
+
+\Sbpp\View\Renderer::render($theme, new \Sbpp\View\AdminUpgradeView(
+    permission_owner: $userbank->HasAccess(ADMIN_OWNER),
+    plan: $planArr,
+    plan_error: $planError,
+));

--- a/web/pages/core/navbar.php
+++ b/web/pages/core/navbar.php
@@ -81,6 +81,11 @@ $admin = [
         'title' => 'Mods',
         'endpoint' => 'mods',
         'permission' => ADMIN_OWNER|ADMIN_LIST_MODS|ADMIN_ADD_MODS|ADMIN_EDIT_MODS|ADMIN_DELETE_MODS
+    ],
+    [
+        'title' => 'Upgrade',
+        'endpoint' => 'upgrade',
+        'permission' => ADMIN_OWNER
     ]
 ];
 

--- a/web/pages/page.admin.php
+++ b/web/pages/page.admin.php
@@ -39,6 +39,7 @@ $theme->assign('access_bans', $userbank->HasAccess(ADMIN_OWNER | ADMIN_ADD_BAN |
 $theme->assign('access_groups', $userbank->HasAccess(ADMIN_OWNER | ADMIN_LIST_GROUPS | ADMIN_ADD_GROUP | ADMIN_EDIT_GROUPS | ADMIN_DELETE_GROUPS));
 $theme->assign('access_settings', $userbank->HasAccess(ADMIN_OWNER | ADMIN_WEB_SETTINGS));
 $theme->assign('access_mods', $userbank->HasAccess(ADMIN_OWNER | ADMIN_LIST_MODS | ADMIN_ADD_MODS | ADMIN_EDIT_MODS | ADMIN_DELETE_MODS));
+$theme->assign('access_upgrade', $userbank->HasAccess(ADMIN_OWNER));
 
 $theme->assign('dev', SB_DEV);
 

--- a/web/scripts/api-contract.js
+++ b/web/scripts/api-contract.js
@@ -252,6 +252,34 @@
  * @typedef {Object} ApiSystemSendMailRequest
  * @typedef {Object} ApiSystemSendMailResponse
  */
+/**
+ * Apply the schema-migrator plan against the live database.  Re-computes the
+ * plan inside the handler so the apply always reflects the live diff at the
+ * moment of click — staleness between a "Refresh" view and the "Apply" click
+ * would otherwise let an admin try to apply a change that's already been
+ * satisfied. Permission gating (`ADMIN_OWNER`) is enforced at the {@see
+ * Api::register()} call in `_register.php`.  The exact response shape is
+ * documented on {@see \Sbpp\Migrator\MigrationResult::toArray()}; we keep the
+ * @return tag loose here on purpose — the api-contract generator's JSDoc
+ * emitter trips on `?T`-followed-by-comma in nested array shapes, and the JS
+ * caller (`UpgradeApply()`) re-types the response inline anyway.
+ *
+ * @typedef {Object} ApiSystemUpgradeApplyRequest
+ * @typedef {Object} ApiSystemUpgradeApplyResponse
+ */
+/**
+ * Compute the schema-migrator dry-run plan against the live database.  Backs
+ * the `?p=admin&c=upgrade` page's "Refresh dry-run" button. Read-only —
+ * never mutates the schema. Permission gating (`ADMIN_OWNER`) is enforced at
+ * the {@see Api::register()} call in `_register.php`.  The exact response
+ * shape is documented on {@see \Sbpp\Migrator\MigrationPlan::toArray()}; we
+ * keep the @return tag loose here on purpose — the api-contract generator's
+ * JSDoc emitter trips on `?T`-followed-by-comma in nested array shapes, and
+ * the JS caller (`UpgradeRefresh()`) re-types the response inline anyway.
+ *
+ * @typedef {Object} ApiSystemUpgradeDiffRequest
+ * @typedef {Object} ApiSystemUpgradeDiffResponse
+ */
 
 /**
  * Action names accepted by sb.api.call(). Keys are PascalCase derived from
@@ -316,6 +344,8 @@ var Actions = Object.freeze({
     SystemRehashAdmins: 'system.rehash_admins',
     SystemSelTheme: 'system.sel_theme',
     SystemSendMail: 'system.send_mail',
+    SystemUpgradeApply: 'system.upgrade_apply',
+    SystemUpgradeDiff: 'system.upgrade_diff',
 });
 
 /**

--- a/web/scripts/sourcebans.js
+++ b/web/scripts/sourcebans.js
@@ -1769,3 +1769,78 @@ function LoadGroupBan(groupuri, isgrpurl, queue, reason, last) {
 // (each calls sb.api.call(Actions.BansAdd / Actions.CommsAdd) against its
 // own form). No global wrapper here on purpose — both pages would collide.
 
+// =====================================================================
+// Schema upgrade page (?p=admin&c=upgrade)
+//
+// Backed by api/handlers/system.php#api_system_upgrade_diff /
+// api_system_upgrade_apply. Both are gated to `Perms.ADMIN_OWNER` by
+// the registry. The page server-side renders an initial dry run, so
+// these are only invoked on operator action (refresh / apply button).
+// =====================================================================
+
+/**
+ * Re-fetch the dry-run plan and reload the page so the freshly-computed
+ * summary replaces the one we rendered server-side. Reload (rather than
+ * patching the DOM in place) keeps the apply button visibility logic in
+ * exactly one place — the template.
+ */
+function UpgradeRefresh() {
+    sb.api.callOrAlert(Actions.SystemUpgradeDiff, {}).then((r) => {
+        if (!r || r.ok === false) return;
+        window.location.reload();
+    });
+}
+
+/**
+ * Apply the queued plan. The handler re-computes the diff inside the
+ * call so we never apply a stale snapshot. Renders the per-step result
+ * table inline and reloads on success so the dry-run summary at the top
+ * collapses to "nothing to do".
+ */
+function UpgradeApply() {
+    if (!confirm('Apply the pending schema changes? This is non-destructive (additive only) but cannot be reverted by this tool.')) {
+        return;
+    }
+    const apply = sb.$id('upgrade-apply');
+    if (apply) apply.disabled = true;
+
+    sb.api.callOrAlert(Actions.SystemUpgradeApply, {}).then((r) => {
+        if (apply) apply.disabled = false;
+        if (!r || r.ok === false) return;
+
+        const data = r.data || {};
+        const steps = Array.isArray(data.steps) ? data.steps : [];
+
+        const wrap = sb.$id('upgrade-results');
+        const body = sb.$id('upgrade-results-body');
+        const errBox = sb.$id('upgrade-results-error');
+        if (!wrap || !body) return;
+
+        body.innerHTML = '';
+        /** @type {Array<{kind: string, target: string, summary: string, success: boolean, error: string|null}>} */
+        const typedSteps = steps;
+        typedSteps.forEach((s) => {
+            const row = document.createElement('tr');
+            row.innerHTML =
+                '<td class="listtable_1">' + (s.success ? '<span style="color:green">&#10003;</span>' : '<span style="color:red">&#10007;</span>') + '</td>' +
+                '<td class="listtable_1">' + sb.escapeHtml(s.kind) + '</td>' +
+                '<td class="listtable_1">' + sb.escapeHtml(s.target) + '</td>' +
+                '<td class="listtable_1">' + sb.escapeHtml(s.summary) + (s.error ? '<br /><i>' + sb.escapeHtml(s.error) + '</i>' : '') + '</td>';
+            body.appendChild(row);
+        });
+
+        wrap.style.display = '';
+
+        if (data.ok && !data.error) {
+            if (errBox) errBox.style.display = 'none';
+            sb.message.success('Upgrade complete', 'Schema is now up to date. Reloading…', 'index.php?p=admin&c=upgrade');
+        } else {
+            if (errBox) {
+                errBox.style.display = '';
+                errBox.textContent = data.error || 'Apply failed; see the per-step log.';
+            }
+            sb.message.error('Upgrade failed', data.error || 'See the per-step log.');
+        }
+    });
+}
+

--- a/web/tests/Fixture.php
+++ b/web/tests/Fixture.php
@@ -13,6 +13,21 @@ class Fixture
     private static bool $installed = false;
     private static int $adminAid   = 0;
 
+    /**
+     * Forget the once-per-process install flag so the next call to
+     * {@see install()} re-runs the full DROP DATABASE / re-render of
+     * struc.sql + data.sql.
+     *
+     * Useful for tests (e.g. `UpgradeRunnerTest`) that intentionally
+     * mutate the schema with DROP TABLE / DROP COLUMN; the default
+     * `reset()` only truncates rows, so a dropped table would otherwise
+     * stay missing for every subsequent test in the run.
+     */
+    public static function forgetInstallFlag(): void
+    {
+        self::$installed = false;
+    }
+
     public static function install(): void
     {
         if (self::$installed) {

--- a/web/tests/integration/UpgradeRunnerTest.php
+++ b/web/tests/integration/UpgradeRunnerTest.php
@@ -1,0 +1,246 @@
+<?php
+
+namespace Sbpp\Tests\Integration;
+
+use PHPUnit\Framework\TestCase;
+use Sbpp\Migrator\MigrationApplier;
+use Sbpp\Migrator\Migrator;
+use Sbpp\Tests\Fixture;
+
+/**
+ * Issue #1111: integration coverage for the schema migrator.
+ *
+ * The fixture installs `sourcebans_test` from `web/install/includes/sql/struc.sql`
+ * + `data.sql` before each test. We then knock out three different kinds of
+ * additions a 1.x → 2.0 upgrade is expected to introduce — a missing
+ * column, a missing table, and a missing settings row — and assert that
+ * the migrator:
+ *
+ *   1. Reports them on the dry run (so the `--apply`-less CLI / panel
+ *      preview shows operators *exactly* what's coming).
+ *   2. Applies them cleanly.
+ *   3. Converges on a re-run — the second `plan()` is empty, the second
+ *      `apply()` is a no-op. This is the "Nothing to do." guarantee in
+ *      the issue's acceptance criteria.
+ *
+ * The deltas below were chosen to exercise each pathway in the differ
+ * (`SchemaDiffer::listExistingTables`, `listExistingColumns`,
+ * `diffSettings`) so a regression in any one would break exactly one
+ * sub-assertion rather than the whole test.
+ */
+final class UpgradeRunnerTest extends TestCase
+{
+    /** @var \PDO Fresh raw PDO held for the lifetime of one test method. */
+    private \PDO $pdo;
+
+    private Migrator $migrator;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        // We mutate the schema below (DROP TABLE / DROP COLUMN), so the
+        // once-per-process optimisation in `Fixture::install()` would
+        // leave the DB inconsistent for subsequent tests. Force a fresh
+        // re-install so every test method starts from a clean copy of
+        // struc.sql + data.sql.
+        Fixture::forgetInstallFlag();
+        Fixture::reset();
+
+        $this->pdo = Fixture::rawPdo();
+        $this->migrator = Migrator::fromInstallSql(ROOT, DB_PREFIX, DB_CHARSET);
+    }
+
+    public function testFreshSchemaIsAlreadyUpToDate(): void
+    {
+        $plan = $this->migrator->plan($this->pdo);
+        $this->assertTrue(
+            $plan->isEmpty(),
+            'A freshly-installed `sourcebans_test` should match struc.sql: '
+            . json_encode($plan->toArray(), JSON_PRETTY_PRINT),
+        );
+    }
+
+    public function testDropAndConvergeForColumnTableAndSetting(): void
+    {
+        // --- 1. Knock out one of each kind of 2.0 addition. ----------
+        // Missing column: `lockout_until` — added by the 1.6 → 1.8
+        //   lockout work and shipped in struc.sql.
+        // Missing table:  `:prefix_login_tokens` — JWT GC table added
+        //   in the 1.6 → 1.7 jump.
+        // Missing setting: `config.enablesteamlogin` — issue #1102 work.
+        $this->dropColumn(DB_PREFIX . '_admins', 'lockout_until');
+        $this->dropTable(DB_PREFIX . '_login_tokens');
+        $this->deleteSetting('config.enablesteamlogin');
+
+        // --- 2. Dry run reports all three. ----------------------------
+        $plan = $this->migrator->plan($this->pdo);
+
+        $this->assertSame(3, $plan->totalChanges(),
+            'Expected exactly 3 deltas (1 col + 1 table + 1 setting), got: '
+            . json_encode($plan->toArray(), JSON_PRETTY_PRINT));
+
+        $tableNames = array_map(fn($t) => $t->table, $plan->missingTables);
+        $this->assertSame(['login_tokens'], $tableNames,
+            'Missing-table set should contain `login_tokens`.');
+
+        $columnDescriptors = array_map(
+            fn($c) => $c->table . '.' . $c->column,
+            $plan->missingColumns,
+        );
+        $this->assertSame(['admins.lockout_until'], $columnDescriptors,
+            'Missing-column set should contain `admins.lockout_until`.');
+
+        $settingKeys = array_map(fn($s) => $s->key, $plan->missingSettings);
+        $this->assertSame(['config.enablesteamlogin'], $settingKeys,
+            'Missing-setting set should contain `config.enablesteamlogin`.');
+
+        // The DDL placeholders must already be substituted; the applier
+        // hands these straight to PDO.
+        $tableSql = $plan->missingTables[0]->sql;
+        $this->assertStringNotContainsString('{prefix}', $tableSql,
+            'Plan SQL must have {prefix} substituted before reaching apply.');
+        $this->assertStringNotContainsString('{charset}', $tableSql,
+            'Plan SQL must have {charset} substituted before reaching apply.');
+        $this->assertStringContainsString('`' . DB_PREFIX . '_login_tokens`', $tableSql);
+
+        // --- 3. Apply, every step succeeds. --------------------------
+        $applier = new MigrationApplier(DB_PREFIX);
+        $result  = $applier->apply($this->pdo, $plan);
+
+        $this->assertTrue($result->success,
+            'Apply should succeed; error was: ' . ($result->error ?? '<null>'));
+        $this->assertSame(3, count($result->steps),
+            'Expected one step per delta. Got: '
+            . json_encode($result->toArray(), JSON_PRETTY_PRINT));
+        foreach ($result->steps as $step) {
+            $this->assertTrue($step->success, "Step '{$step->summary}' should have succeeded.");
+        }
+
+        // The deltas physically landed in the live DB.
+        $this->assertTrue($this->columnExists(DB_PREFIX . '_admins', 'lockout_until'));
+        $this->assertTrue($this->tableExists(DB_PREFIX . '_login_tokens'));
+        $this->assertSame('1', $this->readSetting('config.enablesteamlogin'),
+            "Backfilled setting should match data.sql's seed value.");
+
+        // --- 4. Convergence: re-running is a clean no-op. ------------
+        $rePlan = $this->migrator->plan($this->pdo);
+        $this->assertTrue($rePlan->isEmpty(),
+            'Re-planning after apply should yield an empty plan; got: '
+            . json_encode($rePlan->toArray(), JSON_PRETTY_PRINT));
+
+        $reApply = $applier->apply($this->pdo, $rePlan);
+        $this->assertTrue($reApply->success);
+        $this->assertSame([], $reApply->steps,
+            'Empty plan should produce zero apply steps.');
+    }
+
+    public function testApplyHonoursExistingSettingValues(): void
+    {
+        // Operators routinely tweak settings (e.g. flipping
+        // `config.enablesteamlogin` off). The migrator must never clobber
+        // an admin-edited value when re-running. We INSERT IGNORE on the
+        // `setting` UNIQUE key, so an existing row stays intact even if
+        // the seed shipped a different value.
+        $this->setSetting('config.enablesteamlogin', '0');
+
+        // Now drop *another* setting so the planner still has work to
+        // do; otherwise the apply path is trivially a no-op.
+        $this->deleteSetting('config.enablenormallogin');
+
+        $plan = $this->migrator->plan($this->pdo);
+        $applier = new MigrationApplier(DB_PREFIX);
+        $applier->apply($this->pdo, $plan);
+
+        $this->assertSame('0', $this->readSetting('config.enablesteamlogin'),
+            'Apply must not overwrite an admin-customised setting.');
+        $this->assertSame('1', $this->readSetting('config.enablenormallogin'),
+            'Apply must backfill the missing setting from data.sql.');
+    }
+
+    public function testTableDropImpliesAllSettingsRebuild(): void
+    {
+        // Edge case: if the entire `:prefix_settings` table is missing
+        // (which would only happen on an extraordinarily corrupt panel,
+        // but the migrator should still cope), the planner should queue
+        // the CREATE TABLE *and* every seed row, and the applier should
+        // run them in the right order so the inserts find a target.
+        $this->dropTable(DB_PREFIX . '_settings');
+
+        $plan = $this->migrator->plan($this->pdo);
+
+        $tableNames = array_map(fn($t) => $t->table, $plan->missingTables);
+        $this->assertContains('settings', $tableNames,
+            'Missing the settings table should be reported.');
+
+        $this->assertNotEmpty($plan->missingSettings,
+            'When the settings table is gone, every seed row should be queued.');
+
+        $applier = new MigrationApplier(DB_PREFIX);
+        $result  = $applier->apply($this->pdo, $plan);
+
+        $this->assertTrue($result->success,
+            'Settings-table rebuild should succeed; error was: ' . ($result->error ?? '<null>'));
+
+        // And convergence still holds.
+        $this->assertTrue($this->migrator->plan($this->pdo)->isEmpty());
+    }
+
+    private function dropColumn(string $table, string $column): void
+    {
+        $this->pdo->exec(sprintf('ALTER TABLE `%s` DROP COLUMN `%s`', $table, $column));
+    }
+
+    private function dropTable(string $table): void
+    {
+        $this->pdo->exec(sprintf('DROP TABLE `%s`', $table));
+    }
+
+    private function deleteSetting(string $key): void
+    {
+        $stmt = $this->pdo->prepare(sprintf(
+            'DELETE FROM `%s_settings` WHERE `setting` = ?',
+            DB_PREFIX,
+        ));
+        $stmt->execute([$key]);
+    }
+
+    private function setSetting(string $key, string $value): void
+    {
+        $stmt = $this->pdo->prepare(sprintf(
+            'REPLACE INTO `%s_settings` (`setting`, `value`) VALUES (?, ?)',
+            DB_PREFIX,
+        ));
+        $stmt->execute([$key, $value]);
+    }
+
+    private function readSetting(string $key): ?string
+    {
+        $stmt = $this->pdo->prepare(sprintf(
+            'SELECT `value` FROM `%s_settings` WHERE `setting` = ?',
+            DB_PREFIX,
+        ));
+        $stmt->execute([$key]);
+        $row = $stmt->fetch(\PDO::FETCH_ASSOC);
+        return $row === false ? null : (string) $row['value'];
+    }
+
+    private function tableExists(string $name): bool
+    {
+        $stmt = $this->pdo->prepare(
+            'SELECT 1 FROM information_schema.TABLES '
+            . "WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ?",
+        );
+        $stmt->execute([$name]);
+        return (bool) $stmt->fetchColumn();
+    }
+
+    private function columnExists(string $table, string $column): bool
+    {
+        $stmt = $this->pdo->prepare(
+            'SELECT 1 FROM information_schema.COLUMNS '
+            . 'WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ? AND COLUMN_NAME = ?',
+        );
+        $stmt->execute([$table, $column]);
+        return (bool) $stmt->fetchColumn();
+    }
+}

--- a/web/themes/default/page_admin.tpl
+++ b/web/themes/default/page_admin.tpl
@@ -68,6 +68,15 @@
                 </a>
             </li>
         {/if}
+        {if $access_upgrade}
+            <li>
+                <a href="index.php?p=admin&amp;c=upgrade">
+                    <i class="fas fa-database fa-5x"></i>
+                    <br/><br/>
+                    <b>Schema Upgrade</b>
+                </a>
+            </li>
+        {/if}
     </ul>
 </div>
 <br />

--- a/web/themes/default/page_admin_upgrade.tpl
+++ b/web/themes/default/page_admin_upgrade.tpl
@@ -1,0 +1,78 @@
+{if NOT $permission_owner}
+    Access Denied!
+{else}
+    <h3>Schema upgrade (1.x → 2.0)</h3>
+    <p>
+        This page wraps the same code path as <code>php web/bin/upgrade.php</code>.
+        Use it to compare the live database against the canonical schema in
+        <code>web/install/includes/sql/struc.sql</code> and apply the additive
+        changes (missing tables, missing columns, missing settings keys).
+        The migrator never drops anything; running it twice is a no-op.
+    </p>
+
+    {if $plan_error}
+        <div class="badentry">
+            <strong>Could not compute the diff:</strong>
+            {$plan_error}
+        </div>
+    {else}
+        <div id="upgrade-summary">
+            {if $plan.ok}
+                <p><strong>Schema is up to date — nothing to do.</strong></p>
+            {else}
+                <p><strong>Pending changes: {$plan.total}</strong></p>
+
+                {if $plan.tables}
+                    <h4>Missing tables ({$plan.tables|@count})</h4>
+                    <ul>
+                        {foreach from=$plan.tables item=t}
+                            <li><code>:prefix_{$t.name}</code></li>
+                        {/foreach}
+                    </ul>
+                {/if}
+
+                {if $plan.columns}
+                    <h4>Missing columns ({$plan.columns|@count})</h4>
+                    <ul>
+                        {foreach from=$plan.columns item=c}
+                            <li><code>:prefix_{$c.table}.{$c.column}</code></li>
+                        {/foreach}
+                    </ul>
+                {/if}
+
+                {if $plan.settings}
+                    <h4>Missing settings keys ({$plan.settings|@count})</h4>
+                    <ul>
+                        {foreach from=$plan.settings item=s}
+                            <li><code>{$s.key}</code> = <code>{$s.value}</code></li>
+                        {/foreach}
+                    </ul>
+                {/if}
+            {/if}
+        </div>
+
+        <br />
+        <div id="upgrade-actions">
+            {sb_button text="Refresh dry-run" onclick="UpgradeRefresh();" class="cancel" id="upgrade-refresh"}
+            &nbsp;
+            {if NOT $plan.ok}
+                {sb_button text="Apply changes" onclick="UpgradeApply();" class="ok" id="upgrade-apply"}
+            {/if}
+        </div>
+
+        <br />
+        <div id="upgrade-results" style="display:none;">
+            <h4>Apply log</h4>
+            <table width="100%" cellspacing="0" cellpadding="0" class="listtable">
+                <tr>
+                    <td width="10%" class="listtable_top"><strong>Status</strong></td>
+                    <td width="15%" class="listtable_top"><strong>Kind</strong></td>
+                    <td width="25%" class="listtable_top"><strong>Target</strong></td>
+                    <td class="listtable_top"><strong>Summary</strong></td>
+                </tr>
+                <tbody id="upgrade-results-body"></tbody>
+            </table>
+            <div id="upgrade-results-error" class="badentry" style="display:none;"></div>
+        </div>
+    {/if}
+{/if}


### PR DESCRIPTION
Closes #1111

## Summary

`web/upgrade.php` only writes the JWT secret. Operators upgrading from a
1.7/1.8 panel today have no runner that picks up the 2.0 schema deltas
(new `sb_login_tokens` table, `attempts` / `lockout_until` columns on
`sb_admins`, new settings keys). This PR adds an idempotent migrator
that diffs the live database against the canonical schema in
`web/install/includes/sql/struc.sql` + `data.sql` and applies the
additive deltas — never destructive — through three surfaces backed by
the same code path:

- **CLI**: `php web/bin/upgrade.php` (dry-run) / `--apply`.
- **JSON API**: `system.upgrade_diff` / `system.upgrade_apply`, both
  gated to `ADMIN_OWNER`.
- **Panel page**: `?p=admin&c=upgrade` with a dry-run preview and an
  "Apply changes" button (also `ADMIN_OWNER` only).

The migrator is a brand-new code path under `web/includes/Migrator/`; it
does **not** extend `web/install/` or `web/updater/`, per `AGENTS.md`.
`struc.sql` / `data.sql` remain the single source of truth; the runner
just reads them.

## Acceptance criteria

- [x] `php web/bin/upgrade.php` (no flags) prints a clean diff summary.
  - `web/bin/upgrade.php:43` shells into `Sbpp\Migrator\CliRunner::main`.
  - `web/includes/Migrator/CliRunner.php:88-103` builds the plan and pretty-prints it via `CliPrinter::printPlan`.
  - `web/includes/Migrator/CliPrinter.php:38-69` renders the per-section "Missing tables / columns / settings" output.
  - End-to-end verification (dev DB) — see Test plan.
- [x] `php web/bin/upgrade.php --apply` makes the live DB match `struc.sql` and is a no-op the second time.
  - `web/includes/Migrator/CliRunner.php:104-115` runs `MigrationApplier::apply`.
  - `web/includes/Migrator/MigrationApplier.php:55-95` runs DDL fail-fast then wraps settings INSERT IGNOREs in one transaction.
  - Convergence proven by `UpgradeRunnerTest::testDropAndConvergeForColumnTableAndSetting` (`web/tests/integration/UpgradeRunnerTest.php:60-127`) — re-`plan()` after apply returns an empty plan.
- [x] Panel UI wraps the same runner; only `ADMIN_OWNER` can invoke it.
  - Page route + permission check: `web/includes/page-builder.php:113-117`.
  - Page calls the same `Sbpp\Migrator\Migrator` façade as the CLI: `web/pages/admin.upgrade.php:34-58`.
  - JSON API actions (Refresh / Apply buttons): `web/api/handlers/_register.php:114-119` (`ADMIN_OWNER`); `web/api/handlers/system.php:191-243`.
  - Template gates again with `{if NOT $permission_owner}Access Denied!{...}`: `web/themes/default/page_admin_upgrade.tpl:1-2`.
- [x] Test in `web/tests/integration/UpgradeRunnerTest.php` covers the drop-and-converge case for at least three different deltas (a missing column, a missing table, a missing settings key).
  - `testDropAndConvergeForColumnTableAndSetting` drops `lockout_until` (column), `:prefix_login_tokens` (table) and deletes `config.enablesteamlogin` (setting), then asserts `plan()` reports each, `apply()` succeeds with three steps, the deltas physically land, and re-`plan()` is empty: `web/tests/integration/UpgradeRunnerTest.php:60-127`.
  - Two additional regression tests: settings backfill never overwrites admin-edited values (`testApplyHonoursExistingSettingValues`, lines 129-149) and a full settings-table rebuild still converges (`testTableDropImpliesAllSettingsRebuild`, lines 151-176).
- [x] `web/install/` is unchanged — the migrator is a separate concern; install is for greenfield deployments.
  - `git diff main...HEAD -- web/install/` is empty (no files touched under `web/install/`).
  - The migrator reads `web/install/includes/sql/struc.sql` and `data.sql` as inputs (`web/includes/Migrator/Migrator.php:50-58`) but writes nothing there.

## Test plan

Quality gates (run with `COMPOSE_PROJECT_NAME=sbpp-issue-1111`):

- `./sbpp.sh phpstan` → `[OK] No errors`
- `./sbpp.sh test` → `OK (41 tests, 124 assertions)`, including the four new `UpgradeRunner` tests
- `./sbpp.sh ts-check` → no errors after the autogenerated contract update
- `./sbpp.sh composer api-contract` → regen produces no further diff vs the committed `web/scripts/api-contract.js`

Manual verification against the dev stack:

1. **Dry-run on a clean DB**:
   ```
   $ php web/bin/upgrade.php
   SourceBans++ schema migrator
     ✓ Schema is up to date.
   Nothing to do.
   ```
2. **Dry-run after dropping three deltas** (col `sb_admins.lockout_until`, table `sb_login_tokens`, setting `config.enablesteamlogin`):
   ```
   Missing tables (1):    + :prefix_login_tokens
   Missing columns (1):   + :prefix_admins.lockout_until
   Missing settings keys (1):  + config.enablesteamlogin = 1
   Total: 3 change(s).
   Run with --apply to execute the 3 change(s) above.
   ```
3. **Apply** runs CREATE TABLE → ALTER TABLE → INSERT IGNORE in order, all three steps marked ✓.
4. **Re-run dry** prints "Schema is up to date." (idempotency).
5. `--help` and unknown-arg paths return exit codes 0 and 2 respectively, with usage printed to stdout / stderr.


Made with [Cursor](https://cursor.com)