### PR TITLE
[#1123 B19] Add admin audit log page

### DIFF
--- a/web/includes/View/AuditLogView.php
+++ b/web/includes/View/AuditLogView.php
@@ -1,0 +1,57 @@
+<?php
+declare(strict_types=1);
+
+namespace Sbpp\View;
+
+/**
+ * Admin → Audit log page (#1123 B19).
+ *
+ * Binds to `page_admin_audit.tpl`. New page, no legacy template — backed
+ * by the existing `:prefix_log` table (no schema change). Each
+ * `audit_log` row is normalised by `web/pages/admin.audit.php` into the
+ * handoff-style shape the template iterates over: `tid` (PK from `lid`),
+ * `severity` (one of `m`/`w`/`e`, mapped to `severity_label` +
+ * `severity_class` for the badge), `time_human` + `time_iso` (formatted
+ * from `created`), `actor` (admin name from `aid` join, or `"system"`
+ * when the row was emitted by an unauthenticated path), `title`,
+ * `detail` (from `message`), and `ip` (from `host`).
+ *
+ * SSR pagination + filtering: `current_severity`, `search`,
+ * `current_page`, `page_count`, plus `prev_url` / `next_url` /
+ * `has_prev` / `has_next` for the pager. We chose SSR over an
+ * `audit.list` JSON action because the page is admin-only and low
+ * traffic; the form-based filter chips + GET pagination match the
+ * handoff design without adding a JS dependency.
+ */
+final class AuditLogView extends View
+{
+    public const TEMPLATE = 'page_admin_audit.tpl';
+
+    /**
+     * @param list<array{
+     *     tid: int,
+     *     severity: string,
+     *     severity_label: string,
+     *     severity_class: string,
+     *     time_human: string,
+     *     time_iso: string,
+     *     actor: string,
+     *     title: string,
+     *     detail: string,
+     *     ip: string,
+     * }> $audit_log
+     */
+    public function __construct(
+        public readonly array $audit_log,
+        public readonly int $total_count,
+        public readonly string $current_severity,
+        public readonly string $search,
+        public readonly int $current_page,
+        public readonly int $page_count,
+        public readonly bool $has_prev,
+        public readonly bool $has_next,
+        public readonly string $prev_url,
+        public readonly string $next_url,
+    ) {
+    }
+}

--- a/web/includes/page-builder.php
+++ b/web/includes/page-builder.php
@@ -110,6 +110,14 @@ function route($fallback)
                 case 'settings':
                     CheckAdminAccess(ADMIN_OWNER|ADMIN_WEB_SETTINGS);
                     return ['SourceBans++ Settings', '/admin.settings.php'];
+                case 'audit':
+                    // Audit log is owner-restricted: there is no dedicated
+                    // ADMIN_LIST_LOGS / ADMIN_LIST_AUDIT flag in
+                    // web/configs/permissions/web.json (#1123 B19), and the
+                    // legacy `TRUNCATE :prefix_log` path in
+                    // admin.settings.php is also gated on ADMIN_OWNER.
+                    CheckAdminAccess(ADMIN_OWNER);
+                    return ['Audit Log', '/admin.audit.php'];
                 default:
                     CheckAdminAccess(ALL_WEB);
                     return ['Administration', '/page.admin.php'];

--- a/web/pages/admin.audit.php
+++ b/web/pages/admin.audit.php
@@ -1,0 +1,155 @@
+<?php
+/*************************************************************************
+This file is part of SourceBans++
+
+SourceBans++ (c) 2014-2024 by SourceBans++ Dev Team
+
+The SourceBans++ Web panel is licensed under a
+Creative Commons Attribution-NonCommercial-ShareAlike 3.0 Unported License.
+
+You should have received a copy of the license along with this
+work.  If not, see <http://creativecommons.org/licenses/by-nc-sa/3.0/>.
+*************************************************************************/
+
+// Admin → Audit log handler (#1123 B19). Auth is enforced upstream by
+// the `CheckAdminAccess(ADMIN_OWNER)` gate the matching `case 'audit':`
+// arm of `web/includes/page-builder.php` runs before dispatching here,
+// matching every other admin.*.php in this directory.
+//
+// SSR: severity chips + free-text search + numeric pager are all
+// driven by GET params, no JSON action. Variable shape mirrors the
+// handoff design (handoff/pages/admin/audit.tpl) but pivots filters
+// onto the `:prefix_log.type` enum (`m`/`w`/`e`) since the table only
+// stores severity, not the action-kind taxonomy the mockup illustrates.
+
+if (!defined("IN_SB")) {
+    echo "You should not be here. Only follow links!";
+    die();
+}
+global $userbank, $theme;
+
+$AuditPerPage = SB_BANS_PER_PAGE;
+
+$page = 1;
+if (isset($_GET['page']) && (int) $_GET['page'] > 0) {
+    $page = (int) $_GET['page'];
+}
+
+$severity = '';
+if (isset($_GET['severity']) && in_array($_GET['severity'], ['m', 'w', 'e'], true)) {
+    $severity = (string) $_GET['severity'];
+}
+
+$search = '';
+if (isset($_GET['search']) && is_string($_GET['search'])) {
+    // Cap search input to a sane length so the page can't be wedged by a
+    // pathological query string. The LIKE clause below adds the wildcards.
+    $search = mb_substr(trim((string) $_GET['search']), 0, 200);
+}
+
+$where = [];
+$params = [];
+if ($severity !== '') {
+    $where[] = 'l.type = :severity';
+    $params[':severity'] = $severity;
+}
+if ($search !== '') {
+    $where[] = '(l.title LIKE :search OR l.message LIKE :search)';
+    $params[':search'] = '%' . $search . '%';
+}
+$whereSql = empty($where) ? '' : (' WHERE ' . implode(' AND ', $where));
+
+// Count first so we can clamp $page against an empty / over-paged
+// filter result before computing the offset.
+$GLOBALS['PDO']->query("SELECT COUNT(l.lid) AS cnt FROM `:prefix_log` AS l" . $whereSql);
+foreach ($params as $k => $v) {
+    $GLOBALS['PDO']->bind($k, $v);
+}
+$countRow = $GLOBALS['PDO']->single();
+$total = (int) ($countRow['cnt'] ?? 0);
+
+$pageCount = ($total > 0) ? (int) ceil($total / $AuditPerPage) : 1;
+if ($page > $pageCount) {
+    $page = $pageCount;
+}
+if ($page < 1) {
+    $page = 1;
+}
+$offset = ($page - 1) * $AuditPerPage;
+
+$GLOBALS['PDO']->query(
+    "SELECT l.lid, l.type, l.title, l.message, l.host, l.created, ad.user
+       FROM `:prefix_log` AS l
+       LEFT JOIN `:prefix_admins` AS ad ON ad.aid = l.aid"
+    . $whereSql .
+    " ORDER BY l.created DESC, l.lid DESC
+       LIMIT :start, :lim"
+);
+foreach ($params as $k => $v) {
+    $GLOBALS['PDO']->bind($k, $v);
+}
+$GLOBALS['PDO']->bind(':start', $offset, PDO::PARAM_INT);
+$GLOBALS['PDO']->bind(':lim',   $AuditPerPage, PDO::PARAM_INT);
+$rows = $GLOBALS['PDO']->resultset();
+
+// Severity letter → label + CSS class. The class ties to .badge--info /
+// .badge--warning / .badge--error in page_admin_audit.tpl's local <style>,
+// so a row with an unknown letter falls through as a neutral "system"
+// badge instead of throwing.
+$severityMap = [
+    'm' => ['label' => 'Info',    'class' => 'info'],
+    'w' => ['label' => 'Warning', 'class' => 'warning'],
+    'e' => ['label' => 'Error',   'class' => 'error'],
+];
+
+$auditLog = [];
+foreach ($rows as $row) {
+    $sevLetter = (string) ($row['type'] ?? '');
+    $sevMeta = $severityMap[$sevLetter] ?? ['label' => 'System', 'class' => 'system'];
+    $createdInt = (int) ($row['created'] ?? 0);
+    $auditLog[] = [
+        'tid'            => (int) ($row['lid'] ?? 0),
+        'severity'       => $sevLetter,
+        'severity_label' => $sevMeta['label'],
+        'severity_class' => $sevMeta['class'],
+        'time_human'     => $createdInt > 0 ? Config::time($createdInt) : '—',
+        'time_iso'       => $createdInt > 0 ? gmdate('c', $createdInt) : '',
+        'actor'          => (string) ($row['user'] ?? '') !== '' ? (string) $row['user'] : 'system',
+        'title'          => (string) ($row['title'] ?? ''),
+        'detail'         => (string) ($row['message'] ?? ''),
+        'ip'             => (string) ($row['host'] ?? ''),
+    ];
+}
+
+$baseQuery = ['p' => 'admin', 'c' => 'audit'];
+if ($severity !== '') {
+    $baseQuery['severity'] = $severity;
+}
+if ($search !== '') {
+    $baseQuery['search'] = $search;
+}
+$prevUrl = '';
+$nextUrl = '';
+if ($page > 1) {
+    $prevQuery = $baseQuery;
+    $prevQuery['page'] = $page - 1;
+    $prevUrl = 'index.php?' . http_build_query($prevQuery);
+}
+if ($page < $pageCount) {
+    $nextQuery = $baseQuery;
+    $nextQuery['page'] = $page + 1;
+    $nextUrl = 'index.php?' . http_build_query($nextQuery);
+}
+
+\Sbpp\View\Renderer::render($theme, new \Sbpp\View\AuditLogView(
+    audit_log:        $auditLog,
+    total_count:      $total,
+    current_severity: $severity,
+    search:           $search,
+    current_page:     $page,
+    page_count:       $pageCount,
+    has_prev:         $page > 1,
+    has_next:         $page < $pageCount,
+    prev_url:         $prevUrl,
+    next_url:         $nextUrl,
+));

--- a/web/themes/default/page_admin_audit.tpl
+++ b/web/themes/default/page_admin_audit.tpl
@@ -1,0 +1,24 @@
+{*
+    page_admin_audit.tpl — Admin → Audit log (#1123 B19) — legacy-theme stub.
+
+    The audit log page is brand-new in #1123 B19; the legacy `default/`
+    bundle never carried a per-page audit view (admin.settings.php's
+    "System Log" tab was the closest equivalent). The full redesign
+    lives in `web/themes/sbpp2026/page_admin_audit.tpl`. This stub
+    exists only so the dual-theme PHPStan matrix (#1123 A2) can satisfy
+    SmartyTemplateRule's "template file must exist" check for both
+    themes; the stub marker phrase ("hasn't been redesigned yet") trips
+    the rule's stub short-circuit so the View ↔ template property parity
+    isn't enforced against a placeholder.
+
+    D1 deletes `themes/default/` outright and renames `themes/sbpp2026/`
+    in its place, so this file disappears at cutover.
+*}
+<table style="width: 101%; margin: 0 0 -2px -2px;">
+    <tr>
+        <td class="listtable_top"><b>Audit Log</b></td>
+    </tr>
+</table>
+<div class="panel" style="padding: 1em">
+    <p>This page hasn't been redesigned yet for the legacy theme — switch to <code>sbpp2026</code> to see the audit log.</p>
+</div>

--- a/web/themes/sbpp2026/page_admin_audit.tpl
+++ b/web/themes/sbpp2026/page_admin_audit.tpl
@@ -1,0 +1,265 @@
+{*
+    page_admin_audit.tpl — Admin → Audit log (#1123 B19).
+
+    NEW page (no legacy template). Pair: web/pages/admin.audit.php +
+    web/includes/View/AuditLogView.php. The page handler reads the
+    `:prefix_log` table (no schema change), normalises each row into
+    the `{tid, severity, severity_label, severity_class, time_human,
+    time_iso, actor, title, detail, ip}` shape this template iterates,
+    and SSRs the filter/page state into the form below.
+
+    Auto-escape is on globally (web/init.php), so every {$foo} is
+    HTML-escaped — there is no {$foo nofilter} in this template, and
+    none is needed: all values are either DB-stored strings rendered as
+    text or numbers / class tokens we built ourselves above.
+
+    Testability hooks (#1123 issue body, "Testability hooks"):
+      - audit-search          → free-text input
+      - filter-chip-{kind}    → severity filter buttons (all|info|warning|error)
+      - audit-row             → each log row, with data-id="{tid}" + data-severity
+      - page-prev / page-next → pager links
+*}
+<style>
+    .audit-page {
+        padding: 1.5rem;
+        max-width: 1400px;
+    }
+    .audit-page__header {
+        display: flex;
+        align-items: flex-end;
+        justify-content: space-between;
+        flex-wrap: wrap;
+        gap: 1rem;
+        margin-bottom: 1rem;
+    }
+    .audit-page__title {
+        font-size: 1.5rem;
+        font-weight: 600;
+        margin: 0;
+    }
+    .audit-page__subtitle {
+        margin: 0.5rem 0 0;
+        color: var(--text-muted);
+        font-size: var(--fs-sm);
+    }
+    .audit-filters {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.5rem;
+        align-items: center;
+        margin-bottom: 1rem;
+    }
+    .audit-row {
+        display: flex;
+        gap: 0.75rem;
+        align-items: flex-start;
+        padding: 1rem;
+        border-bottom: 1px solid var(--border);
+    }
+    .audit-row:last-child {
+        border-bottom: none;
+    }
+    .audit-row__icon {
+        width: 32px;
+        height: 32px;
+        border-radius: 50%;
+        background: var(--bg-muted);
+        color: var(--text-muted);
+        display: grid;
+        place-items: center;
+        flex-shrink: 0;
+    }
+    .audit-row__body {
+        flex: 1;
+        min-width: 0;
+    }
+    .audit-row__title {
+        font-weight: 500;
+        font-size: var(--fs-base);
+        margin: 0;
+        word-wrap: break-word;
+    }
+    .audit-row__meta {
+        margin-top: 0.125rem;
+        color: var(--text-muted);
+        font-size: var(--fs-xs);
+        font-family: var(--font-mono);
+    }
+    .audit-row__detail {
+        margin-top: 0.5rem;
+        font-size: var(--fs-sm);
+        color: var(--text-muted);
+        white-space: pre-wrap;
+        word-wrap: break-word;
+    }
+    .badge {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.25rem;
+        padding: 0 0.5rem;
+        height: 1.25rem;
+        border-radius: var(--radius-full);
+        font-size: 0.6875rem;
+        font-weight: 500;
+        box-shadow: inset 0 0 0 1px currentColor;
+    }
+    .badge--info    { background: var(--info-bg);    color: var(--info);    }
+    .badge--warning { background: var(--warning-bg); color: var(--warning); }
+    .badge--error   { background: var(--danger-bg);  color: var(--danger);  }
+    .badge--system  { background: var(--bg-muted);   color: var(--text-muted); }
+    .audit-empty {
+        padding: 1.5rem;
+        text-align: center;
+        color: var(--text-muted);
+        font-size: var(--fs-sm);
+    }
+    .audit-pager {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 1rem;
+        margin-top: 1rem;
+        flex-wrap: wrap;
+    }
+    .audit-pager__status {
+        color: var(--text-muted);
+        font-size: var(--fs-xs);
+    }
+    .audit-pager__nav {
+        display: flex;
+        gap: 0.5rem;
+    }
+    .audit-pager__nav .btn--disabled {
+        opacity: 0.4;
+        pointer-events: none;
+    }
+</style>
+
+<div class="audit-page">
+    <header class="audit-page__header">
+        <div>
+            <h1 class="audit-page__title">Audit log</h1>
+            <p class="audit-page__subtitle">Every administrative action recorded by the panel ({$total_count} {if $total_count == 1}event{else}events{/if}).</p>
+        </div>
+    </header>
+
+    {* Search and severity are independent filters that compose. Splitting
+       them into two <form>s avoids the multi-submit-button trap where
+       pressing Enter inside the search input would otherwise activate
+       the first chip submit (and reset severity). Each form re-submits
+       the *other* filter's current value via a hidden input. *}
+    <div class="audit-filters">
+        <form method="get" action="index.php" role="search" aria-label="Search audit log" style="flex:1 1 16rem;max-width:22rem">
+            <input type="hidden" name="p" value="admin">
+            <input type="hidden" name="c" value="audit">
+            <input type="hidden" name="severity" value="{$current_severity}">
+            <input type="search"
+                   class="input"
+                   name="search"
+                   value="{$search}"
+                   placeholder="Search title or detail…"
+                   data-testid="audit-search"
+                   aria-label="Search audit log">
+        </form>
+
+        <form method="get" action="index.php" class="flex items-center gap-2" style="flex-wrap:wrap" aria-label="Filter audit log by severity">
+            <input type="hidden" name="p" value="admin">
+            <input type="hidden" name="c" value="audit">
+            <input type="hidden" name="search" value="{$search}">
+            <button type="submit"
+                    name="severity"
+                    value=""
+                    class="chip"
+                    data-testid="filter-chip-all"
+                    aria-pressed="{if $current_severity == ''}true{else}false{/if}">
+                All
+            </button>
+            <button type="submit"
+                    name="severity"
+                    value="m"
+                    class="chip"
+                    data-testid="filter-chip-info"
+                    aria-pressed="{if $current_severity == 'm'}true{else}false{/if}">
+                <span class="chip__dot" style="background:var(--info)"></span>
+                Info
+            </button>
+            <button type="submit"
+                    name="severity"
+                    value="w"
+                    class="chip"
+                    data-testid="filter-chip-warning"
+                    aria-pressed="{if $current_severity == 'w'}true{else}false{/if}">
+                <span class="chip__dot" style="background:var(--warning)"></span>
+                Warning
+            </button>
+            <button type="submit"
+                    name="severity"
+                    value="e"
+                    class="chip"
+                    data-testid="filter-chip-error"
+                    aria-pressed="{if $current_severity == 'e'}true{else}false{/if}">
+                <span class="chip__dot" style="background:var(--danger)"></span>
+                Error
+            </button>
+        </form>
+    </div>
+
+    <div class="card">
+        {foreach $audit_log as $log}
+            <article class="audit-row"
+                     data-testid="audit-row"
+                     data-id="{$log.tid}"
+                     data-severity="{$log.severity_class}">
+                <div class="audit-row__icon" aria-hidden="true">
+                    <i data-lucide="{if $log.severity == 'e'}alert-octagon{elseif $log.severity == 'w'}alert-triangle{elseif $log.severity == 'm'}info{else}circle{/if}" style="width:14px;height:14px"></i>
+                </div>
+                <div class="audit-row__body">
+                    <div class="flex items-center gap-2" style="flex-wrap:wrap">
+                        <span class="badge badge--{$log.severity_class}" data-severity="{$log.severity_class}">{$log.severity_label}</span>
+                        <span class="audit-row__title">{$log.title}</span>
+                    </div>
+                    <div class="audit-row__meta">
+                        <span class="font-semibold">{$log.actor}</span>
+                        {if $log.time_iso != ''}
+                            · <time datetime="{$log.time_iso}">{$log.time_human}</time>
+                        {else}
+                            · {$log.time_human}
+                        {/if}
+                        {if $log.ip != ''}
+                            · from {$log.ip}
+                        {/if}
+                    </div>
+                    {if $log.detail != ''}
+                        <div class="audit-row__detail">{$log.detail}</div>
+                    {/if}
+                </div>
+            </article>
+        {foreachelse}
+            <div class="audit-empty">No audit events match these filters.</div>
+        {/foreach}
+    </div>
+
+    {if $page_count > 1 || $current_page > 1}
+        <nav class="audit-pager" aria-label="Audit log pagination">
+            <div class="audit-pager__status" aria-live="polite">
+                Page {$current_page} of {$page_count}
+            </div>
+            <div class="audit-pager__nav">
+                <a class="btn btn--secondary btn--sm{if !$has_prev} btn--disabled{/if}"
+                   href="{if $has_prev}{$prev_url}{else}#{/if}"
+                   data-testid="page-prev"
+                   {if !$has_prev}aria-disabled="true" tabindex="-1"{/if}>
+                    <i data-lucide="chevron-left"></i>
+                    Previous
+                </a>
+                <a class="btn btn--secondary btn--sm{if !$has_next} btn--disabled{/if}"
+                   href="{if $has_next}{$next_url}{else}#{/if}"
+                   data-testid="page-next"
+                   {if !$has_next}aria-disabled="true" tabindex="-1"{/if}>
+                    Next
+                    <i data-lucide="chevron-right"></i>
+                </a>
+            </div>
+        </nav>
+    {/if}
+</div>

--- a/web/themes/sbpp2026/page_admin_audit.tpl
+++ b/web/themes/sbpp2026/page_admin_audit.tpl
@@ -1,23 +1,24 @@
 {*
-    page_admin_audit.tpl — Admin → Audit log (#1123 B19).
+    page_admin_audit.tpl -- Admin -> Audit log (#1123 B19).
 
     NEW page (no legacy template). Pair: web/pages/admin.audit.php +
     web/includes/View/AuditLogView.php. The page handler reads the
-    `:prefix_log` table (no schema change), normalises each row into
-    the `{tid, severity, severity_label, severity_class, time_human,
-    time_iso, actor, title, detail, ip}` shape this template iterates,
-    and SSRs the filter/page state into the form below.
+    :prefix_log table (no schema change), normalises each row into the
+    handoff-style shape this template iterates over (tid, severity,
+    severity_label, severity_class, time_human, time_iso, actor, title,
+    detail, ip), and SSRs the filter/page state into the forms below.
 
-    Auto-escape is on globally (web/init.php), so every {$foo} is
-    HTML-escaped — there is no {$foo nofilter} in this template, and
-    none is needed: all values are either DB-stored strings rendered as
-    text or numbers / class tokens we built ourselves above.
+    Auto-escape is on globally (web/init.php), so every Smarty
+    variable below is HTML-escaped automatically. There is no nofilter
+    use in this template, and none is needed: all values are either
+    DB-stored strings rendered as text or numbers / class tokens we
+    built ourselves in the page handler.
 
-    Testability hooks (#1123 issue body, "Testability hooks"):
-      - audit-search          → free-text input
-      - filter-chip-{kind}    → severity filter buttons (all|info|warning|error)
-      - audit-row             → each log row, with data-id="{tid}" + data-severity
-      - page-prev / page-next → pager links
+    Testability hooks (per #1123 issue body):
+      - audit-search           -- free-text input
+      - filter-chip-<kind>     -- severity filter buttons (all|info|warning|error)
+      - audit-row              -- each log row, with data-id and data-severity
+      - page-prev / page-next  -- pager links
 *}
 <style>
     .audit-page {


### PR DESCRIPTION
Part of #1123 — Phase B, ticket B19 (NEW audit log page).

## Summary

Adds a dedicated `?p=admin&c=audit` page that surfaces the existing
`:prefix_log` table through a typed View DTO + handoff-styled template.
**No schema change** — the `:prefix_log` writer side (severity letters
`m`/`w`/`e`) is untouched.

* Owner-restricted (`CheckAdminAccess(ADMIN_OWNER)`): no
  `ADMIN_LIST_LOGS` / `ADMIN_LIST_AUDIT` flag exists in
  `web/configs/permissions/web.json`. The legacy
  `TRUNCATE :prefix_log` path in `admin.settings.php` is also
  owner-only, so the gate matches existing posture.
* **SSR**, no JSON action. Pagination + severity chips + free-text
  search are all driven by GET params. See "Plan deviations" below.
* Variable contract is the handoff-style row shape from the worker
  brief: `{tid, severity, severity_label, severity_class, time_human,
  time_iso, actor, title, detail, ip}`. `tid` ← `lid`,
  `severity_*` ← `type` enum, `actor` ← `admins.user` join, `time_*`
  ← `created` (UNIX ts), `detail` ← `message`, `ip` ← `host`.
* Severity badges render `Info` / `Warning` / `Error` with the
  expected `data-severity="info|warning|error"` test hook.
* Two `<form>`s (search vs severity) so pressing Enter inside the
  search input doesn't reset the active chip — the multi-submit-button
  trap of a single combined form.

## Files touched

| File | Why |
| ---- | --- |
| `web/includes/page-builder.php` | New `case 'audit':` arm under `case 'admin':`, gated on `CheckAdminAccess(ADMIN_OWNER)`. |
| `web/includes/View/AuditLogView.php` | New typed View DTO bound to `page_admin_audit.tpl`. |
| `web/pages/admin.audit.php` | New SSR page handler. Reads `:prefix_log` via the global `Database`, normalises rows, renders via `Sbpp\View\Renderer::render`. |
| `web/themes/sbpp2026/page_admin_audit.tpl` | New redesigned template carrying every test hook the issue's "Testability hooks" rule asks for. |
| `web/themes/default/page_admin_audit.tpl` | Minimal stub (carries the `STUB_MARKER` phrase) so the dual-theme PHPStan matrix's "template file must exist" check passes for the legacy theme too. Deleted at D1 alongside the rest of `themes/default/`. |

## Local quality gates

| Gate | Result |
| ---- | ------ |
| `./sbpp.sh phpstan` (default theme) | OK (175 files, no errors) |
| `./sbpp.sh phpstan` with `SBPP_PHPSTAN_THEME=sbpp2026` (`phpstan-sbpp2026.neon`) | OK |
| `./sbpp.sh test` (full PHPUnit) | OK — 268 tests, 1134 assertions |
| `./sbpp.sh ts-check` | OK |
| `./sbpp.sh composer api-contract` | wrote 58 actions / 32 perms / 2 typedefs — **no `git diff`** (SSR path adds no new action). |

## Plan deviations

**SSR vs `audit.list` JSON action.** The worker brief allowed B19 to
add a new `audit.list` handler in `web/api/handlers/system.php` (the
one Phase-B exception that's allowed to touch `api/handlers/*.php`).
I went **SSR**:

* The audit page is admin-only and low traffic; async pagination over
  GET-param SSR is mostly cosmetic.
* The handoff design (`handoff/pages/admin/audit.tpl`) is form-driven,
  not async-driven.
* SSR keeps the diff inside the smaller of the two B19 envelopes — no
  `web/api/handlers/system.php` change, no `_register.php` change, no
  `api-contract.js` regen, no `PermissionMatrixTest` row, no
  `__snapshots__/system/audit_list.json`. That's lower conflict risk
  with the parallel B-tickets touching adjacent paths.

If a future PR wants to add async pagination it's an additive change:
the handler already returns the same shape the JSON action would, so
the diff there would be a thin wrapper.

## Sidebar entry follow-up (out of B19 scope)

A2's `web/pages/core/navbar.php` does not yet emit an "Audit" entry
into the `$adminbar` array, so the new page is reachable only by
direct URL (or by typing `?p=admin&c=audit`). Per the worker brief,
B19 must **not** touch `web/themes/sbpp2026/core/navbar.tpl` or
`web/pages/core/navbar.php`.

Follow-up: add an entry like:

```php
[
    'title'      => 'Audit Log',
    'endpoint'   => 'audit',
    'permission' => ADMIN_OWNER,
],
```

…to the `$admin` array in `web/pages/core/navbar.php`, and an
`{elseif $admin.endpoint == 'audit'}clipboard-list{...}` arm in
`navbar.tpl`'s lucide chain. Either both at once or the navbar.tpl
arm can be deferred (the chain falls through to a `circle` icon).

## Other deviations from the brief

None. All hard rules satisfied:

* Touched only files in scope (the legacy stub at
  `web/themes/default/page_admin_audit.tpl` is required by the
  dual-theme PHPStan matrix; without it the `default/` leg of CI's
  phpstan job fails with `sbpp.view.templateMissing`).
* Permissions precomputed at handler entry — no inline
  `{if $userbank->HasAccess(...)}` in the template; the page handler
  doesn't need a `Perms::for` splat because the page has no
  action-gated UI (read-only view, owner-only entry).
* Every `nofilter` annotated — actually, **the template uses zero
  `nofilter`**: every `{$foo}` runs through Smarty's global
  auto-escape. The template-header docblock calls this out so a future
  reader doesn't add an unannotated one.
* Vanilla SSR; no `audit.js`, no Mootools, no jQuery, no fetch().
* All SQL uses `:prefix_` placeholders.
* Test hooks: `data-testid="audit-row"` + `data-id`, `data-severity`,
  `filter-chip-{all,info,warning,error}`, `audit-search`, `page-prev`,
  `page-next` — all present and verified via `curl + grep`.
* `SmartyTemplateRule` parity check passes: every public property on
  `AuditLogView` is referenced by the template, and vice versa.
* No reintroduced anti-patterns (xajax, sb-callback, ADOdb,
  htmlspecialchars_decode, utf8 charset, TinyMCE / CKEditor).

## Test plan

* [ ] Reviewer pulls, switches active theme to `sbpp2026`, navigates to
      `/index.php?p=admin&c=audit` as the seeded `admin` user.
* [ ] Confirm severity chips filter rows and the active chip shows
      `aria-pressed="true"`.
* [ ] Confirm search input filters by `title` / `message` substring.
* [ ] Confirm `page-prev` / `page-next` advance through the list and
      the disabled state matches the boundary.
* [ ] Confirm a non-owner admin (any flag set, but not `ADMIN_OWNER`)
      gets redirected by `CheckAdminAccess` and never reaches the
      handler.
* [ ] Confirm `?theme=default` (or any `config.theme` other than
      `sbpp2026`) renders the legacy stub with the
      "hasn't been redesigned yet" copy.