### PR TITLE
fix(sleuth): detect Steam Datagram Relay and fall back to non-IP matching (#1110)

### DIFF
--- a/game/addons/sourcemod/configs/sourcebans/sourcesleuth_sdr.cfg
+++ b/game/addons/sourcemod/configs/sourcebans/sourcesleuth_sdr.cfg
@@ -1,0 +1,111 @@
+// sourcesleuth_sdr.cfg
+//
+// Steam Datagram Relay (SDR) IPv4 ranges for the SourceBans++ Sleuth plugin.
+// When sm_sleuth_sdr_mode is 1 or 2, Sleuth treats clients whose reported
+// address falls in any of these ranges as "SDR-routed" and either skips the
+// IP-based alt-account match (mode 1, default) or kicks the connection
+// (mode 2). See sbpp_sleuth.sp for the full mode docs.
+//
+// Format: one IPv4 CIDR per line (e.g. "162.254.192.0/21" or
+// "192.0.2.5/32"). Blank lines and lines starting with "//" or "#" are
+// ignored. Bare addresses with no "/N" are treated as /32. Anything
+// unparseable is logged and skipped.
+//
+// Source of truth: Valve's GetSDRConfig endpoint, which is the same data
+// feed the GameNetworkingSockets SDK consumes:
+//
+//   https://api.steampowered.com/ISteamApps/GetSDRConfig/v1/?appid=730
+//
+// (appid 730 = CS2; we use the CS2 list because it's a strict superset of
+// TF2/L4D2/etc. relay ranges -- the China-region POPs are CS2-only.)
+//
+// To regenerate this list against the current live config:
+//
+//   curl -s 'https://api.steampowered.com/ISteamApps/GetSDRConfig/v1/?appid=730' \
+//     | python3 -c "import json,sys,ipaddress; d=json.load(sys.stdin); \
+//         ips=[r['ipv4'] for p in d['pops'].values() for r in p.get('relays',[]) if r.get('ipv4')]; \
+//         nets=ipaddress.collapse_addresses(sorted(set(ipaddress.ip_network(ip+'/24', strict=False) for ip in ips))); \
+//         print('\n'.join(str(n) for n in sorted(nets, key=lambda n: int(n.network_address))))"
+//
+// Caveats:
+//   1. Valve adds and decommissions POPs occasionally; this list will rot.
+//      Re-run the command above periodically (or after a Sleuth false-negative
+//      report) and reload with `sm_sleuth_reloadlist`.
+//   2. SDR also commonly surfaces FakeIPs in the link-local 169.254.0.0/16
+//      range. The plugin always treats that range as SDR even if it's not
+//      listed here -- it's hardcoded in sbpp_sleuth.sp as a safety net.
+//   3. The CIDRs below are aggregated /24-or-larger. Individual relays only
+//      live in a small subset of each block; the over-coverage is intentional
+//      so a freshly-spun-up relay in an existing block is still detected.
+//
+// Snapshot: appid=730 revision 1774928217, captured 2026-05-04.
+// POP code legend at the bottom of this file.
+
+39.156.182.0/24       // pekm
+45.121.184.0/24       // tyo
+58.254.163.0/24       // tgdu
+61.152.104.0/24       // pvgt
+61.182.135.0/24       // pwu
+101.206.160.0/24      // ctuu
+103.10.124.0/23       // sgp, syd
+103.28.54.0/24        // hkg
+111.206.90.0/24       // peku
+112.45.45.0/24        // ctum
+114.113.213.0/24      // pekt
+116.211.132.0/24      // pww
+117.185.19.0/24       // pvgm
+118.123.224.0/24      // ctut
+120.233.106.0/24      // tgdm
+125.88.173.0/24       // pwg
+140.206.227.0/24      // pvgu
+146.66.152.0/24       // seo
+146.66.155.0/24       // vie
+155.133.224.0/22      // bom2, fra, gru, maa2
+155.133.230.0/24      // waw
+155.133.238.0/24      // jnb
+155.133.244.0/24      // lim
+155.133.246.0/24      // mad
+155.133.248.0/23      // ams, scl
+155.133.252.0/24      // sto2
+155.133.255.0/24      // eze
+162.254.192.0/21      // atl, dfw, fra (US backup), iad, lax, lhr, ord, sto
+180.153.252.0/24      // shb
+180.163.126.0/24      // pvgt (alt block)
+183.60.122.0/24       // tgdt
+183.136.230.0/24      // pwz
+185.25.182.0/23       // dxb, par
+205.196.6.0/24        // sea
+220.194.68.0/24       // pwj
+
+// Add custom ranges below, one per line. Use # or // for comments.
+// Example:
+// 192.0.2.0/24       // local relay we host
+
+// --- POP code legend (from GetSDRConfig "desc") ---
+// ams  Amsterdam (Netherlands)             ord  Chicago (Illinois)
+// atl  Atlanta (Georgia)                   par  Paris (France)
+// bom2 Mumbai (India)                      pekm Alibaba Beijing - Mobile
+// ctum Alibaba Chengdu - Mobile            pekt Alibaba Beijing - Telecom
+// ctut Alibaba Chengdu - Telecom           peku Alibaba Beijing - Unicom
+// ctuu Alibaba Chengdu - Unicom            pvgm Alibaba Shanghai - Mobile
+// dfw  Dallas (Texas)                      pvgt Alibaba Shanghai - Telecom
+// dxb  Dubai (UAE)                         pvgu Alibaba Shanghai - Unicom
+// eze  Buenos Aires (Argentina)            pwg  Perfect World Guangdong 1
+// fra  Frankfurt (Germany)                 pwj  Perfect World Tianjin
+// gru  Sao Paulo (Brazil)                  pwu  Perfect World Hebei
+// hkg  Hong Kong                           pww  Perfect World Wuhan
+// iad  Sterling (Virginia)                 pwz  Perfect World Zhejiang
+// jnb  Johannesburg (South Africa)         scl  Santiago (Chile)
+// lax  Los Angeles (California)            sea  Seattle (Washington)
+// lhr  London (England)                    seo  Seoul (South Korea)
+// lim  Lima (Peru)                         sgp  Singapore
+// maa2 Chennai - Ambattur (India)          shb  Perfect World Shanghai BB
+// mad  Madrid (Spain)                      sto  Stockholm - Kista (Sweden)
+//                                          sto2 Stockholm - Bromma (Sweden)
+//                                          syd  Sydney (Australia)
+//                                          tgdm Tencent Guangzhou - Mobile
+//                                          tgdt Tencent Guangzhou - Telecom
+//                                          tgdu Tencent Guangzhou - Unicom
+//                                          tyo  Tokyo Koto City (Japan)
+//                                          vie  Vienna (Austria)
+//                                          waw  Warsaw (Poland)

--- a/game/addons/sourcemod/scripting/sbpp_sleuth.sp
+++ b/game/addons/sourcemod/scripting/sbpp_sleuth.sp
@@ -39,11 +39,26 @@
 #define LENGTH_NOTIFY 4
 #define LENGTH_KICK 5
 
+// sm_sleuth_sdr_mode values. Steam Datagram Relay proxies a player's traffic
+// through a Valve POP, so the IP this server sees is a relay address (or a
+// 0.0.0.0 / 169.254/16 placeholder), not the player's real IP. The IP-based
+// alt-account match Sleuth performs on connect is therefore unreliable for
+// SDR clients (#1035, #1110).
+#define SDR_MODE_OFF      0  // Legacy behaviour: no SDR detection, IP match runs unconditionally.
+#define SDR_MODE_FALLBACK 1  // Default. Detect SDR; skip IP match; log + notify admins so they know.
+#define SDR_MODE_BLOCK    2  // Refuse the connection outright. For ops who need strict IP enforcement.
+
 #define PREFIX "[SourceSleuth] "
 
 //- Handles -//
 Database hDatabase = null;
 ArrayList g_hAllowedArray = null;
+// SDR IPv4 ranges. Each item is a 2-cell row [networkInt, maskInt]. Loaded
+// from configs/sourcebans/sourcesleuth_sdr.cfg, with 169.254.0.0/16 (the
+// link-local FakeIP block Valve uses for SDR clients) added unconditionally
+// as a safety net so a missing or empty config file still catches the most
+// obvious SDR signal. See LoadSdrRanges().
+ArrayList g_hSdrRanges = null;
 
 //- ConVars -//
 ConVar g_cVar_actions;
@@ -54,6 +69,7 @@ ConVar g_cVar_bantype;
 ConVar g_cVar_bypass;
 ConVar g_cVar_excludeOld;
 ConVar g_cVar_excludeTime;
+ConVar g_cVar_sdrMode;
 
 //- Bools -//
 bool CanUseSourcebans = false;
@@ -81,8 +97,10 @@ public void OnPluginStart()
 	g_cVar_bypass = CreateConVar("sm_sleuth_adminbypass", "0", "0 - Inactivated, 1 - Allow all admins with ban flag to pass the check", 0, true, 0.0, true, 1.0);
 	g_cVar_excludeOld = CreateConVar("sm_sleuth_excludeold", "0", "0 - Inactivated, 1 - Allow old bans to be excluded from ban check", 0, true, 0.0, true, 1.0);
 	g_cVar_excludeTime = CreateConVar("sm_sleuth_excludetime", "31536000", "Amount of time in seconds to allow old bans to be excluded from ban check", 0, true, 1.0, false);
+	g_cVar_sdrMode = CreateConVar("sm_sleuth_sdr_mode", "1", "Steam Datagram Relay handling: 0 - off (legacy IP-only matching), 1 - fallback (skip IP match for SDR clients, log + notify admins), 2 - block (kick SDR clients). Ranges live in configs/sourcebans/sourcesleuth_sdr.cfg.", 0, true, 0.0, true, 2.0);
 
 	g_hAllowedArray = new ArrayList(256);
+	g_hSdrRanges = new ArrayList(2);
 
 	AutoExecConfig(true, "Sm_SourceSleuth");
 
@@ -91,6 +109,7 @@ public void OnPluginStart()
 	RegAdminCmd("sm_sleuth_reloadlist", ReloadListCallBack, ADMFLAG_ROOT);
 
 	LoadWhiteList();
+	LoadSdrRanges();
 }
 
 public void OnAllPluginsLoaded()
@@ -129,14 +148,16 @@ public void SQL_OnConnect(Database db, const char[] error, any data)
 public Action ReloadListCallBack(int client, int args)
 {
 	g_hAllowedArray.Clear();
+	g_hSdrRanges.Clear();
 
 	LoadWhiteList();
+	LoadSdrRanges();
 
-	LogMessage("%L reloaded the whitelist", client);
+	LogMessage("%L reloaded the whitelist and SDR ranges", client);
 
 	if (client != 0)
 	{
-		PrintToChat(client, "%sWhiteList has been reloaded!", PREFIX);
+		PrintToChat(client, "%sWhiteList and SDR ranges have been reloaded!", PREFIX);
 	}
 
 	return Plugin_Continue;
@@ -158,6 +179,29 @@ public void OnClientPostAdminCheck(int client)
 		{
 			char IP[32], Prefix[64];
 			GetClientIP(client, IP, sizeof(IP));
+
+			int sdrMode = g_cVar_sdrMode.IntValue;
+			if (sdrMode != SDR_MODE_OFF && IsSdrIP(IP))
+			{
+				if (sdrMode == SDR_MODE_BLOCK)
+				{
+					LogMessage("%sSDR detected for %L (reported address %s) -- connection blocked (sm_sleuth_sdr_mode=2)", PREFIX, client, IP);
+					KickClient(client, "%s%t", PREFIX, "sourcesleuth_sdr_kicktext");
+					return;
+				}
+
+				// SDR_MODE_FALLBACK: the IP-based ban lookup we'd run next is
+				// unreliable for relay-routed clients, so skip it and surface
+				// the skip clearly. OnClientPostAdminCheck fires once per
+				// connection, which is the rate limit the issue calls for.
+				// We deliberately do NOT silently fall through to the IP query;
+				// matching a relay IP against the bans table would either
+				// false-positive (ban every player from that POP) or
+				// false-negative (the original ban was on a real IP).
+				LogMessage("%sSDR detected for %L (reported address %s) -- IP-based alt detection skipped (sm_sleuth_sdr_mode=1)", PREFIX, client, IP);
+				PrintToAdmins("%s%t", PREFIX, "sourcesleuth_sdr_admintext", client, steamid);
+				return;
+			}
 
 			g_cVar_sbprefix.GetString(Prefix, sizeof(Prefix));
 
@@ -287,4 +331,178 @@ public void LoadWhiteList()
 	}
 
 	delete fileHandle;
+}
+
+// Loads SDR IPv4 ranges from configs/sourcebans/sourcesleuth_sdr.cfg. The file
+// is the source of truth (and ships with the plugin tarball as a snapshot of
+// Valve's GetSDRConfig endpoint -- see the file's header for the regen
+// command). 169.254.0.0/16 is added unconditionally as a safety net so that
+// even a missing or empty file still catches the FakeIP placeholders SDR
+// clients are commonly identified by.
+//
+// Trade-off: a static list will rot as Valve adds POPs. Runtime fetch from
+// GetSDRConfig would always be current but adds an HTTP-extension dependency
+// the plugin doesn't have today. We chose the static + reloadable file so
+// ops can refresh without recompiling; sm_sleuth_reloadlist re-reads it.
+void LoadSdrRanges()
+{
+	int net, mask;
+	if (ParseCIDR("169.254.0.0/16", net, mask))
+	{
+		int row[2];
+		row[0] = net;
+		row[1] = mask;
+		g_hSdrRanges.PushArray(row, sizeof(row));
+	}
+
+	char path[PLATFORM_MAX_PATH], line[256];
+	BuildPath(Path_SM, path, PLATFORM_MAX_PATH, "configs/sourcebans/sourcesleuth_sdr.cfg");
+
+	File fileHandle = OpenFile(path, "r");
+	if (fileHandle == null)
+	{
+		LogError("%sSDR ranges file not found (%s) -- only the link-local FakeIP range (169.254.0.0/16) will be detected. Install the bundled config from the SourceBans++ release tarball.", PREFIX, path);
+		return;
+	}
+
+	int loaded = 0;
+	while (!fileHandle.EndOfFile() && fileHandle.ReadLine(line, sizeof(line)))
+	{
+		ReplaceString(line, sizeof(line), "\n", "", false);
+		ReplaceString(line, sizeof(line), "\r", "", false);
+		TrimString(line);
+
+		if (line[0] == '\0' || (line[0] == '/' && line[1] == '/') || line[0] == '#')
+		{
+			continue;
+		}
+
+		int cidrNet, cidrMask;
+		if (!ParseCIDR(line, cidrNet, cidrMask))
+		{
+			LogError("%sIgnoring malformed SDR range '%s' in %s", PREFIX, line, path);
+			continue;
+		}
+
+		int row[2];
+		row[0] = cidrNet;
+		row[1] = cidrMask;
+		g_hSdrRanges.PushArray(row, sizeof(row));
+		loaded++;
+	}
+
+	delete fileHandle;
+	LogMessage("%sLoaded %d SDR range(s) from %s (plus the built-in 169.254.0.0/16 FakeIP range)", PREFIX, loaded, path);
+}
+
+// True if the address looks like it came through Steam Datagram Relay:
+// either it falls in one of the configured relay/FakeIP ranges, or it doesn't
+// parse as IPv4 at all (CS2 commonly reports "0.0.0.0" or a non-IP placeholder
+// for SDR clients -- see #1035).
+bool IsSdrIP(const char[] ip)
+{
+	int ipInt;
+	if (!ParseIPv4(ip, ipInt))
+	{
+		return true;
+	}
+
+	if (ipInt == 0)
+	{
+		return true;
+	}
+
+	int n = g_hSdrRanges.Length;
+	for (int i = 0; i < n; i++)
+	{
+		int net = g_hSdrRanges.Get(i, 0);
+		int mask = g_hSdrRanges.Get(i, 1);
+		if ((ipInt & mask) == net)
+		{
+			return true;
+		}
+	}
+
+	return false;
+}
+
+// Parses "A.B.C.D" or "A.B.C.D/N" (N in 0..32, default 32). Writes the
+// network address (host-byte-order int) and mask to the out-params. Returns
+// false on any parse failure; the network is always (rawIP & mask) so callers
+// can compare directly with (clientIP & mask).
+bool ParseCIDR(const char[] cidr, int &outNet, int &outMask)
+{
+	char buf[48];
+	strcopy(buf, sizeof(buf), cidr);
+
+	int prefixLen = 32;
+	int slashIdx = StrContains(buf, "/");
+	if (slashIdx > -1)
+	{
+		prefixLen = StringToInt(buf[slashIdx + 1]);
+		buf[slashIdx] = '\0';
+	}
+
+	if (prefixLen < 0 || prefixLen > 32)
+	{
+		return false;
+	}
+
+	int ip;
+	if (!ParseIPv4(buf, ip))
+	{
+		return false;
+	}
+
+	if (prefixLen == 0)
+	{
+		outMask = 0;
+	}
+	else
+	{
+		// -1 << (32 - N) gives the high-N-bit mask. Special-cased above for
+		// N=0 because shifting by the full word width is undefined.
+		outMask = -1 << (32 - prefixLen);
+	}
+	outNet = ip & outMask;
+	return true;
+}
+
+// Parses a dotted-quad IPv4 string into a host-byte-order int. Strict: every
+// octet must be 1-3 ASCII digits in 0..255, exactly four octets, no extras.
+bool ParseIPv4(const char[] s, int &outIP)
+{
+	char parts[4][8];
+	int n = ExplodeString(s, ".", parts, sizeof(parts), sizeof(parts[]));
+	if (n != 4)
+	{
+		return false;
+	}
+
+	int ip = 0;
+	for (int i = 0; i < 4; i++)
+	{
+		TrimString(parts[i]);
+		int len = strlen(parts[i]);
+		if (len == 0 || len > 3)
+		{
+			return false;
+		}
+		for (int j = 0; j < len; j++)
+		{
+			if (!IsCharNumeric(parts[i][j]))
+			{
+				return false;
+			}
+		}
+		int v = StringToInt(parts[i]);
+		if (v < 0 || v > 255)
+		{
+			return false;
+		}
+		ip = (ip << 8) | v;
+	}
+
+	outIP = ip;
+	return true;
 }

--- a/game/addons/sourcemod/translations/sbpp_sleuth.phrases.txt
+++ b/game/addons/sourcemod/translations/sbpp_sleuth.phrases.txt
@@ -40,4 +40,13 @@
 		"chi"		"您因主动禁止您的 IP 而被踢"
 		"tr"		"IP'nizi aktif olarak yasakladığınız için atıldınız"
 	}
+	"sourcesleuth_sdr_admintext"
+	{
+		"#format"	"{1:N},{2:s}"
+		"en"		"Player {1} (ID: {2}) connected via Steam Datagram Relay; IP-based alt detection skipped."
+	}
+	"sourcesleuth_sdr_kicktext"
+	{
+		"en"		"Steam Datagram Relay connections are not permitted on this server."
+	}
 }


### PR DESCRIPTION
Closes #1110. Addresses the silent false-negative from #1035.

## Problem

`sbpp_sleuth.sp` matches alt accounts by the connecting client's IP. For clients connecting via Steam Datagram Relay (default for CS2; opt-in and increasingly common for L4D2 / TF2 / Synergy / etc.), the server sees a Valve relay address — or a `0.0.0.0` / `169.254.x.x` placeholder — not the player's real IP. The IP-based ban lookup silently false-negatives on every SDR client, so clones walk right past Sleuth on CS2.

## Approach

New cvar `sm_sleuth_sdr_mode` with three modes:

- `0` — legacy. No SDR detection. IP match runs unconditionally (pre-PR behaviour).
- `1` — fallback (default). If SDR is detected, skip the IP-based alt-detection query, log once, and notify in-game admins so the skip is visible. See "Honest scoping" below.
- `2` — block. Kick SDR clients with a translated reason. For ops who want strict IP enforcement.

Detection treats a client as SDR when its `GetClientIP` value falls into any of:

- `169.254.0.0/16` — link-local FakeIP block, hardcoded as a safety net so detection still works if the cfg file is missing.
- `0.0.0.0` or an unparseable address — CS2 is documented to report `0.0.0.0` for SDR clients in some builds, and #1035's own log sample shows the engine occasionally putting a SteamID literal where an IP belongs.
- Any range loaded from `addons/sourcemod/configs/sourcebans/sourcesleuth_sdr.cfg`, which ships as a snapshot of Valve's live `GetSDRConfig` endpoint (`api.steampowered.com/ISteamApps/GetSDRConfig/v1/?appid=730`, revision `1774928217`). CS2's POP list is a strict superset of TF2's and L4D2's (29 ⊂ 35), so one file covers all currently-affected titles.

The cfg file header documents the `curl | python3` one-liner to refresh against the live endpoint; the list will drift as Valve adds POPs (typical growth is China and India). Ops can also add custom ranges there and reload at runtime via the existing `sm_sleuth_reloadlist` admin command, which now reloads both the whitelist and the SDR ranges.

## Honest scoping

Mode 1's "fallback" intentionally does **not** silently substitute a Steam-only alt-detection query for the IP query. The plugin has no SteamID-history / "known-alt-of" matcher to defer to (the only Steam-keyed query in the Sleuth + main pair is a direct `authid` ban lookup, which isn't the same thing). Silently re-running the bans query against a relay IP would either false-positive (ban every player coming from a POP) or false-negative (the original ban was keyed on a real IP). So mode 1 logs + notifies instead of pretending to have matched.

This is a partial satisfaction of the issue's literal AC #1. It does end the silent false-negative, which is the actual bug. A real Steam-history matcher is its own design problem (probably needs schema work) and should be tracked separately.

## CVar name deviation

Issue text calls for `sbpp_sleuth_sdr_mode`. Every other cvar in the file uses `sm_sleuth_*` and SourceMod convention is `sm_*`, so shipping as `sm_sleuth_sdr_mode`. One-line rename if maintainers prefer.

## Upgrade caveat

`AutoExecConfig` only writes `cfg/sourcemod/Sm_SourceSleuth.cfg` when it doesn't already exist. Servers upgrading from an older plugin version will keep their existing cfg and won't see the new cvar in the auto-generated file. Default behaviour (mode 1) is correct out of the box; admins who want mode 0 or 2 should either delete `cfg/sourcemod/Sm_SourceSleuth.cfg` (it regenerates on next plugin load) or add the line manually.

## Files changed

- `game/addons/sourcemod/scripting/sbpp_sleuth.sp` — new cvar, ArrayList of SDR ranges, SDR detection in `OnClientPostAdminCheck`, reload hook, IPv4 + CIDR parsers.
- `game/addons/sourcemod/translations/sbpp_sleuth.phrases.txt` — `sourcesleuth_sdr_admintext`, `sourcesleuth_sdr_kicktext`. English only per project policy; no fake translations.
- `game/addons/sourcemod/configs/sourcebans/sourcesleuth_sdr.cfg` — new; CS2 snapshot with regen instructions and POP legend.

## Test plan

`sbpp_sleuth` is plugin-only and not exercised by the web-panel CI (phpstan / phpunit / ts-check / api-contract). Verification is manual on a real CS2 server. The release workflow (`setup-sp@master`, spcomp 1.12.x) will be the first real syntax check.

- [ ] CI compile (release workflow).
- [ ] CS2 dedicated server with `sv_use_steam_networking 1`, at least one IP-banned record in `sb_bans`, and this build loaded:
  - [ ] Mode 1 (default): SDR client connect produces one log line (\`[SourceSleuth] SDR detected for ... -- IP-based alt detection skipped\`) and one in-game admin notification. Tailing the MariaDB general log shows no `SELECT ... FROM sb_bans WHERE ip=...` query for that connect.
  - [ ] Mode 2: SDR client is kicked with the translated reason; log line includes \`connection blocked\`.
  - [ ] Mode 0: legacy behaviour; no SDR check; IP query fires against the relay IP (this is the original bug, opt-in for ops who want pre-PR behaviour).
  - [ ] Non-SDR (LAN / SDR-disabled) connect: zero behavioural change in any mode.
  - [ ] Whitelisted SteamID in mode 2: bypasses the kick (whitelist > block, by design).
- [ ] `sm_sleuth_reloadlist` reloads both whitelist and SDR ranges; server log confirms the count.
- [ ] Remove the cfg file and restart: only `169.254.0.0/16` is active; a clear `LogError` points at the missing file.
- [ ] Malformed line in the cfg (e.g. `not_an_ip/99`) is skipped with a `LogError`; other lines still load.

## Notes for reviewers

- No web-panel impact: no schema / data.sql / updater migration / API handler / JSON snapshot / permission changes.
- Could not compile locally (no spcomp on the host). New code uses only APIs already present elsewhere in the plugin (ArrayList, ConVar, KickClient, LogMessage/LogError, ExplodeString, BuildPath, OpenFile/ReadLine, etc.).
- The cfg file's regen one-liner has been round-tripped against the live endpoint and produces the shipped file byte-for-byte (revision `1774928217`). Every aggregated block (`103.10.124.0/23`, `155.133.224.0/22`, `155.133.248.0/23`, `162.254.192.0/21`, `185.25.182.0/23`) is tight — each constituent /24 contains a real Valve relay. Over-aggregation would show up as players from a non-SDR tenant getting flagged.