### PR TITLE
[#1123 A2] Layout shell wired into page-builder.php + PHPStan dual-theme matrix

### DIFF
--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -14,11 +14,25 @@ on:
 
 jobs:
   phpstan:
-    name: Static analysis
+    name: Static analysis (theme=${{ matrix.theme }})
     runs-on: ubuntu-24.04
     defaults:
       run:
         working-directory: web
+
+    # During the v2.0.0 theme rollout (#1123) we ship two coexistent
+    # themes — the legacy `default/` bundle and the new `sbpp2026/`
+    # incrementally being redesigned per-page. SmartyTemplateRule only
+    # scans the active theme, so without this matrix new template/View
+    # drift in `sbpp2026/` would only surface at D1's hard cutover.
+    # The matrix collapses back to a single run when D1 deletes
+    # `sbpp2026/` and renames it into `default/` (see plan A2 + D1).
+    strategy:
+      fail-fast: false
+      matrix:
+        theme:
+          - default
+          - sbpp2026
 
     # Schema-only MariaDB so phpstan-dba (#1100) can introspect column types.
     # Mirrors test.yml's service block deliberately — same image, same creds —
@@ -103,4 +117,14 @@ jobs:
           # Refuse to run if the bootstrap can't connect — otherwise a creds
           # mismatch would silently disable phpstan-dba and CI would stay green.
           DBA_REQUIRE: '1'
-        run: includes/vendor/bin/phpstan analyse --no-progress --error-format=github --memory-limit=1G
+          # Tells SmartyTemplateRule which theme directory to scan (see
+          # the rule's class-level docblock + plan A2). The default scan
+          # is `web/themes/default/`; this matrix also runs against
+          # `web/themes/sbpp2026/` so per-page PRs catch View ↔ template
+          # drift in the new theme during the rollout window.
+          SBPP_PHPSTAN_THEME: ${{ matrix.theme }}
+        # The sbpp2026 leg uses phpstan-sbpp2026.neon (which inherits
+        # phpstan.neon) so it can disable reportUnmatchedIgnoredErrors —
+        # see that file's header for the why. D1 deletes both the
+        # override config and this matrix step.
+        run: includes/vendor/bin/phpstan analyse --configuration=${{ matrix.theme == 'sbpp2026' && 'phpstan-sbpp2026.neon' || 'phpstan.neon' }} --no-progress --error-format=github --memory-limit=1G

--- a/web/includes/PHPStan/SmartyTemplateRule.php
+++ b/web/includes/PHPStan/SmartyTemplateRule.php
@@ -29,10 +29,35 @@ use Sbpp\View\View;
  * can be found on disk; unresolvable includes are skipped silently so a
  * broken include never crashes the analyser.
  *
+ * The `templatesDir` constructor argument is the *default* theme to scan
+ * (wired in `web/phpstan.neon`). Setting the `SBPP_PHPSTAN_THEME`
+ * environment variable swaps in a sibling theme directory under the same
+ * parent — the v2.0.0 theme rollout (#1123 A2) uses this to drive a CI
+ * matrix that scans both `web/themes/default/` (the legacy bundle) and
+ * `web/themes/sbpp2026/` (the new theme) on every PR until D1 cuts over.
+ * The override collapses back to a single run once D1 deletes the
+ * sbpp2026 directory and renames it into `default/`.
+ *
  * @implements Rule<Node\Stmt\Class_>
  */
 final class SmartyTemplateRule implements Rule
 {
+    /**
+     * Marker phrase shared by every A1 stub template under
+     * `web/themes/sbpp2026/`. Each Phase B/C ticket replaces a stub with
+     * a real redesign keyed to its View; until a stub is replaced the
+     * View → template diff would explode into noise (the stub renders
+     * only `{$title}`, so every other declared property fires
+     * "unused property"). Skipping templates that contain this exact
+     * phrase keeps the dual-theme PHPStan matrix added in #1123 A2
+     * actionable during the rollout window. D1's pre-flight check fails
+     * the cutover if any template still contains this marker, so this
+     * escape hatch can't silently leak past v2.0.0.
+     */
+    private const STUB_MARKER = "hasn't been redesigned yet";
+
+    private readonly string $templatesDir;
+
     /**
      * Cache of variables referenced per template file, keyed by the
      * template's absolute path plus delimiter pair. Scanning each template
@@ -44,9 +69,20 @@ final class SmartyTemplateRule implements Rule
     private array $templateCache = [];
 
     public function __construct(
-        private readonly string $templatesDir,
+        string $templatesDir,
         private readonly ReflectionProvider $reflectionProvider,
     ) {
+        // CI matrix override: see class-level docblock. Only swaps the
+        // theme name, never escapes the parent themes/ directory.
+        $envTheme = getenv('SBPP_PHPSTAN_THEME');
+        if (is_string($envTheme) && $envTheme !== '' && preg_match('/^[a-zA-Z0-9_.-]+$/', $envTheme) === 1) {
+            $parent = dirname($templatesDir);
+            $candidate = $parent . '/' . $envTheme;
+            if (is_dir($candidate)) {
+                $templatesDir = $candidate;
+            }
+        }
+        $this->templatesDir = $templatesDir;
     }
 
     public function getNodeType(): string
@@ -97,6 +133,10 @@ final class SmartyTemplateRule implements Rule
             ];
         }
 
+        if ($this->isStubTemplate($templatePath)) {
+            return [];
+        }
+
         $referenced = $this->collectTemplateVars($templatePath, $delimiters, []);
 
         $declared = [];
@@ -136,6 +176,21 @@ final class SmartyTemplateRule implements Rule
         }
 
         return $errors;
+    }
+
+    /**
+     * Whether the template at $path is an A1 rollout stub (see
+     * STUB_MARKER docblock). Stubs intentionally drop their View's
+     * properties so their {missing,unused} property diff is not
+     * meaningful.
+     */
+    private function isStubTemplate(string $path): bool
+    {
+        $source = @file_get_contents($path);
+        if ($source === false) {
+            return false;
+        }
+        return str_contains($source, self::STUB_MARKER);
     }
 
     private function constantStringValue(

--- a/web/init.php
+++ b/web/init.php
@@ -225,6 +225,12 @@ $theme->registerPlugin('modifier', 'smarty_htmlspecialchars', 'smarty_htmlspecia
 
 $theme->assign('csrf_token', CSRF::token());
 $theme->assign('csrf_field_name', CSRF::FIELD_NAME);
+// Public web path to the active theme directory (e.g. "themes/sbpp2026").
+// Templates use it to reference theme-local CSS / JS / fonts / images
+// without hardcoding the theme name. SB_THEMES is an absolute filesystem
+// path; the public-facing equivalent is just "themes/<theme>" because
+// web/index.php is the document root.
+$theme->assign('theme_url', 'themes/' . $theme_name);
 
 if ((isset($_GET['debug']) && $_GET['debug'] == 1) || DEBUG_MODE) {
     $theme->setForceCompile(true);

--- a/web/phpstan-sbpp2026.neon
+++ b/web/phpstan-sbpp2026.neon
@@ -1,0 +1,27 @@
+# Override config for the second leg of the dual-theme PHPStan CI matrix
+# added by #1123 A2.
+#
+# The matrix runs PHPStan twice: the default leg uses phpstan.neon
+# (SBPP_PHPSTAN_THEME=default) and matches phpstan-baseline.neon
+# normally. The sbpp2026 leg uses THIS config (SBPP_PHPSTAN_THEME=sbpp2026)
+# which:
+#
+#   - Inherits everything from phpstan.neon (including the baseline).
+#   - Disables `reportUnmatchedIgnoredErrors` because in sbpp2026 mode
+#     SmartyTemplateRule short-circuits every A1 stub template (see
+#     SmartyTemplateRule::STUB_MARKER), so the baseline entries that
+#     target legacy default-theme view drift fire 0 times instead of
+#     once and PHPStan would otherwise fail with "Ignored error pattern
+#     was not matched in reported errors". We still want the rule to
+#     catch *new* template/View drift in the sbpp2026 chrome (or in
+#     non-stub templates landed by Phase B/C tickets), and the rule
+#     does — non-baseline errors still fail the build.
+#
+# D1's plan section deletes this file when the dual-theme matrix
+# collapses back to a single run. Until then, keep this file's diff
+# narrow so D1 can remove it cleanly.
+includes:
+    - phpstan.neon
+
+parameters:
+    reportUnmatchedIgnoredErrors: false

--- a/web/themes/sbpp2026/core/admin_tabs.tpl
+++ b/web/themes/sbpp2026/core/admin_tabs.tpl
@@ -1,0 +1,24 @@
+{*
+    SourceBans++ 2026 — chrome / admin_tabs.tpl
+
+    Admin sub-tab bar. Pair: includes/AdminTabs.php (assigns $tabs —
+    same contract as web/themes/default/core/admin_tabs.tpl). Pure
+    visual reskin: same {foreach} over the AdminTabs data the PHP
+    layer already builds, just rendered with the new theme's button
+    primitives.
+
+    The "openTab(this, '<name>')" handler is defined inline by each
+    admin page that uses tabs (legacy convention preserved by AdminTabs.php).
+*}
+<div class="admin-tabs flex gap-2 mb-4" role="tablist" aria-label="Admin tabs">
+    {foreach from=$tabs item=tab}
+        <button type="button"
+                class="btn btn--secondary btn--sm"
+                role="tab"
+                data-testid="admin-tab-{$tab.name}"
+                onclick="openTab(this, '{$tab.name}');">{$tab.name}</button>
+    {/foreach}
+    <a class="btn btn--ghost btn--sm"
+       href="javascript:history.go(-1);"
+       data-testid="admin-tab-back">Back</a>
+</div>

--- a/web/themes/sbpp2026/core/footer.tpl
+++ b/web/themes/sbpp2026/core/footer.tpl
@@ -1,0 +1,52 @@
+{*
+    SourceBans++ 2026 — chrome / footer.tpl
+
+    Closes <main>, .main, .app, then mounts the drawer + palette
+    scaffolds and loads vendored Lucide + theme.js. Pair:
+    web/pages/core/footer.php (assigns $version, $git, $query — same
+    contract as web/themes/default/core/footer.tpl).
+
+    The drawer + palette scaffolds use semantic <aside> + <dialog> with
+    role/aria-label per the issue's "Testability hooks" rule that
+    "state belongs in attributes, not just styling" — both ship with
+    the `hidden` boolean attribute as the deterministic terminal
+    state. The C1/C2 tickets wire theme.js (vendored at A1) to
+    populate the inner markup and toggle visibility via
+    sb.api.call(Actions.BansDetail / Actions.BansSearch).
+
+    Legacy hooks intentionally NOT carried over from
+    web/themes/default/core/footer.tpl:
+      - {$query nofilter}: emits LoadServerHostProperty() calls that
+        live in web/scripts/sourcebans.js; the new theme drops that
+        bulk file (#1123 D1) so the calls would error. B3 will
+        re-implement the live-server widget via sb.api.call.
+      - sb.ready/tabs.init/tooltip: legacy MooTools-flavored helpers
+        replaced by theme.js's vanilla wiring.
+    Footer credits ($version + $git) are kept — pure display, no JS.
+*}
+    </main>{* /.page *}
+  </div>{* /.main *}
+</div>{* /.app *}
+
+{* Drawer scaffold — C1 wires inner markup via sb.api.call(Actions.BansDetail). *}
+<aside id="drawer-root"
+       role="complementary"
+       aria-label="Player details"
+       data-drawer-open="false"
+       hidden></aside>
+
+{* Palette scaffold — C2 wires inner markup via sb.api.call(Actions.BansSearch). *}
+<dialog id="palette-root"
+        aria-label="Command palette"
+        hidden></dialog>
+
+<footer class="text-xs text-faint" style="text-align:center;padding:1rem 0">
+    <a href="https://sbpp.github.io/" target="_blank" rel="noopener">SourceBans++</a>
+    {$version}{$git}
+</footer>
+
+<script src="{$theme_url}/js/lucide.min.js"></script>
+<script src="{$theme_url}/js/theme.js"></script>
+
+</body>
+</html>

--- a/web/themes/sbpp2026/core/header.tpl
+++ b/web/themes/sbpp2026/core/header.tpl
@@ -1,0 +1,36 @@
+{*
+    SourceBans++ 2026 — chrome / header.tpl
+
+    Renders <!DOCTYPE>, <head>, and the opening <body><div class="app">.
+    Pair: web/pages/core/header.php (assigns $title, $logo, $theme).
+    Globals from web/init.php: $csrf_token, $csrf_field_name, $theme_url.
+
+    Variable contract is identical to web/themes/default/core/header.tpl
+    except for the new $theme_url assigned by web/init.php in this PR;
+    all other vars (title, theme, logo) come from web/pages/core/header.php
+    unchanged. The legacy navbar.php, title.php, footer.php files keep
+    invoking their templates by literal name (core/navbar.tpl etc.), so
+    page-builder.php's build() pulls in this chrome automatically when
+    config.theme=sbpp2026.
+
+    Vendored Inter + JetBrains Mono are loaded via @font-face in
+    {$theme_url}/css/theme.css; the handoff's Google Fonts <link> tags
+    are intentionally omitted (self-hosters install offline).
+    Lucide is vendored too (web/themes/sbpp2026/js/lucide.min.js) and
+    pulled in from the footer alongside theme.js.
+*}
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <meta name="csrf-token" content="{$csrf_token}">
+    <title>{$title}</title>
+    <link rel="icon" href="{$theme_url}/images/favicon.ico">
+    <link rel="stylesheet" href="{$theme_url}/css/theme.css">
+    <script src="./scripts/api-contract.js"></script>
+    <script src="./scripts/sb.js"></script>
+    <script src="./scripts/api.js"></script>
+</head>
+<body>
+<div class="app">

--- a/web/themes/sbpp2026/core/navbar.tpl
+++ b/web/themes/sbpp2026/core/navbar.tpl
@@ -1,0 +1,95 @@
+{*
+    SourceBans++ 2026 — chrome / navbar.tpl
+
+    Sidebar nav. Pair: web/pages/core/navbar.php (assigns $navbar,
+    $adminbar, $isAdmin, $login, $username — same contract as
+    web/themes/default/core/navbar.tpl). The $navbar / $adminbar
+    arrays come from navbar.php unchanged; this template just reskins
+    the legacy <div id="tabs"> markup as the new collapsible sidebar.
+
+    Endpoint→icon mapping is inline because the chrome PHP files
+    intentionally don't grow new fields in this PR (variable contract
+    is locked per A2; B/C tickets touch their own templates). The
+    {if/elseif} chain keeps the data flow PHP→template untouched.
+
+    Interactive surfaces carry data-testid + ARIA per the issue's
+    "Testability hooks" rule. The <nav> wrapper carries
+    role="navigation" + aria-label; each link gets data-testid
+    "nav-<endpoint>" and aria-current="page" when active.
+*}
+<aside class="sidebar" id="sidebar" data-mobile-open="false">
+    <div class="sidebar__brand">
+        <div class="sidebar__brand-mark">S</div>
+        <div>
+            <div class="font-semibold text-sm">SourceBans++</div>
+        </div>
+    </div>
+    <nav class="sidebar__nav" role="navigation" aria-label="Primary">
+        <div class="sidebar__section">
+            <div class="sidebar__section-label">Public</div>
+            {foreach from=$navbar item=nav}
+                {if $nav.endpoint != 'admin'}
+                    <a class="sidebar__link"
+                       href="index.php?p={$nav.endpoint}"
+                       data-testid="nav-{$nav.endpoint}"
+                       title="{$nav.description}"
+                       {if $nav.state == 'active'}aria-current="page"{/if}>
+                        <i data-lucide="{if $nav.endpoint == 'home'}layout-dashboard{elseif $nav.endpoint == 'banlist'}ban{elseif $nav.endpoint == 'commslist'}mic-off{elseif $nav.endpoint == 'submit'}flag{elseif $nav.endpoint == 'protest'}megaphone{elseif $nav.endpoint == 'servers'}server{else}circle{/if}"></i>
+                        {$nav.title}
+                    </a>
+                {/if}
+            {/foreach}
+        </div>
+
+        {if $isAdmin}
+            <div class="sidebar__section">
+                <div class="sidebar__section-label">Admin</div>
+                {foreach from=$navbar item=nav}
+                    {if $nav.endpoint == 'admin'}
+                        <a class="sidebar__link"
+                           href="index.php?p={$nav.endpoint}"
+                           data-testid="nav-{$nav.endpoint}"
+                           title="{$nav.description}"
+                           {if $nav.state == 'active'}aria-current="page"{/if}>
+                            <i data-lucide="shield"></i>
+                            {$nav.title}
+                        </a>
+                    {/if}
+                {/foreach}
+                {foreach from=$adminbar item=admin}
+                    <a class="sidebar__link"
+                       href="index.php?p=admin&c={$admin.endpoint}"
+                       data-testid="nav-admin-{$admin.endpoint}"
+                       {if $admin.state == 'active'}aria-current="page"{/if}>
+                        <i data-lucide="{if $admin.endpoint == 'admins'}users{elseif $admin.endpoint == 'servers'}server{elseif $admin.endpoint == 'bans'}ban{elseif $admin.endpoint == 'comms'}mic-off{elseif $admin.endpoint == 'groups'}shield-check{elseif $admin.endpoint == 'settings'}settings{elseif $admin.endpoint == 'mods'}puzzle{else}circle{/if}"></i>
+                        {$admin.title}
+                    </a>
+                {/foreach}
+            </div>
+        {/if}
+    </nav>
+
+    <div style="border-top: 1px solid var(--border); padding: 0.5rem;">
+        {if $login}
+            <a class="sidebar__link"
+               href="index.php?p=account"
+               data-testid="nav-account">
+                <i data-lucide="user"></i>
+                <div style="flex:1;min-width:0">
+                    <div class="font-semibold text-xs truncate">{$username}</div>
+                </div>
+            </a>
+            <a class="sidebar__link"
+               href="index.php?p=logout"
+               data-testid="nav-logout">
+                <i data-lucide="log-out"></i> Logout
+            </a>
+        {else}
+            <a class="sidebar__link"
+               href="index.php?p=login"
+               data-testid="nav-login">
+                <i data-lucide="log-in"></i> Login
+            </a>
+        {/if}
+    </div>
+</aside>

--- a/web/themes/sbpp2026/core/title.tpl
+++ b/web/themes/sbpp2026/core/title.tpl
@@ -1,0 +1,63 @@
+{*
+    SourceBans++ 2026 — chrome / title.tpl
+
+    Topbar (breadcrumbs + ⌘K palette trigger + theme toggle), then opens
+    <main class="page"> for the page handler's content. Pair:
+    web/pages/core/title.php (assigns $title, $breadcrumb, $board_name —
+    same contract as web/themes/default/core/title.tpl).
+
+    Interactive surfaces carry data-testid + ARIA per the issue's
+    "Testability hooks" rule:
+      - palette trigger: data-testid="palette-trigger" + aria-label
+      - theme toggle:    data-testid="theme-toggle"    + aria-label
+      - mobile menu:     data-testid="mobile-menu-toggle" + aria-label
+      - active breadcrumb: aria-current="page"
+
+    The palette / drawer JS that consumes data-palette-open and
+    data-theme-toggle ships in C1/C2 — the buttons render now so the
+    static markup contract is locked from A2 onward.
+*}
+<div class="main">
+    <header class="topbar">
+        <button type="button"
+                class="btn--ghost btn--icon"
+                data-mobile-menu
+                data-testid="mobile-menu-toggle"
+                aria-label="Open navigation menu"
+                aria-controls="sidebar"
+                style="display:none">
+            <i data-lucide="menu"></i>
+        </button>
+
+        <nav class="topbar__breadcrumbs" aria-label="Breadcrumb">
+            {foreach from=$breadcrumb item=crumb name=bc}
+                {if !$smarty.foreach.bc.first}
+                    <i data-lucide="chevron-right" style="width:12px;height:12px;color:var(--text-faint)"></i>
+                {/if}
+                <a href="{$crumb.url}"
+                   {if $smarty.foreach.bc.last}aria-current="page"{/if}>{$crumb.title}</a>
+            {/foreach}
+        </nav>
+
+        <div style="flex:1"></div>
+
+        <button type="button"
+                class="topbar__search"
+                data-palette-open
+                data-testid="palette-trigger"
+                aria-label="Open command palette (search players, SteamIDs, pages)">
+            <i data-lucide="search" style="width:14px;height:14px"></i>
+            <span>Search players, SteamIDs…</span>
+            <kbd>&#8984;K</kbd>
+        </button>
+
+        <button type="button"
+                class="btn--ghost btn--icon"
+                data-theme-toggle
+                data-testid="theme-toggle"
+                aria-label="Toggle color theme">
+            <i data-lucide="sun"></i>
+        </button>
+    </header>
+
+    <main class="page" id="page">


### PR DESCRIPTION
Part of #1123 (v2.0.0 theme rollout). Plan: `/home/fishy/.cursor/plans/sbpp2026-theme-rollout-4c702e97.plan.md` — A2 section.

## What

Wires the new `web/themes/sbpp2026/` chrome into the existing page-builder lifecycle and adds a CI matrix that runs PHPStan against both the legacy `default/` and the new `sbpp2026/` themes during the rollout window.

### Layout shell

Splits the handoff design's app shell into the four chrome templates `web/includes/page-builder.php`'s `build()` already includes (`header`, `navbar`, `title`, `footer`) plus `admin_tabs`, all under `web/themes/sbpp2026/core/`:

- `header.tpl` — `<!DOCTYPE>` through opening `<body><div class="app">`. Loads `{$theme_url}/css/theme.css` (the vendored Inter + JetBrains Mono ride along via `@font-face`) plus the legacy JSON-API plumbing scripts (`api-contract.js`, `sb.js`, `api.js`). The handoff's Google Fonts and unpkg-hosted Lucide `<link>`/`<script>` tags are intentionally omitted — A1 vendored both.
- `navbar.tpl` — `<aside class="sidebar">` reskin. Iterates the existing `$navbar` / `$adminbar` arrays, mapping `endpoint → lucide icon` inline so the chrome PHP files don't grow new fields. Every link gets `data-testid="nav-<endpoint>"` + `aria-current="page"` when its `state == 'active'`. The `<nav>` wrapper carries `role="navigation"` + `aria-label="Primary"`.
- `title.tpl` — opens `<div class="main">` and renders the topbar (breadcrumbs from `$breadcrumb`, ⌘K palette trigger, theme-toggle button, mobile-menu button) before opening `<main class="page">`. Theme toggle has `data-testid="theme-toggle"` + `aria-label="Toggle color theme"`; palette trigger has `data-testid="palette-trigger"` + `aria-label`. The active breadcrumb gets `aria-current="page"`.
- `footer.tpl` — closes `</main>`, `.main`, `.app`, then mounts the drawer + palette scaffolds and loads vendored `lucide.min.js` + `theme.js` from `{$theme_url}/js/`. Drawer is `<aside id="drawer-root" role="complementary" aria-label="Player details" data-drawer-open="false" hidden>`; palette is `<dialog id="palette-root" aria-label="Command palette" hidden>`. Both ship with `hidden` as the deterministic terminal state per the issue's "Testability hooks" rule. C1 / C2 wire the inner markup + `sb.api.call`.
- `admin_tabs.tpl` — same `{foreach}` over the `AdminTabs` data the PHP layer already builds, restyled with the new theme's button primitives. `data-testid="admin-tab-<name>"` per tab.

The chrome PHP files (`web/pages/core/{header,navbar,title,footer}.php`) and `AdminTabs.php` invoke their templates by literal name (`$theme->display('core/header.tpl')`), so flipping `config.theme=sbpp2026` picks up the new chrome with **zero PHP changes**.

### `web/init.php`

One new `$theme->assign(...)` line, next to the existing CSRF assigns:

```php
$theme->assign('theme_url', 'themes/' . $theme_name);
```

`SB_THEMES` is a filesystem path; the public-facing equivalent is just `themes/<theme>` because `web/index.php` is the document root. Templates use `{$theme_url}/css/theme.css`, `{$theme_url}/js/theme.js`, etc.

### PHPStan dual-theme matrix

`SmartyTemplateRule` only scans the active theme. During the rollout window, drift between a new sbpp2026 template's `{$foo}` references and its View's properties would only surface at D1's hard cutover. To catch it sooner:

1. `.github/workflows/phpstan.yml` grows a `strategy.matrix.theme: [default, sbpp2026]` axis and exports `SBPP_PHPSTAN_THEME=${{ matrix.theme }}` to the analyse step. Job display name is `Static analysis (theme=<theme>)`.
2. `web/includes/PHPStan/SmartyTemplateRule.php` reads `SBPP_PHPSTAN_THEME` in its constructor and swaps the templates directory to a sibling under `web/themes/`. Defaults to whatever `phpstan.neon` configures (current behaviour).
3. To keep the sbpp2026 leg actionable while every page template under `web/themes/sbpp2026/*.tpl` is still an A1 stub, `SmartyTemplateRule` short-circuits any template that contains the literal marker phrase **"hasn't been redesigned yet"** (the exact text A1's stubs all share). D1's pre-flight check fails the cutover if any template still contains this marker, so the escape hatch can't silently leak past v2.0.0.
4. The 5 SmartyTemplateRule-related entries in `web/phpstan-baseline.neon` fire 0 times in stub-only sbpp2026 mode, which would normally fail the build with "ignored error pattern was not matched". The sbpp2026 leg therefore loads `web/phpstan-sbpp2026.neon` — a 5-line override that inherits `phpstan.neon` and disables `reportUnmatchedIgnoredErrors`. The default leg keeps the gate.

**Both the matrix step and the override config are temporary scaffolding for the rollout window.** D1's plan section explicitly says "Collapse the PHPStan dual-theme CI matrix added in A2 back to a single run". The diff is intentionally localized — D1 deletes the matrix block, the env var, the override config, and the rule's stub-skip + env-var override in one swoop.

## Files touched

Per the plan's A2 "Files" list:

- new `web/themes/sbpp2026/core/header.tpl`
- new `web/themes/sbpp2026/core/navbar.tpl`
- new `web/themes/sbpp2026/core/title.tpl`
- new `web/themes/sbpp2026/core/footer.tpl`
- new `web/themes/sbpp2026/core/admin_tabs.tpl`
- modified `web/init.php` (one `$theme->assign('theme_url', ...)` line near the existing CSRF assigns)
- modified `.github/workflows/phpstan.yml` (matrix axis + per-leg config selection + `SBPP_PHPSTAN_THEME` env var)

Two additional files outside the plan's literal "Files" list, both explicitly allowed by the dispatch prompt as part of "making the dual-theme matrix viable":

- modified `web/includes/PHPStan/SmartyTemplateRule.php` — env-var-driven theme override + stub-template short-circuit (option 1 from the dispatch prompt's "Critical for A2's success" guidance).
- new `web/phpstan-sbpp2026.neon` — 5-line override config that inherits `phpstan.neon` and disables `reportUnmatchedIgnoredErrors` for the sbpp2026 leg only (option 3 from the dispatch prompt's mitigation list, needed alongside option 1 because the existing baseline has 5 SmartyTemplateRule entries that go unmatched when every sbpp2026 page template is a stub).

## Local validation

Local quality gates were **deferred to CI** — this worktree has neither Docker (`./sbpp.sh` won't run) nor a host PHP / Node toolchain available, so `phpstan`, `test`, `ts-check`, and `composer api-contract` couldn't be exercised locally. CI runs all four gates and is the authoritative signal:

- PHPStan (this PR) — both matrix legs (`theme=default`, `theme=sbpp2026`) must pass.
- PHPUnit — no test surface added (chrome templates have no Views, and the env-var override on the rule is a runtime branch that the existing rule tests cover the default path of).
- ts-check — A2 adds no JS files (theme.js was vendored in A1).
- API contract — A2 touches no `web/api/handlers/*.php` and adds no new actions.

## Screenshots

**Deferred** — Docker isn't available in this worktree so the dev panel couldn't be brought up to flip `config.theme=sbpp2026` in adminer. CI gates are the primary signal; the Reviewer subagent or a follow-up can attach screenshots after `./sbpp.sh up`.

The expected manual smoke test (per the dispatch prompt) is:

1. `UPDATE sb_settings SET value='sbpp2026' WHERE name='config.theme';`
2. Load `http://localhost:8080/`. Expected: sidebar with brand mark + nav links; topbar with breadcrumb + ⌘K palette button + theme toggle; footer with hidden `<aside id="drawer-root">` + `<dialog id="palette-root">` scaffolds; the page content area shows the A1 stub card.
3. Toggle light/dark via the theme button (or `document.documentElement.classList.toggle('dark')` in devtools).
4. `UPDATE sb_settings SET value='default' WHERE name='config.theme';` to revert.

## Out of scope (explicit)

- No JS changes — `theme.js` was vendored verbatim in A1 and is not touched here. C1 wires the drawer's inner markup; C2 wires the palette's. Both are tracked separately.
- No View DTOs for `core/*.tpl` — chrome templates render with vars assigned directly by the chrome PHP files (`$navbar`, `$adminbar`, `$breadcrumb`, etc.), the same way `web/themes/default/core/*.tpl` works today. `SmartyTemplateRule` only scans concrete `Sbpp\View\View` subclasses, so chrome templates aren't subject to the rule (and don't need to be — they have no per-page DB drift surface).
- No `nofilter` annotations needed — none of the new chrome templates use `nofilter`. All template-variable output is auto-escaped per `init.php`'s `setEscapeHtml(true)`.
- No `web/themes/default/` edits — legacy chrome continues to render unchanged when `config.theme=default`.