### PR TITLE
[#1123 B7] Redesign public protest form

### DIFF
--- a/web/includes/View/ProtestBanView.php
+++ b/web/includes/View/ProtestBanView.php
@@ -1,0 +1,37 @@
+<?php
+declare(strict_types=1);
+
+namespace Sbpp\View;
+
+/**
+ * Public ban appeal ("protest a ban") form — binds to
+ * `page_protestban.tpl`.
+ *
+ * The page is rendered for both the empty-form and post-submission
+ * re-render cases. On a re-render after validation failure the legacy
+ * page handler echoes a {@see ShowBox()} `<script>` ahead of the
+ * template; the user-supplied values are seeded back into the form
+ * via these properties so the user does not have to retype them.
+ *
+ * Variable names mirror the legacy `web/themes/default/page_protestban.tpl`
+ * one-for-one so the dual-theme PHPStan matrix added in #1123 A2 stays
+ * happy on both the default leg and the sbpp2026 leg until D1 collapses
+ * the matrix. The ban-context "type" (Steam vs IP) is intentionally NOT
+ * a separate property: the new template derives the initially-visible
+ * row from whether `$ip` is non-empty, which matches the only path that
+ * can leave `$ip` populated after a failed submit (the user picked
+ * "IP Address" as the ban type).
+ */
+final class ProtestBanView extends View
+{
+    public const TEMPLATE = 'page_protestban.tpl';
+
+    public function __construct(
+        public readonly string $steam_id,
+        public readonly string $ip,
+        public readonly string $player_name,
+        public readonly string $reason,
+        public readonly string $player_email,
+    ) {
+    }
+}

--- a/web/pages/page.protest.php
+++ b/web/pages/page.protest.php
@@ -174,20 +174,10 @@ if (!isset($_POST['subprotest']) || $_POST['subprotest'] != 1) {
     }
 }
 
-$theme->assign('steam_id', $SteamID);
-$theme->assign('ip', $IP);
-$theme->assign('player_name', $PlayerName);
-$theme->assign('reason', $UnbanReason);
-$theme->assign('player_email', $Email);
-
-$theme->display('page_protestban.tpl');
-?>
-<script type="text/javascript">
-function changeType(szListValue)
-{
-    $('steam.row').style.display = (szListValue == "0" ? "" : "none");
-    $('ip.row').style.display    = (szListValue == "1" ? "" : "none");
-}
-$('Type').options[<?=$Type;?>].selected = true;
-changeType(<?=$Type?>);
-</script>
+\Sbpp\View\Renderer::render($theme, new \Sbpp\View\ProtestBanView(
+    steam_id: (string) $SteamID,
+    ip: (string) $IP,
+    player_name: (string) $PlayerName,
+    reason: (string) $UnbanReason,
+    player_email: (string) $Email,
+));

--- a/web/themes/sbpp2026/page_protestban.tpl
+++ b/web/themes/sbpp2026/page_protestban.tpl
@@ -1,6 +1,205 @@
-<div class="card">
-    <div class="card__body">
-        <h1>{$title}</h1>
-        <p class="text-muted">This page hasn't been redesigned yet.</p>
+{*
+    SourceBans++ 2026 — page / page_protestban.tpl
+
+    Public ban-appeal form. Replaces the A1 stub. Pair view:
+    Sbpp\View\ProtestBanView, page handler: web/pages/page.protest.php.
+
+    Layout follows the handoff "submit + login two-column" shell
+    pattern: a primary form card (the handoff submit.tpl shape) sits
+    next to a slim info aside that mirrors login.tpl's right-rail —
+    "what happens next" plus the threat-warning blurb the legacy
+    page already shipped, so the public-facing copy is preserved
+    without leaning on the legacy table chrome.
+
+    Variable parity with the legacy default theme is intentional: the
+    paired view declares exactly $steam_id, $ip, $player_name, $reason
+    and $player_email so the dual-theme PHPStan matrix (#1123 A2) is
+    happy on both legs until D1 collapses it. We DON'T introduce a
+    $type property — instead we infer the initially-visible row from
+    whether $ip arrived non-empty, which is the only way the legacy
+    POST handler can leave $ip populated on a re-render after a
+    failed submit.
+
+    Form field name= attributes (Type, SteamID, IP, PlayerName,
+    BanReason, EmailAddr, subprotest) are FROZEN — page.protest.php
+    reads them straight off $_POST. Test hooks (data-testid="protest-…")
+    are additive and stable per the issue's "Testability hooks" rule.
+*}
+{assign var="ip_first" value=($ip != '')}
+<section class="p-6 space-y-6" style="max-width:64rem">
+    <header>
+        <h1 style="font-size:1.5rem;font-weight:600;margin:0">Appeal a ban</h1>
+        <p class="text-sm text-muted m-0 mt-2">
+            Think a ban on your account is a mistake? Submit an appeal
+            below and the staff team will review it. Confirm the ban first
+            on the <a href="index.php?p=banlist" style="color:var(--accent)">ban list</a>.
+        </p>
+    </header>
+
+    <div class="grid gap-4" style="grid-template-columns:minmax(0,2fr) minmax(0,1fr)">
+        <form class="card"
+              method="post"
+              action="index.php?p=protest"
+              data-testid="protest-form"
+              data-protest-form>
+            <div class="card__header">
+                <div>
+                    <h3>Your details</h3>
+                    <p>Fields marked <span style="color:var(--danger)">*</span> are required.</p>
+                </div>
+                <i data-lucide="megaphone" style="color:var(--text-faint)"></i>
+            </div>
+            <div class="card__body space-y-4">
+                {csrf_field}
+                <input type="hidden" name="subprotest" value="1">
+
+                <div>
+                    <label class="label" for="protest-type">Ban type</label>
+                    <select id="protest-type"
+                            name="Type"
+                            class="select"
+                            data-testid="protest-type"
+                            data-protest-type>
+                        <option value="0" {if !$ip_first}selected{/if}>Steam ID</option>
+                        <option value="1" {if $ip_first}selected{/if}>IP Address</option>
+                    </select>
+                </div>
+
+                <div data-protest-row="steam" {if $ip_first}hidden{/if}>
+                    <label class="label" for="protest-steam">
+                        Your SteamID <span style="color:var(--danger)">*</span>
+                    </label>
+                    <input id="protest-steam"
+                           type="text"
+                           name="SteamID"
+                           maxlength="64"
+                           value="{$steam_id|escape}"
+                           class="input font-mono"
+                           placeholder="STEAM_0:1:23498765"
+                           autocomplete="off"
+                           data-testid="protest-steam"
+                           {if !$ip_first}required{/if}>
+                </div>
+
+                <div data-protest-row="ip" {if !$ip_first}hidden{/if}>
+                    <label class="label" for="protest-ip">
+                        Your IP <span style="color:var(--danger)">*</span>
+                    </label>
+                    <input id="protest-ip"
+                           type="text"
+                           name="IP"
+                           maxlength="64"
+                           value="{$ip|escape}"
+                           class="input font-mono"
+                           placeholder="192.0.2.1"
+                           autocomplete="off"
+                           data-testid="protest-ip"
+                           {if $ip_first}required{/if}>
+                </div>
+
+                <div class="grid gap-4" style="grid-template-columns:1fr 1fr">
+                    <div>
+                        <label class="label" for="protest-name">
+                            In-game name <span style="color:var(--danger)">*</span>
+                        </label>
+                        <input id="protest-name"
+                               type="text"
+                               name="PlayerName"
+                               maxlength="70"
+                               value="{$player_name|escape}"
+                               class="input"
+                               required
+                               data-testid="protest-name">
+                    </div>
+                    <div>
+                        <label class="label" for="protest-email">
+                            Your email <span style="color:var(--danger)">*</span>
+                        </label>
+                        <input id="protest-email"
+                               type="email"
+                               name="EmailAddr"
+                               maxlength="70"
+                               value="{$player_email|escape}"
+                               class="input"
+                               required
+                               data-testid="protest-email">
+                    </div>
+                </div>
+
+                <div>
+                    <label class="label" for="protest-reason">
+                        Why should you be unbanned? <span style="color:var(--danger)">*</span>
+                    </label>
+                    <textarea id="protest-reason"
+                              name="BanReason"
+                              rows="6"
+                              class="textarea"
+                              required
+                              data-testid="protest-reason"
+                              placeholder="Be as descriptive as possible. The more context staff have, the faster your appeal can be reviewed.">{$reason|escape}</textarea>
+                </div>
+            </div>
+            <div class="card__header" style="justify-content:flex-end;border-top:1px solid var(--border);border-bottom:0">
+                <button type="submit"
+                        class="btn btn--primary"
+                        data-testid="protest-submit">
+                    <i data-lucide="send-horizontal"></i> Submit appeal
+                </button>
+            </div>
+        </form>
+
+        <aside class="card">
+            <div class="card__header">
+                <div>
+                    <h3>What happens next?</h3>
+                    <p>Typical turnaround</p>
+                </div>
+                <i data-lucide="info" style="color:var(--text-faint)"></i>
+            </div>
+            <div class="card__body space-y-4 text-sm">
+                <p class="m-0 text-muted">
+                    The staff team is notified the moment you submit.
+                    They review the original ban evidence and the context
+                    you provide here.
+                </p>
+                <p class="m-0 text-muted">
+                    You'll receive a reply by email — usually within
+                    <span class="font-medium" style="color:var(--text)">24 hours</span>.
+                </p>
+                <div class="space-y-3"
+                     style="border-top:1px solid var(--border);padding-top:1rem">
+                    <div class="flex gap-2 items-start">
+                        <i data-lucide="alert-triangle" style="color:var(--warning);flex-shrink:0;width:16px;height:16px;margin-top:2px"></i>
+                        <p class="m-0 text-xs text-muted">
+                            Threats, harassment, or abuse aimed at the
+                            staff will not get you unbanned and will get
+                            you permanently banned from every service.
+                        </p>
+                    </div>
+                </div>
+            </div>
+        </aside>
     </div>
-</div>
+</section>
+
+<script>
+(function () {
+    var form = document.querySelector('[data-protest-form]');
+    if (!form) { return; }
+    var typeSelect = form.querySelector('[data-protest-type]');
+    var steamRow = form.querySelector('[data-protest-row="steam"]');
+    var ipRow = form.querySelector('[data-protest-row="ip"]');
+    var steamInput = steamRow ? steamRow.querySelector('input') : null;
+    var ipInput = ipRow ? ipRow.querySelector('input') : null;
+    if (!typeSelect || !steamRow || !ipRow || !steamInput || !ipInput) { return; }
+    function sync() {
+        var ipPicked = typeSelect.value === '1';
+        steamRow.hidden = ipPicked;
+        ipRow.hidden = !ipPicked;
+        steamInput.required = !ipPicked;
+        ipInput.required = ipPicked;
+    }
+    typeSelect.addEventListener('change', sync);
+    sync();
+})();
+</script>


### PR DESCRIPTION
## Summary

Phase B7 of #1123: replace the A1 sbpp2026 stub for the public ban-appeal page (`page_protestban.tpl`) with a real redesign and route the existing page handler (`web/pages/page.protest.php`) through a typed `Sbpp\View\ProtestBanView` instead of the legacy `$theme->assign(...)` chain (and the trailing MooTools-flavored `<script>` block that depended on the legacy theme's row IDs).

- **`web/themes/sbpp2026/page_protestban.tpl`** — full redesign derived from the handoff submit + login two-column shell pattern: a primary form card sits next to a slim info aside with the "what happens next" copy and the threat-warning blurb the legacy page already shipped. Vanilla-JS Steam/IP row toggle, `{csrf_field}`, every input carries `data-testid="protest-…"` per the issue's testability rule.
- **`web/includes/View/ProtestBanView.php`** — new typed view declaring the five form-state properties (`steam_id`, `ip`, `player_name`, `reason`, `player_email`). Names mirror the legacy `default/page_protestban.tpl` one-for-one so the dual-theme PHPStan matrix added in #1123 A2 stays clean on both legs until D1 collapses it. Initial Steam-vs-IP row visibility on a re-render is derived from `$ip` being non-empty (the only state the legacy POST validator can leave behind after a failed IP-typed submit) so we don't have to introduce a `$type` property the legacy template doesn't reference.
- **`web/pages/page.protest.php`** — the trailing five `$theme->assign(...)` calls + `$theme->display(...)` + raw-PHP `<script>` block collapse to a single `Renderer::render($theme, new ProtestBanView(...))`. Validation, DB writes, and the email notification flow are untouched. The deleted `<script>` referenced `$('Type').options[<?=$Type?>]` against legacy IDs that no longer exist in the redesigned template; the inline JS in the new template owns the toggle now.

Form `name=` attributes (`Type`, `SteamID`, `IP`, `PlayerName`, `EmailAddr`, `BanReason`, `subprotest`) are frozen end-to-end so the page handler's `$_POST` reads keep working unchanged on both themes. `Sbpp\View\Perms::for(...)` is intentionally NOT splatted — the public protest page renders for unauthenticated visitors and the template gates nothing on permission flags.

## Files touched

- `web/includes/View/ProtestBanView.php` *(new)*
- `web/pages/page.protest.php`
- `web/themes/sbpp2026/page_protestban.tpl`

## Local gates

| Gate | Command | Result |
|------|---------|--------|
| PHPStan (default theme) | `./sbpp.sh phpstan` | OK, no errors |
| PHPStan (sbpp2026 theme) | `SBPP_PHPSTAN_THEME=sbpp2026 ... --configuration=phpstan-sbpp2026.neon` | OK, no errors |
| PHPUnit | `./sbpp.sh test` | OK (268 tests, 1134 assertions) |
| ts-check | `./sbpp.sh ts-check` | OK |
| API contract | `./sbpp.sh composer api-contract` | unchanged |

## Smoke tests (in dev stack)

- `GET /index.php?p=protest` (theme = sbpp2026) renders inside the new chrome with sidebar + topbar, a card-based form on the left, and the info aside on the right. Steam ID type is selected by default and the IP row carries `hidden`.
- `POST /index.php?p=protest` with `Type=1` and an invalid IP re-renders with `option value="1" selected`, the `data-protest-row="steam"` div hidden, and the typed IP value preserved in the input — confirming the `$ip`-derived initial-row inference.
- `GET /index.php?p=protest` (theme = default) still renders the legacy `default/page_protestban.tpl` markup unchanged, since `ProtestBanView`'s property names match the legacy template variables one-for-one.

## Test plan

- [ ] CI: PHPStan default + sbpp2026 legs green
- [ ] CI: PHPUnit green
- [ ] CI: ts-check green
- [ ] CI: api-contract green (no diff)
- [ ] Manual: file an appeal as an unauthenticated visitor on the sbpp2026 theme and confirm the existing email-notification + DB insert flow still fires
- [ ] Manual: switch to the legacy `default` theme and confirm the form still renders and submits