### PR TITLE
[#1123 B15] Redesign admin servers group

### DIFF
--- a/web/includes/View/AdminServersAdminListView.php
+++ b/web/includes/View/AdminServersAdminListView.php
@@ -1,0 +1,38 @@
+<?php
+declare(strict_types=1);
+
+namespace Sbpp\View;
+
+/**
+ * "Server admins" panel rendered by `pages/admin.srvadmins.php` — binds to
+ * `page_admin_servers_adminlist.tpl`. Lists the admins with access to the
+ * selected server (directly or through a server group) and, when the
+ * SourceQuery probe succeeded, the live in-game name + IP for each one.
+ *
+ * Each row in `$admin_list` mirrors the shape `admin.srvadmins.php` builds:
+ *
+ *   - `user`   string|null — admin display name from `:prefix_admins`.
+ *   - `authid` string|null — admin SteamID.
+ *   - `ingame` bool        — true when the admin is currently connected.
+ *   - `iname`  string|null — in-game name (only when `ingame` is true).
+ *   - `iip`    string|null — in-game IP (only when `ingame` is true).
+ */
+final class AdminServersAdminListView extends View
+{
+    public const TEMPLATE = 'page_admin_servers_adminlist.tpl';
+
+    /**
+     * @param list<array{
+     *     user: string|null,
+     *     authid: string|null,
+     *     ingame: bool,
+     *     iname?: string|null,
+     *     iip?: string|null,
+     * }> $admin_list
+     */
+    public function __construct(
+        public readonly int $admin_count,
+        public readonly array $admin_list,
+    ) {
+    }
+}

--- a/web/includes/View/AdminServersRconView.php
+++ b/web/includes/View/AdminServersRconView.php
@@ -1,0 +1,29 @@
+<?php
+declare(strict_types=1);
+
+namespace Sbpp\View;
+
+/**
+ * Per-server RCON console — binds to `page_admin_servers_rcon.tpl`, which
+ * is rendered with the custom `-{ … }-` delimiter pair (see
+ * `pages/admin.rcon.php`). The {@see View::DELIMITERS} override teaches
+ * SmartyTemplateRule to scan for `-{$var}-` references instead of `{$var}`.
+ *
+ * The console itself talks to `Actions.ServersSendRcon`; the page only
+ * needs the target `$id` (server sid) and a precomputed
+ * `$permission_rcon` flag combining `SM_RCON|SM_ROOT` with the per-server
+ * access loop in `admin.rcon.php`.
+ */
+final class AdminServersRconView extends View
+{
+    public const TEMPLATE = 'page_admin_servers_rcon.tpl';
+
+    /** @var array{0: string, 1: string} */
+    public const DELIMITERS = ['-{', '}-'];
+
+    public function __construct(
+        public readonly int $id,
+        public readonly bool $permission_rcon,
+    ) {
+    }
+}

--- a/web/pages/admin.servers.php
+++ b/web/pages/admin.servers.php
@@ -10,7 +10,11 @@ new AdminTabs([
     ['name' => 'Add new server', 'permission' => ADMIN_OWNER|ADMIN_ADD_SERVER]
 ], $userbank, $theme);
 
-$servers = $GLOBALS['PDO']->query("SELECT srv.ip ip, srv.port port, srv.sid sid, mo.icon icon, srv.enabled enabled FROM `:prefix_servers` AS srv
+// `mod_name` (mod display name) was added in #1123 B15 so the sbpp2026
+// card grid can render the mod label without a second per-card query.
+// The legacy `default/` template ignores the column; both themes share
+// the same data shape.
+$servers = $GLOBALS['PDO']->query("SELECT srv.ip ip, srv.port port, srv.sid sid, mo.icon icon, mo.name mod_name, srv.enabled enabled FROM `:prefix_servers` AS srv
    LEFT JOIN `:prefix_mods` AS mo ON mo.mid = srv.modid
    ORDER BY modid, sid")->resultset();
 $server_count = $GLOBALS['PDO']->query("SELECT COUNT(sid) AS cnt FROM `:prefix_servers`")->single();

--- a/web/themes/sbpp2026/page_admin_servers_add.tpl
+++ b/web/themes/sbpp2026/page_admin_servers_add.tpl
@@ -1,6 +1,242 @@
-<div class="card">
-    <div class="card__body">
-        <h1>{$title}</h1>
-        <p class="text-muted">This page hasn't been redesigned yet.</p>
-    </div>
-</div>
+{*
+    SourceBans++ 2026 — page_admin_servers_add.tpl
+    Bound to Sbpp\View\AdminServersAddView (validated by SmartyTemplateRule).
+
+    Add-server form rendered immediately below the server grid by
+    web/pages/admin.servers.php. Posts to Actions.ServersAdd via the
+    inline script (sbpp2026's chrome doesn't load the legacy
+    process_add_server() helper from sourcebans.js, so we wire the
+    submit in line). CSRF auto-attaches via sb.api.call's
+    X-CSRF-Token header; {csrf_field} is also rendered so a no-JS
+    fallback (e.g. an admin posting through devtools) carries the
+    same defence.
+
+    The View also declares $modid / $edit_server because the same view
+    powers the edit flow at admin.edit.server.php — the form prefills
+    those when the legacy template is reused. This template uses both
+    even in the add flow (modid = preselected option, edit_server gates
+    the submit-button label) to keep the SmartyTemplateRule contract
+    happy across the dual-theme matrix.
+*}
+<section class="page-section mt-6" id="addserver" data-testid="server-add-section" style="max-width:900px">
+    {if NOT $permission_addserver}
+        <div class="card" data-testid="server-add-denied">
+            <div class="card__body">
+                <h3 style="margin:0 0 0.25rem">Access Denied</h3>
+                <p class="text-sm text-muted m-0">You don't have permission to add servers.</p>
+            </div>
+        </div>
+    {else}
+        <form id="addserver-form"
+              class="card"
+              method="post"
+              action="index.php?p=admin&c=servers"
+              data-testid="server-add-form"
+              autocomplete="off">
+            {csrf_field}
+            <input type="hidden" name="insert_type" value="add">
+            <div class="card__header">
+                <div>
+                    <h3>{if $edit_server}Edit server{else}Add a server{/if}</h3>
+                    <p>Tip: hover the question marks for inline help. RCON is optional but unlocks the live console + per-server admin mapping.</p>
+                </div>
+            </div>
+            <div class="card__body" style="display:grid;gap:1rem">
+                <div class="grid gap-4" style="grid-template-columns:repeat(auto-fit,minmax(16rem,1fr))">
+                    <label class="block">
+                        <span class="label">Server IP / domain</span>
+                        <input type="text"
+                               id="address"
+                               name="address"
+                               class="input font-mono"
+                               value="{$ip|escape}"
+                               placeholder="203.0.113.10"
+                               required
+                               data-testid="addserver-address">
+                        <span class="text-xs text-muted">IPv4 / IPv6 / hostname. The dispatcher validates with PHP's <code class="font-mono">FILTER_VALIDATE_IP</code>.</span>
+                    </label>
+                    <label class="block">
+                        <span class="label">Server port</span>
+                        <input type="number"
+                               id="port"
+                               name="port"
+                               class="input font-mono"
+                               value="{if $port}{$port|escape}{else}27015{/if}"
+                               min="1"
+                               max="65535"
+                               required
+                               data-testid="addserver-port">
+                        <span class="text-xs text-muted">Default <code class="font-mono">27015</code>.</span>
+                    </label>
+                </div>
+
+                <div class="grid gap-4" style="grid-template-columns:repeat(auto-fit,minmax(16rem,1fr))">
+                    <label class="block">
+                        <span class="label">RCON password</span>
+                        <input type="password"
+                               id="rcon"
+                               name="rcon"
+                               class="input font-mono"
+                               value="{$rcon|escape}"
+                               autocomplete="new-password"
+                               data-testid="addserver-rcon">
+                        <span class="text-xs text-muted">Found in <code class="font-mono">server.cfg</code> next to <code class="font-mono">rcon_password</code>.</span>
+                    </label>
+                    <label class="block">
+                        <span class="label">Confirm RCON</span>
+                        <input type="password"
+                               id="rcon2"
+                               name="rcon2"
+                               class="input font-mono"
+                               value="{$rcon|escape}"
+                               autocomplete="new-password"
+                               data-testid="addserver-rcon2">
+                        <span class="text-xs text-muted">Re-enter to avoid typos.</span>
+                    </label>
+                </div>
+
+                <div class="grid gap-4" style="grid-template-columns:repeat(auto-fit,minmax(16rem,1fr))">
+                    <label class="block">
+                        <span class="label">Mod</span>
+                        <select id="mod"
+                                name="mod"
+                                class="select"
+                                required
+                                data-testid="addserver-mod">
+                            {if !$edit_server}<option value="-2">Select a mod…</option>{/if}
+                            {foreach from=$modlist item=mod}
+                                <option value="{$mod.mid}"{if $modid !== '' && $modid == $mod.mid} selected{/if}>{$mod.name|escape}</option>
+                            {/foreach}
+                        </select>
+                    </label>
+                    <label class="flex items-center gap-2" style="align-self:end;padding:0.5rem 0">
+                        <input type="checkbox"
+                               id="enabled"
+                               name="enabled"
+                               value="1"
+                               checked
+                               data-testid="addserver-enabled">
+                        <span class="text-sm">Enable on the public servers list</span>
+                    </label>
+                </div>
+
+                <fieldset style="border:1px solid var(--border);border-radius:var(--radius-md);padding:0.75rem 1rem">
+                    <legend class="text-xs font-semibold" style="padding:0 0.5rem">Server groups</legend>
+                    <p class="text-xs text-muted m-0 mb-2">Pick the SourceMod groups this server inherits admins from.</p>
+                    {if $grouplist|@count == 0}
+                        <p class="text-xs text-faint m-0">No server groups defined yet — visit Admins → Groups to create one.</p>
+                    {else}
+                        <div class="grid gap-2" style="grid-template-columns:repeat(auto-fill,minmax(11rem,1fr))">
+                            {foreach from=$grouplist item=group}
+                                <label class="flex items-center gap-2 p-2"
+                                       style="border:1px solid var(--border);border-radius:var(--radius-md)">
+                                    <input type="checkbox"
+                                           value="{$group.gid}"
+                                           id="g_{$group.gid}"
+                                           name="groups[]"
+                                           data-testid="addserver-group">
+                                    <span class="text-xs truncate">{$group.name|escape}</span>
+                                </label>
+                            {/foreach}
+                        </div>
+                    {/if}
+                </fieldset>
+            </div>
+            <div class="flex justify-end gap-2"
+                 style="border-top:1px solid var(--border);padding:0.75rem 1.25rem">
+                <button type="button"
+                        class="btn btn--ghost"
+                        onclick="history.go(-1)"
+                        data-testid="addserver-back">
+                    Back
+                </button>
+                <button type="submit"
+                        class="btn btn--primary"
+                        id="aserver"
+                        data-testid="addserver-submit">
+                    {$submit_text|escape}
+                </button>
+            </div>
+            <p id="addserver-error"
+               class="text-xs"
+               role="alert"
+               aria-live="polite"
+               data-testid="addserver-error"
+               style="margin:0 1.25rem 1rem;color:var(--danger);min-height:1rem"></p>
+        </form>
+    {/if}
+</section>
+{* Smarty default delimiters are { and }; the JSDoc + object literals
+   below would otherwise be parsed as template tags. {literal}…{/literal}
+   keeps the entire script body verbatim. *}
+{literal}
+<script>
+(function () {
+    'use strict';
+    var form = document.getElementById('addserver-form');
+    if (!form) return;
+    var submit = document.getElementById('aserver');
+    var errEl = document.getElementById('addserver-error');
+
+    function setError(msg) { if (errEl) errEl.textContent = msg || ''; }
+    function field(id) {
+        var el = document.getElementById(id);
+        return el ? el.value : '';
+    }
+    function checked(id) {
+        var el = document.getElementById(id);
+        return !!(el && el.checked);
+    }
+
+    form.addEventListener('submit', function (e) {
+        e.preventDefault();
+        setError('');
+        if (submit) submit.disabled = true;
+
+        var groups = '';
+        var inputs = form.querySelectorAll('input[name="groups[]"]');
+        for (var i = 0; i < inputs.length; i++) {
+            var cb = inputs[i];
+            if (cb.checked) groups += ',' + cb.value;
+        }
+
+        var api = window.sb && window.sb.api;
+        if (!api || !window.Actions) {
+            setError('JS API not loaded; refresh the page.');
+            if (submit) submit.disabled = false;
+            return;
+        }
+
+        api.call(window.Actions.ServersAdd, {
+            ip:       field('address'),
+            port:     field('port'),
+            rcon:     field('rcon'),
+            rcon2:    field('rcon2'),
+            mod:      Number(field('mod')),
+            enabled:  checked('enabled'),
+            group:    groups
+        }).then(function (r) {
+            if (submit) submit.disabled = false;
+            if (!r || r.ok === false) {
+                var msg = (r && r.error && r.error.message) || 'Could not add server.';
+                setError(msg);
+                if (window.SBPP && window.SBPP.showToast) {
+                    window.SBPP.showToast({ kind: 'error', title: 'Add server failed', body: msg });
+                }
+                return;
+            }
+            // The handler returns message.redir; navigate there ourselves
+            // since sbpp2026 does not ship the legacy applyApiResponse.
+            var d = (r && r.data) || {};
+            var redir = d.message && d.message.redir;
+            if (window.SBPP && window.SBPP.showToast && d.message) {
+                window.SBPP.showToast({ kind: 'success', title: d.message.title || 'Server added', body: d.message.body || '' });
+            }
+            if (typeof redir === 'string' && redir.length > 0) {
+                window.location.href = redir;
+            }
+        });
+    });
+})();
+</script>
+{/literal}

--- a/web/themes/sbpp2026/page_admin_servers_adminlist.tpl
+++ b/web/themes/sbpp2026/page_admin_servers_adminlist.tpl
@@ -1,6 +1,64 @@
-<div class="card">
-    <div class="card__body">
-        <h1>{$title}</h1>
-        <p class="text-muted">This page hasn't been redesigned yet.</p>
+{*
+    SourceBans++ 2026 — page_admin_servers_adminlist.tpl
+    Bound to Sbpp\View\AdminServersAdminListView (validated by SmartyTemplateRule).
+
+    Rendered by web/pages/admin.srvadmins.php — read-only list of admins
+    that have access to the selected server (directly or via a server
+    group). When the SourceQuery probe succeeded, each admin row also
+    surfaces their live in-game name + IP under an `In-game` column.
+
+    Auto-escape is on globally (init.php $theme->setEscapeHtml(true));
+    {$admin.user|escape} etc. are belt-and-braces because each value comes
+    out of the DB (admin display names) or a third-party gameserver
+    (in-game name / IP). No `nofilter` is used — every value goes through
+    the escaper.
+*}
+<section class="card" data-testid="server-admin-list">
+    <div class="card__header">
+        <div>
+            <h3>Admins on this server</h3>
+            <p>{$admin_count} {if $admin_count == 1}admin has{else}admins have{/if} access. Live in-game rows show the current connection details.</p>
+        </div>
     </div>
-</div>
+    {if $admin_count == 0}
+        <div class="card__body text-sm text-muted" data-testid="server-admin-empty">
+            No admins are mapped to this server yet.
+        </div>
+    {else}
+        <table class="table" data-testid="server-admin-table">
+            <thead>
+                <tr>
+                    <th style="width:30%">Admin</th>
+                    <th style="width:30%">SteamID</th>
+                    <th>In-game</th>
+                </tr>
+            </thead>
+            <tbody>
+                {foreach from=$admin_list item=admin}
+                    {if $admin.user}
+                        <tr data-testid="server-admin-row">
+                            <td>
+                                <span class="font-medium">{$admin.user|escape}</span>
+                            </td>
+                            <td class="font-mono text-xs">{$admin.authid|escape}</td>
+                            <td>
+                                {if $admin.ingame}
+                                    <span class="pill pill--online" data-testid="server-admin-ingame">
+                                        <span style="width:6px;height:6px;border-radius:50%;background:#10b981"></span>
+                                        Online
+                                    </span>
+                                    <div class="text-xs text-muted" style="margin-top:0.25rem">
+                                        as <span class="font-medium">{$admin.iname|escape}</span>
+                                        from <span class="font-mono">{$admin.iip|escape}</span>
+                                    </div>
+                                {else}
+                                    <span class="pill pill--offline">Offline</span>
+                                {/if}
+                            </td>
+                        </tr>
+                    {/if}
+                {/foreach}
+            </tbody>
+        </table>
+    {/if}
+</section>

--- a/web/themes/sbpp2026/page_admin_servers_list.tpl
+++ b/web/themes/sbpp2026/page_admin_servers_list.tpl
@@ -1,6 +1,197 @@
-<div class="card">
-    <div class="card__body">
-        <h1>{$title}</h1>
-        <p class="text-muted">This page hasn't been redesigned yet.</p>
-    </div>
-</div>
+{*
+    SourceBans++ 2026 — page_admin_servers_list.tpl
+    Bound to Sbpp\View\AdminServersListView (validated by SmartyTemplateRule).
+
+    Card grid replacement for the legacy table at
+    web/themes/default/page_admin_servers_list.tpl. Each row in the
+    server_list array carries: sid, ip, port, icon, enabled, rcon_access
+    (always present from admin.servers.php) plus mod_name (added in B15
+    so the card can render the mod label without a second query).
+
+    Live host / players / map are left as JS hydration targets — the
+    sbpp2026 chrome doesn't load the legacy LoadServerHost helper from
+    sourcebans.js, so until a Phase C JS lands, cards display the
+    canonical IP:port and a neutral status pill. data-id="{$server.sid}"
+    is the deterministic hook that hydration will key off (see the
+    "Testability hooks" rule in the B15 plan).
+
+    Remove flow uses Actions.ServersRemove via the inline script at the
+    bottom; CSRF is auto-attached by sb.api.call from the
+    meta[name=csrf-token] header (see web/scripts/api.js).
+*}
+<section class="page-section" data-testid="server-list-section" style="max-width:1400px">
+    {if NOT $permission_list}
+        <div class="card" data-testid="server-list-denied">
+            <div class="card__body">
+                <h3 style="margin:0 0 0.25rem">Access Denied</h3>
+                <p class="text-sm text-muted m-0">You don't have permission to list servers.</p>
+            </div>
+        </div>
+    {else}
+        <div class="flex items-center justify-between gap-4 mb-4" style="flex-wrap:wrap">
+            <div>
+                <h1 style="font-size:var(--fs-2xl);font-weight:600;margin:0">Servers</h1>
+                <p class="text-sm text-muted m-0 mt-2">
+                    <span data-testid="server-count" id="srvcount">{$server_count}</span>
+                    registered {if $server_count == 1}server{else}servers{/if}.
+                    Live host / map / player counts hydrate after first paint.
+                </p>
+            </div>
+            {if $permission_addserver}
+                <a class="btn btn--primary"
+                   href="#addserver"
+                   data-testid="server-list-add">
+                    Add server
+                </a>
+            {/if}
+        </div>
+
+        {if $server_count == 0}
+            <div class="card" data-testid="server-list-empty">
+                <div class="card__body text-sm text-muted">
+                    No servers configured yet.
+                    {if $permission_addserver}Use the form below to add one.{/if}
+                </div>
+            </div>
+        {else}
+            <div class="grid gap-4"
+                 style="grid-template-columns:repeat(auto-fill,minmax(20rem,1fr))"
+                 data-testid="server-grid">
+                {foreach from=$server_list item=server}
+                    <article class="card{if !$server.enabled} card--disabled{/if}"
+                             data-testid="server-tile"
+                             data-id="{$server.sid}"
+                             id="sid_{$server.sid}"
+                             style="{if !$server.enabled}opacity:0.65;{/if}display:flex;flex-direction:column;gap:0.75rem;padding:1rem">
+                        <header class="flex items-start gap-3">
+                            <span aria-hidden="true"
+                                  data-testid="server-tile-modicon"
+                                  style="width:36px;height:36px;border-radius:var(--radius-md);background:var(--bg-muted);display:grid;place-items:center;flex-shrink:0;overflow:hidden">
+                                {if $server.icon}
+                                    <img src="images/games/{$server.icon|escape}"
+                                         alt=""
+                                         style="width:24px;height:24px;object-fit:contain"
+                                         loading="lazy"
+                                         onerror="this.style.display='none'">
+                                {else}
+                                    <span class="text-xs font-semibold text-muted">#{$server.sid}</span>
+                                {/if}
+                            </span>
+                            <div style="flex:1;min-width:0">
+                                <div class="font-semibold truncate" data-testid="server-tile-name">
+                                    Server #{$server.sid}
+                                </div>
+                                <div class="font-mono text-xs text-muted truncate" data-testid="server-tile-host">
+                                    {$server.ip|escape}:{$server.port}
+                                </div>
+                            </div>
+                            {if !$server.enabled}
+                                <span class="pill pill--offline" title="Disabled — hidden from public lists">Disabled</span>
+                            {/if}
+                        </header>
+
+                        <dl class="text-xs text-muted" style="margin:0;display:grid;grid-template-columns:auto 1fr;gap:0.25rem 0.5rem">
+                            <dt style="font-weight:500;color:var(--text)">Mod</dt>
+                            <dd style="margin:0">{if isset($server.mod_name)}{$server.mod_name|escape}{else}<span class="text-faint">unknown</span>{/if}</dd>
+                            <dt style="font-weight:500;color:var(--text)">Players</dt>
+                            <dd style="margin:0" data-hydrate="players">—</dd>
+                            <dt style="font-weight:500;color:var(--text)">Map</dt>
+                            <dd style="margin:0" data-hydrate="map">—</dd>
+                        </dl>
+
+                        <footer class="flex gap-1" style="border-top:1px solid var(--border);padding-top:0.75rem;flex-wrap:wrap">
+                            {if $server.rcon_access}
+                                <a class="btn btn--secondary btn--sm"
+                                   data-testid="server-tile-rcon"
+                                   href="index.php?p=admin&c=servers&o=rcon&id={$server.sid|escape:'url'}">
+                                    RCON
+                                </a>
+                            {/if}
+                            <a class="btn btn--secondary btn--sm"
+                               data-testid="server-tile-admins"
+                               href="index.php?p=admin&c=servers&o=admincheck&id={$server.sid|escape:'url'}">
+                                Admins
+                            </a>
+                            {if $permission_editserver}
+                                <a class="btn btn--ghost btn--sm"
+                                   data-testid="server-tile-edit"
+                                   href="index.php?p=admin&c=servers&o=edit&id={$server.sid|escape:'url'}">
+                                    Edit
+                                </a>
+                            {/if}
+                            {if $pemission_delserver}
+                                <button type="button"
+                                        class="btn btn--ghost btn--sm"
+                                        data-testid="server-tile-delete"
+                                        data-action="server-delete"
+                                        data-sid="{$server.sid}"
+                                        data-label="{$server.ip|escape}:{$server.port}"
+                                        style="color:var(--danger);margin-left:auto">
+                                    Delete
+                                </button>
+                            {/if}
+                        </footer>
+                    </article>
+                {/foreach}
+            </div>
+        {/if}
+
+        {if $permission_addserver}
+            <div class="text-xs text-muted mt-4" data-testid="server-list-mapimg-hint">
+                Need to upload a map screenshot? Drop it under
+                <code class="font-mono">web/images/maps/</code> using the map name as the filename
+                (e.g. <code class="font-mono">de_dust2.jpg</code>).
+            </div>
+        {/if}
+    {/if}
+</section>
+{* Smarty default delimiters are { and }; the object literals below
+   would otherwise be parsed as template tags. {literal}…{/literal}
+   keeps the entire script body verbatim. *}
+{literal}
+<script>
+(function () {
+    'use strict';
+    document.addEventListener('click', function (e) {
+        var t = e.target;
+        if (!t || !t.closest) return;
+        var btn = t.closest('[data-action="server-delete"]');
+        if (!btn) return;
+        e.preventDefault();
+        var sid = Number(btn.dataset.sid);
+        var label = btn.dataset.label || ('Server #' + sid);
+        if (!Number.isFinite(sid) || sid <= 0) return;
+        if (!window.confirm('Delete ' + label + '?\n\nThis removes the server entry and any group/admin mappings. Bans logged from it are retained.')) {
+            return;
+        }
+        var api = window.sb && window.sb.api;
+        if (!api || !window.Actions) return;
+        btn.disabled = true;
+        api.call(window.Actions.ServersRemove, { sid: sid }).then(function (r) {
+            if (!r || r.ok === false) {
+                btn.disabled = false;
+                if (r && r.error && window.SBPP && window.SBPP.showToast) {
+                    window.SBPP.showToast({ kind: 'error', title: 'Delete failed', body: r.error.message || 'Unknown error' });
+                }
+                return;
+            }
+            // The handler returns { remove: 'sid_<id>', counter: { srvcount: <n> } };
+            // mirror what applyApiResponse does in sourcebans.js without
+            // dragging in the legacy module.
+            var d = (r && r.data) || {};
+            if (d.remove) {
+                var node = document.getElementById(String(d.remove));
+                if (node && node.parentNode) node.parentNode.removeChild(node);
+            }
+            if (d.counter && typeof d.counter.srvcount !== 'undefined') {
+                var counter = document.getElementById('srvcount');
+                if (counter) counter.textContent = String(d.counter.srvcount);
+            }
+            if (window.SBPP && window.SBPP.showToast) {
+                window.SBPP.showToast({ kind: 'success', title: 'Server deleted', body: label });
+            }
+        });
+    });
+})();
+</script>
+{/literal}

--- a/web/themes/sbpp2026/page_admin_servers_rcon.tpl
+++ b/web/themes/sbpp2026/page_admin_servers_rcon.tpl
@@ -1,6 +1,155 @@
-<div class="card">
-    <div class="card__body">
-        <h1>{$title}</h1>
-        <p class="text-muted">This page hasn't been redesigned yet.</p>
+-{*
+    SourceBans++ 2026 — page_admin_servers_rcon.tpl
+    Bound to Sbpp\View\AdminServersRconView (validated by SmartyTemplateRule).
+
+    Rendered by web/pages/admin.rcon.php with the custom -{ … }- delimiter
+    pair (the legacy template body shipped with literal jQuery/JS braces
+    that would otherwise collide with default { … } Smarty markers). The
+    paired view declares DELIMITERS = ['-{', '}-'] so the analyser knows
+    to scan for -{$var}- references.
+
+    The console talks to Actions.ServersSendRcon (registered in
+    web/api/handlers/_register.php with the SM_RCON|SM_ROOT mask). The
+    dispatcher enforces the permission flag and the per-server scoping
+    re-check; this page additionally hides the UI entirely when
+    $permission_rcon is false so a stray link can't surface a console an
+    admin can't actually use.
+
+    Inline <script> is intentional — sbpp2026's chrome only loads sb.js
+    + api.js + theme.js, not the legacy sourcebans.js, so we wire the
+    handful of UX behaviours in line rather than depending on a
+    helper that won't exist at runtime. CSRF is auto-attached by
+    sb.api.call via the meta[name=csrf-token] header.
+*}-
+-{if NOT $permission_rcon}-
+    <section class="card" data-testid="rcon-denied">
+        <div class="card__body">
+            <h3 style="margin:0 0 0.25rem">Access Denied</h3>
+            <p class="text-sm text-muted m-0">You don't have RCON access to this server.</p>
+        </div>
+    </section>
+-{else}-
+<section class="card" data-testid="rcon-console" data-sid="-{$id}-">
+    <div class="card__header">
+        <div>
+            <h3>RCON Console</h3>
+            <p>Server #-{$id}- · type <code class="font-mono">clr</code> to clear · output is rendered as plain text.</p>
+        </div>
     </div>
-</div>
+    <div class="card__body">
+        -{*
+            Output area is the deterministic rendering target for
+            Actions.ServersSendRcon. Keep id="rcon_con" as the container
+            (matches the structural contract the legacy theme uses) and
+            id="rcon" as the scroll wrapper so the inline script can
+            re-scroll on append. data-testid is the new attribute the
+            redesign tests target.
+        *}-
+        <pre id="rcon"
+             data-testid="rcon-output"
+             style="margin:0;background:var(--bg-page);border:1px solid var(--border);border-radius:var(--radius-md);padding:0.75rem;height:18rem;overflow:auto;font-family:var(--font-mono);font-size:var(--fs-xs);color:var(--text);white-space:pre-wrap;word-break:break-word"><div id="rcon_con">SourceBans++ RCON console
+==========================================================
+Type your command in the box below and hit Enter.
+Type 'clr' to clear the console.
+==========================================================
+</div></pre>
+        <form id="rcon-form" class="flex gap-2 mt-4" autocomplete="off">
+            -{csrf_field}-
+            <input type="text"
+                   id="cmd"
+                   name="cmd"
+                   class="input font-mono"
+                   data-testid="rcon-input"
+                   placeholder="status"
+                   autocomplete="off"
+                   spellcheck="false"
+                   style="flex:1">
+            <button type="submit"
+                    id="rcon_btn"
+                    class="btn btn--primary"
+                    data-testid="rcon-send">
+                Send
+            </button>
+        </form>
+    </div>
+</section>
+<script>
+(function () {
+    'use strict';
+    var sid = -{$id}-;
+    var form = document.getElementById('rcon-form');
+    var input = document.getElementById('cmd');
+    var btn = document.getElementById('rcon_btn');
+    var out = document.getElementById('rcon_con');
+    var box = document.getElementById('rcon');
+    if (!form || !input || !btn || !out || !box) return;
+
+    function scrollToBottom() { box.scrollTop = box.scrollHeight; }
+
+    function appendLine(prefix, text, kind) {
+        var div = document.createElement('div');
+        if (kind) div.dataset.kind = kind;
+        div.textContent = prefix + (text || '');
+        out.appendChild(div);
+    }
+
+    function appendOutput(raw) {
+        // textContent splits + appendChild guarantees the gameserver-controlled
+        // bytes never touch innerHTML — same defensive shape the legacy
+        // LoadSendRcon helper uses in web/scripts/sourcebans.js.
+        String(raw || '').split('\n').forEach(function (line, i, arr) {
+            var span = document.createElement('span');
+            span.textContent = line;
+            out.appendChild(span);
+            if (i < arr.length - 1) out.appendChild(document.createElement('br'));
+        });
+        out.appendChild(document.createElement('br'));
+    }
+
+    function setBusy(busy) {
+        input.disabled = busy;
+        btn.disabled = busy;
+        if (!busy) input.focus();
+    }
+
+    function send() {
+        var command = input.value;
+        if (!command) return;
+        setBusy(true);
+        var api = window.sb && window.sb.api;
+        if (!api || !window.Actions) {
+            setBusy(false);
+            return;
+        }
+        api.call(window.Actions.ServersSendRcon, { sid: sid, command: command, output: true }).then(function (r) {
+            input.value = '';
+            setBusy(false);
+            if (!r || !r.ok || !r.data) {
+                if (r && r.error && window.SBPP && window.SBPP.showToast) {
+                    window.SBPP.showToast({ kind: 'error', title: 'RCON failed', body: r.error.message || 'Unknown error' });
+                }
+                return;
+            }
+            var d = r.data;
+            if (d.kind === 'clear') { out.innerHTML = ''; return; }
+            if (d.kind === 'noop') { return; }
+            if (d.kind === 'error') {
+                appendLine('> Error: ', d.error || '', 'error');
+                out.appendChild(document.createElement('br'));
+                scrollToBottom();
+                return;
+            }
+            if (d.kind === 'append') {
+                appendLine('-> ', d.command || '', 'cmd');
+                appendOutput(d.output);
+                scrollToBottom();
+            }
+        });
+    }
+
+    form.addEventListener('submit', function (e) { e.preventDefault(); send(); });
+    input.focus();
+    scrollToBottom();
+})();
+</script>
+-{/if}-

--- a/web/themes/sbpp2026/page_admin_servers_rcon.tpl
+++ b/web/themes/sbpp2026/page_admin_servers_rcon.tpl
@@ -2,17 +2,18 @@
     SourceBans++ 2026 — page_admin_servers_rcon.tpl
     Bound to Sbpp\View\AdminServersRconView (validated by SmartyTemplateRule).
 
-    Rendered by web/pages/admin.rcon.php with the custom -{ … }- delimiter
-    pair (the legacy template body shipped with literal jQuery/JS braces
-    that would otherwise collide with default { … } Smarty markers). The
-    paired view declares DELIMITERS = ['-{', '}-'] so the analyser knows
-    to scan for -{$var}- references.
+    Rendered by web/pages/admin.rcon.php with the custom alternate
+    delimiter pair (the legacy template body shipped with literal
+    jQuery/JS braces that would otherwise collide with the default
+    Smarty markers). The paired view overrides View::DELIMITERS so the
+    analyser scans this template with the alternate pair too — see the
+    AdminServersRconView class docblock for the literal pair.
 
     The console talks to Actions.ServersSendRcon (registered in
     web/api/handlers/_register.php with the SM_RCON|SM_ROOT mask). The
     dispatcher enforces the permission flag and the per-server scoping
     re-check; this page additionally hides the UI entirely when
-    $permission_rcon is false so a stray link can't surface a console an
+    permission_rcon is false so a stray link can't surface a console an
     admin can't actually use.
 
     Inline <script> is intentional — sbpp2026's chrome only loads sb.js


### PR DESCRIPTION
## Summary

Phase B15 of the #1123 sbpp2026 theme rollout: swap the four admin
"Servers" templates for the new theme and finish wiring the page
handler to the View DTO pattern Phase A established. Touches only
files in scope per the plan; no API handlers / `init.php` / `core/` /
`css/` / `js/` / contract changes.

The screens covered:

- **Server list** (`?p=admin&c=servers`) — card grid replacing the
  legacy table. Each card has `data-testid=\"server-tile\"` +
  `data-id=\"{$server.sid}\"`, a status pill, mod label, and gated
  RCON / Admins / Edit / Delete buttons. Inline `{literal}` script
  wires Delete confirmation through `Actions.ServersRemove`.
- **Add server** (rendered just below the grid) — full form with
  `{csrf_field}`, every input tagged `data-testid=\"addserver-*\"`,
  inline submit handler calling `Actions.ServersAdd` (sbpp2026 doesn't
  load the legacy `process_add_server()` helper from
  `web/scripts/sourcebans.js`, so the form posts via `sb.api.call`
  directly).
- **Server admin list** (`?p=admin&c=servers&o=admincheck&id=…`,
  rendered by `admin.srvadmins.php`) — table of admins mapped to a
  server, with a live status pill when the SourceQuery probe
  succeeded.
- **RCON console** (`?p=admin&c=servers&o=rcon&id=…`, rendered by
  `admin.rcon.php`) — terminal-style console with
  `data-testid=\"rcon-input\"` / `rcon-output`. Inline script speaks
  `Actions.ServersSendRcon`; the legacy `id=\"rcon\"` /
  `id=\"rcon_con\"` / `id=\"cmd\"` IDs are preserved so any external
  scripting that targets the console still finds them. Uses the
  custom `-{ … }-` delimiter pair to match how `admin.rcon.php`
  configures Smarty.

## What changed

- `web/themes/sbpp2026/page_admin_servers_list.tpl` — card grid.
- `web/themes/sbpp2026/page_admin_servers_add.tpl` — add form with
  `{csrf_field}` + JSON-API submit.
- `web/themes/sbpp2026/page_admin_servers_adminlist.tpl` — admins on
  this server.
- `web/themes/sbpp2026/page_admin_servers_rcon.tpl` — RCON console
  using the `-{ … }-` delimiter pair.
- `web/includes/View/AdminServersAdminListView.php` (new) — declares
  `\$admin_count` + `\$admin_list`.
- `web/includes/View/AdminServersRconView.php` (new) — declares
  `\$id` + `\$permission_rcon`, overrides `View::DELIMITERS` so
  SmartyTemplateRule scans the template with the `-{ … }-` pair.
- `web/pages/admin.servers.php` — extended the existing list query
  with `mo.name AS mod_name` so the new card can render the mod
  label without a second per-tile query (the legacy default-theme
  template ignores the column, so both themes share the same data
  shape). The `Renderer::render` calls were already in place from
  Phase A.

## Notes

- No new permission flags. `permission_list` / `permission_addserver`
  / `permission_editserver` / `pemission_delserver` (historical typo
  preserved to match the existing baseline) are still precomputed in
  `admin.servers.php`.
- No changes to API handlers — the four screens reuse
  `servers.add`, `servers.remove`, `servers.send_rcon`.
- Every `{literal}…{/literal}` block exists because the inline JS
  uses object literals + control-flow braces that would otherwise be
  parsed as Smarty tags. **No `nofilter` is used anywhere** in the
  four templates; every dynamic value goes through Smarty's
  auto-escape (or an explicit `|escape`) before reaching the page.
- `admin.rcon.php` and `admin.srvadmins.php` are unchanged — they
  already drive their templates through `\$theme->display(...)` and
  the paired Views satisfy SmartyTemplateRule.

## Test plan

- [x] `./sbpp.sh phpstan` (default theme matrix leg) → **OK**
- [x] `SBPP_PHPSTAN_THEME=sbpp2026 phpstan` (sbpp2026 leg) → **OK**
- [x] `./sbpp.sh ts-check` → **OK**
- [x] `./sbpp.sh composer api-contract` → no diff (handlers untouched)
- [x] `./sbpp.sh test` → 268 tests, 1134 assertions → **OK**
- [x] Smoke test in browser via `./sbpp.sh up`:
  - `?p=admin&c=servers` (list + add form) renders end-to-end.
  - `?p=admin&c=servers&o=rcon&id=…` renders the console (Access
    Denied path also verified by clearing the per-server mapping).
  - `?p=admin&c=servers&o=admincheck&id=…` renders the admin list
    with both online + offline states (verified by mocking
    \`checkMultiplePlayers\`'s output).