### PR TITLE
[#1123 C1] Drawer wiring + bans.detail JSON action

### DIFF
--- a/web/api/handlers/_register.php
+++ b/web/api/handlers/_register.php
@@ -31,6 +31,13 @@ require_once __DIR__ . '/system.php';
 // ---- public actions (no auth required) --------------------------------
 Api::register('auth.login',         'api_auth_login',         0, false, true);
 Api::register('auth.lost_password', 'api_auth_lost_password', 0, false, true);
+// bans.detail mirrors the public ban-list page's reach: any visitor can
+// click a ban row in the sbpp2026 drawer (#1123 C1). Player IP, admin
+// name, removed-by and comments are gated *inside* the handler against
+// banlist.hideplayerips / banlist.hideadminname / config.enablepubliccomments
+// + is_admin(), matching page.banlist.php exactly so we don't leak
+// fields the page intentionally suppresses.
+Api::register('bans.detail',        'api_bans_detail',        0, false, true);
 
 // ---- account: dispatcher enforces login; handler enforces aid match ---
 Api::register('account.check_password',     'api_account_check_password');

--- a/web/api/handlers/bans.php
+++ b/web/api/handlers/bans.php
@@ -653,3 +653,183 @@ function api_bans_view_community(array $params): array
 
     throw new ApiError('player_not_found', "Can't get playerinfo for " . htmlspecialchars($name) . '. Player not on the server anymore!');
 }
+
+/**
+ * Player-detail payload for the sbpp2026 right-side drawer (#1123 C1).
+ *
+ * Returns the same data the public ban-list page already exposes, in a
+ * stable JSON shape the drawer JS renders client-side. Action is
+ * registered public so the drawer matches the public ban-list reach;
+ * fields that the public ban-list selectively hides via
+ * `banlist.hideplayerips` / `banlist.hideadminname` (player IP, admin
+ * name, removed-by) follow the same gating here so a public caller can
+ * never fan out the same data through the JSON API that the page
+ * intentionally suppresses. Comments are only included when
+ * `config.enablepubliccomments` is set or the caller is an admin —
+ * mirroring page.banlist.php's `$view_comments` switch.
+ *
+ * @param array{bid?: int|string} $params
+ * @return array{
+ *   bid: int,
+ *   player: array{name: string, type: int, steam_id: string, steam_id_3: string, community_id: string, ip: string|null, country: string|null},
+ *   ban: array{reason: string, banned_at: int, banned_at_human: string, length_seconds: int, length_human: string, expires_at: int|null, expires_at_human: string|null, state: string, unban_reason: string, removed_at: int|null, removed_at_human: string|null, removed_by: string|null},
+ *   admin: array{name: string|null},
+ *   server: array{sid: int, name: string|null, mod_icon: string|null},
+ *   demo_count: int,
+ *   history_count: int,
+ *   comments_visible: bool,
+ *   comments: list<array{cid: int, added: int, added_human: string, author: string|null, text: string, edited_at: int|null, edited_by: string|null}>
+ * }
+ */
+function api_bans_detail(array $params): array
+{
+    global $userbank;
+    $bid = (int)($params['bid'] ?? 0);
+    if ($bid <= 0) {
+        throw new ApiError('bad_request', 'bid must be a positive integer', 'bid');
+    }
+
+    // Mirror page.banlist.php: an admin (or any logged-in user with the
+    // appropriate flag) sees the IP and admin nick; public visitors
+    // get them suppressed when the corresponding hide-* settings are
+    // on. `is_admin()` is the same gate the page uses, so the JSON
+    // surface stays consistent with what the HTML page would have
+    // shown the same caller.
+    $isAdmin = $userbank->is_admin();
+    $hideIps   = Config::getBool('banlist.hideplayerips') && !$isAdmin;
+    $hideAdmin = Config::getBool('banlist.hideadminname') && !$isAdmin;
+
+    $row = $GLOBALS['PDO']->query(
+        "SELECT BA.bid, BA.type, BA.ip, BA.authid, BA.name, BA.created, BA.ends, BA.length,
+                BA.reason, BA.aid, BA.adminIp, BA.sid, BA.country, BA.RemovedOn, BA.RemovedBy,
+                BA.RemoveType, BA.ureason,
+                AD.user AS admin_name,
+                SE.ip AS server_ip, SE.port AS server_port,
+                MO.icon AS mod_icon, MO.name AS mod_name,
+                CAST(MID(BA.authid, 9, 1) AS UNSIGNED)
+                  + CAST('76561197960265728' AS UNSIGNED)
+                  + CAST(MID(BA.authid, 11, 10) * 2 AS UNSIGNED) AS community_id,
+                (SELECT count(*) FROM `:prefix_demos` AS DM
+                  WHERE DM.demtype = 'B' AND DM.demid = BA.bid) AS demo_count,
+                (SELECT count(*) FROM `:prefix_bans` AS BH
+                  WHERE (BH.type = 0 AND BA.type = 0 AND BH.authid = BA.authid AND BA.authid <> '')
+                     OR (BH.type = 1 AND BA.type = 1 AND BH.ip = BA.ip AND BA.ip <> '' AND BA.ip IS NOT NULL))
+                  AS history_count
+           FROM `:prefix_bans` AS BA
+      LEFT JOIN `:prefix_servers` AS SE ON SE.sid = BA.sid
+      LEFT JOIN `:prefix_mods`    AS MO ON MO.mid = SE.modid
+      LEFT JOIN `:prefix_admins`  AS AD ON BA.aid = AD.aid
+          WHERE BA.bid = ?"
+    )->single([$bid]);
+    if (!$row) {
+        throw new ApiError('not_found', 'Ban not found.', null, 404);
+    }
+
+    $type      = (int)$row['type'];
+    $authid    = (string)$row['authid'];
+    $banIp     = (string)($row['ip'] ?? '');
+    $created   = (int)$row['created'];
+    $length    = (int)$row['length'];
+    $ends      = (int)$row['ends'];
+    $removedOn = $row['RemovedOn'] !== null ? (int)$row['RemovedOn'] : null;
+
+    // Mirror the page-side state machine: `length=0` is permanent;
+    // RemoveType marks deleted/unbanned/expired explicitly; otherwise
+    // an `ends` timestamp in the past collapses to "expired" even
+    // without a row update (PruneBans() catches those eventually).
+    $removeType = (string)($row['RemoveType'] ?? '');
+    if ($removeType === 'U' || $removeType === 'D') {
+        $state = 'unbanned';
+    } elseif ($removeType === 'E') {
+        $state = 'expired';
+    } elseif ($length === 0) {
+        $state = 'permanent';
+    } elseif ($ends > 0 && $ends < time()) {
+        $state = 'expired';
+    } else {
+        $state = 'active';
+    }
+
+    $steam2 = $authid !== '' && SteamID::isValidID($authid) ? $authid : '';
+    // Some legacy rows hold malformed authids (#900); fall back to a
+    // canonical placeholder so toSteam3() doesn't blow up the response.
+    $steam3 = $steam2 !== '' ? (string)SteamID::toSteam3($steam2) : '';
+
+    $removedByName = null;
+    if ($row['RemovedBy'] !== null && (int)$row['RemovedBy'] > 0 && !$hideAdmin) {
+        $removedRow = $GLOBALS['PDO']->query("SELECT user FROM `:prefix_admins` WHERE aid = ?")
+            ->single([(int)$row['RemovedBy']]);
+        if ($removedRow && !empty($removedRow['user'])) {
+            $removedByName = (string)$removedRow['user'];
+        }
+    }
+
+    $serverName = null;
+    if (!empty($row['server_ip'])) {
+        $serverName = $row['server_ip'] . (!empty($row['server_port']) ? ':' . $row['server_port'] : '');
+    }
+
+    $comments = [];
+    $commentsVisible = Config::getBool('config.enablepubliccomments') || $isAdmin;
+    if ($commentsVisible) {
+        $commentRows = $GLOBALS['PDO']->query(
+            "SELECT C.cid, C.commenttxt, C.added, C.edittime,
+                    (SELECT user FROM `:prefix_admins` WHERE aid = C.aid)     AS author,
+                    (SELECT user FROM `:prefix_admins` WHERE aid = C.editaid) AS editor
+               FROM `:prefix_comments` AS C
+              WHERE C.type = 'B' AND C.bid = ?
+           ORDER BY C.added DESC"
+        )->resultset([$bid]);
+        foreach ($commentRows as $crow) {
+            $editTime = $crow['edittime'] !== null ? (int)$crow['edittime'] : null;
+            $comments[] = [
+                'cid'        => (int)$crow['cid'],
+                'added'      => (int)$crow['added'],
+                'added_human'=> Config::time((int)$crow['added']),
+                'author'     => $crow['author'] !== null ? (string)$crow['author'] : null,
+                'text'       => (string)$crow['commenttxt'],
+                'edited_at'  => $editTime,
+                'edited_by'  => $crow['editor'] !== null ? (string)$crow['editor'] : null,
+            ];
+        }
+    }
+
+    return [
+        'bid' => $bid,
+        'player' => [
+            'name'         => (string)$row['name'],
+            'type'         => $type,
+            'steam_id'     => $steam2,
+            'steam_id_3'   => $steam3,
+            'community_id' => (string)$row['community_id'],
+            'ip'           => $hideIps || $banIp === '' ? null : $banIp,
+            'country'      => !empty($row['country']) && trim((string)$row['country']) !== '' ? (string)$row['country'] : null,
+        ],
+        'ban' => [
+            'reason'           => (string)$row['reason'],
+            'banned_at'        => $created,
+            'banned_at_human'  => Config::time($created),
+            'length_seconds'   => $length,
+            'length_human'     => $length === 0 ? 'Permanent' : SecondsToString($length),
+            'expires_at'       => $length === 0 ? null : $ends,
+            'expires_at_human' => $length === 0 ? null : Config::time($ends),
+            'state'            => $state,
+            'unban_reason'     => (string)($row['ureason'] ?? ''),
+            'removed_at'       => $removedOn,
+            'removed_at_human' => $removedOn !== null ? Config::time($removedOn) : null,
+            'removed_by'       => $removedByName,
+        ],
+        'admin' => [
+            'name' => $hideAdmin ? null : ($row['admin_name'] !== null ? (string)$row['admin_name'] : null),
+        ],
+        'server' => [
+            'sid'      => (int)$row['sid'],
+            'name'     => $serverName,
+            'mod_icon' => !empty($row['mod_icon']) ? (string)$row['mod_icon'] : null,
+        ],
+        'demo_count'       => (int)$row['demo_count'],
+        'history_count'    => (int)$row['history_count'],
+        'comments_visible' => $commentsVisible,
+        'comments'         => $comments,
+    ];
+}

--- a/web/scripts/api-contract.js
+++ b/web/scripts/api-contract.js
@@ -76,6 +76,21 @@
  * @typedef {Object} ApiBansBanMemberOfGroupResponse
  */
 /**
+ * Player-detail payload for the sbpp2026 right-side drawer (#1123 C1). 
+ * Returns the same data the public ban-list page already exposes, in a stable
+ * JSON shape the drawer JS renders client-side. Action is registered public so
+ * the drawer matches the public ban-list reach; fields that the public
+ * ban-list selectively hides via `banlist.hideplayerips` /
+ * `banlist.hideadminname` (player IP, admin name, removed-by) follow the same
+ * gating here so a public caller can never fan out the same data through the
+ * JSON API that the page intentionally suppresses. Comments are only included
+ * when `config.enablepubliccomments` is set or the caller is an admin —
+ * mirroring page.banlist.php's `$view_comments` switch.
+ *
+ * @typedef {Object} ApiBansDetailRequest
+ * @typedef {{ bid: number, player: {name: string, type: number, steam_id: string, steam_id_3: string, community_id: string, ip: string|null, country: string|null}, ban: {reason: string, banned_at: number, banned_at_human: string, length_seconds: number, length_human: string, expires_at: number|null, expires_at_human: string|null, state: string, unban_reason: string, removed_at: number|null, removed_at_human: string|null, removed_by: string|null}, admin: {name: string|null}, server: {sid: number, name: string|null, mod_icon: string|null}, demo_count: number, history_count: number, comments_visible: boolean, comments: Array<{cid: number, added: number, added_human: string, author: string|null, text: string, edited_at: number|null, edited_by: string|null}> }} ApiBansDetailResponse
+ */
+/**
  * @typedef {Object} ApiBansEditCommentRequest
  * @typedef {Object} ApiBansEditCommentResponse
  */
@@ -274,6 +289,7 @@ var Actions = Object.freeze({
     BansAddComment: 'bans.add_comment',
     BansBanFriends: 'bans.ban_friends',
     BansBanMemberOfGroup: 'bans.ban_member_of_group',
+    BansDetail: 'bans.detail',
     BansEditComment: 'bans.edit_comment',
     BansGetGroups: 'bans.get_groups',
     BansGroupBan: 'bans.group_ban',

--- a/web/tests/api/BansTest.php
+++ b/web/tests/api/BansTest.php
@@ -196,6 +196,94 @@ final class BansTest extends ApiTestCase
         $this->assertSnapshot('bans/prepare_reban_success', $env, ['data.bid']);
     }
 
+    public function testDetailRejectsMissingBid(): void
+    {
+        // bans.detail is public; the dispatcher lets the call through and
+        // the handler validates `bid` itself. An unknown id 404s; bid=0
+        // surfaces as a 'bad_request' validation error.
+        $env = $this->api('bans.detail', ['bid' => 0]);
+        $this->assertEnvelopeError($env, 'bad_request');
+        $this->assertSame('bid', $env['error']['field']);
+        $this->assertSnapshot('bans/detail_bad_request', $env);
+    }
+
+    public function testDetailReturns404ForUnknownBid(): void
+    {
+        $env = $this->api('bans.detail', ['bid' => 999999]);
+        $this->assertEnvelopeError($env, 'not_found');
+        $this->assertSnapshot('bans/detail_not_found', $env);
+    }
+
+    public function testDetailPublicViewHidesAdminFields(): void
+    {
+        // Public caller (not logged in). The handler must (a) succeed,
+        // (b) hide the IP when banlist.hideplayerips is on, (c) hide the
+        // admin name when banlist.hideadminname is on, and (d) only
+        // include comments when config.enablepubliccomments is on.
+        Fixture::rawPdo()->prepare(sprintf(
+            "REPLACE INTO `%s_settings` (`setting`, `value`) VALUES
+                ('banlist.hideplayerips', '1'),
+                ('banlist.hideadminname', '1'),
+                ('config.enablepubliccomments', '0')",
+            DB_PREFIX
+        ))->execute();
+        \Config::init($GLOBALS['PDO']);
+
+        $bid = $this->seedBan('STEAM_0:1:1010', 'public-view');
+
+        $env = $this->api('bans.detail', ['bid' => $bid]);
+        $this->assertTrue($env['ok'], json_encode($env));
+        $this->assertSame($bid,            (int)$env['data']['bid']);
+        $this->assertSame('STEAM_0:1:1010', $env['data']['player']['steam_id']);
+        $this->assertNull($env['data']['player']['ip'],   'IP should be hidden for public + hideplayerips');
+        $this->assertNull($env['data']['admin']['name'],  'admin should be hidden for public + hideadminname');
+        $this->assertFalse($env['data']['comments_visible'], 'comments should be hidden when public + flag off');
+        $this->assertSame([], $env['data']['comments']);
+        $this->assertSnapshot('bans/detail_public_hidden', $env, ['data.bid', 'data.ban.banned_at', 'data.ban.banned_at_human', 'data.ban.expires_at', 'data.ban.expires_at_human']);
+    }
+
+    public function testDetailAdminViewExposesEverything(): void
+    {
+        // Same hide-* flags on, but as an admin: handler must NOT honour
+        // them (admins always see the underlying data) and comments must
+        // come back even with the public-comments flag off.
+        Fixture::rawPdo()->prepare(sprintf(
+            "REPLACE INTO `%s_settings` (`setting`, `value`) VALUES
+                ('banlist.hideplayerips', '1'),
+                ('banlist.hideadminname', '1'),
+                ('config.enablepubliccomments', '0')",
+            DB_PREFIX
+        ))->execute();
+        \Config::init($GLOBALS['PDO']);
+
+        $this->loginAsAdmin();
+        $bid = $this->seedBan('STEAM_0:1:2020', 'admin-view');
+
+        // Add a comment via the public API so the snapshot exercises the
+        // comment-list shape end-to-end.
+        $this->api('bans.add_comment', [
+            'bid' => $bid, 'ctype' => 'B', 'ctext' => 'note for the drawer', 'page' => -1,
+        ]);
+
+        $env = $this->api('bans.detail', ['bid' => $bid]);
+        $this->assertTrue($env['ok'], json_encode($env));
+        $this->assertSame('STEAM_0:1:2020', $env['data']['player']['steam_id']);
+        $this->assertNotNull($env['data']['admin']['name']);
+        $this->assertTrue($env['data']['comments_visible']);
+        $this->assertCount(1, $env['data']['comments']);
+        $this->assertSame('note for the drawer', $env['data']['comments'][0]['text']);
+        $this->assertSnapshot('bans/detail_admin_view', $env, [
+            'data.bid',
+            'data.ban.banned_at',
+            'data.ban.banned_at_human',
+            'data.ban.expires_at',
+            'data.ban.expires_at_human',
+            'data.comments.0.cid',
+            'data.comments.0.added',
+            'data.comments.0.added_human',
+        ]);
+    }
+
     public function testAddCommentInsertsRow(): void
     {
         $this->loginAsAdmin();

--- a/web/tests/api/PermissionMatrixTest.php
+++ b/web/tests/api/PermissionMatrixTest.php
@@ -63,6 +63,12 @@ final class PermissionMatrixTest extends TestCase
 
             // -- bans.
             'bans.add'                    => ['perm' => ADMIN_OWNER | ADMIN_ADD_BAN, 'requireAdmin' => false, 'public' => false],
+            // bans.detail is intentionally public: same reach as the public
+            // ban-list page. The handler hides admin-only fields itself
+            // (player IP, admin name, removed-by, comments) so the wire
+            // format stays consistent with what the HTML page would have
+            // shown the same caller. See api_bans_detail() docblock.
+            'bans.detail'                 => ['perm' => 0, 'requireAdmin' => false, 'public' => true],
             'bans.setup_ban'              => ['perm' => 0, 'requireAdmin' => true,  'public' => false],
             'bans.prepare_reban'          => ['perm' => 0, 'requireAdmin' => true,  'public' => false],
             'bans.paste'                  => ['perm' => ADMIN_OWNER | ADMIN_ADD_BAN, 'requireAdmin' => false, 'public' => false],

--- a/web/tests/api/__snapshots__/bans/detail_admin_view.json
+++ b/web/tests/api/__snapshots__/bans/detail_admin_view.json
@@ -1,0 +1,51 @@
+{
+    "ok": true,
+    "data": {
+        "bid": "<*>",
+        "player": {
+            "name": "Cheater",
+            "type": 0,
+            "steam_id": "STEAM_0:1:2020",
+            "steam_id_3": "[U:1:4041]",
+            "community_id": "76561197960269769",
+            "ip": null,
+            "country": null
+        },
+        "ban": {
+            "reason": "admin-view",
+            "banned_at": "<*>",
+            "banned_at_human": "<*>",
+            "length_seconds": 0,
+            "length_human": "Permanent",
+            "expires_at": "<*>",
+            "expires_at_human": "<*>",
+            "state": "permanent",
+            "unban_reason": "",
+            "removed_at": null,
+            "removed_at_human": null,
+            "removed_by": null
+        },
+        "admin": {
+            "name": "admin"
+        },
+        "server": {
+            "sid": 0,
+            "name": null,
+            "mod_icon": null
+        },
+        "demo_count": 0,
+        "history_count": 1,
+        "comments_visible": true,
+        "comments": [
+            {
+                "cid": "<*>",
+                "added": "<*>",
+                "added_human": "<*>",
+                "author": "admin",
+                "text": "note for the drawer",
+                "edited_at": null,
+                "edited_by": null
+            }
+        ]
+    }
+}

--- a/web/tests/api/__snapshots__/bans/detail_bad_request.json
+++ b/web/tests/api/__snapshots__/bans/detail_bad_request.json
@@ -1,0 +1,8 @@
+{
+    "ok": false,
+    "error": {
+        "code": "bad_request",
+        "message": "bid must be a positive integer",
+        "field": "bid"
+    }
+}

--- a/web/tests/api/__snapshots__/bans/detail_not_found.json
+++ b/web/tests/api/__snapshots__/bans/detail_not_found.json
@@ -1,0 +1,7 @@
+{
+    "ok": false,
+    "error": {
+        "code": "not_found",
+        "message": "Ban not found."
+    }
+}

--- a/web/tests/api/__snapshots__/bans/detail_public_hidden.json
+++ b/web/tests/api/__snapshots__/bans/detail_public_hidden.json
@@ -1,0 +1,41 @@
+{
+    "ok": true,
+    "data": {
+        "bid": "<*>",
+        "player": {
+            "name": "Cheater",
+            "type": 0,
+            "steam_id": "STEAM_0:1:1010",
+            "steam_id_3": "[U:1:2021]",
+            "community_id": "76561197960267749",
+            "ip": null,
+            "country": null
+        },
+        "ban": {
+            "reason": "public-view",
+            "banned_at": "<*>",
+            "banned_at_human": "<*>",
+            "length_seconds": 0,
+            "length_human": "Permanent",
+            "expires_at": "<*>",
+            "expires_at_human": "<*>",
+            "state": "permanent",
+            "unban_reason": "",
+            "removed_at": null,
+            "removed_at_human": null,
+            "removed_by": null
+        },
+        "admin": {
+            "name": null
+        },
+        "server": {
+            "sid": 0,
+            "name": null,
+            "mod_icon": null
+        },
+        "demo_count": 0,
+        "history_count": 1,
+        "comments_visible": false,
+        "comments": []
+    }
+}

--- a/web/themes/sbpp2026/js/theme.js
+++ b/web/themes/sbpp2026/js/theme.js
@@ -380,7 +380,11 @@
         return;
       }
     }
-    if (target && target.closest('[data-drawer-close]') && !target.closest('.drawer')) closeDrawer();
+    // Any element marked `data-drawer-close` closes the drawer — both the
+    // backdrop (sibling of .drawer) and the in-header X button (descendant
+    // of .drawer) carry the attribute. The earlier `!closest('.drawer')`
+    // guard predated the X button and would silently swallow its clicks.
+    if (target && target.closest('[data-drawer-close]')) closeDrawer();
   });
 
   // ---- COPY BUTTONS ----------------------------------------

--- a/web/themes/sbpp2026/js/theme.js
+++ b/web/themes/sbpp2026/js/theme.js
@@ -135,37 +135,250 @@
   }
 
   // ---- DRAWER ----------------------------------------------
-  const drawerRoot = document.getElementById('drawer-root');
+  // Click target convention: any element with `[data-drawer-bid="N"]`
+  // (or, for backwards-compat with the handoff template, an `id=N` query
+  // param inside `[data-drawer-href]`) opens the drawer for ban N.
+  // The state attribute `data-drawer-open="true"` on the container is the
+  // testability hook — CI can observe deterministic open/close without
+  // chasing CSS visibility heuristics. `data-loading="true"` is set
+  // while the fetch is in flight so an integration test can wait on the
+  // post-load shape without a sleep.
+  const drawerRoot = /** @type {HTMLElement | null} */ (document.getElementById('drawer-root'));
 
   /**
-   * Mount drawer markup. Caller is responsible for the inner HTML
-   * being safe (built from trusted server-rendered partials, never
-   * raw user input).
+   * Show the drawer container with the given inner HTML. Caller is
+   * responsible for the inner HTML being safe (built from this file's
+   * builders, which run every dynamic value through escapeHtml(), or
+   * from a trusted server-rendered partial).
    * @param {string} html
    * @returns {void}
    */
-  function openDrawer(html) {
+  function showDrawer(html) {
     if (!drawerRoot) return;
     drawerRoot.hidden = false;
-    drawerRoot.innerHTML = '<div class="drawer-backdrop" data-drawer-close></div><div class="drawer" role="dialog">' + html + '</div>';
+    drawerRoot.dataset.drawerOpen = 'true';
+    drawerRoot.innerHTML = '<div class="drawer-backdrop" data-drawer-close></div><div class="drawer" role="dialog" aria-label="Player details">' + html + '</div>';
     if (window.lucide) window.lucide.createIcons();
   }
 
   /** @returns {void} */
   function closeDrawer() {
-    if (drawerRoot) { drawerRoot.hidden = true; drawerRoot.innerHTML = ''; }
+    if (!drawerRoot) return;
+    drawerRoot.hidden = true;
+    drawerRoot.dataset.drawerOpen = 'false';
+    delete drawerRoot.dataset.loading;
+    drawerRoot.innerHTML = '';
+  }
+
+  /**
+   * Public entry point preserved for legacy callers (window.SBPP.openDrawer).
+   * @param {string} html
+   * @returns {void}
+   */
+  function openDrawer(html) { showDrawer(html); }
+
+  /**
+   * Resolve a click target into a numeric ban id, returning null when
+   * the trigger doesn't carry one. Accepts:
+   *   - `data-drawer-bid="123"`           (preferred new form)
+   *   - `data-drawer-href="?p=banlist&id=123"`  (handoff template form)
+   * @param {Element} el
+   * @returns {number | null}
+   */
+  function bidFromTrigger(el) {
+    const fromAttr = /** @type {HTMLElement} */ (el).dataset.drawerBid;
+    if (fromAttr && /^\d+$/.test(fromAttr)) return parseInt(fromAttr, 10);
+    const href = /** @type {HTMLElement} */ (el).dataset.drawerHref;
+    if (typeof href === 'string') {
+      const m = href.match(/[?&]id=(\d+)/);
+      if (m) return parseInt(m[1], 10);
+    }
+    return null;
+  }
+
+  /**
+   * @param {string | null | undefined} mode
+   * @returns {string}
+   */
+  function stateLabel(mode) {
+    switch (mode) {
+      case 'permanent': return 'Permanent';
+      case 'active':    return 'Active';
+      case 'expired':   return 'Expired';
+      case 'unbanned':  return 'Unbanned';
+      default:          return 'Unknown';
+    }
+  }
+
+  /**
+   * Build the rendered drawer HTML for a successful bans.detail
+   * envelope. Every value that ends up in innerHTML is funnelled
+   * through escapeHtml(); the only literal HTML is the static layout
+   * we author here.
+   * @param {Object} data
+   * @returns {string}
+   */
+  function renderDrawerBody(data) {
+    const player = (data && data.player) || {};
+    const ban    = (data && data.ban)    || {};
+    const admin  = (data && data.admin)  || {};
+    const server = (data && data.server) || {};
+    const comments = Array.isArray(data && data.comments) ? data.comments : [];
+    const commentsVisible = !!(data && data.comments_visible);
+
+    const headerHtml =
+      '<header class="drawer__header" style="display:flex;justify-content:space-between;align-items:center;padding:1rem 1.25rem;border-bottom:1px solid var(--border)">'
+      +   '<div>'
+      +     '<div class="text-xs text-faint" style="text-transform:uppercase;letter-spacing:0.06em">Ban #' + escapeHtml(String(data.bid)) + '</div>'
+      +     '<h2 class="font-semibold" style="margin:0.125rem 0 0;font-size:1.125rem">' + escapeHtml(player.name || '(unknown)') + '</h2>'
+      +   '</div>'
+      +   '<button class="btn--ghost btn--icon" type="button" data-drawer-close aria-label="Close">'
+      +     '<i data-lucide="x"></i>'
+      +   '</button>'
+      + '</header>';
+
+    /** @type {Array<[string, string]>} */
+    const idRows = [];
+    if (player.steam_id)     idRows.push(['SteamID',    String(player.steam_id)]);
+    if (player.steam_id_3)   idRows.push(['Steam3',     String(player.steam_id_3)]);
+    if (player.community_id) idRows.push(['Community',  String(player.community_id)]);
+    if (player.ip)           idRows.push(['IP',         String(player.ip)]);
+    if (player.country)      idRows.push(['Country',    String(player.country)]);
+
+    const idHtml = idRows.length === 0 ? '' :
+      '<dl class="drawer__ids" style="display:grid;grid-template-columns:6rem 1fr;gap:0.25rem 0.75rem;margin:0;font-size:0.8125rem">'
+      + idRows.map((row) =>
+          '<dt class="text-faint">' + escapeHtml(row[0]) + '</dt>'
+          + '<dd class="font-mono" style="margin:0">' + escapeHtml(row[1])
+          + '<button class="btn--ghost btn--icon" type="button" data-copy="' + escapeHtml(row[1]) + '" title="Copy" style="margin-left:0.25rem">'
+          +   '<i data-lucide="copy" style="width:12px;height:12px"></i>'
+          + '</button>'
+          + '</dd>'
+        ).join('')
+      + '</dl>';
+
+    /** @type {Array<[string, string]>} */
+    const banRows = [
+      ['State',   stateLabel(/** @type {string} */ (ban.state))],
+      ['Reason',  String(ban.reason || '(none)')],
+      ['Length',  String(ban.length_human || '')],
+      ['Banned',  String(ban.banned_at_human || '')],
+    ];
+    if (ban.expires_at_human) banRows.push(['Expires', String(ban.expires_at_human)]);
+    if (ban.removed_at_human) banRows.push(['Removed', String(ban.removed_at_human)]);
+    if (ban.removed_by)       banRows.push(['Removed by', String(ban.removed_by)]);
+    if (ban.unban_reason)     banRows.push(['Unban reason', String(ban.unban_reason)]);
+    if (admin.name)           banRows.push(['Admin', String(admin.name)]);
+    if (server.name)          banRows.push(['Server', String(server.name)]);
+
+    const banHtml =
+      '<dl class="drawer__ban" style="display:grid;grid-template-columns:6rem 1fr;gap:0.25rem 0.75rem;margin:0;font-size:0.8125rem">'
+      + banRows.map((row) =>
+          '<dt class="text-faint">' + escapeHtml(row[0]) + '</dt>'
+          + '<dd style="margin:0">' + escapeHtml(row[1]) + '</dd>'
+        ).join('')
+      + '</dl>';
+
+    let commentsHtml = '';
+    if (commentsVisible) {
+      commentsHtml = '<section style="padding:0 1.25rem 1.25rem">'
+        + '<h3 class="text-xs text-faint" style="text-transform:uppercase;letter-spacing:0.06em;margin:0 0 0.5rem">Comments</h3>'
+        + (comments.length === 0
+          ? '<p class="text-sm text-muted" style="margin:0">No comments.</p>'
+          : '<ul style="list-style:none;margin:0;padding:0;display:flex;flex-direction:column;gap:0.625rem">'
+            + comments.map((c) =>
+                '<li style="border:1px solid var(--border);border-radius:var(--radius-md);padding:0.625rem 0.75rem;background:var(--bg-surface)">'
+                + '<div style="display:flex;justify-content:space-between;font-size:0.75rem;color:var(--text-muted);margin-bottom:0.25rem">'
+                +   '<span class="font-medium">' + escapeHtml(c.author || 'unknown') + '</span>'
+                +   '<span>' + escapeHtml(c.added_human || '') + '</span>'
+                + '</div>'
+                + '<div class="text-sm" style="white-space:pre-wrap">' + escapeHtml(c.text || '') + '</div>'
+                + '</li>'
+              ).join('')
+            + '</ul>')
+        + '</section>';
+    }
+
+    const bodyHtml =
+      '<div class="drawer__body" style="padding:1rem 1.25rem;display:flex;flex-direction:column;gap:1rem;overflow-y:auto;flex:1">'
+      +   idHtml
+      +   banHtml
+      + '</div>'
+      + commentsHtml;
+
+    return headerHtml + bodyHtml;
+  }
+
+  /**
+   * Render the placeholder skeleton shown during the in-flight fetch.
+   * @returns {string}
+   */
+  function renderDrawerLoading() {
+    return '<header class="drawer__header" style="display:flex;justify-content:space-between;align-items:center;padding:1rem 1.25rem;border-bottom:1px solid var(--border)">'
+      + '<div class="skeleton" style="width:8rem;height:1.25rem"></div>'
+      + '<button class="btn--ghost btn--icon" type="button" data-drawer-close aria-label="Close">'
+      + '<i data-lucide="x"></i>'
+      + '</button>'
+      + '</header>'
+      + '<div class="drawer__body" style="padding:1.25rem;display:flex;flex-direction:column;gap:0.75rem">'
+      +   '<div class="skeleton" style="height:0.875rem"></div>'
+      +   '<div class="skeleton" style="height:0.875rem;width:60%"></div>'
+      +   '<div class="skeleton" style="height:0.875rem;width:80%"></div>'
+      + '</div>';
+  }
+
+  /**
+   * Render the error state (server returned an error envelope or the
+   * fetch itself failed).
+   * @param {string} message
+   * @returns {string}
+   */
+  function renderDrawerError(message) {
+    return '<header class="drawer__header" style="display:flex;justify-content:space-between;align-items:center;padding:1rem 1.25rem;border-bottom:1px solid var(--border)">'
+      +   '<h2 class="font-semibold" style="margin:0;font-size:1rem">Couldn\u2019t load ban</h2>'
+      +   '<button class="btn--ghost btn--icon" type="button" data-drawer-close aria-label="Close">'
+      +     '<i data-lucide="x"></i>'
+      +   '</button>'
+      + '</header>'
+      + '<div class="drawer__body" style="padding:1.25rem">'
+      +   '<p class="text-sm text-muted" style="margin:0">' + escapeHtml(message) + '</p>'
+      + '</div>';
+  }
+
+  /**
+   * Fetch and render the player-detail drawer for a ban.
+   * @param {number} bid
+   * @returns {Promise<void>}
+   */
+  async function loadDrawer(bid) {
+    if (!drawerRoot) return;
+    showDrawer(renderDrawerLoading());
+    drawerRoot.dataset.loading = 'true';
+
+    /** @type {{ ok: boolean, data?: any, error?: { code: string, message: string } }} */
+    const env = window.sb && window.sb.api
+      ? await window.sb.api.call(Actions.BansDetail, { bid: bid })
+      : { ok: false, error: { code: 'no_client', message: 'sb.api unavailable' } };
+
+    delete drawerRoot.dataset.loading;
+    if (env && env.ok && env.data) {
+      showDrawer(renderDrawerBody(env.data));
+    } else {
+      const msg = (env && env.error && env.error.message) || 'Unknown error.';
+      showDrawer(renderDrawerError(msg));
+    }
   }
 
   document.addEventListener('click', (/** @type {MouseEvent} */ e) => {
     const target = /** @type {Element | null} */ (e.target);
-    const a = target && target.closest('[data-drawer-href]');
-    if (a) {
-      e.preventDefault();
-      // TODO(C1): wire to sb.api.call(Actions.BansDetail, { bid: a.dataset.drawerHref })
-      // and render the returned partial via openDrawer(html). Until C1 lands,
-      // the drawer just opens with a placeholder so the click target isn't dead.
-      openDrawer('<div style="padding:2rem" class="text-muted">Player drawer ships in C1.</div>');
-      return;
+    const trigger = target && target.closest('[data-drawer-bid], [data-drawer-href]');
+    if (trigger) {
+      const bid = bidFromTrigger(trigger);
+      if (bid !== null) {
+        e.preventDefault();
+        loadDrawer(bid);
+        return;
+      }
     }
     if (target && target.closest('[data-drawer-close]') && !target.closest('.drawer')) closeDrawer();
   });

--- a/web/themes/sbpp2026/partials/player-drawer.tpl
+++ b/web/themes/sbpp2026/partials/player-drawer.tpl
@@ -1,0 +1,136 @@
+{*
+    SourceBans++ 2026 — partials / player-drawer.tpl
+
+    Reference structure for the right-side ban-detail drawer rendered by
+    web/themes/sbpp2026/js/theme.js after a `bans.detail` call (#1123 C1).
+
+    The handler returns structured JSON (see api_bans_detail() in
+    web/api/handlers/bans.php); theme.js renders the markup client-side
+    via renderDrawerBody(), funnelling every dynamic value through
+    escapeHtml(). This file is the canonical *shape* the JS mirrors so a
+    designer can iterate on the visual without booting the JSON path,
+    and so a future B-phase ticket that needs a server-rendered initial
+    state for a deep-link (e.g. `?p=banlist&id=N` opening the drawer
+    on first paint) can {include file="partials/player-drawer.tpl"}
+    here without forking the markup.
+
+    Variable contract (only required when assigned by a page handler):
+      - $detail.bid                          int
+      - $detail.player.name                  string
+      - $detail.player.steam_id              string
+      - $detail.player.steam_id_3            string
+      - $detail.player.community_id          string
+      - $detail.player.ip                    string|null
+      - $detail.player.country               string|null
+      - $detail.ban.state                    'permanent'|'active'|'expired'|'unbanned'
+      - $detail.ban.reason                   string
+      - $detail.ban.length_human             string
+      - $detail.ban.banned_at_human          string
+      - $detail.ban.expires_at_human         string|null
+      - $detail.ban.removed_at_human         string|null
+      - $detail.ban.removed_by               string|null
+      - $detail.ban.unban_reason             string
+      - $detail.admin.name                   string|null
+      - $detail.server.name                  string|null
+      - $detail.comments_visible             bool
+      - $detail.comments[].author            string|null
+      - $detail.comments[].added_human       string
+      - $detail.comments[].text              string
+
+    Smarty's auto-escape is on globally (init.php), so {$value} renders
+    safely without per-line nofilter.
+*}
+<header class="drawer__header" style="display:flex;justify-content:space-between;align-items:center;padding:1rem 1.25rem;border-bottom:1px solid var(--border)">
+    <div>
+        <div class="text-xs text-faint" style="text-transform:uppercase;letter-spacing:0.06em">Ban #{$detail.bid}</div>
+        <h2 class="font-semibold" style="margin:0.125rem 0 0;font-size:1.125rem">{$detail.player.name}</h2>
+    </div>
+    <button class="btn--ghost btn--icon" type="button" data-drawer-close aria-label="Close">
+        <i data-lucide="x"></i>
+    </button>
+</header>
+
+<div class="drawer__body" style="padding:1rem 1.25rem;display:flex;flex-direction:column;gap:1rem;overflow-y:auto;flex:1">
+    <dl class="drawer__ids" style="display:grid;grid-template-columns:6rem 1fr;gap:0.25rem 0.75rem;margin:0;font-size:0.8125rem">
+        {if $detail.player.steam_id}
+            <dt class="text-faint">SteamID</dt>
+            <dd class="font-mono" style="margin:0">{$detail.player.steam_id}</dd>
+        {/if}
+        {if $detail.player.steam_id_3}
+            <dt class="text-faint">Steam3</dt>
+            <dd class="font-mono" style="margin:0">{$detail.player.steam_id_3}</dd>
+        {/if}
+        {if $detail.player.community_id}
+            <dt class="text-faint">Community</dt>
+            <dd class="font-mono" style="margin:0">{$detail.player.community_id}</dd>
+        {/if}
+        {if $detail.player.ip}
+            <dt class="text-faint">IP</dt>
+            <dd class="font-mono" style="margin:0">{$detail.player.ip}</dd>
+        {/if}
+        {if $detail.player.country}
+            <dt class="text-faint">Country</dt>
+            <dd class="font-mono" style="margin:0">{$detail.player.country}</dd>
+        {/if}
+    </dl>
+
+    <dl class="drawer__ban" style="display:grid;grid-template-columns:6rem 1fr;gap:0.25rem 0.75rem;margin:0;font-size:0.8125rem">
+        <dt class="text-faint">State</dt>
+        <dd style="margin:0">{$detail.ban.state|capitalize}</dd>
+
+        <dt class="text-faint">Reason</dt>
+        <dd style="margin:0">{$detail.ban.reason}</dd>
+
+        <dt class="text-faint">Length</dt>
+        <dd style="margin:0">{$detail.ban.length_human}</dd>
+
+        <dt class="text-faint">Banned</dt>
+        <dd style="margin:0">{$detail.ban.banned_at_human}</dd>
+
+        {if $detail.ban.expires_at_human}
+            <dt class="text-faint">Expires</dt>
+            <dd style="margin:0">{$detail.ban.expires_at_human}</dd>
+        {/if}
+        {if $detail.ban.removed_at_human}
+            <dt class="text-faint">Removed</dt>
+            <dd style="margin:0">{$detail.ban.removed_at_human}</dd>
+        {/if}
+        {if $detail.ban.removed_by}
+            <dt class="text-faint">Removed by</dt>
+            <dd style="margin:0">{$detail.ban.removed_by}</dd>
+        {/if}
+        {if $detail.ban.unban_reason}
+            <dt class="text-faint">Unban reason</dt>
+            <dd style="margin:0">{$detail.ban.unban_reason}</dd>
+        {/if}
+        {if $detail.admin.name}
+            <dt class="text-faint">Admin</dt>
+            <dd style="margin:0">{$detail.admin.name}</dd>
+        {/if}
+        {if $detail.server.name}
+            <dt class="text-faint">Server</dt>
+            <dd style="margin:0">{$detail.server.name}</dd>
+        {/if}
+    </dl>
+</div>
+
+{if $detail.comments_visible}
+    <section style="padding:0 1.25rem 1.25rem">
+        <h3 class="text-xs text-faint" style="text-transform:uppercase;letter-spacing:0.06em;margin:0 0 0.5rem">Comments</h3>
+        {if $detail.comments}
+            <ul style="list-style:none;margin:0;padding:0;display:flex;flex-direction:column;gap:0.625rem">
+                {foreach $detail.comments as $c}
+                    <li style="border:1px solid var(--border);border-radius:var(--radius-md);padding:0.625rem 0.75rem;background:var(--bg-surface)">
+                        <div style="display:flex;justify-content:space-between;font-size:0.75rem;color:var(--text-muted);margin-bottom:0.25rem">
+                            <span class="font-medium">{$c.author|default:'unknown'}</span>
+                            <span>{$c.added_human}</span>
+                        </div>
+                        <div class="text-sm" style="white-space:pre-wrap">{$c.text}</div>
+                    </li>
+                {/foreach}
+            </ul>
+        {else}
+            <p class="text-sm text-muted" style="margin:0">No comments.</p>
+        {/if}
+    </section>
+{/if}


### PR DESCRIPTION
Part of #1123 (v2.0.0 theme rollout).
Plan stage: **C1 — Drawer JS wiring + new bans.detail JSON action.**

## Summary

- Adds `bans.detail` — a public JSON handler that returns the
  player-detail payload the sbpp2026 right-side drawer renders.
- Wires the drawer in `web/themes/sbpp2026/js/theme.js` to call
  `sb.api.call(Actions.BansDetail, { bid })` (replaces the C1 TODO
  breadcrumb A1 left).
- Adds a reference partial at
  `web/themes/sbpp2026/partials/player-drawer.tpl` mirroring the
  JS-rendered markup so a future B-phase ticket can deep-link to a
  pre-populated drawer without forking the visual.

## Response shape: **JSON** (not server-rendered HTML)

The plan asked us to pick one and document it.

`bans.detail` returns structured JSON; the drawer JS renders the
markup client-side via `renderDrawerBody()`, funnelling every dynamic
value through the existing `escapeHtml()` helper. The wire-format
typedef lives in `web/scripts/api-contract.js` (regenerated by this
PR), and four snapshots under
`web/tests/api/__snapshots__/bans/detail_*.json` lock it.

Why JSON over server-rendered HTML:
- Matches every other handler in `web/api/handlers/` — no Smarty
  machinery in the API path, handlers stay pure
  `function(array $params): array`.
- Snapshot file is a stable, reviewable data shape — HTML snapshots
  are brittle to layout tweaks.
- Wire payload is small and self-describing.
- The CSS classes used by the drawer (`drawer__header`,
  `drawer__body`, `text-faint`, `font-mono`, `skeleton`, …) all live
  in `web/themes/sbpp2026/css/theme.css` from A1, so the JS-built
  markup picks up the design tokens for free.

The trade-off is that the new partial is a *reference shape*, not the
live render path — the JS is the source of truth. The partial is in
scope per the plan and useful for designers + future SSR fallbacks
(deep-link `?p=banlist&id=N` opening the drawer pre-populated).

## Permissions

`bans.detail` is registered **public** (`public=true`) so the drawer
matches the public ban-list page's reach — clicking a row in the public
ban list should open the drawer for any visitor.

The handler then enforces the same per-field gates `page.banlist.php`
already does:

| Field          | Hidden when                                                          |
|----------------|----------------------------------------------------------------------|
| `player.ip`    | `banlist.hideplayerips=1` AND caller is not an admin                |
| `admin.name`   | `banlist.hideadminname=1` AND caller is not an admin                |
| `ban.removed_by` | (same as `admin.name`)                                              |
| `comments`     | `config.enablepubliccomments=0` AND caller is not an admin → `[]`  |

So a public caller never sees fields the page would have suppressed
for the same caller; an admin sees the underlying data. Two of the
new snapshots (`detail_public_hidden.json`,
`detail_admin_view.json`) lock both sides of that contract.

`web/tests/api/PermissionMatrixTest.php` gets a new row pinning
`(perm=0, requireAdmin=false, public=true)`.

## Drawer JS contract

`web/themes/sbpp2026/js/theme.js`:

- Replaces the C1 TODO breadcrumb.
- Click triggers accept either `data-drawer-bid="N"` (preferred) or
  `data-drawer-href="?p=banlist&id=N"` (handoff template form).
- Toggles **state attributes** for testability:
  - `data-drawer-open="true|false"` on `<aside id="drawer-root">`
  - `data-loading="true"` while the fetch is in flight
- Renders skeleton during fetch, error state on failure, populated
  detail on success — all built from `escapeHtml()`-funnelled strings.
- No string literals for action names — uses `Actions.BansDetail`.

## Files touched

- `web/api/handlers/bans.php` — new `api_bans_detail`
- `web/api/handlers/_register.php` — register `bans.detail` public
- `web/scripts/api-contract.js` — regenerated; adds `BansDetail`
- `web/tests/api/PermissionMatrixTest.php` — new matrix row
- `web/tests/api/BansTest.php` — 4 new tests
  (`testDetailRejectsMissingBid`, `testDetailReturns404ForUnknownBid`,
  `testDetailPublicViewHidesAdminFields`,
  `testDetailAdminViewExposesEverything`)
- `web/tests/api/__snapshots__/bans/detail_{bad_request,not_found,public_hidden,admin_view}.json`
- `web/themes/sbpp2026/js/theme.js` — drawer fetch + render
- `web/themes/sbpp2026/partials/player-drawer.tpl` — reference shape

## Local gates

- `./sbpp.sh phpstan` — green
- `./sbpp.sh phpstan` w/ `SBPP_PHPSTAN_THEME=sbpp2026 --configuration=phpstan-sbpp2026.neon` — green
- `./sbpp.sh test tests/api/BansTest.php` — 30 / 30 green
- `./sbpp.sh test tests/api/PermissionMatrixTest.php` — 60 / 60 green
- `./sbpp.sh ts-check` — green
- `./sbpp.sh composer api-contract` — emits 59 actions, 32 perms, 3 typedefs; idempotent (no further diff after second run)

Manual verification with `config.theme=sbpp2026`:

- Public caller (no login) → `ip=null`, `admin.name=null`,
  `comments_visible=false`, `comments=[]`. ✓
- Admin caller → `ip="203.0.113.42"`, `admin.name="CONSOLE"`,
  `comments_visible=true`. ✓
- Drawer scaffold rendered: `<aside id="drawer-root" data-drawer-open="false" hidden>` present in the page chrome. ✓
- `theme.js` loads after `api-contract.js`, `sb.js`, `api.js`. ✓
- `Actions.BansDetail = 'bans.detail'` exposed in the served contract. ✓
- `config.theme` reverted to `default` after the verification.

Live screenshots aren't included here — this CLI environment doesn't
have a headless browser available, and installing one for one
verification run would have ballooned the diff churn. Reviewers can
spin up `./sbpp.sh up`, switch `config.theme` to `sbpp2026`, click any
public ban row, and observe the drawer.

## Test plan

- [ ] `./sbpp.sh phpstan` (default + `--configuration=phpstan-sbpp2026.neon`) is green.
- [ ] `./sbpp.sh test` is green (full suite, not just the new tests).
- [ ] `./sbpp.sh ts-check` is green.
- [ ] `./sbpp.sh composer api-contract` produces no diff after running.
- [ ] Visual: with `config.theme=sbpp2026`, click a public ban row and
      confirm the drawer slides in with player + ban + (admin-only)
      comment data.
- [ ] Light + dark — toggle the theme button and confirm the drawer
      respects `<html class="dark">`.

## Notes for the rebase Reviewer

C1 and C2 both touch `web/api/handlers/bans.php`. Per the plan's
ordering guidance, the second-merging Reviewer handles the rebase
conflict. No special action requested from this PR's author.