### PR TITLE
fix(search): match both STEAM_0 and STEAM_1 stored authid variants (#1130)

### DIFF
--- a/web/includes/SteamID/SteamID.php
+++ b/web/includes/SteamID/SteamID.php
@@ -139,6 +139,45 @@ class SteamID
     }
 
     /**
+     * Build a MySQL REGEXP that matches an `authid` column against both
+     * `STEAM_0:Y:Z` and `STEAM_1:Y:Z` forms of the same account, mirroring
+     * the pattern the SourceMod plugin uses (see `sbpp_main.sp` /
+     * `sbpp_checker.sp`, which always query `authid REGEXP '^STEAM_[0-9]:Y:Z$'`
+     * because both universe digits legitimately end up in the column —
+     * `GetClientAuthId(client, AuthId_Steam2, …)` returns `STEAM_1:…` on
+     * TF2/L4D and similar Source titles).
+     *
+     * Returns `null` when `$value` isn't a recognisable Steam ID, so callers
+     * can fall back to plain equality / LIKE for non-Steam inputs.
+     *
+     * Defends #1128 / #1130: `toSteam2()` always rewrites `STEAM_1` →
+     * `STEAM_0`, so a strict-equality search after that normalisation
+     * silently misses any row stored under the other universe digit.
+     *
+     * @param  mixed $value
+     * @return string|null
+     */
+    public static function toSearchPattern($value): ?string
+    {
+        if (!is_string($value) || $value === '') {
+            return null;
+        }
+        try {
+            self::init();
+            if (!self::isValidID($value)) {
+                return null;
+            }
+            $steam2 = self::toSteam2($value);
+            if (!is_string($steam2) || !preg_match('/^STEAM_[01]:([01]):(\d+)$/', $steam2, $m)) {
+                return null;
+            }
+            return '^STEAM_[0-9]:' . $m[1] . ':' . $m[2] . '$';
+        } catch (Exception $e) {
+            return null;
+        }
+    }
+
+    /**
      * @return string
      */
     private static function getCalcMethod()

--- a/web/pages/page.banlist.php
+++ b/web/pages/page.banlist.php
@@ -233,6 +233,13 @@ if (isset($_SESSION["hideinactive"])) {
 if (isset($_GET['searchText'])) {
     $searchText = trim($_GET['searchText']);
 
+    // #1130: when the input parses as any Steam-ID format, match `authid`
+    // via REGEXP so both STEAM_0:Y:Z and STEAM_1:Y:Z stored variants hit
+    // (the SourceMod plugin can write either depending on the game). The
+    // Y:Z tail is invariant across the normalisation block below, so the
+    // ordering of the two calls is academic.
+    $authidPattern = SteamID::toSearchPattern($searchText);
+
     try {
         SteamID::init();
         if (SteamID::isValidID($searchText)) {
@@ -245,6 +252,14 @@ if (isset($_GET['searchText'])) {
     } catch (Exception $e) { }
 
     $search = "%{$searchText}%";
+
+    if ($authidPattern !== null) {
+        $authidClause = "BA.authid REGEXP ?";
+        $authidParam  = $authidPattern;
+    } else {
+        $authidClause = "BA.authid LIKE ?";
+        $authidParam  = $search;
+    }
 
     // disable ip search if hiding player ips
     $search_ips   = "";
@@ -263,10 +278,10 @@ if (isset($_GET['searchText'])) {
   LEFT JOIN `:prefix_servers` AS SE ON SE.sid = BA.sid
   LEFT JOIN `:prefix_mods` AS MO on SE.modid = MO.mid
   LEFT JOIN `:prefix_admins` AS AD ON BA.aid = AD.aid
-      WHERE " . $search_ips . "BA.authid LIKE ? or BA.name LIKE ? or BA.reason LIKE ?" . $hideinactive . "
+      WHERE " . $search_ips . $authidClause . " or BA.name LIKE ? or BA.reason LIKE ?" . $hideinactive . "
    ORDER BY BA.created DESC
    LIMIT ?,?")->resultset(array_merge($search_array, [
-        $search,
+        $authidParam,
         $search,
         $search,
         intval($BansStart),
@@ -274,8 +289,8 @@ if (isset($_GET['searchText'])) {
     ]));
 
 
-    $res_count  = $GLOBALS['PDO']->query("SELECT count(BA.bid) AS cnt FROM `:prefix_bans` AS BA WHERE " . $search_ips . "BA.authid LIKE ? OR BA.name LIKE ? OR BA.reason LIKE ?" . $hideinactive)->resultset(array_merge($search_array, [
-        $search,
+    $res_count  = $GLOBALS['PDO']->query("SELECT count(BA.bid) AS cnt FROM `:prefix_bans` AS BA WHERE " . $search_ips . $authidClause . " OR BA.name LIKE ? OR BA.reason LIKE ?" . $hideinactive)->resultset(array_merge($search_array, [
+        $authidParam,
         $search,
         $search,
     ]));
@@ -331,10 +346,19 @@ if (isset($_GET['advSearch'])) {
             );
             break;
         case "steamid":
-            $where   = "WHERE BA.authid = ?";
-            $advcrit = array(
-                $value
-            );
+            // #1130: match both STEAM_0:Y:Z and STEAM_1:Y:Z stored variants;
+            // see SteamID::toSearchPattern() for rationale. The pre-switch
+            // normalisation block above has already canonicalised $value to
+            // STEAM_0 form, but the Y:Z tail is invariant so the pattern is
+            // the same either way.
+            $authidPattern = SteamID::toSearchPattern($value);
+            if ($authidPattern !== null) {
+                $where   = "WHERE BA.authid REGEXP ?";
+                $advcrit = array($authidPattern);
+            } else {
+                $where   = "WHERE BA.authid = ?";
+                $advcrit = array($value);
+            }
             break;
         case "steam":
             $where   = "WHERE BA.authid LIKE ?";

--- a/web/pages/page.commslist.php
+++ b/web/pages/page.commslist.php
@@ -234,6 +234,11 @@ if (isset($_SESSION["hideinactive"])) {
 if (isset($_GET['searchText'])) {
     $searchText = trim($_GET['searchText']);
 
+    // #1130: when the input parses as any Steam-ID format, match `authid`
+    // via REGEXP so both STEAM_0:Y:Z and STEAM_1:Y:Z stored variants hit
+    // (the SourceMod plugin can write either depending on the game).
+    $authidPattern = SteamID::toSearchPattern($searchText);
+
     try {
         SteamID::init();
         if (SteamID::isValidID($searchText)) {
@@ -247,6 +252,14 @@ if (isset($_GET['searchText'])) {
 
     $search = "%{$searchText}%";
 
+    if ($authidPattern !== null) {
+        $authidClause = "CO.authid REGEXP ?";
+        $authidParam  = $authidPattern;
+    } else {
+        $authidClause = "CO.authid LIKE ?";
+        $authidParam  = $search;
+    }
+
     $res = $GLOBALS['PDO']->query("SELECT bid ban_id, CO.type, CO.authid, CO.name player_name, created ban_created, ends ban_ends, length ban_length, reason ban_reason, CO.ureason unban_reason, CO.aid, AD.gid AS gid, adminIp, CO.sid ban_server, RemovedOn, RemovedBy, RemoveType row_type,
 		SE.ip server_ip, AD.user admin_name, MO.icon as mod_icon,
 		CAST(MID(CO.authid, 9, 1) AS UNSIGNED) + CAST('76561197960265728' AS UNSIGNED) + CAST(MID(CO.authid, 11, 10) * 2 AS UNSIGNED) AS community_id,
@@ -257,9 +270,9 @@ if (isset($_GET['searchText'])) {
 		LEFT JOIN `:prefix_servers` AS SE ON SE.sid = CO.sid
 		LEFT JOIN `:prefix_mods` AS MO on SE.modid = MO.mid
 		LEFT JOIN `:prefix_admins` AS AD ON CO.aid = AD.aid
-      	WHERE CO.authid LIKE ? or CO.name LIKE ? or CO.reason LIKE ?" . $hideinactive . "
+      	WHERE " . $authidClause . " or CO.name LIKE ? or CO.reason LIKE ?" . $hideinactive . "
    		ORDER BY CO.created DESC LIMIT ?,?")->resultset(array(
-        $search,
+        $authidParam,
         $search,
         $search,
         intval($BansStart),
@@ -267,8 +280,8 @@ if (isset($_GET['searchText'])) {
     ));
 
 
-    $res_count  = $GLOBALS['PDO']->query("SELECT count(CO.bid) AS cnt FROM `:prefix_comms` AS CO WHERE CO.authid LIKE ? OR CO.name LIKE ? OR CO.reason LIKE ?" . $hideinactive)->resultset(array(
-        $search,
+    $res_count  = $GLOBALS['PDO']->query("SELECT count(CO.bid) AS cnt FROM `:prefix_comms` AS CO WHERE " . $authidClause . " OR CO.name LIKE ? OR CO.reason LIKE ?" . $hideinactive)->resultset(array(
+        $authidParam,
         $search,
         $search
     ));
@@ -325,10 +338,16 @@ if (isset($_GET['advSearch'])) {
             );
             break;
         case "steamid":
-            $where   = "WHERE CO.authid = ?";
-            $advcrit = array(
-                $value
-            );
+            // #1130: match both STEAM_0:Y:Z and STEAM_1:Y:Z stored variants;
+            // see SteamID::toSearchPattern() for rationale.
+            $authidPattern = SteamID::toSearchPattern($value);
+            if ($authidPattern !== null) {
+                $where   = "WHERE CO.authid REGEXP ?";
+                $advcrit = array($authidPattern);
+            } else {
+                $where   = "WHERE CO.authid = ?";
+                $advcrit = array($value);
+            }
             break;
         case "steam":
             $where   = "WHERE CO.authid LIKE ?";


### PR DESCRIPTION
## Summary

Fixes #1130 (the `main` instance of the bug originally reported in #1128 against 1.8.2).

The 1.8.0 input-format work added a `SteamID::isValidID` + `SteamID::toSteam2` block in front of every authid search, but `SteamID::to()` always rewrites \`STEAM_1\` → \`STEAM_0\` for already-Steam2 input. Downstream queries then use strict \`=\` (advSearch \`case \"steamid\"\`) or substring \`LIKE\` (simple search) on the normalised value, so any ban or comms row whose \`authid\` is stored under the *other* universe digit silently becomes unreachable from the UI search.

This is the common case for SourceMod plugin writes: \`GetClientAuthId(client, AuthId_Steam2, …)\` returns \`STEAM_1:Y:Z\` on TF2/L4D and similar Source titles, and that's what \`sb_bans.authid\` ends up storing. The plugin itself dodges the issue by querying with \`REGEXP '^STEAM_[0-9]:Y:Z$'\` (see \`game/addons/sourcemod/scripting/sbpp_main.sp:372\`, \`sbpp_checker.sp:146\` / \`:233\`); the webpanel didn't.

This PR adds \`SteamID::toSearchPattern(\$value): ?string\` returning that REGEXP for any valid Steam-ID input (Steam2 / Steam3 / Steam64), or \`null\` to fall back to the existing equality / LIKE for non-Steam inputs. Three call sites:

- \`page.banlist.php\` simple-search authid clause
- \`page.banlist.php\` advSearch \`case \"steamid\"\`
- \`page.commslist.php\` mirror of both

The \`bans.php\` / \`comms.php\` / \`admins.php\` API handlers continue to canonicalise inputs to \`STEAM_0\` on writes — that's defensible for new panel-created bans and not what's being reported here.

The same fix already shipped as **1.8.4** off \`release/1.8.x\` (commit \`290a9ddf\`) to close #1128. The 1.8.x and \`main\` diffs differ only in that \`main\` uses the PDO API (\`\$GLOBALS['PDO']->query(...)\` + \`:prefix_\` placeholders); the helper itself and its three call-site shapes are identical.

## Test plan

- [ ] CI: PHPStan (level 5 + dba), PHPUnit, ts-check, api-contract — none of the affected files appear in the API contract; expect all green
- [ ] Manual: with a ban whose \`sb_bans.authid\` is stored as \`STEAM_1:0:1234\`:
  - [ ] \`/index.php?p=banlist&advSearch=STEAM_1:0:1234&advType=steamid&Submit\` → returns the ban
  - [ ] \`/index.php?p=banlist&advSearch=STEAM_0:0:1234&advType=steamid&Submit\` → returns the same ban
  - [ ] Simple-search box: \`STEAM_1:0:1234\` and \`STEAM_0:0:1234\` both find the ban
  - [ ] Steam3 form (\`[U:1:2469]\`) and Steam64 form also find it
- [ ] Manual: same four checks against a row stored as \`STEAM_0:0:1234\` (regression-guard the inverse universe)
- [ ] Manual: comms list (\`p=commslist\`) — same four checks
- [ ] Manual: searching for a non-Steam string (e.g. a player name) still hits the \`LIKE\` fallback and returns name matches

## Related

- Bug report: #1128 (closed by 1.8.4)
- Tracking: #1130
- Origin: direct commits \`69d30380\` + \`d066b9e6\` ('feat: extend input compatibility to all steam id formats'). The corresponding PR (#1002) was closed without merging — the changes were pushed to \`php81\` directly and rode in via the branch merge.