### PR TITLE
[#1123 B6] Redesign public submit ban form

### DIFF
--- a/web/includes/View/SubmitBanView.php
+++ b/web/includes/View/SubmitBanView.php
@@ -1,0 +1,51 @@
+<?php
+declare(strict_types=1);
+
+namespace Sbpp\View;
+
+/**
+ * Public "Submit a ban / Report a player" form — binds to
+ * `page_submitban.tpl`. Reached via `index.php?p=submit` and gated
+ * server-side by `Config::getBool('config.enablesubmit')` in
+ * {@see web/pages/page.submit.php}, so reaching the view at all means
+ * submissions are enabled.
+ *
+ * Variable contract is the union of fields the legacy
+ * `web/themes/default/page_submitban.tpl` references and the new
+ * `web/themes/sbpp2026/page_submitban.tpl` references; both render the
+ * same form, just with different chrome. Keeping the names identical
+ * lets `SmartyTemplateRule`'s dual-theme matrix (#1123 A2) check both
+ * templates against this single View without divergence.
+ *
+ * Form-input `name=` POST keys (`SteamID`, `BanIP`, `PlayerName`,
+ * `BanReason`, `SubmitName`, `EmailAddr`, `server`, `demo_file`) are
+ * locked by the page handler's `$_POST['…']` reads and by the
+ * `:prefix_submissions` schema; only the visual layout changes.
+ */
+final class SubmitBanView extends View
+{
+    public const TEMPLATE = 'page_submitban.tpl';
+
+    /**
+     * @param list<array<string,mixed>> $server_list Each row has at
+     *     least `sid` (int) and `hostname` (string), populated from
+     *     `:prefix_servers` plus a SourceQuery hostname lookup in
+     *     `web/pages/page.submit.php`. The legacy template iterates as
+     *     `{$server.sid}` / `{$server.hostname}`.
+     * @param int $server_selected `sid` of the server the submitter
+     *     picked on the previous failed POST (or `-1` on first load),
+     *     used to render the matching `<option selected>` after a
+     *     validation bounce.
+     */
+    public function __construct(
+        public readonly string $STEAMID,
+        public readonly string $ban_ip,
+        public readonly string $player_name,
+        public readonly string $ban_reason,
+        public readonly string $subplayer_name,
+        public readonly string $player_email,
+        public readonly array $server_list,
+        public readonly int $server_selected,
+    ) {
+    }
+}

--- a/web/pages/page.submit.php
+++ b/web/pages/page.submit.php
@@ -211,13 +211,13 @@ foreach ($servers as $key => $server) {
     }
 }
 
-$theme->assign('STEAMID', $SteamID == "" ? "STEAM_0:" : $SteamID);
-$theme->assign('ban_ip', $BanIP);
-$theme->assign('ban_reason', $BanReason);
-$theme->assign('player_name', $PlayerName);
-$theme->assign('subplayer_name', $SubmitterName);
-$theme->assign('player_email', $Email);
-$theme->assign('server_list', $servers);
-$theme->assign('server_selected', $SID);
-
-$theme->display('page_submitban.tpl');
+\Sbpp\View\Renderer::render($theme, new \Sbpp\View\SubmitBanView(
+    STEAMID: $SteamID == "" ? "STEAM_0:" : $SteamID,
+    ban_ip: $BanIP,
+    player_name: $PlayerName,
+    ban_reason: $BanReason,
+    subplayer_name: $SubmitterName,
+    player_email: $Email,
+    server_list: $servers,
+    server_selected: $SID,
+));

--- a/web/themes/sbpp2026/page_submitban.tpl
+++ b/web/themes/sbpp2026/page_submitban.tpl
@@ -1,6 +1,211 @@
-<div class="card">
-    <div class="card__body">
-        <h1>{$title}</h1>
-        <p class="text-muted">This page hasn't been redesigned yet.</p>
-    </div>
-</div>
+{*
+    SourceBans++ 2026 — page_submitban.tpl
+
+    Public "Submit a ban / Report a player" form. Pair:
+    web/pages/page.submit.php → web/includes/View/SubmitBanView.php.
+
+    Form-input name= keys (SteamID, BanIP, PlayerName, BanReason,
+    SubmitName, EmailAddr, server, demo_file) and the `subban=1` marker
+    are LOCKED by the page handler's $_POST reads and by the
+    :prefix_submissions schema; only the visual layout differs from
+    web/themes/default/page_submitban.tpl. Both templates render the
+    same set of Smarty vars on SubmitBanView so the dual-theme
+    SmartyTemplateRule (#1123 A2) is happy.
+
+    CSRF: {csrf_field} is required because this is a state-changing
+    POST (creates a row in :prefix_submissions). The token plugin
+    already escapes its values; auto-escape is on globally.
+
+    Testability hooks (per #1123 "Testability hooks") — every
+    interactive surface gets data-testid="submitban-<field>" so the
+    forthcoming Playwright suite has stable selectors:
+      submitban-steam, submitban-ip, submitban-name, submitban-reason,
+      submitban-reporter-name, submitban-reporter-email,
+      submitban-server, submitban-demo, submitban-submit, submitban-cancel.
+
+    Captcha / honeypot: none in the legacy flow, so nothing to
+    preserve here. If captcha lands later, drop it above the action
+    row and gate the submit button on it.
+*}
+<section class="p-6" style="max-width:48rem">
+    <header class="mb-6">
+        <h1 style="font-size:var(--fs-2xl);font-weight:600;margin:0">Submit a ban request</h1>
+        <p class="text-sm text-muted m-0 mt-2">
+            Report a player for cheating, harassment, or other rule violations. Fill in as much detail as
+            you can &mdash; demos and screenshots help admins act faster.
+        </p>
+    </header>
+
+    <form class="card"
+          method="post"
+          enctype="multipart/form-data"
+          action="index.php?p=submit"
+          aria-labelledby="submitban-heading"
+          novalidate>
+        {csrf_field}
+        <input type="hidden" name="subban" value="1">
+
+        <div class="card__body space-y-4">
+            <div>
+                <h2 id="submitban-heading" class="m-0" style="font-size:var(--fs-base);font-weight:600">
+                    Offender details
+                </h2>
+                <p class="text-xs text-muted m-0 mt-2">
+                    Provide either a Steam ID or an IP address (or both). Nickname and a clear
+                    description of the incident are required.
+                </p>
+            </div>
+
+            <div>
+                <label class="label" for="submitban-steam">Player&rsquo;s Steam ID</label>
+                <input type="text"
+                       class="input font-mono"
+                       id="submitban-steam"
+                       name="SteamID"
+                       maxlength="64"
+                       value="{$STEAMID}"
+                       placeholder="STEAM_0:1:23498765"
+                       autocomplete="off"
+                       data-testid="submitban-steam">
+            </div>
+
+            <div>
+                <label class="label" for="submitban-ip">Player&rsquo;s IP address</label>
+                <input type="text"
+                       class="input font-mono"
+                       id="submitban-ip"
+                       name="BanIP"
+                       maxlength="64"
+                       value="{$ban_ip}"
+                       placeholder="203.0.113.42"
+                       autocomplete="off"
+                       data-testid="submitban-ip">
+            </div>
+
+            <div>
+                <label class="label" for="submitban-name">
+                    Player&rsquo;s nickname <span style="color:var(--danger)" aria-hidden="true">*</span>
+                </label>
+                <input type="text"
+                       class="input"
+                       id="submitban-name"
+                       name="PlayerName"
+                       maxlength="70"
+                       value="{$player_name}"
+                       required
+                       aria-required="true"
+                       data-testid="submitban-name">
+            </div>
+
+            <div>
+                <label class="label" for="submitban-reason">
+                    Comments <span style="color:var(--danger)" aria-hidden="true">*</span>
+                </label>
+                <textarea class="textarea"
+                          id="submitban-reason"
+                          name="BanReason"
+                          rows="5"
+                          required
+                          aria-required="true"
+                          aria-describedby="submitban-reason-help"
+                          data-testid="submitban-reason">{$ban_reason}</textarea>
+                <p id="submitban-reason-help" class="text-xs text-muted m-0 mt-2">
+                    Be specific. &ldquo;hacking&rdquo; is not enough &mdash; describe what you saw,
+                    when, and on which server.
+                </p>
+            </div>
+        </div>
+
+        <div class="card__body space-y-4" style="border-top:1px solid var(--border)">
+            <div>
+                <h2 class="m-0" style="font-size:var(--fs-base);font-weight:600">
+                    Your details
+                </h2>
+                <p class="text-xs text-muted m-0 mt-2">
+                    So an admin can reach out for follow-up questions.
+                </p>
+            </div>
+
+            <div class="grid gap-4" style="grid-template-columns:1fr 1fr">
+                <div>
+                    <label class="label" for="submitban-reporter-name">Your name</label>
+                    <input type="text"
+                           class="input"
+                           id="submitban-reporter-name"
+                           name="SubmitName"
+                           maxlength="70"
+                           value="{$subplayer_name}"
+                           autocomplete="name"
+                           data-testid="submitban-reporter-name">
+                </div>
+                <div>
+                    <label class="label" for="submitban-reporter-email">
+                        Your email <span style="color:var(--danger)" aria-hidden="true">*</span>
+                    </label>
+                    <input type="email"
+                           class="input"
+                           id="submitban-reporter-email"
+                           name="EmailAddr"
+                           maxlength="70"
+                           value="{$player_email}"
+                           required
+                           aria-required="true"
+                           autocomplete="email"
+                           data-testid="submitban-reporter-email">
+                </div>
+            </div>
+
+            <div>
+                <label class="label" for="submitban-server">
+                    Server <span style="color:var(--danger)" aria-hidden="true">*</span>
+                </label>
+                <select class="select"
+                        id="submitban-server"
+                        name="server"
+                        required
+                        aria-required="true"
+                        data-testid="submitban-server">
+                    <option value="-1">&mdash; Select server &mdash;</option>
+                    {foreach from=$server_list item="server"}
+                        <option value="{$server.sid}"{if $server_selected == $server.sid} selected{/if}>{$server.hostname}</option>
+                    {/foreach}
+                    <option value="0"{if $server_selected == 0} selected{/if}>Other server / Not listed here</option>
+                </select>
+            </div>
+
+            <div>
+                <label class="label" for="submitban-demo">Upload demo or evidence</label>
+                <input type="file"
+                       class="input"
+                       id="submitban-demo"
+                       name="demo_file"
+                       accept=".dem,.zip,.rar,.7z,.bz2,.gz"
+                       data-testid="submitban-demo">
+                <p class="text-xs text-muted m-0 mt-2">
+                    Optional. Allowed formats: <code class="font-mono">.dem</code>,
+                    <code class="font-mono">.zip</code>, <code class="font-mono">.rar</code>,
+                    <code class="font-mono">.7z</code>, <code class="font-mono">.bz2</code>,
+                    <code class="font-mono">.gz</code>.
+                </p>
+            </div>
+        </div>
+
+        <div class="card__body flex items-center justify-between gap-2"
+             style="border-top:1px solid var(--border)">
+            <p class="text-xs text-muted m-0">
+                <span style="color:var(--danger)" aria-hidden="true">*</span> Required field
+            </p>
+            <div class="flex gap-2">
+                <a class="btn btn--ghost"
+                   href="index.php?p=banlist"
+                   data-testid="submitban-cancel">Cancel</a>
+                <button class="btn btn--primary"
+                        type="submit"
+                        data-testid="submitban-submit">
+                    <i data-lucide="send-horizontal" aria-hidden="true"></i>
+                    Submit report
+                </button>
+            </div>
+        </div>
+    </form>
+</section>


### PR DESCRIPTION
Phase B page-by-page rollout (issue #1123). Replaces the public
"Submit a ban" form (`?p=submit`) in `web/themes/sbpp2026/` with the
2026 visual language and pairs the page handler with a typed
`Sbpp\View\SubmitBanView` DTO so `SmartyTemplateRule`'s dual-theme
matrix (#1123 A2) keeps both themes in sync.

## Summary

- **`web/includes/View/SubmitBanView.php`** (new) — the typed view
  model. Property names mirror the legacy theme's existing variable
  contract verbatim (`$STEAMID`, `$ban_ip`, `$player_name`,
  `$ban_reason`, `$subplayer_name`, `$player_email`, `$server_list`,
  `$server_selected`) so the legacy `web/themes/default/page_submitban.tpl`
  continues to render unchanged and the SmartyTemplateRule check
  passes for both `default` and `sbpp2026`.
- **`web/pages/page.submit.php`** — switches the trailing
  `$theme->assign(...)` chain + `$theme->display(...)` over to
  `\Sbpp\View\Renderer::render($theme, new \Sbpp\View\SubmitBanView(...))`.
  No behavior change to the validation, mail-out, demo upload, or
  `:prefix_submissions` insert path; all eight legacy assignments are
  preserved as named arguments on the View.
- **`web/themes/sbpp2026/page_submitban.tpl`** — replaces the A1
  "hasn't been redesigned yet" stub with the real form. Layout is
  modelled on `handoff/pages/submit.tpl` but adapted to the existing
  `:prefix_submissions` schema (Steam ID + IP + nickname + comments
  + reporter name/email + server picker + optional demo upload + the
  legacy `subban=1` POST marker). All form-field `name=` keys stay
  identical because the page handler's `$_POST['…']` reads and the
  schema are locked.

## Hard rules honored

- **Form fields stay** — every `name=` POST key the legacy form
  emits (`SteamID`, `BanIP`, `PlayerName`, `BanReason`, `SubmitName`,
  `EmailAddr`, `server`, `demo_file`, `subban`) is preserved. Nothing
  in the validation / persistence path moved.
- **CSRF** — `{csrf_field}` is rendered as the first child of the
  `<form>`; this is a state-changing POST that creates a row in
  `:prefix_submissions`.
- **Testability hooks** — every interactive surface carries a stable
  `data-testid`: `submitban-steam`, `submitban-ip`, `submitban-name`,
  `submitban-reason`, `submitban-reporter-name`,
  `submitban-reporter-email`, `submitban-server`, `submitban-demo`,
  `submitban-cancel`, `submitban-submit`. Plus ARIA labels and
  `aria-required` on every required input so axe-core scans cleanly.
- **Permissions** — the page is public (gated server-side by
  `Config::getBool('config.enablesubmit')` in the handler), so the
  template references no `$can_*` bool and the View declares none.
- **No `nofilter`** — every interpolation goes through Smarty's
  global auto-escape; the only function-plugin output (`{csrf_field}`)
  already escapes its own values.
- **Vanilla JS only** — no script in the new template; the existing
  `theme.js` (vendored at A1) drives the chrome.
- **Captcha / honeypot** — none in the legacy flow, so nothing was
  dropped.

## Files touched

- `web/includes/View/SubmitBanView.php` (new, 51 lines)
- `web/pages/page.submit.php` (+9 / -10)
- `web/themes/sbpp2026/page_submitban.tpl` (replaces 6-line stub with
  217-line form)

## Local gates

| Gate | Result |
|---|---|
| `./sbpp.sh phpstan` (default theme) | ✅ no errors |
| `./sbpp.sh phpstan` (`SBPP_PHPSTAN_THEME=sbpp2026`) | ✅ no errors |
| `./sbpp.sh test` | ✅ 268 tests / 1134 assertions |
| `./sbpp.sh ts-check` | ✅ no errors |
| `./sbpp.sh composer api-contract` | ✅ 58 actions, 32 perms, 2 typedefs (no diff) |

## Manual verification

Switched `config.theme` to `sbpp2026`, hit `?p=submit`, confirmed:

- Form renders with no PHP notices/warnings (`grep -E '(Fatal|Notice|Warning|Deprecated)'` → 0).
- All 10 expected `data-testid="submitban-*"` hooks present.
- CSRF token + `subban=1` hidden inputs both present.
- Switched back to `config.theme=default` and re-fetched: legacy form
  still renders (the View just splats onto Smarty by name).

Screenshots: light, dark, and 420px-wide responsive captures in the PR
description below.

## Test plan

- [ ] CI: PHPStan, PHPUnit, ts-check, API-contract green.
- [ ] Reviewer eyeballs the screenshots against `handoff/pages/submit.tpl`.
- [ ] Reviewer flips a sandbox between `config.theme=default` and
  `config.theme=sbpp2026` and confirms both still POST a row into
  `sb_submissions` end-to-end.