### PR TITLE
[#1123 A3] Permission helper + View base extension + {has_access} Smarty plugin

### DIFF
--- a/web/includes/SmartyCustomFunctions.php
+++ b/web/includes/SmartyCustomFunctions.php
@@ -96,3 +96,62 @@ function smarty_function_csrf_field()
     $name = htmlspecialchars(CSRF::FIELD_NAME, ENT_QUOTES, 'UTF-8');
     return '<input type="hidden" name="' . $name . '" value="' . $token . '" />';
 }
+
+/**
+ * Smarty {has_access flag=…}…{/has_access} BLOCK plugin: render the inner
+ * content only when the current user holds the given permission flag.
+ *
+ * This is the deliberate ESCAPE HATCH for ad-hoc per-row checks (e.g.
+ * gating an action button inside a `{foreach}` over admins). The
+ * PRIMARY pattern stays precomputed `can_*` booleans on the View — see
+ * `Sbpp\View\Perms::for()` and the convention block on
+ * `Sbpp\View\View` — so most templates should keep using
+ * `{if $can_add_ban} … {/if}`.
+ *
+ * Usage examples (the `flag=` parameter accepts either a web-flag
+ * integer or a SourceMod char-flag string; `CUserManager::HasAccess()`
+ * dispatches on the type):
+ *
+ * ```smarty
+ * {has_access flag=$smarty.const.ADMIN_ADD_BAN}
+ *     <a href="?p=admin&c=bans&o=add">Add ban</a>
+ * {/has_access}
+ *
+ * {foreach $admins as $a}
+ *     {has_access flag=$smarty.const.ADMIN_EDIT_ADMINS}
+ *         <a href="?p=admin&c=admins&o=edit&id={$a.aid}">Edit</a>
+ *     {/has_access}
+ * {/foreach}
+ * ```
+ *
+ * Smarty 5 invokes block plugins twice per render — once on the
+ * opening tag (`$content === null`, `$repeat === true`) and once on
+ * the closing tag (`$content` populated, `$repeat === false`). We
+ * suppress output on the opening pass and gate on the closing pass.
+ *
+ * Reads `$userbank` from the request-global the rest of the panel
+ * exposes (set by `init.php`; same convention as every page handler's
+ * `global $userbank;`). When unset (no session, no user manager
+ * bound — should not happen in normal request flow), the plugin
+ * fails closed and emits nothing.
+ *
+ * @param array{flag?: int|string} $params
+ * @param string|null              $content
+ * @param mixed                    $template
+ * @param bool                     $repeat
+ */
+function smarty_block_has_access(array $params, ?string $content, $template, &$repeat): string
+{
+    if ($content === null) {
+        return '';
+    }
+    global $userbank;
+    if (!$userbank instanceof CUserManager) {
+        return '';
+    }
+    $flag = $params['flag'] ?? null;
+    if ($flag === null || $flag === '' || $flag === 0) {
+        return '';
+    }
+    return $userbank->HasAccess($flag) ? $content : '';
+}

--- a/web/includes/SmartyCustomFunctions.php
+++ b/web/includes/SmartyCustomFunctions.php
@@ -135,6 +135,17 @@ function smarty_function_csrf_field()
  * bound — should not happen in normal request flow), the plugin
  * fails closed and emits nothing.
  *
+ * Owner bypass (numeric web flags only): `ADMIN_OWNER` is OR'd into
+ * the mask before the `HasAccess()` call, mirroring `Sbpp\View\Perms::for()`
+ * and the `CheckAdminAccess(ADMIN_OWNER|…)` convention used throughout
+ * `web/includes/page-builder.php`. This guarantees the two helpers
+ * agree for owners — `{if $can_add_ban}` and
+ * `{has_access flag=$smarty.const.ADMIN_ADD_BAN}` evaluate identically
+ * regardless of which one the template author reaches for. Char-flag
+ * strings (SourceMod's `'a'`–`'z'`) are a separate permission system
+ * with their own root flag (`SM_ROOT='z'`) that `HasAccess()` already
+ * matches via substring scan; the OR is skipped on that path.
+ *
  * @param array{flag?: int|string} $params
  * @param string|null              $content
  * @param mixed                    $template
@@ -152,6 +163,9 @@ function smarty_block_has_access(array $params, ?string $content, $template, &$r
     $flag = $params['flag'] ?? null;
     if ($flag === null || $flag === '' || $flag === 0) {
         return '';
+    }
+    if (is_numeric($flag) && defined('ADMIN_OWNER')) {
+        $flag = (int) $flag | (int) constant('ADMIN_OWNER');
     }
     return $userbank->HasAccess($flag) ? $content : '';
 }

--- a/web/includes/View/Perms.php
+++ b/web/includes/View/Perms.php
@@ -1,0 +1,121 @@
+<?php
+declare(strict_types=1);
+
+namespace Sbpp\View;
+
+/**
+ * Snapshot the current user's web-permission flags as a flat
+ * `can_*` => bool array suitable for splatting into a {@see View}
+ * subclass's named constructor.
+ *
+ * The convention each `Sbpp\View\<Page>View` follows:
+ *
+ *   1. Each permission the template needs is a constructor-promoted
+ *      `public readonly bool $can_<flag>` property (e.g.
+ *      `$can_add_ban`, `$can_edit_all_bans`, `$can_owner`).
+ *   2. The page handler builds the View like:
+ *
+ *      ```php
+ *      use Sbpp\View\Perms;
+ *      use Sbpp\View\Renderer;
+ *
+ *      Renderer::render($theme, new BanListView(
+ *          ...Perms::for($userbank),
+ *          ban_list: $bans,
+ *          // …
+ *      ));
+ *      ```
+ *
+ *      PHP discards splatted `can_*` keys the View doesn't declare, so
+ *      a View only opts in to the booleans its template actually
+ *      consumes — `SmartyTemplateRule` keeps that opt-in honest by
+ *      flagging unused properties.
+ *   3. Templates render `{if $can_add_ban} … {/if}` — never raw
+ *      `{if $user.web_flags & …}` — and never need to know the
+ *      bitmask values.
+ *
+ * The boolean set is derived at runtime by enumerating every
+ * `ADMIN_*` constant defined by `init.php` from
+ * `web/configs/permissions/web.json`. Adding a new permission flag in
+ * that JSON automatically grows the array next request — no
+ * maintenance burden here.
+ *
+ * Naming convention: each constant `ADMIN_FOO_BAR` becomes the array
+ * key `can_foo_bar`. The `ADMIN_` prefix is stripped and the rest is
+ * lowercased, matching the `{if $can_foo_bar}` style the templates use.
+ *
+ * For the rare case a template needs an ad-hoc check the View couldn't
+ * precompute (e.g. inside a `{foreach}` over admins, gating one column
+ * per row), use the paired `{has_access flag=$smarty.const.ADMIN_FOO}`
+ * Smarty block plugin in `SmartyCustomFunctions.php`.
+ */
+final class Perms
+{
+    /**
+     * Disallow instantiation — this class is a static helper namespace.
+     */
+    private function __construct()
+    {
+    }
+
+    /**
+     * Build the `['can_<flag>' => bool, …]` snapshot for $userbank.
+     *
+     * Returns all-false (every `can_*` => false) when:
+     *   - $userbank is null (rare; CSRF/error pages reach the View
+     *     without a bound user manager), or
+     *   - the user is not logged in (`HasAccess()` short-circuits to
+     *     false on aid <= 0, so the loop below converges on false for
+     *     every flag without a special case).
+     *
+     * Owner bypass: every per-flag check is OR'd with `ADMIN_OWNER`
+     * before being passed to `HasAccess()`, mirroring the convention
+     * baked into `CheckAdminAccess(ADMIN_OWNER|…)` in
+     * `web/includes/page-builder.php` and `system-functions.php`.
+     * The effect is that a user holding the `ADMIN_OWNER` bit gets
+     * `can_*` => true for every flag — templates can write
+     * `{if $can_add_ban}` without remembering to also check
+     * `$can_owner`. The standalone `can_owner` key is still emitted so
+     * templates that want to gate strictly on the owner bit (e.g. a
+     * "transfer ownership" panel) can do so explicitly.
+     *
+     * @return array<string, bool>
+     */
+    public static function for(?\CUserManager $userbank): array
+    {
+        $perms = [];
+        $owner = defined('ADMIN_OWNER') ? (int) constant('ADMIN_OWNER') : 0;
+        foreach (self::adminFlags() as $name => $value) {
+            $key = strtolower(substr($name, strlen('ADMIN_')));
+            $mask = $value | $owner;
+            $perms['can_' . $key] = $userbank !== null
+                && (bool) $userbank->HasAccess($mask);
+        }
+        return $perms;
+    }
+
+    /**
+     * Enumerate every currently-defined `ADMIN_*` constant from the
+     * `user` bucket. `init.php` populates this set at bootstrap from
+     * `web/configs/permissions/web.json`; this getter is therefore
+     * future-proof against new flags being added to that JSON.
+     *
+     * @return array<string, int>
+     */
+    private static function adminFlags(): array
+    {
+        $flags = [];
+        $defined = get_defined_constants(true);
+        $userBucket = $defined['user'] ?? [];
+        foreach ($userBucket as $name => $value) {
+            if (!str_starts_with($name, 'ADMIN_')) {
+                continue;
+            }
+            if (!is_int($value)) {
+                continue;
+            }
+            $flags[$name] = $value;
+        }
+        return $flags;
+    }
+}

--- a/web/includes/View/View.php
+++ b/web/includes/View/View.php
@@ -19,6 +19,38 @@ namespace Sbpp\View;
  * uses the custom `-{…}-` pair (currently only `page_youraccount.tpl`) must
  * override {@see View::DELIMITERS} with the matching pair so the rule parses
  * the template correctly.
+ *
+ * ### Permission booleans
+ *
+ * Views that gate template content on the current user's permissions
+ * declare each gate as its own constructor-promoted
+ * `public readonly bool $can_<flag>` property (e.g. `$can_add_ban`,
+ * `$can_edit_all_bans`, `$can_owner`). The page handler builds the View
+ * by splatting {@see Perms::for()} into the named arguments:
+ *
+ * ```php
+ * use Sbpp\View\Perms;
+ * use Sbpp\View\Renderer;
+ *
+ * Renderer::render($theme, new BanListView(
+ *     ...Perms::for($userbank),
+ *     ban_list: $bans,
+ *     // …
+ * ));
+ * ```
+ *
+ * `Perms::for()` returns a flat `['can_<flag>' => bool, …]` array
+ * covering every `ADMIN_*` constant defined from
+ * `web/configs/permissions/web.json`. PHP discards splatted keys the
+ * View doesn't declare, so each subclass opts in to only the booleans
+ * its template actually consumes. `SmartyTemplateRule` keeps both
+ * sides honest: every template-referenced `$can_*` must be declared,
+ * and every declared `$can_*` must be referenced.
+ *
+ * Each `bool` lives on the concrete subclass (NOT on this base) on
+ * purpose: declaring booleans the template never reads would silently
+ * defeat `SmartyTemplateRule`'s parity check, so dead permission
+ * checks would accumulate untestably across pages.
  */
 abstract class View
 {

--- a/web/init.php
+++ b/web/init.php
@@ -220,6 +220,7 @@ $theme->registerPlugin(Smarty::PLUGIN_FUNCTION, 'help_icon', 'smarty_function_he
 $theme->registerPlugin(Smarty::PLUGIN_FUNCTION, 'sb_button', 'smarty_function_sb_button');
 $theme->registerPlugin(Smarty::PLUGIN_FUNCTION, 'load_template', 'smarty_function_load_template');
 $theme->registerPlugin(Smarty::PLUGIN_FUNCTION, 'csrf_field', 'smarty_function_csrf_field');
+$theme->registerPlugin(Smarty::PLUGIN_BLOCK, 'has_access', 'smarty_block_has_access');
 $theme->registerPlugin('modifier', 'smarty_stripslashes', 'smarty_stripslashes');
 $theme->registerPlugin('modifier', 'smarty_htmlspecialchars', 'smarty_htmlspecialchars');
 

--- a/web/tests/integration/PermsHelperTest.php
+++ b/web/tests/integration/PermsHelperTest.php
@@ -1,0 +1,193 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sbpp\Tests\Integration;
+
+use Sbpp\Tests\ApiTestCase;
+use Sbpp\Tests\Fixture;
+use Sbpp\View\Perms;
+
+/**
+ * Regression suite for `Sbpp\View\Perms::for()` — the helper that
+ * snapshots a user's web permissions into a flat `['can_*' => bool, …]`
+ * array for splatting into `Sbpp\View\<Page>View` constructors.
+ *
+ * The helper is the single source of truth for permission booleans
+ * across every Phase B/C view in the v2.0.0 theme rollout (#1123 A3).
+ * If any of the contracts below regresses, every gated UI element on
+ * every page silently flips state, so this test is intentionally
+ * exhaustive about the auto-discovery + owner-bypass + null-user
+ * semantics.
+ */
+final class PermsHelperTest extends ApiTestCase
+{
+    /**
+     * No `$userbank` means we're rendering for a request that never
+     * reached the auth layer (CSRF reject, hard error). Every gate
+     * must fail closed — never let a `null` look like an admin.
+     */
+    public function testNullUserBankReturnsAllFalse(): void
+    {
+        $perms = Perms::for(null);
+
+        $this->assertNotEmpty($perms, 'Perms::for(null) must still emit the can_* keys (all false), so View constructors that splat them keep their named-args contract.');
+        foreach ($perms as $key => $value) {
+            $this->assertFalse($value, "Expected $key=false for null userbank, got " . var_export($value, true));
+        }
+    }
+
+    /**
+     * Logged-out user (aid = -1, what `Auth::verify()` returns when no
+     * session exists). `CUserManager::HasAccess()` short-circuits to
+     * false on aid <= 0; the helper must propagate that.
+     */
+    public function testAnonymousUserReturnsAllFalse(): void
+    {
+        $userbank = new \CUserManager(null);
+
+        $perms = Perms::for($userbank);
+
+        $this->assertNotEmpty($perms);
+        foreach ($perms as $key => $value) {
+            $this->assertFalse($value, "Expected $key=false for anonymous userbank, got " . var_export($value, true));
+        }
+    }
+
+    /**
+     * Auto-discovery: the helper enumerates every `ADMIN_*` constant
+     * `init.php` defines from `web/configs/permissions/web.json`.
+     * Adding a row to that JSON should grow the array next request
+     * with NO code change here — these assertions pin the discovery
+     * shape so a future refactor can't silently drop flags.
+     */
+    public function testKeysCoverEveryAdminConstant(): void
+    {
+        $perms = Perms::for(null);
+
+        $expected = [
+            // Bin in lockstep with web/configs/permissions/web.json.
+            // Adding a new ADMIN_* row to the JSON should add the
+            // corresponding can_* key here too.
+            'can_list_admins',
+            'can_add_admins',
+            'can_edit_admins',
+            'can_delete_admins',
+            'can_list_servers',
+            'can_add_server',
+            'can_edit_servers',
+            'can_delete_servers',
+            'can_add_ban',
+            'can_edit_own_bans',
+            'can_edit_group_bans',
+            'can_edit_all_bans',
+            'can_ban_protests',
+            'can_ban_submissions',
+            'can_delete_ban',
+            'can_unban',
+            'can_ban_import',
+            'can_unban_own_bans',
+            'can_unban_group_bans',
+            'can_list_groups',
+            'can_add_group',
+            'can_edit_groups',
+            'can_delete_groups',
+            'can_web_settings',
+            'can_list_mods',
+            'can_add_mods',
+            'can_edit_mods',
+            'can_delete_mods',
+            'can_notify_sub',
+            'can_notify_protest',
+            'can_owner',
+        ];
+        foreach ($expected as $key) {
+            $this->assertArrayHasKey($key, $perms, "Missing $key — Perms::for() must auto-discover every ADMIN_* constant.");
+        }
+
+        // Anti-leakage: ALL_WEB lives in web.json but is not an
+        // ADMIN_* constant; SM_* SourceMod char flags are a different
+        // permission system entirely. Neither belongs in the can_*
+        // surface — keep both out so consumers don't end up with
+        // confusing keys like `can_all_web` or `can_kick`.
+        $this->assertArrayNotHasKey('can_all_web', $perms);
+        foreach (array_keys($perms) as $key) {
+            $this->assertStringStartsWith('can_', (string) $key);
+        }
+    }
+
+    /**
+     * The seeded fixture admin has `extraflags = ADMIN_OWNER` only
+     * (see `Fixture::seedAdmin()`). Owner bypass is the convention
+     * baked into every `CheckAdminAccess(ADMIN_OWNER|…)` call site in
+     * `page-builder.php`; `Perms::for()` mirrors it by OR'ing
+     * `ADMIN_OWNER` into every check before hitting `HasAccess()`. So
+     * the resulting array must light up `can_*` for every gated
+     * action — `{if $can_add_ban}` Just Works for owners without the
+     * template having to also check `$can_owner`.
+     */
+    public function testOwnerSeesEveryCanFlag(): void
+    {
+        $this->loginAsAdmin();
+        /** @var \CUserManager $userbank */
+        $userbank = $GLOBALS['userbank'];
+
+        $perms = Perms::for($userbank);
+
+        foreach ($perms as $key => $value) {
+            $this->assertTrue($value, "Expected $key=true for ADMIN_OWNER user, got " . var_export($value, true));
+        }
+    }
+
+    /**
+     * Realistic non-owner case: an admin with a narrow flag set. Only
+     * the flags they hold should produce true; every other gate stays
+     * false. This is the daily-driver test — most admins are NOT
+     * owners and rely on per-flag granularity.
+     */
+    public function testNonOwnerSeesOnlyGrantedFlags(): void
+    {
+        $mask = ADMIN_ADD_BAN | ADMIN_EDIT_OWN_BANS;
+        $aid  = $this->createAdminWithFlags($mask);
+        $this->loginAs($aid);
+        /** @var \CUserManager $userbank */
+        $userbank = $GLOBALS['userbank'];
+
+        $perms = Perms::for($userbank);
+
+        $this->assertTrue($perms['can_add_ban'],       'admin holds ADMIN_ADD_BAN');
+        $this->assertTrue($perms['can_edit_own_bans'], 'admin holds ADMIN_EDIT_OWN_BANS');
+
+        $this->assertFalse($perms['can_owner'],       'admin does NOT hold ADMIN_OWNER');
+        $this->assertFalse($perms['can_delete_ban'],  'admin does NOT hold ADMIN_DELETE_BAN');
+        $this->assertFalse($perms['can_unban'],       'admin does NOT hold ADMIN_UNBAN');
+        $this->assertFalse($perms['can_web_settings'], 'admin does NOT hold ADMIN_WEB_SETTINGS');
+        $this->assertFalse($perms['can_list_admins'], 'admin does NOT hold ADMIN_LIST_ADMINS');
+    }
+
+    /**
+     * Insert a non-owner admin row directly via the test PDO so we can
+     * exercise an arbitrary `extraflags` mask without going through
+     * the `admins.add` JSON handler (which has its own permission
+     * checks and would couple this test to that handler's contract).
+     * `gid = -1` keeps the LEFT JOIN to `sb_groups` empty so the
+     * mask we pass in is exactly what `extraflags` ends up holding.
+     */
+    private function createAdminWithFlags(int $mask): int
+    {
+        $pdo = Fixture::rawPdo();
+        $stmt = $pdo->prepare(sprintf(
+            'INSERT INTO `%s_admins` (user, authid, password, gid, email, validate, extraflags, immunity)
+             VALUES (?, ?, ?, -1, ?, NULL, ?, 50)',
+            DB_PREFIX,
+        ));
+        $stmt->execute([
+            'flagged-' . $mask,
+            'STEAM_0:0:' . $mask,
+            password_hash('x', PASSWORD_BCRYPT),
+            'flagged@example.test',
+            $mask,
+        ]);
+        return (int) $pdo->lastInsertId();
+    }
+}


### PR DESCRIPTION
Part of #1123 — Phase A3 of the v2.0.0 theme rollout. Sets up the foundation Phase B/C views consume to gate template content on web permissions.

Plan: [`sbpp2026-theme-rollout-4c702e97.plan.md`](/home/fishy/.cursor/plans/sbpp2026-theme-rollout-4c702e97.plan.md), section **A3 — Permission helper + `View` base extension for the new theme**.

## What this PR adds

1. **`Sbpp\View\Perms` static helper** — `Perms::for(?CUserManager $userbank): array` returns a flat `['can_<flag>' => bool, …]` snapshot of every `ADMIN_*` constant `init.php` defines from `web/configs/permissions/web.json`. Page handlers splat the result into a `<Page>View` named-arg constructor; PHP discards splatted keys the View doesn't declare, so each subclass opts in to only the booleans its template actually consumes. New flags added to the JSON automatically grow the array next request — no maintenance burden.
2. **`Sbpp\View\View` docblock convention** — extended the abstract base's docblock to spell out the splat-into-named-args pattern, and the rationale for keeping `can_*` properties on each concrete subclass (so `SmartyTemplateRule`'s parity check still catches dead permission references). No structural change to the class.
3. **`{has_access flag=…}…{/has_access}` Smarty 5 BLOCK plugin** — escape hatch in `SmartyCustomFunctions.php` for the rare per-row check the View couldn't precompute (e.g. inside a `{foreach}` over admins). Primary pattern stays `{if \$can_*}` on the View; this plugin is the deliberate exception.
4. **`PermsHelperTest` integration test** — pins the null-userbank, anonymous, owner-bypass, granted-flags-only, and key-set-coverage contracts.

## Files touched

Matches the plan's A3 \"Files\" list verbatim:

- **new** `web/includes/View/Perms.php`
- small edits to `web/includes/View/View.php` (docblock only — class shape unchanged)
- small edits to `web/includes/SmartyCustomFunctions.php` (one new function)

Plus one in-scope exception per the orchestrator brief:

- **new** `web/tests/integration/PermsHelperTest.php` — 5 cases / 165 assertions, paired with the new helper. Lives under `web/tests/integration/` because exercising `HasAccess()` against a real admin row requires the seeded `sb_admins` fixture (`Fixture::seedAdmin()` puts the admin's `extraflags = ADMIN_OWNER`); a unit-only test could only cover the null-userbank case.

Plus one one-line registration the plan flagged ahead of time:

- `web/init.php` — single new line `\$theme->registerPlugin(Smarty::PLUGIN_BLOCK, 'has_access', 'smarty_block_has_access');` next to the existing five `registerPlugin(...)` calls, mirroring how `help_icon`, `csrf_field`, etc. are wired. `SmartyCustomFunctions.php` does NOT expose a `register_smarty_custom_functions(Smarty)` extension point — every plugin in this repo is registered directly from `init.php` — so the only way to make `{has_access}` actually fire was to add the registration alongside its siblings. The plan's A3 \"Files\" list explicitly carved this case out: \"If you need to add a registerPlugin call, it's a one-liner that mirrors how existing plugins are registered. Document the change in the PR body.\"

## Design choice: docblock-only convention on the View base

I went with the **docblock-only** path on `View.php` instead of adding a trait or a `View::withPerms()` factory. Rationale:

- The plan offers a trait/factory option but also flags it as potentially over-engineered. PHP's named-args splat already does the work the factory would: `new BanListView(...Perms::for(\$userbank), ban_list: \$bans)` is two lines that any B-ticket can write without indirection.
- A trait that adds `can_*` properties on the base would silently defeat `SmartyTemplateRule`'s template-vs-View parity check — every concrete View would inherit booleans its template never reads, and dead permission checks would pile up across pages. Keeping the booleans on the concrete subclass forces the rule to flag drift on both directions (missing template ref → unused property; missing View prop → undeclared template var).
- A static factory (`SomeView::withPerms(\$userbank, …)`) buys nothing over the splat: the Renderer only reads public properties, the splat handles the wiring, and named-args make the call site read the same as without the helper. Adding a factory just means each subclass has to remember to override it.

So the surface area is: ONE helper class (`Perms`), ONE docblock paragraph on the base (`View.php`), and ONE plugin function (`smarty_block_has_access`). Phase B tickets get a 2-line consumer pattern.

## Sample usage (for B/C ticket authors)

```php
use Sbpp\View\Perms;
use Sbpp\View\Renderer;

global \$userbank, \$theme;

Renderer::render(\$theme, new BanListView(
    ...Perms::for(\$userbank),
    ban_list: \$bans,
    page: \$page,
    total: \$total,
));
```

The `BanListView` declares each `public readonly bool \$can_*` it needs (e.g. `\$can_add_ban`, `\$can_edit_all_bans`, `\$can_unban`, `\$can_owner`); PHP silently drops every other splatted key. The template then writes `{if \$can_add_ban}…{/if}` — no bitmask gymnastics, no `{if \$user.web_flags & …}`.

For the rare per-row gate inside a `{foreach}`:

```smarty
{foreach \$admins as \$a}
  …
  {has_access flag=\$smarty.const.ADMIN_EDIT_ADMINS}
    <a href=\"?p=admin&c=admins&o=edit&id={\$a.aid}\">Edit</a>
  {/has_access}
{/foreach}
```

## Owner-bypass semantic

`Perms::for()` ORs `ADMIN_OWNER` into every per-flag `HasAccess()` check, mirroring the convention baked into `CheckAdminAccess(ADMIN_OWNER|…)` in [`web/includes/page-builder.php`](web/includes/page-builder.php) and [`web/includes/system-functions.php`](web/includes/system-functions.php). A user holding `ADMIN_OWNER` therefore lights up every `can_*` => true; templates can write `{if \$can_add_ban}` without remembering to also check `\$can_owner`. The standalone `can_owner` key is still emitted for the rare panel that needs to gate strictly on owner status (e.g. \"transfer ownership\").

## Quality gates (all green locally)

- `./sbpp.sh phpstan` — default theme: OK
- `./sbpp.sh phpstan` (`SBPP_PHPSTAN_THEME=sbpp2026 + phpstan-sbpp2026.neon`) — sbpp2026 theme: OK
- `./sbpp.sh test` — full suite: 268 tests / 1134 assertions OK (incl. 5 new `PermsHelperTest` cases, 165 assertions)
- `./sbpp.sh ts-check` — clean
- `./sbpp.sh composer api-contract` — clean diff (no API surface change)

## Out of scope

- Templates are NOT updated to consume `\$can_*` or `{has_access}` here — that lands per-page in B1–B20.
- The `{has_access}` plugin's `flag=` parameter accepts SourceMod char-flag strings too (because `CUserManager::HasAccess()` already dispatches on `is_numeric()`); this PR doesn't introduce a separate `Sm\Perms` helper for SourceMod flags. If a B/C ticket needs one, that's a tiny follow-up.