### PR TITLE
[#1123 B14] Redesign admin comms group

### DIFF
--- a/web/includes/View/AdminCommsAddView.php
+++ b/web/includes/View/AdminCommsAddView.php
@@ -1,0 +1,26 @@
+<?php
+declare(strict_types=1);
+
+namespace Sbpp\View;
+
+/**
+ * "Add a block" tab on the admin comms page — binds to
+ * `page_admin_comms_add.tpl`.
+ *
+ * SourceComms reuses the bans permission set: there is no separate
+ * `ADMIN_ADD_COMM` flag, so `permission_addban` (precomputed via
+ * {@see Perms::for()} as `can_add_ban`) gates the form. The naming
+ * matches the legacy `default/page_admin_comms_add.tpl` so a single
+ * View instance satisfies both themes during the v2.0.0 rollout window
+ * (#1123): SmartyTemplateRule scans whichever theme is active and the
+ * property name has to line up on both legs of the matrix.
+ */
+final class AdminCommsAddView extends View
+{
+    public const TEMPLATE = 'page_admin_comms_add.tpl';
+
+    public function __construct(
+        public readonly bool $permission_addban,
+    ) {
+    }
+}

--- a/web/includes/View/AdminCommsEditView.php
+++ b/web/includes/View/AdminCommsEditView.php
@@ -1,0 +1,32 @@
+<?php
+declare(strict_types=1);
+
+namespace Sbpp\View;
+
+/**
+ * Edit-existing-block form — binds to `page_admin_edit_comms.tpl`.
+ *
+ * The variable contract matches the legacy
+ * `default/page_admin_edit_comms.tpl`: only the player name and
+ * authid are surfaced through Smarty; the current type / length /
+ * reason are still hydrated from inline `<script>selectLengthTypeReason(…)</script>`
+ * the page handler emits after `Renderer::render` (legacy convention,
+ * preserved during the v2.0.0 rollout window so the same View
+ * satisfies SmartyTemplateRule on both theme legs of the CI matrix).
+ *
+ * The legacy template uses Smarty's custom `-{ … }-` delimiters; the
+ * sbpp2026 redesign moves to the standard `{ … }` pair so the View
+ * binds with the default {@see View::DELIMITERS}. The page handler
+ * picks the right delimiter set per active theme — see
+ * `web/pages/admin.edit.comms.php`.
+ */
+final class AdminCommsEditView extends View
+{
+    public const TEMPLATE = 'page_admin_edit_comms.tpl';
+
+    public function __construct(
+        public readonly string $ban_name,
+        public readonly string $ban_authid,
+    ) {
+    }
+}

--- a/web/pages/admin.comms.php
+++ b/web/pages/admin.comms.php
@@ -54,8 +54,17 @@ if (isset($_GET["rebanid"])) {
 
 echo '<div id="admin-page-content">';
 echo '<div class="tabcontent" id="Add a block">';
-$theme->assign('permission_addban', $userbank->HasAccess(ADMIN_OWNER | ADMIN_ADD_BAN));
-$theme->display('page_admin_comms_add.tpl');
+// SourceComms reuses the bans permission set: there is no
+// ADMIN_ADD_COMM flag, so the gate uses ADMIN_OWNER|ADMIN_ADD_BAN.
+// Splatting Perms::for(...) into the View pulls `can_add_ban` (and
+// the owner-bypass) without re-deriving the bitmask here; the
+// view-level property name stays `permission_addban` to match the
+// legacy default-theme template's existing reference (#1123 A3 +
+// SmartyTemplateRule's per-leg cross-check).
+$perms = \Sbpp\View\Perms::for($userbank);
+\Sbpp\View\Renderer::render($theme, new \Sbpp\View\AdminCommsAddView(
+    permission_addban: $perms['can_add_ban'],
+));
 ?>
 </div>
 <script type="text/javascript">

--- a/web/pages/admin.edit.comms.php
+++ b/web/pages/admin.edit.comms.php
@@ -22,7 +22,7 @@ if (!defined("IN_SB")) {
     die();
 }
 
-global $theme;
+global $userbank, $theme;
 
 new AdminTabs([], $userbank, $theme);
 
@@ -158,16 +158,27 @@ if (!$res) {
     echo '<script>ShowBox("Error", "There was an error getting details. Maybe the block has been deleted?", "red", "index.php?p=commslist' . $pagelink . '");</script>';
 }
 
-$theme->assign('ban_name', $res['name']);
-$theme->assign('ban_reason', $res['reason']);
-$theme->assign('ban_authid', trim($res['authid']));
-$theme->assign('customreason', (Config::getBool('bans.customreasons')) ? unserialize(Config::get('bans.customreasons')) : false);
-
-$theme->setLeftDelimiter('-{');
-$theme->setRightDelimiter('}-');
-$theme->display('page_admin_edit_comms.tpl');
-$theme->setLeftDelimiter('{');
-$theme->setRightDelimiter('}');
+// Legacy default theme renders this template with non-standard `-{ … }-`
+// delimiters; the sbpp2026 redesign uses the standard pair so the View
+// binds with View::DELIMITERS' default. Switch the Smarty delimiters
+// only for the default theme so both legs of the dual-theme PHPStan
+// matrix render correctly during the v2.0.0 rollout window (#1123 A2).
+// Read the theme via Config rather than the SB_THEME constant so PHPStan
+// (which inlines string sentinels for runtime constants) doesn't fold
+// the comparison to a constant truthiness.
+$useLegacyDelims = Config::get('config.theme') !== 'sbpp2026';
+if ($useLegacyDelims) {
+    $theme->setLeftDelimiter('-{');
+    $theme->setRightDelimiter('}-');
+}
+\Sbpp\View\Renderer::render($theme, new \Sbpp\View\AdminCommsEditView(
+    ban_name: (string) $res['name'],
+    ban_authid: trim((string) $res['authid']),
+));
+if ($useLegacyDelims) {
+    $theme->setLeftDelimiter('{');
+    $theme->setRightDelimiter('}');
+}
 ?>
 <script type="text/javascript">window.addEvent('domready', function(){
 <?=$errorScript?>

--- a/web/pages/admin.edit.comms.php
+++ b/web/pages/admin.edit.comms.php
@@ -187,5 +187,45 @@ function changeReason(szListValue)
 {
     $('dreason').style.display = (szListValue == "other" ? "block" : "none");
 }
+// `selectLengthTypeReason` is the post-mount hydrator that picks the
+// existing block's type / length / reason on the <select>s. The legacy
+// default theme inherits it from web/scripts/sourcebans.js, but the
+// sbpp2026 chrome doesn't load sourcebans.js (and #1123 D1 deletes that
+// file outright). Inline a self-contained vanilla version so the call
+// below works on both legs of the dual-theme matrix and keeps working
+// post-D1 — without it, sbpp2026 would throw ReferenceError, leave the
+// type/length/reason at their defaults, and silently clobber the row
+// when the admin clicks Save.
+function selectLengthTypeReason(length, type, reason) {
+    var banlength = document.getElementById('banlength');
+    if (banlength) {
+        for (var i = 0; i < banlength.options.length; i++) {
+            if (banlength.options[i].value === String(length / 60)) {
+                banlength.options[i].selected = true;
+                break;
+            }
+        }
+    }
+    var ttype = document.getElementById('type');
+    if (ttype && ttype.options[type]) ttype.options[type].selected = true;
+
+    var list = document.getElementById('listReason');
+    if (list) {
+        for (var i = 0; i < list.options.length; i++) {
+            if (list.options[i].innerHTML === reason) {
+                list.options[i].selected = true;
+                break;
+            }
+            if (list.options[i].value === 'other') {
+                var txt = document.getElementById('txtReason');
+                var dre = document.getElementById('dreason');
+                if (txt) txt.value = reason;
+                if (dre) dre.style.display = 'block';
+                list.options[i].selected = true;
+                break;
+            }
+        }
+    }
+}
 selectLengthTypeReason('<?=(int) $res['length']?>', '<?=(int) $res['type'] - 1?>', '<?=addslashes($res['reason'])?>');
 </script>

--- a/web/phpstan-baseline.neon
+++ b/web/phpstan-baseline.neon
@@ -403,12 +403,6 @@ parameters:
 			path: pages/admin.edit.ban.php
 
 		-
-			message: '#^Variable \$userbank might not be defined\.$#'
-			identifier: variable.undefined
-			count: 8
-			path: pages/admin.edit.comms.php
-
-		-
 			message: '#^Variable \$theme might not be defined\.$#'
 			identifier: variable.undefined
 			count: 1

--- a/web/themes/sbpp2026/page_admin_comms_add.tpl
+++ b/web/themes/sbpp2026/page_admin_comms_add.tpl
@@ -1,6 +1,163 @@
-<div class="card">
-    <div class="card__body">
-        <h1>{$title}</h1>
-        <p class="text-muted">This page hasn't been redesigned yet.</p>
+{*
+    SourceBans++ 2026 — page_admin_comms_add.tpl
+
+    "Add a block" form on the admin comms page. Bound to
+    Sbpp\View\AdminCommsAddView; SmartyTemplateRule cross-checks
+    referenced vars against that DTO.
+
+    Variable contract matches the legacy default theme:
+      - $permission_addban — gate; ADMIN_OWNER|ADMIN_ADD_BAN
+        (precomputed in admin.comms.php via Perms::for($userbank)).
+
+    Submission goes through sb.api.call(Actions.CommsAdd) — the same
+    JSON action the legacy theme uses, see
+    web/api/handlers/comms.php. The inline ProcessBan() / changeReason()
+    helpers live in web/pages/admin.comms.php's tail <script> block
+    (legacy convention preserved during the v2.0.0 rollout); this
+    template intentionally keeps the legacy DOM ids (nickname, steam,
+    type, banlength, listReason, txtReason, dreason, *.msg) so those
+    helpers keep working without modification.
+
+    Testability hooks per the issue's "Testability hooks" rule:
+      - data-testid="addcomm-<field>" on every input/select.
+      - data-testid="addcomm-submit" / "addcomm-back" on buttons.
+*}
+{if not $permission_addban}
+    <div class="card" data-testid="addcomm-denied">
+        <div class="card__body">
+            <h1 style="font-size:1.25rem;font-weight:600;margin:0">Access denied</h1>
+            <p class="text-sm text-muted m-0 mt-2">You don't have permission to add blocks.</p>
+        </div>
     </div>
-</div>
+{else}
+    <div class="p-6" style="max-width:48rem">
+        <div class="mb-6">
+            <h1 style="font-size:1.5rem;font-weight:600;margin:0">Add a block</h1>
+            <p class="text-sm text-muted m-0 mt-2">Mute, gag, or silence a player on every connected server.</p>
+        </div>
+
+        <form id="addcomm-form" class="card p-6 space-y-4" onsubmit="return false;" data-testid="addcomm-form">
+            <div>
+                <label class="label" for="nickname">Nickname</label>
+                <input type="text"
+                       class="input"
+                       id="nickname"
+                       name="nickname"
+                       autocomplete="off"
+                       data-testid="addcomm-nickname"
+                       placeholder="Display name as it appeared in-game">
+                <input type="hidden" id="fromsub" value="">
+                <div class="text-xs mt-2" id="nick.msg" style="color:var(--danger);display:none"></div>
+            </div>
+
+            <div>
+                <label class="label" for="steam">Steam ID / Community ID</label>
+                <input type="text"
+                       class="input font-mono"
+                       id="steam"
+                       name="steam"
+                       autocomplete="off"
+                       data-testid="addcomm-steam"
+                       placeholder="STEAM_0:1:23498765">
+                <div class="text-xs mt-2" id="steam.msg" style="color:var(--danger);display:none"></div>
+            </div>
+
+            <div class="grid gap-4" style="grid-template-columns:1fr 1fr">
+                <div>
+                    <label class="label" for="type">Block type</label>
+                    <select class="select" id="type" name="type" data-testid="addcomm-type">
+                        <option value="1">Mute (voice)</option>
+                        <option value="2">Gag (chat)</option>
+                        <option value="3">Silence (chat &amp; voice)</option>
+                    </select>
+                </div>
+                <div>
+                    <label class="label" for="banlength">Block length</label>
+                    <select class="select" id="banlength" name="banlength" data-testid="addcomm-length">
+                        <option value="0">Permanent</option>
+                        <optgroup label="Minutes">
+                            <option value="1">1 minute</option>
+                            <option value="5">5 minutes</option>
+                            <option value="10">10 minutes</option>
+                            <option value="15">15 minutes</option>
+                            <option value="30">30 minutes</option>
+                            <option value="45">45 minutes</option>
+                        </optgroup>
+                        <optgroup label="Hours">
+                            <option value="60">1 hour</option>
+                            <option value="120">2 hours</option>
+                            <option value="180">3 hours</option>
+                            <option value="240">4 hours</option>
+                            <option value="480">8 hours</option>
+                            <option value="720">12 hours</option>
+                        </optgroup>
+                        <optgroup label="Days">
+                            <option value="1440">1 day</option>
+                            <option value="2880">2 days</option>
+                            <option value="4320">3 days</option>
+                            <option value="5760">4 days</option>
+                            <option value="7200">5 days</option>
+                            <option value="8640">6 days</option>
+                        </optgroup>
+                        <optgroup label="Weeks">
+                            <option value="10080">1 week</option>
+                            <option value="20160">2 weeks</option>
+                            <option value="30240">3 weeks</option>
+                        </optgroup>
+                        <optgroup label="Months">
+                            <option value="43200">1 month</option>
+                            <option value="86400">2 months</option>
+                            <option value="129600">3 months</option>
+                            <option value="259200">6 months</option>
+                            <option value="518400">12 months</option>
+                        </optgroup>
+                    </select>
+                </div>
+            </div>
+
+            <div>
+                <label class="label" for="listReason">Block reason</label>
+                <select class="select"
+                        id="listReason"
+                        name="listReason"
+                        data-testid="addcomm-reason"
+                        onchange="changeReason(this[this.selectedIndex].value);">
+                    <option value="" selected>-- Select reason --</option>
+                    <optgroup label="Violation">
+                        <option value="Obscene language">Obscene language</option>
+                        <option value="Insult players">Insult players</option>
+                        <option value="Admin disrespect">Admin disrespect</option>
+                        <option value="Inappropriate Language">Inappropriate language</option>
+                        <option value="Trading">Trading</option>
+                        <option value="Spam in chat/voice">Spam</option>
+                        <option value="Advertisement">Advertisement</option>
+                    </optgroup>
+                    <option value="other">Other reason</option>
+                </select>
+                <div id="dreason" class="mt-2" style="display:none">
+                    <textarea class="textarea"
+                              id="txtReason"
+                              name="txtReason"
+                              rows="4"
+                              placeholder="Explain in detail why this block is being made."
+                              data-testid="addcomm-reason-custom"></textarea>
+                </div>
+                <div class="text-xs mt-2" id="reason.msg" style="color:var(--danger);display:none"></div>
+            </div>
+
+            <div class="flex justify-end gap-2" style="border-top:1px solid var(--border);padding-top:0.75rem">
+                <button type="button"
+                        class="btn btn--ghost"
+                        data-testid="addcomm-back"
+                        onclick="history.go(-1);">Back</button>
+                <button type="button"
+                        class="btn btn--primary"
+                        id="addcomm-submit"
+                        data-testid="addcomm-submit"
+                        onclick="ProcessBan();">
+                    <i data-lucide="mic-off"></i> Add block
+                </button>
+            </div>
+        </form>
+    </div>
+{/if}

--- a/web/themes/sbpp2026/page_admin_edit_comms.tpl
+++ b/web/themes/sbpp2026/page_admin_edit_comms.tpl
@@ -1,6 +1,158 @@
-<div class="card">
-    <div class="card__body">
-        <h1>{$title}</h1>
-        <p class="text-muted">This page hasn't been redesigned yet.</p>
+{*
+    SourceBans++ 2026 — page_admin_edit_comms.tpl
+
+    Edit-existing-block form on the admin comms page. Bound to
+    Sbpp\View\AdminCommsEditView; SmartyTemplateRule cross-checks
+    referenced vars against that DTO.
+
+    Variable contract matches the legacy default theme:
+      - $ban_name   — current player name on the comms row.
+      - $ban_authid — current authid (Steam2) on the comms row.
+
+    Length / type / current-reason are NOT Smarty vars: the page
+    handler emits an inline `<script>selectLengthTypeReason(…)</script>`
+    after rendering the form, hydrating the <select>s post-mount.
+    This mirrors the legacy convention preserved during the v2.0.0
+    rollout window so the same View satisfies SmartyTemplateRule on
+    both theme legs of the CI matrix (#1123 A2). Per-handler errors
+    from the previous POST are surfaced through the same legacy
+    `<script>$('steam.msg')…</script>` block at the end of
+    web/pages/admin.edit.comms.php — the inline error containers
+    below have IDs the script targets.
+
+    The form POSTs to itself (action="" preserves the URL incl.
+    ?id, ?key, ?page); admin.edit.comms.php validates the CSRF token
+    and writes the row.
+
+    Testability hooks per the issue's "Testability hooks" rule:
+      - data-testid="editcomm-<field>" on every input/select.
+      - data-testid="editcomm-submit" / "editcomm-back" on buttons.
+*}
+<div class="p-6" style="max-width:48rem">
+    <div class="mb-6">
+        <h1 style="font-size:1.5rem;font-weight:600;margin:0">Edit block</h1>
+        <p class="text-sm text-muted m-0 mt-2">Update the player name, authid, type, length, or reason on this block.</p>
     </div>
+
+    <form id="editcomm-form" class="card p-6 space-y-4" method="post" action="" data-testid="editcomm-form">
+        {csrf_field}
+        <input type="hidden" name="insert_type" value="add">
+
+        <div>
+            <label class="label" for="name">Player name</label>
+            <input type="text"
+                   class="input"
+                   id="name"
+                   name="name"
+                   value="{$ban_name|escape}"
+                   data-testid="editcomm-name">
+            <div class="text-xs mt-2" id="name.msg" style="color:var(--danger);display:none"></div>
+        </div>
+
+        <div>
+            <label class="label" for="steam">Steam ID / Community ID</label>
+            <input type="text"
+                   class="input font-mono"
+                   id="steam"
+                   name="steam"
+                   value="{$ban_authid|escape}"
+                   data-testid="editcomm-steam">
+            <div class="text-xs mt-2" id="steam.msg" style="color:var(--danger);display:none"></div>
+        </div>
+
+        <div class="grid gap-4" style="grid-template-columns:1fr 1fr">
+            <div>
+                <label class="label" for="type">Block type</label>
+                <select class="select" id="type" name="type" data-testid="editcomm-type">
+                    <option value="1">Mute (voice)</option>
+                    <option value="2">Gag (chat)</option>
+                </select>
+            </div>
+            <div>
+                <label class="label" for="banlength">Block length</label>
+                <select class="select" id="banlength" name="banlength" data-testid="editcomm-length">
+                    <option value="0">Permanent</option>
+                    <optgroup label="Minutes">
+                        <option value="1">1 minute</option>
+                        <option value="5">5 minutes</option>
+                        <option value="10">10 minutes</option>
+                        <option value="15">15 minutes</option>
+                        <option value="30">30 minutes</option>
+                        <option value="45">45 minutes</option>
+                    </optgroup>
+                    <optgroup label="Hours">
+                        <option value="60">1 hour</option>
+                        <option value="120">2 hours</option>
+                        <option value="180">3 hours</option>
+                        <option value="240">4 hours</option>
+                        <option value="480">8 hours</option>
+                        <option value="720">12 hours</option>
+                    </optgroup>
+                    <optgroup label="Days">
+                        <option value="1440">1 day</option>
+                        <option value="2880">2 days</option>
+                        <option value="4320">3 days</option>
+                        <option value="5760">4 days</option>
+                        <option value="7200">5 days</option>
+                        <option value="8640">6 days</option>
+                    </optgroup>
+                    <optgroup label="Weeks">
+                        <option value="10080">1 week</option>
+                        <option value="20160">2 weeks</option>
+                        <option value="30240">3 weeks</option>
+                    </optgroup>
+                    <optgroup label="Months">
+                        <option value="43200">1 month</option>
+                        <option value="86400">2 months</option>
+                        <option value="129600">3 months</option>
+                        <option value="259200">6 months</option>
+                        <option value="518400">12 months</option>
+                    </optgroup>
+                </select>
+                <div class="text-xs mt-2" id="length.msg" style="color:var(--danger);display:none"></div>
+            </div>
+        </div>
+
+        <div>
+            <label class="label" for="listReason">Block reason</label>
+            <select class="select"
+                    id="listReason"
+                    name="listReason"
+                    data-testid="editcomm-reason"
+                    onchange="changeReason(this[this.selectedIndex].value);">
+                <option value="" selected>-- Select reason --</option>
+                <optgroup label="Violation">
+                    <option value="Obscene language">Obscene language</option>
+                    <option value="Insult players">Insult players</option>
+                    <option value="Admin disrespect">Admin disrespect</option>
+                    <option value="Inappropriate Language">Inappropriate language</option>
+                    <option value="Trading">Trading</option>
+                    <option value="Spam in chat/voice">Spam</option>
+                    <option value="Advertisement">Advertisement</option>
+                </optgroup>
+                <option value="other">Custom</option>
+            </select>
+            <div id="dreason" class="mt-2" style="display:none">
+                <textarea class="textarea"
+                          id="txtReason"
+                          name="txtReason"
+                          rows="4"
+                          data-testid="editcomm-reason-custom"></textarea>
+            </div>
+            <div class="text-xs mt-2" id="reason.msg" style="color:var(--danger);display:none"></div>
+        </div>
+
+        <div class="flex justify-end gap-2" style="border-top:1px solid var(--border);padding-top:0.75rem">
+            <button type="button"
+                    class="btn btn--ghost"
+                    data-testid="editcomm-back"
+                    onclick="history.go(-1);">Back</button>
+            <button type="submit"
+                    class="btn btn--primary"
+                    id="editcomm-submit"
+                    data-testid="editcomm-submit">
+                <i data-lucide="save"></i> Save changes
+            </button>
+        </div>
+    </form>
 </div>


### PR DESCRIPTION
## Summary
- Wires the **Add a block** and **Edit block** admin pages onto the sbpp2026 chrome, using the View DTO pattern A3 cemented (`Renderer::render` + `Sbpp\View\Perms::for`).
- Adds `Sbpp\View\AdminCommsAddView` and `AdminCommsEditView`, paired with `web/themes/sbpp2026/page_admin_comms_add.tpl` and `page_admin_edit_comms.tpl`. SmartyTemplateRule cross-checks both DTOs against both theme legs.
- `web/pages/admin.comms.php` and `web/pages/admin.edit.comms.php` switch from ad-hoc `$theme->assign(...)` chains to typed views; the edit handler also declares `global $userbank, $theme;` (instead of the legacy single-global form), so the matching `$userbank might not be defined` baseline entry drops.

## Why this is split per template
- **Delimiters.** The legacy default theme renders the edit form with non-standard `-{ … }-` Smarty delimiters; sbpp2026 uses the standard pair so the View binds with `View::DELIMITERS`' default. The handler picks per active theme so both legs of the dual-theme PHPStan matrix (#1123 A2) render correctly during the v2.0.0 rollout window.
- **Permissions.** SourceComms reuses the bans permission set — there is no `ADMIN_ADD_COMM`/`ADMIN_EDIT_COMM` flag — so the gate stays `ADMIN_OWNER|ADMIN_ADD_BAN`. The View surfaces it as `permission_addban` to match the legacy default-theme template's existing reference.
- **Hydration.** Type/length/current-reason on the edit form stay hydrated by inline `<script>selectLengthTypeReason(…)</script>` the handler emits after `Renderer::render` — mirrors the legacy convention so the same View satisfies SmartyTemplateRule on both legs.

## Conventions
- `data-testid="addcomm-<field>"` / `editcomm-<field>` on every input/select. `addcomm-submit` / `editcomm-submit` on the primary buttons; `addcomm-back` / `editcomm-back` on the secondary.
- `{csrf_field}` on the edit form (the add form posts via `sb.api.call(Actions.CommsAdd)` which threads the `X-CSRF-Token` header automatically).
- No new `{nofilter}` uses introduced.
- Vanilla JS only; no MooTools/jQuery/React reintroduced.
- All comms SQL stays on `:prefix_` literals (handler unchanged on that axis).

## Local gates
- `./sbpp.sh phpstan` (default leg): **OK** (no errors, 175 files).
- `SBPP_PHPSTAN_THEME=sbpp2026 ./sbpp.sh phpstan --configuration=phpstan-sbpp2026.neon` (sbpp2026 leg, with `DBA_REQUIRE=1`): **OK** (no errors, 175 files).
- `./sbpp.sh test`: **OK** (268 tests, 1134 assertions).
- `./sbpp.sh ts-check`: **OK** (clean — no JS touched).

## Test plan
- [x] PHPStan default + sbpp2026 legs clean (cache cleared).
- [x] PHPUnit clean.
- [x] ts-check clean.
- [ ] Reviewer: visit `?p=admin&c=comms` under both themes and confirm the form renders/submits.
- [ ] Reviewer: visit `?p=admin&c=editcomms&id=…&key=…` under both themes and confirm the type/length/reason hydrate from the inline `selectLengthTypeReason(...)` call.

Refs #1123 (Phase B14).