### PR TITLE
[#1123 B20] Redesign your account + updater

### DIFF
--- a/web/includes/View/UpdaterView.php
+++ b/web/includes/View/UpdaterView.php
@@ -1,0 +1,43 @@
+<?php
+declare(strict_types=1);
+
+namespace Sbpp\View;
+
+/**
+ * Updater wizard page — binds to `updater.tpl`.
+ *
+ * The updater is bootstrapped by `web/updater/index.php`, NOT by the
+ * normal `index.php` -> `route()` -> `pages/*.php` lifecycle. It still
+ * loads `web/init.php`, so the global `$theme` Smarty instance, the
+ * `$theme_url` assignment, and the configured template directory are
+ * all available — but `init.php` deliberately forces
+ * `$theme_name = "default"` when `IS_UPDATE` is defined (see the
+ * `defined("IS_UPDATE")` branch in `init.php`). That means the updater
+ * always renders the **legacy** `themes/default/updater.tpl` until D1
+ * deletes the legacy theme and renames `sbpp2026/` into `default/`,
+ * at which point this redesigned template takes over with no other
+ * code change.
+ *
+ * `SmartyTemplateRule` resolves the template against whichever
+ * theme directory is active (set per-leg via `SBPP_PHPSTAN_THEME` —
+ * see `phpstan.yml`'s matrix). Both legs of the matrix scan a
+ * template named `updater.tpl`; they share the same one-element
+ * variable contract (`$updates`) so the View doesn't need a
+ * per-theme alternate.
+ */
+final class UpdaterView extends View
+{
+    public const TEMPLATE = 'updater.tpl';
+
+    /**
+     * @param list<string> $updates Pre-formatted message lines from
+     *     {@see \Updater::getMessageStack()}. Each line may contain a
+     *     small subset of HTML markup (only `<b>` for emphasis around
+     *     int version numbers / static filenames built inside
+     *     `Updater.php`); no user input flows into them.
+     */
+    public function __construct(
+        public readonly array $updates,
+    ) {
+    }
+}

--- a/web/includes/View/View.php
+++ b/web/includes/View/View.php
@@ -16,9 +16,9 @@ namespace Sbpp\View;
  * See `web/includes/PHPStan/SmartyTemplateRule.php`.
  *
  * Most templates use Smarty's default `{…}` delimiters. Views whose template
- * uses the custom `-{…}-` pair (currently only `page_youraccount.tpl`) must
- * override {@see View::DELIMITERS} with the matching pair so the rule parses
- * the template correctly.
+ * uses the custom `-{…}-` pair (currently only `page_login.tpl`, in both the
+ * legacy and sbpp2026 themes) must override {@see View::DELIMITERS} with the
+ * matching pair so the rule parses the template correctly.
  *
  * ### Permission booleans
  *

--- a/web/includes/View/YourAccountView.php
+++ b/web/includes/View/YourAccountView.php
@@ -4,20 +4,31 @@ declare(strict_types=1);
 namespace Sbpp\View;
 
 /**
- * Your-account (self-service) page — binds to `page_youraccount.tpl`, which
- * is rendered with the custom `-{ … }-` delimiter pair (see
- * `page.youraccount.php`). The {@see View::DELIMITERS} override teaches
- * SmartyTemplateRule to scan for `-{$var}-` references instead of `{$var}`.
+ * Your-account (self-service) page — binds to `page_youraccount.tpl`.
+ *
+ * Historical note: prior to #1123 B20 this view rendered the legacy
+ * `default/page_youraccount.tpl`, which used the non-default `-{ … }-`
+ * Smarty delimiter pair (a SourceBans-1.x convention; see
+ * `web/pages/page.youraccount.php` history). The View overrode
+ * {@see View::DELIMITERS} so SmartyTemplateRule could parse the
+ * `-{$var}-` references; the page handler also had to swap delimiters
+ * on the live `$theme` before and after `display()`. The B20 redesign
+ * rewrites the template under `web/themes/sbpp2026/` in **standard**
+ * `{ }` Smarty delimiters so neither workaround is needed.
+ *
+ * The legacy `web/themes/default/page_youraccount.tpl` stays on disk
+ * with its `-{ }-` markers until D1 deletes the entire `default/`
+ * directory; SmartyTemplateRule's tag regex matches the inner `{$var}`
+ * inside each `-{$var}-` so the dual-theme PHPStan matrix's "default"
+ * leg keeps finding every property here as "referenced". No baseline
+ * entry is needed for that interim window.
  */
 final class YourAccountView extends View
 {
     public const TEMPLATE = 'page_youraccount.tpl';
 
-    /** @var array{0: string, 1: string} */
-    public const DELIMITERS = ['-{', '}-'];
-
     /**
-     * @param false|list<string> $web_permissions  `false` when the admin
+     * @param false|list<string> $web_permissions    `false` when the admin
      *     has no web permissions, otherwise the list of display strings.
      * @param false|list<string> $server_permissions Same shape as above for
      *     server permissions.

--- a/web/pages/page.youraccount.php
+++ b/web/pages/page.youraccount.php
@@ -28,29 +28,16 @@ if ($userbank->GetAid() == -1) {
     die();
 }
 
-new AdminTabs([
-    ['name' => 'View Permissions', 'permission' => ALL_WEB],
-    ['name' => 'Change Password', 'permission' => ALL_WEB],
-    ['name' => 'Server Password', 'permission' => ALL_WEB],
-    ['name' => 'Change Email', 'permission' => ALL_WEB]
-], $userbank, $theme);
-
 $GLOBALS['PDO']->query("SELECT `srv_password`, `email` FROM `:prefix_admins` WHERE `aid` = :aid");
 $GLOBALS['PDO']->bind(':aid', $userbank->GetAid());
 $res      = $GLOBALS['PDO']->single();
 $srvpwset = !empty($res['srv_password']);
 
-$youraccountView = new \Sbpp\View\YourAccountView(
-    srvpwset: $srvpwset,
-    email: (string) ($res['email'] ?? ''),
-    user_aid: (int) $userbank->GetAid(),
-    web_permissions: BitToString($userbank->GetProperty("extraflags")),
+\Sbpp\View\Renderer::render($theme, new \Sbpp\View\YourAccountView(
+    srvpwset:           $srvpwset,
+    email:              (string) ($res['email'] ?? ''),
+    user_aid:           (int) $userbank->GetAid(),
+    web_permissions:    BitToString($userbank->GetProperty("extraflags")),
     server_permissions: SmFlagsToSb($userbank->GetProperty("srv_flags")),
-    min_pass_len: (int) MIN_PASS_LENGTH,
-);
-
-$theme->setLeftDelimiter('-{');
-$theme->setRightDelimiter('}-');
-\Sbpp\View\Renderer::render($theme, $youraccountView);
-$theme->setLeftDelimiter('{');
-$theme->setRightDelimiter('}');
+    min_pass_len:       (int) MIN_PASS_LENGTH,
+));

--- a/web/phpstan-baseline.neon
+++ b/web/phpstan-baseline.neon
@@ -857,9 +857,3 @@ parameters:
 			identifier: variable.undefined
 			count: 4
 			path: updater/data/801.php
-
-		-
-			message: '#^Variable \$theme might not be defined\.$#'
-			identifier: variable.undefined
-			count: 2
-			path: updater/index.php

--- a/web/themes/sbpp2026/page_youraccount.tpl
+++ b/web/themes/sbpp2026/page_youraccount.tpl
@@ -1,6 +1,483 @@
-<div class="card">
-    <div class="card__body">
-        <h1>{$title}</h1>
-        <p class="text-muted">This page hasn't been redesigned yet.</p>
-    </div>
+{*
+    SourceBans++ 2026 — page_youraccount.tpl
+
+    Self-service account page. View: Sbpp\View\YourAccountView.
+
+    Delimiters: standard `{ }`. The legacy default theme's
+    `page_youraccount.tpl` used `-{ }-` (a SourceBans-1.x oddity). The
+    redesign deliberately drops that override so the View doesn't have
+    to carry a `View::DELIMITERS` exception; see the View's docblock
+    for the rollout note. D1 deletes the legacy delimiter use entirely.
+
+    Each form below is state-changing and submits via sb.api.call,
+    which sends the CSRF token in the `X-CSRF-Token` header (see
+    web/scripts/api.js). `{csrf_field}` is still included in every
+    form so the markup follows the project-wide convention — it
+    becomes a bonus belt-and-braces hidden input the dispatcher would
+    accept as `params.csrf_token` even if a future submit path were
+    to bypass the JS helper.
+
+    The forms are wired by inline vanilla JS at the bottom of the page
+    (no MooTools, no jQuery — only `sb.api.call(Actions.*)` and
+    standard DOM APIs). Submit handlers preventDefault and call the
+    Account* JSON actions registered in
+    web/api/handlers/_register.php; on success the dispatcher already
+    returns either an `Api::redirect` envelope (password change) or a
+    `data.message` describing a success toast (server password / email
+    change).
+
+    Test hooks: every input + submit button carries a stable
+    `data-testid="account-<field>"` attribute matching the names
+    listed in plan #1123 B20.
+*}
+<div class="p-6 space-y-6" style="max-width:64rem;margin:0 auto;width:100%">
+
+    <header data-testid="account-header">
+        <h1 style="font-size:var(--fs-2xl);font-weight:600;margin:0">Your account</h1>
+        <p class="text-sm text-muted m-0 mt-2">Permissions, password, server password, and email.</p>
+    </header>
+
+    {* -- Permissions card --------------------------------------------- *}
+    <section class="card" data-testid="account-permissions">
+        <div class="card__header">
+            <div>
+                <h3>Your permissions</h3>
+                <p>The flags currently granted to your admin account.</p>
+            </div>
+        </div>
+        <div class="card__body">
+            <div class="grid gap-6" style="grid-template-columns:repeat(auto-fit,minmax(15rem,1fr))">
+                <div>
+                    <div class="text-xs font-semibold text-muted mb-2" style="text-transform:uppercase;letter-spacing:0.06em">Web</div>
+                    {if $web_permissions}
+                        <ul class="m-0 text-sm" style="padding-left:1.25rem">
+                            {foreach from=$web_permissions item=permission}
+                                <li>{$permission}</li>
+                            {/foreach}
+                        </ul>
+                    {else}
+                        <div class="text-sm text-muted" data-testid="account-permissions-web-empty"><em>None</em></div>
+                    {/if}
+                </div>
+                <div>
+                    <div class="text-xs font-semibold text-muted mb-2" style="text-transform:uppercase;letter-spacing:0.06em">Server</div>
+                    {if $server_permissions}
+                        <ul class="m-0 text-sm" style="padding-left:1.25rem">
+                            {foreach from=$server_permissions item=permission}
+                                <li>{$permission}</li>
+                            {/foreach}
+                        </ul>
+                    {else}
+                        <div class="text-sm text-muted" data-testid="account-permissions-server-empty"><em>None</em></div>
+                    {/if}
+                </div>
+            </div>
+        </div>
+    </section>
+
+    {* -- Change password card ----------------------------------------- *}
+    <section class="card" data-testid="account-change-password">
+        <div class="card__header">
+            <div>
+                <h3>Change password</h3>
+                <p>Use at least {$min_pass_len} character{if $min_pass_len != 1}s{/if}. You will be signed out after a successful change.</p>
+            </div>
+        </div>
+        <div class="card__body">
+            <form id="account-password-form"
+                  class="space-y-4"
+                  autocomplete="off"
+                  novalidate
+                  data-aid="{$user_aid}"
+                  data-min-pass-len="{$min_pass_len}">
+                {csrf_field}
+                <div>
+                    <label class="label" for="account-current-password">Current password</label>
+                    <input class="input" type="password"
+                           id="account-current-password"
+                           name="current_password"
+                           data-testid="account-current-password"
+                           autocomplete="current-password" required>
+                    <div id="account-current-password-msg" class="text-xs" style="color:var(--danger);display:none;margin-top:0.375rem"></div>
+                </div>
+                <div>
+                    <label class="label" for="account-new-password">New password</label>
+                    <input class="input" type="password"
+                           id="account-new-password"
+                           name="new_password"
+                           data-testid="account-new-password"
+                           minlength="{$min_pass_len}"
+                           autocomplete="new-password" required>
+                    <div id="account-new-password-msg" class="text-xs" style="color:var(--danger);display:none;margin-top:0.375rem"></div>
+                </div>
+                <div>
+                    <label class="label" for="account-confirm-password">Confirm new password</label>
+                    <input class="input" type="password"
+                           id="account-confirm-password"
+                           name="confirm_password"
+                           data-testid="account-confirm-password"
+                           minlength="{$min_pass_len}"
+                           autocomplete="new-password" required>
+                    <div id="account-confirm-password-msg" class="text-xs" style="color:var(--danger);display:none;margin-top:0.375rem"></div>
+                </div>
+                <div class="flex justify-end gap-2">
+                    <button class="btn btn--secondary" type="reset" data-testid="account-cancel">Cancel</button>
+                    <button class="btn btn--primary" type="submit" data-testid="account-save">Save</button>
+                </div>
+            </form>
+        </div>
+    </section>
+
+    {* -- Server password card ----------------------------------------- *}
+    <section class="card" data-testid="account-server-password">
+        <div class="card__header">
+            <div>
+                <h3>Server password</h3>
+                <p>You need this in the game server to use your admin rights.
+                    <a href="https://wiki.alliedmods.net/Adding_Admins_%28SourceMod%29#Passwords"
+                       target="_blank" rel="noopener"
+                       style="color:var(--accent);text-decoration:underline">SourceMod docs</a>.</p>
+            </div>
+        </div>
+        <div class="card__body">
+            <form id="account-srv-password-form"
+                  class="space-y-4"
+                  autocomplete="off"
+                  novalidate
+                  data-aid="{$user_aid}"
+                  data-min-pass-len="{$min_pass_len}"
+                  data-srv-pw-set="{if $srvpwset}1{else}0{/if}">
+                {csrf_field}
+                {if $srvpwset}
+                    <div>
+                        <label class="label" for="account-current-srv-password">Current server password</label>
+                        <input class="input" type="password"
+                               id="account-current-srv-password"
+                               name="current_srv_password"
+                               data-testid="account-current-srv-password" required>
+                        <div id="account-current-srv-password-msg" class="text-xs" style="color:var(--danger);display:none;margin-top:0.375rem"></div>
+                    </div>
+                {/if}
+                <div>
+                    <label class="label" for="account-new-srv-password">New server password</label>
+                    <input class="input" type="password"
+                           id="account-new-srv-password"
+                           name="new_srv_password"
+                           data-testid="account-new-srv-password"
+                           minlength="{$min_pass_len}">
+                    <div id="account-new-srv-password-msg" class="text-xs" style="color:var(--danger);display:none;margin-top:0.375rem"></div>
+                </div>
+                <div>
+                    <label class="label" for="account-confirm-srv-password">Confirm new server password</label>
+                    <input class="input" type="password"
+                           id="account-confirm-srv-password"
+                           name="confirm_srv_password"
+                           data-testid="account-confirm-srv-password"
+                           minlength="{$min_pass_len}">
+                    <div id="account-confirm-srv-password-msg" class="text-xs" style="color:var(--danger);display:none;margin-top:0.375rem"></div>
+                </div>
+                {if $srvpwset}
+                    <label class="flex items-center gap-2 text-sm">
+                        <input type="checkbox"
+                               id="account-remove-srv-password"
+                               name="remove_srv_password"
+                               data-testid="account-remove-srv-password">
+                        <span>Remove the existing server password (clears the field).</span>
+                    </label>
+                {/if}
+                <div class="flex justify-end gap-2">
+                    <button class="btn btn--secondary" type="reset" data-testid="account-srv-cancel">Cancel</button>
+                    <button class="btn btn--primary" type="submit" data-testid="account-srv-save">Save</button>
+                </div>
+            </form>
+        </div>
+    </section>
+
+    {* -- Change email card -------------------------------------------- *}
+    <section class="card" data-testid="account-change-email">
+        <div class="card__header">
+            <div>
+                <h3>Change email</h3>
+                <p>Current address:
+                    {if $email}
+                        <span class="font-mono text-sm" data-testid="account-current-email">{$email}</span>
+                    {else}
+                        <span class="text-sm text-muted" data-testid="account-current-email-empty">(not set)</span>
+                    {/if}
+                </p>
+            </div>
+        </div>
+        <div class="card__body">
+            <form id="account-email-form"
+                  class="space-y-4"
+                  autocomplete="off"
+                  novalidate
+                  data-aid="{$user_aid}">
+                {csrf_field}
+                <div>
+                    <label class="label" for="account-email-password">Password</label>
+                    <input class="input" type="password"
+                           id="account-email-password"
+                           name="email_password"
+                           data-testid="account-email-password"
+                           autocomplete="current-password" required>
+                    <div id="account-email-password-msg" class="text-xs" style="color:var(--danger);display:none;margin-top:0.375rem"></div>
+                </div>
+                <div>
+                    <label class="label" for="account-email">New email address</label>
+                    <input class="input" type="email"
+                           id="account-email"
+                           name="email"
+                           data-testid="account-email"
+                           autocomplete="email" required>
+                    <div id="account-email-msg" class="text-xs" style="color:var(--danger);display:none;margin-top:0.375rem"></div>
+                </div>
+                <div>
+                    <label class="label" for="account-email-confirm">Confirm new email address</label>
+                    <input class="input" type="email"
+                           id="account-email-confirm"
+                           name="email_confirm"
+                           data-testid="account-email-confirm"
+                           autocomplete="email" required>
+                    <div id="account-email-confirm-msg" class="text-xs" style="color:var(--danger);display:none;margin-top:0.375rem"></div>
+                </div>
+                <div class="flex justify-end gap-2">
+                    <button class="btn btn--secondary" type="reset" data-testid="account-email-cancel">Cancel</button>
+                    <button class="btn btn--primary" type="submit" data-testid="account-email-save">Save</button>
+                </div>
+            </form>
+        </div>
+    </section>
+
 </div>
+
+{*
+    Inline vanilla-JS controllers for the three forms above. We
+    deliberately keep the wiring inline (rather than adding a new file
+    under web/themes/sbpp2026/js/) so this self-contained page stays
+    self-contained — the script only runs when this template is on
+    screen. `Actions.*` is the Action-name registry exported by the
+    auto-generated web/scripts/api-contract.js (loaded by core/header.tpl).
+*}
+{literal}
+<script>
+(function () {
+    'use strict';
+    if (typeof sb === 'undefined' || !sb.api || typeof Actions === 'undefined') return;
+
+    function setMsg(id, text) {
+        var el = document.getElementById(id);
+        if (!el) return;
+        if (text) {
+            el.textContent = text;
+            el.style.display = 'block';
+        } else {
+            el.textContent = '';
+            el.style.display = 'none';
+        }
+    }
+
+    function val(id) {
+        var el = document.getElementById(id);
+        return el && 'value' in el ? String(el.value) : '';
+    }
+
+    function num(form, key, fallback) {
+        var n = parseInt(form.dataset[key] || '', 10);
+        return Number.isFinite(n) ? n : fallback;
+    }
+
+    function clearMsgs(prefix, fields) {
+        fields.forEach(function (f) { setMsg(prefix + f + '-msg', ''); });
+    }
+
+    function showFieldError(prefix, err) {
+        if (err && err.field) {
+            setMsg(prefix + err.field + '-msg', err.message || 'Invalid value.');
+            return true;
+        }
+        return false;
+    }
+
+    function flashSuccess(envelope) {
+        if (envelope && envelope.ok && envelope.data && envelope.data.message && sb.message) {
+            var m = envelope.data.message;
+            sb.message.success(m.title || 'Saved', m.body || '', m.redir || '');
+        }
+    }
+
+    function flashFailure(envelope) {
+        if (sb.message) {
+            var msg = (envelope && envelope.error && envelope.error.message)
+                ? envelope.error.message
+                : 'The request failed. Please try again.';
+            sb.message.error('Error', msg);
+        }
+    }
+
+    // -- Change password ------------------------------------------------
+    var pwForm = document.getElementById('account-password-form');
+    if (pwForm) {
+        pwForm.addEventListener('submit', function (ev) {
+            ev.preventDefault();
+            clearMsgs('account-', ['current-password', 'new-password', 'confirm-password']);
+
+            var minLen = num(pwForm, 'minPassLen', 1);
+            var current = val('account-current-password');
+            var next    = val('account-new-password');
+            var confirm = val('account-confirm-password');
+            var aid     = parseInt(pwForm.dataset.aid || '0', 10);
+            var bad = false;
+
+            if (next.length < minLen) {
+                setMsg('account-new-password-msg', 'Password must be at least ' + minLen + ' characters.');
+                bad = true;
+            }
+            if (confirm !== next) {
+                setMsg('account-confirm-password-msg', 'Passwords do not match.');
+                bad = true;
+            }
+            if (current.length === 0) {
+                setMsg('account-current-password-msg', 'Enter your current password.');
+                bad = true;
+            }
+            if (bad) return;
+
+            sb.api.call(Actions.AccountChangePassword, {
+                aid: aid,
+                old_password: current,
+                new_password: next
+            }).then(function (env) {
+                if (env && env.ok) return; // Dispatcher returns Api::redirect.
+                if (showFieldError('account-', env && env.error)) return;
+                flashFailure(env);
+            });
+        });
+    }
+
+    // -- Server password ------------------------------------------------
+    var srvForm = document.getElementById('account-srv-password-form');
+    if (srvForm) {
+        srvForm.addEventListener('submit', function (ev) {
+            ev.preventDefault();
+            clearMsgs('account-', ['current-srv-password', 'new-srv-password', 'confirm-srv-password']);
+
+            var minLen   = num(srvForm, 'minPassLen', 1);
+            var hasExisting = srvForm.dataset.srvPwSet === '1';
+            var aid      = parseInt(srvForm.dataset.aid || '0', 10);
+            var current  = val('account-current-srv-password');
+            var next     = val('account-new-srv-password');
+            var confirm  = val('account-confirm-srv-password');
+            var removeEl = document.getElementById('account-remove-srv-password');
+            var remove   = !!(removeEl && 'checked' in removeEl && removeEl.checked);
+
+            if (remove) {
+                sb.api.call(Actions.AccountChangeSrvPassword, {
+                    aid: aid,
+                    srv_password: 'NULL'
+                }).then(function (env) {
+                    if (env && env.ok) { flashSuccess(env); return; }
+                    flashFailure(env);
+                });
+                return;
+            }
+
+            var bad = false;
+            if (next.length < minLen) {
+                setMsg('account-new-srv-password-msg', 'Password must be at least ' + minLen + ' characters.');
+                bad = true;
+            }
+            if (confirm !== next) {
+                setMsg('account-confirm-srv-password-msg', 'Passwords do not match.');
+                bad = true;
+            }
+            if (hasExisting && current.length === 0) {
+                setMsg('account-current-srv-password-msg', 'Enter your current server password.');
+                bad = true;
+            }
+            if (bad) return;
+
+            function send() {
+                sb.api.call(Actions.AccountChangeSrvPassword, {
+                    aid: aid,
+                    srv_password: next
+                }).then(function (env) {
+                    if (env && env.ok) { flashSuccess(env); return; }
+                    flashFailure(env);
+                });
+            }
+
+            if (hasExisting) {
+                sb.api.call(Actions.AccountCheckSrvPassword, {
+                    aid: aid,
+                    password: current
+                }).then(function (env) {
+                    if (!env || !env.ok || !env.data) {
+                        flashFailure(env);
+                        return;
+                    }
+                    if (!env.data.matches) {
+                        setMsg('account-current-srv-password-msg', 'Incorrect server password.');
+                        return;
+                    }
+                    send();
+                });
+            } else {
+                send();
+            }
+        });
+    }
+
+    // -- Change email ---------------------------------------------------
+    var emailForm = document.getElementById('account-email-form');
+    if (emailForm) {
+        emailForm.addEventListener('submit', function (ev) {
+            ev.preventDefault();
+            clearMsgs('account-', ['email-password', 'email', 'email-confirm']);
+
+            var aid     = parseInt(emailForm.dataset.aid || '0', 10);
+            var pw      = val('account-email-password');
+            var email   = val('account-email');
+            var confirm = val('account-email-confirm');
+            var bad = false;
+
+            if (email.length === 0) {
+                setMsg('account-email-msg', 'Enter your new email address.');
+                bad = true;
+            }
+            if (confirm.length === 0) {
+                setMsg('account-email-confirm-msg', 'Confirm your new email address.');
+                bad = true;
+            }
+            if (!bad && email !== confirm) {
+                setMsg('account-email-confirm-msg', 'Email addresses do not match.');
+                bad = true;
+            }
+            if (pw.length === 0) {
+                setMsg('account-email-password-msg', 'Enter your password.');
+                bad = true;
+            }
+            if (bad) return;
+
+            sb.api.call(Actions.AccountChangeEmail, {
+                aid: aid,
+                email: email,
+                password: pw
+            }).then(function (env) {
+                if (env && env.ok) { flashSuccess(env); return; }
+                if (env && env.error) {
+                    // Map server-side field names to our DOM ids.
+                    var map = { emailpw: 'email-password', email1: 'email', email2: 'email-confirm' };
+                    var domId = map[env.error.field || ''] || env.error.field || '';
+                    if (domId) {
+                        setMsg('account-' + domId + '-msg', env.error.message || 'Invalid value.');
+                        return;
+                    }
+                }
+                flashFailure(env);
+            });
+        });
+    }
+})();
+</script>
+{/literal}

--- a/web/themes/sbpp2026/page_youraccount.tpl
+++ b/web/themes/sbpp2026/page_youraccount.tpl
@@ -24,7 +24,9 @@
     web/api/handlers/_register.php; on success the dispatcher already
     returns either an `Api::redirect` envelope (password change) or a
     `data.message` describing a success toast (server password / email
-    change).
+    change). Toasts go through window.SBPP.showToast (theme.js), with a
+    sb.message.* fallback so the same JS still works if this page is
+    ever rendered under the legacy default chrome.
 
     Test hooks: every input + submit button carries a stable
     `data-testid="account-<field>"` attribute matching the names
@@ -291,28 +293,49 @@
         fields.forEach(function (f) { setMsg(prefix + f + '-msg', ''); });
     }
 
-    function showFieldError(prefix, err) {
-        if (err && err.field) {
-            setMsg(prefix + err.field + '-msg', err.message || 'Invalid value.');
-            return true;
+    // Server-side ApiError `field` strings don't always match our DOM ids
+    // (e.g. account.change_password throws field='current' but the input
+    // is #account-current-password). Each form passes its own map; missing
+    // keys fall through to the raw field name so newly added fields
+    // surface *something* instead of silently no-opping.
+    function showFieldError(prefix, err, fieldMap) {
+        if (!err || !err.field) return false;
+        var domId = (fieldMap && fieldMap[err.field]) || err.field;
+        setMsg(prefix + domId + '-msg', err.message || 'Invalid value.');
+        return true;
+    }
+
+    // sbpp2026 doesn't ship #dialog-placement (that's a legacy default-theme
+    // chrome element from core/title.tpl), so sb.message.show() silently
+    // no-ops here. Prefer the theme's SBPP.showToast and fall back to
+    // sb.message for callers that survive into the legacy theme.
+    function showToast(kind, title, body) {
+        if (window.SBPP && typeof window.SBPP.showToast === 'function') {
+            window.SBPP.showToast({ kind: kind, title: title, body: body });
+            return;
         }
-        return false;
+        if (sb.message) {
+            if (kind === 'success') sb.message.success(title, body);
+            else sb.message.error(title, body);
+        }
     }
 
     function flashSuccess(envelope) {
-        if (envelope && envelope.ok && envelope.data && envelope.data.message && sb.message) {
-            var m = envelope.data.message;
-            sb.message.success(m.title || 'Saved', m.body || '', m.redir || '');
+        if (!envelope || !envelope.ok || !envelope.data || !envelope.data.message) return;
+        var m = envelope.data.message;
+        showToast('success', m.title || 'Saved', m.body || '');
+        if (m.redir) {
+            // Short delay so the toast is visible before the same-page
+            // refresh swaps in the new email / srv-password state.
+            setTimeout(function () { window.location.href = m.redir; }, 1500);
         }
     }
 
     function flashFailure(envelope) {
-        if (sb.message) {
-            var msg = (envelope && envelope.error && envelope.error.message)
-                ? envelope.error.message
-                : 'The request failed. Please try again.';
-            sb.message.error('Error', msg);
-        }
+        var msg = (envelope && envelope.error && envelope.error.message)
+            ? envelope.error.message
+            : 'The request failed. Please try again.';
+        showToast('error', 'Error', msg);
     }
 
     // -- Change password ------------------------------------------------
@@ -348,8 +371,13 @@
                 old_password: current,
                 new_password: next
             }).then(function (env) {
-                if (env && env.ok) return; // Dispatcher returns Api::redirect.
-                if (showFieldError('account-', env && env.error)) return;
+                // On success the dispatcher returns Api::redirect, which
+                // api.js translates into `window.location.href = …`. The
+                // .then still fires before navigation; bail before the
+                // failure path mistakes the redirect envelope for an error.
+                if (env && env.ok) return;
+                if (env && env.redirect) return;
+                if (showFieldError('account-', env && env.error, { current: 'current-password' })) return;
                 flashFailure(env);
             });
         });
@@ -377,6 +405,7 @@
                     srv_password: 'NULL'
                 }).then(function (env) {
                     if (env && env.ok) { flashSuccess(env); return; }
+                    if (env && env.redirect) return;
                     flashFailure(env);
                 });
                 return;
@@ -403,6 +432,7 @@
                     srv_password: next
                 }).then(function (env) {
                     if (env && env.ok) { flashSuccess(env); return; }
+                    if (env && env.redirect) return;
                     flashFailure(env);
                 });
             }
@@ -465,15 +495,12 @@
                 password: pw
             }).then(function (env) {
                 if (env && env.ok) { flashSuccess(env); return; }
-                if (env && env.error) {
-                    // Map server-side field names to our DOM ids.
-                    var map = { emailpw: 'email-password', email1: 'email', email2: 'email-confirm' };
-                    var domId = map[env.error.field || ''] || env.error.field || '';
-                    if (domId) {
-                        setMsg('account-' + domId + '-msg', env.error.message || 'Invalid value.');
-                        return;
-                    }
-                }
+                if (env && env.redirect) return;
+                if (showFieldError(
+                    'account-',
+                    env && env.error,
+                    { emailpw: 'email-password', email1: 'email', email2: 'email-confirm' }
+                )) return;
                 flashFailure(env);
             });
         });

--- a/web/themes/sbpp2026/updater.tpl
+++ b/web/themes/sbpp2026/updater.tpl
@@ -1,6 +1,89 @@
-<div class="card">
-    <div class="card__body">
-        <h1>{$title}</h1>
-        <p class="text-muted">This page hasn't been redesigned yet.</p>
-    </div>
+{*
+    SourceBans++ 2026 — updater.tpl
+
+    Standalone wizard rendered by web/updater/index.php after Updater.php
+    has finished applying any pending migrations. View:
+    Sbpp\View\UpdaterView (just `$updates`).
+
+    The updater runs in its own bootstrap context — it does NOT go
+    through index.php's page-builder, so the chrome from
+    `core/header.tpl` + `core/footer.tpl` is intentionally not pulled
+    in. This template is therefore a complete <!DOCTYPE html> document
+    and links the theme stylesheet directly. Asset paths are relative
+    to /web/updater/ (where the script runs from), so `../themes/...`
+    points at /web/themes/sbpp2026/.
+
+    Variable contract is exactly `{$updates}` so the same View matches
+    both `web/themes/default/updater.tpl` (legacy, pure-HTML chrome)
+    and this redesigned template under the dual-theme PHPStan matrix
+    (#1123 A2). Adding more variables here would silently break the
+    default leg's "unused property" check.
+
+    Test hooks: each card header carries a stable
+    `data-testid="updater-<step>"` attribute.
+*}
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <title>Updater | SourceBans++</title>
+    <link rel="icon" href="../themes/sbpp2026/images/favicon.ico">
+    <link rel="stylesheet" href="../themes/sbpp2026/css/theme.css">
+</head>
+<body style="background:var(--bg-page);color:var(--text);min-height:100vh">
+
+<div class="p-6 space-y-6" style="max-width:48rem;margin:2.5rem auto;width:100%">
+
+    <header class="flex items-center gap-3" data-testid="updater-header">
+        <div class="sidebar__brand-mark">SB</div>
+        <div>
+            <h1 style="font-size:var(--fs-2xl);font-weight:600;margin:0">SourceBans++ updater</h1>
+            <p class="text-sm text-muted m-0 mt-2">Database migration log.</p>
+        </div>
+    </header>
+
+    <section class="card">
+        <div class="card__header" data-testid="updater-progress">
+            <div>
+                <h3>Progress</h3>
+                <p>Each line below is a step from the migration runner.</p>
+            </div>
+        </div>
+        <div class="card__body">
+            {if $updates}
+                <ol class="font-mono text-sm space-y-3" style="margin:0;padding-left:1.5rem">
+                    {* nofilter: every $update line is built inside Updater.php from int versions
+                       and static templates (see Updater::update()); no user input flows in. *}
+                    {foreach from=$updates item=update}
+                        <li>{$update nofilter}</li>
+                    {/foreach}
+                </ol>
+            {else}
+                <p class="text-sm text-muted m-0" data-testid="updater-empty">No updates were applied.</p>
+            {/if}
+        </div>
+    </section>
+
+    <section class="card">
+        <div class="card__header" data-testid="updater-cleanup">
+            <div>
+                <h3>Next step</h3>
+                <p>Once the run is complete, remove the <code class="font-mono">/updater</code> directory before serving the panel to admins.</p>
+            </div>
+        </div>
+        <div class="card__body">
+            <a class="btn btn--primary" href="../index.php" data-testid="updater-return">
+                Return to panel
+            </a>
+        </div>
+    </section>
+
+    <footer class="text-xs text-faint" style="text-align:center">
+        <a href="https://sbpp.github.io/" target="_blank" rel="noopener" style="color:inherit">SourceBans++</a>
+    </footer>
+
 </div>
+
+</body>
+</html>

--- a/web/updater/index.php
+++ b/web/updater/index.php
@@ -28,11 +28,14 @@
 define('IS_UPDATE', true);
 include "../init.php";
 
+global $theme;
+
 require_once('Updater.php');
 $updater = new Updater($GLOBALS['PDO']);
 
-$theme->assign('updates', $updater->getMessageStack());
-$theme->display('updater.tpl');
+\Sbpp\View\Renderer::render($theme, new \Sbpp\View\UpdaterView(
+    updates: array_values(array_map('strval', $updater->getMessageStack())),
+));
 
 //clear compiled themes
 $cachedir = dir(SB_CACHE);


### PR DESCRIPTION
Two unrelated small templates ported to the new `sbpp2026` theme per
plan #1123 B20.

## Summary

- **Your Account** (`page_youraccount.tpl`) — replaces the legacy
  table-and-tab markup with a card-per-section layout: permissions
  summary, change password, server password, change email. Forms wire
  via inline vanilla JS + `sb.api.call(Actions.Account*)` (no
  MooTools / xajax / jQuery). Inputs and buttons carry stable
  `data-testid="account-<field>"` hooks.
- **Updater** (`updater.tpl`) — standalone HTML doc styled with the
  new theme; cards for the migration log + a "next step" panel. Each
  section header carries a `data-testid="updater-<step>"` hook. Each
  `{$update nofilter}` line carries the canonical safety comment
  pinned to `Updater.php` as the source of those strings (int versions
  + static templates; no user input).

## Delimiter rewrite (special note from the brief)

The legacy `default/page_youraccount.tpl` used the non-default
`-{ … }-` Smarty delimiter pair (a SourceBans-1.x oddity) and the
`YourAccountView` had to override `View::DELIMITERS` while the page
handler swapped `setLeftDelimiter` / `setRightDelimiter` on the live
`$theme` before / after `display()`. **The new template uses the
standard `{ }` pair end-to-end**, so:

- `Sbpp\View\YourAccountView` no longer declares a `DELIMITERS`
  constant.
- `web/pages/page.youraccount.php` no longer swaps delimiters and no
  longer double-renders via `AdminTabs` (the new card layout makes
  the tab bar redundant).
- `SmartyTemplateRule`'s tag regex matches the inner `{$var}` inside
  each legacy `-{$var}-`, so the dual-theme PHPStan matrix's "default"
  leg keeps finding every property here as "referenced" until D1
  deletes the legacy theme — no baseline entry needed for that
  interim window.

## Updater bootstrap note for reviewers

`init.php` pins `$theme_name = 'default'` whenever `IS_UPDATE` is
defined, so at runtime the updater still renders the legacy
`default/updater.tpl` until D1 deletes the legacy theme and renames
`sbpp2026/` into `default/`. SmartyTemplateRule scans whichever theme
`SBPP_PHPSTAN_THEME` selects per matrix leg, so the new template +
`UpdaterView` are statically validated under the `sbpp2026` leg today
— **no test-runtime adaptation needed**. To verify the new template
visually I rendered it through a one-off harness that swapped
`setTemplateDir(SB_THEMES . 'sbpp2026')` after init; the `<b>` markup
inside each `{$update nofilter}` line shows up bold (vs. the legacy
template emitting it as escaped literal text, which is itself a
#1113-shaped bug the new template fixes by making the `nofilter` use
explicit and annotated).

The `UpdaterView` deliberately declares only `$updates` so the same
View matches both templates under the dual-theme matrix — adding
extra fields would break the default leg's "unused property" check.

## PHPStan baseline cleanup

`global $theme;` in `web/updater/index.php` makes the previously
ignored `Variable $theme might not be defined.` warning stop firing,
so the matching baseline entry was removed (otherwise the default-leg
PHPStan would fail on `reportUnmatchedIgnoredErrors`).

## Files in scope

- `web/themes/sbpp2026/page_youraccount.tpl` (rewritten in standard
  `{ }` Smarty)
- `web/themes/sbpp2026/updater.tpl` (new template)
- `web/includes/View/YourAccountView.php` (drops `DELIMITERS`
  override; updated docblock)
- `web/includes/View/UpdaterView.php` (new view)
- `web/pages/page.youraccount.php` (switches to `Renderer::render`;
  drops `AdminTabs` + delimiter swap)
- `web/updater/index.php` (switches to `Renderer::render` with
  `UpdaterView`)
- `web/phpstan-baseline.neon` (drop the now-obsolete `$theme`
  baseline entry from `updater/index.php`)

## Test plan

- [x] `./sbpp.sh phpstan` (default leg) — clean
- [x] `SBPP_PHPSTAN_THEME=sbpp2026 phpstan --configuration=phpstan-sbpp2026.neon` — clean
- [x] `./sbpp.sh test` — 268 tests, 1134 assertions, OK
- [x] `./sbpp.sh ts-check` — clean
- [x] `./sbpp.sh composer api-contract` — no diff (no API change)
- [x] Manually verified `index.php?p=account` renders all four cards,
      emits all `data-testid="account-<field>"` hooks, and embeds
      `{csrf_field}` on every form
- [x] Manually verified the new `updater.tpl` renders via a one-off
      harness with `setTemplateDir(SB_THEMES . 'sbpp2026')` (the
      runtime IS_UPDATE pin still ships the legacy template until D1)

## Out of scope / explicitly NOT touched

Per the Phase B "NEVER touch" list: `web/themes/sbpp2026/{css,js,core}/*`,
`web/init.php`, `web/api/handlers/*.php`, `web/scripts/api-contract.js`,
`AGENTS.md`, `ARCHITECTURE.md`. The pre-existing
`web/updater/data/801.php` non-idempotency (already-seeded `attempts`
column) reproduces on `main`; also out of scope.