### PR TITLE
[#1123 B17] Redesign admin overrides

### DIFF
--- a/web/includes/View/AdminOverridesView.php
+++ b/web/includes/View/AdminOverridesView.php
@@ -1,0 +1,50 @@
+<?php
+declare(strict_types=1);
+
+namespace Sbpp\View;
+
+/**
+ * SourceMod command/group overrides editor — binds to
+ * `page_admin_overrides.tpl`. Overrides let admins flip the required
+ * flags on any in-game command without editing plugin source.
+ *
+ * Until #1123 D1 cuts over, the same DTO has to satisfy both
+ * `web/themes/default/page_admin_overrides.tpl` (legacy markup) and
+ * `web/themes/sbpp2026/page_admin_overrides.tpl` (new redesign), so:
+ *
+ *   - The permission gate is exposed as `$permission_addadmin` (the
+ *     legacy name) rather than the canonical `can_add_admins` from
+ *     {@see Perms::for()}; renaming it would require editing the
+ *     legacy default template, which is out of scope for B17.
+ *   - Each row in `$overrides_list` carries BOTH the legacy
+ *     `id` / `name` keys (read by the default template) AND the
+ *     handoff-style `oid` / `command_or_group` aliases (read by the
+ *     sbpp2026 template). They point at the same underlying DB
+ *     columns; the SmartyTemplateRule only checks top-level vars, so
+ *     row-level alias keys cost nothing.
+ *
+ * The wiring lives in `web/pages/admin.overrides.php`. The legacy
+ * `web/pages/admin.admins.php` `require`s that file at the bottom so
+ * the existing `?p=admin&c=admins` URL keeps its three-tab layout.
+ */
+final class AdminOverridesView extends View
+{
+    public const TEMPLATE = 'page_admin_overrides.tpl';
+
+    /**
+     * @param list<array<string,mixed>> $overrides_list Each entry is a
+     *     row from `:prefix_overrides` augmented with the handoff-style
+     *     aliases. Effective row shape:
+     *     `id` (int), `oid` (int, alias of `id`),
+     *     `type` ('command'|'group'),
+     *     `name` (string), `command_or_group` (string, alias of `name`),
+     *     `flags` (string).
+     */
+    public function __construct(
+        public readonly bool $permission_addadmin,
+        public readonly string $overrides_error,
+        public readonly bool $overrides_save_success,
+        public readonly array $overrides_list,
+    ) {
+    }
+}

--- a/web/pages/admin.admins.php
+++ b/web/pages/admin.admins.php
@@ -279,90 +279,9 @@ $serverscript .= "</script>";
     server_group_list: $server_group_list,
     server_script: $serverscript,
 ));
-// Overrides
 
-// Saving changed overrides
-$overrides_error        = "";
-$overrides_save_success = false;
-try {
-    if (isset($_POST['new_override_name'])) {
-        // Handle old overrides, if there are any.
-        if (isset($_POST['override_id'])) {
-            // Apply changes first
-            $edit_errors = "";
-            foreach ($_POST['override_id'] as $index => $id) {
-                // Skip invalid stuff?!
-                if ($_POST['override_type'][$index] != "command" && $_POST['override_type'][$index] != "group") {
-                    continue;
-                }
-
-                $id = (int) $id;
-                // Wants to delete this override?
-                if (empty($_POST['override_name'][$index])) {
-                    $GLOBALS['PDO']->query("DELETE FROM `:prefix_overrides` WHERE id = :id");
-                    $GLOBALS['PDO']->bind(':id', $id);
-                    $GLOBALS['PDO']->execute();
-                    continue;
-                }
-
-                // Check for duplicates
-                $chk = $GLOBALS['PDO']->query("SELECT * FROM `:prefix_overrides` WHERE name = ? AND type = ? AND id != ?")->resultset([
-                    $_POST['override_name'][$index],
-                    $_POST['override_type'][$index],
-                    $id,
-                ]);
-                if (!empty($chk)) {
-                    $edit_errors .= "&bull; There already is an override with name \\\"" . htmlspecialchars(addslashes($_POST['override_name'][$index])) . "\\\" from the selected type.<br />";
-                    continue;
-                }
-
-                // Edit the override
-                $GLOBALS['PDO']->query("UPDATE `:prefix_overrides` SET name = ?, type = ?, flags = ? WHERE id = ?")->execute([
-                    $_POST['override_name'][$index],
-                    $_POST['override_type'][$index],
-                    trim($_POST['override_flags'][$index]),
-                    $id,
-                ]);
-            }
-
-            if (!empty($edit_errors)) {
-                throw new Exception("There were errors applying your changes:<br /><br />" . $edit_errors);
-            }
-        }
-
-        // Add a new override
-        if (!empty($_POST['new_override_name'])) {
-            if ($_POST['new_override_type'] != "command" && $_POST['new_override_type'] != "group") {
-                throw new Exception("Invalid override type.");
-            }
-
-            // Check for duplicates
-            $chk = $GLOBALS['PDO']->query("SELECT * FROM `:prefix_overrides` WHERE name = ? AND type = ?")->resultset([
-                $_POST['new_override_name'],
-                $_POST['new_override_type'],
-            ]);
-            if (!empty($chk)) {
-                throw new Exception("There already is an override with that name from the selected type.");
-            }
-
-            // Insert the new override
-            $GLOBALS['PDO']->query("INSERT INTO `:prefix_overrides` (type, name, flags) VALUES (?, ?, ?)")->execute([
-                $_POST['new_override_type'],
-                $_POST['new_override_name'],
-                trim($_POST['new_override_flags']),
-            ]);
-        }
-
-        $overrides_save_success = true;
-    }
-} catch (Exception $e) {
-    $overrides_error = $e->getMessage();
-}
-
-$overrides_list = $GLOBALS['PDO']->query("SELECT * FROM `:prefix_overrides`")->resultset();
-
-$theme->assign('overrides_list', $overrides_list);
-$theme->assign('overrides_error', $overrides_error);
-$theme->assign('overrides_save_success', $overrides_save_success);
-$theme->assign('permission_addadmin', $userbank->HasAccess(ADMIN_OWNER | ADMIN_ADD_ADMINS));
-$theme->display('page_admin_overrides.tpl');
+// Overrides — extracted into its own handler in #1123 B17 so the
+// "single-template, single-View" pattern lines up with one .tpl per
+// theme and one Sbpp\View\AdminOverridesView. The require keeps the
+// existing AdminTabs ?p=admin&c=admins URL working unchanged.
+require(TEMPLATES_PATH . "/admin.overrides.php");

--- a/web/pages/admin.overrides.php
+++ b/web/pages/admin.overrides.php
@@ -1,0 +1,129 @@
+<?php
+/*************************************************************************
+This file is part of SourceBans++
+
+SourceBans++ (c) 2014-2026 by SourceBans++ Dev Team
+
+The SourceBans++ Web panel is licensed under a
+Creative Commons Attribution-NonCommercial-ShareAlike 3.0 Unported License.
+
+You should have received a copy of the license along with this
+work.  If not, see <http://creativecommons.org/licenses/by-nc-sa/3.0/>.
+
+This program is based off work covered by the following copyright(s):
+SourceBans 1.4.11
+Copyright © 2007-2014 SourceBans Team - Part of GameConnect
+Licensed under CC-BY-NC-SA 3.0
+Page: <http://www.sourcebans.net/> - <http://www.gameconnect.net/>
+*************************************************************************/
+
+/*
+ * SourceMod command/group override editor — extracted from
+ * admin.admins.php during the #1123 B17 single-template redesign so
+ * the overrides "tab" has a single PHP handler, a single
+ * `Sbpp\View\AdminOverridesView` DTO, and a single `.tpl` per theme
+ * (default + sbpp2026). admin.admins.php still routes here via a
+ * top-level `require`, so the existing `?p=admin&c=admins` URL keeps
+ * its three-tab layout.
+ *
+ * The save/delete/duplicate-check logic below is the verbatim block
+ * that used to live at the bottom of admin.admins.php; the move is
+ * mechanical so behaviour parity (incl. error messages and the
+ * delete-by-blanking-name UX) is preserved.
+ */
+
+if (!defined("IN_SB")) {
+    echo "You should not be here. Only follow links!";
+    die();
+}
+
+global $userbank, $theme;
+
+$overrides_error        = "";
+$overrides_save_success = false;
+
+try {
+    if (isset($_POST['new_override_name'])) {
+        if (isset($_POST['override_id'])) {
+            $edit_errors = "";
+            foreach ($_POST['override_id'] as $index => $id) {
+                if ($_POST['override_type'][$index] != "command" && $_POST['override_type'][$index] != "group") {
+                    continue;
+                }
+
+                $id = (int) $id;
+                if (empty($_POST['override_name'][$index])) {
+                    $GLOBALS['PDO']->query("DELETE FROM `:prefix_overrides` WHERE id = :id");
+                    $GLOBALS['PDO']->bind(':id', $id);
+                    $GLOBALS['PDO']->execute();
+                    continue;
+                }
+
+                $chk = $GLOBALS['PDO']->query("SELECT id FROM `:prefix_overrides` WHERE name = ? AND type = ? AND id != ?")->resultset([
+                    $_POST['override_name'][$index],
+                    $_POST['override_type'][$index],
+                    $id,
+                ]);
+                if (!empty($chk)) {
+                    $edit_errors .= "&bull; There already is an override with name \\\"" . htmlspecialchars(addslashes($_POST['override_name'][$index])) . "\\\" from the selected type.<br />";
+                    continue;
+                }
+
+                $GLOBALS['PDO']->query("UPDATE `:prefix_overrides` SET name = ?, type = ?, flags = ? WHERE id = ?")->execute([
+                    $_POST['override_name'][$index],
+                    $_POST['override_type'][$index],
+                    trim($_POST['override_flags'][$index]),
+                    $id,
+                ]);
+            }
+
+            if (!empty($edit_errors)) {
+                throw new Exception("There were errors applying your changes:<br /><br />" . $edit_errors);
+            }
+        }
+
+        if (!empty($_POST['new_override_name'])) {
+            if ($_POST['new_override_type'] != "command" && $_POST['new_override_type'] != "group") {
+                throw new Exception("Invalid override type.");
+            }
+
+            $chk = $GLOBALS['PDO']->query("SELECT id FROM `:prefix_overrides` WHERE name = ? AND type = ?")->resultset([
+                $_POST['new_override_name'],
+                $_POST['new_override_type'],
+            ]);
+            if (!empty($chk)) {
+                throw new Exception("There already is an override with that name from the selected type.");
+            }
+
+            $GLOBALS['PDO']->query("INSERT INTO `:prefix_overrides` (type, name, flags) VALUES (?, ?, ?)")->execute([
+                $_POST['new_override_type'],
+                $_POST['new_override_name'],
+                trim($_POST['new_override_flags']),
+            ]);
+        }
+
+        $overrides_save_success = true;
+    }
+} catch (Exception $e) {
+    $overrides_error = $e->getMessage();
+}
+
+$overrides_rows = $GLOBALS['PDO']->query("SELECT id, type, name, flags FROM `:prefix_overrides`")->resultset();
+
+// Carry both the legacy `id`/`name` keys (used by the default theme's
+// page_admin_overrides.tpl) and the redesigned `oid`/`command_or_group`
+// aliases (used by the sbpp2026 template) so the same DTO satisfies
+// both .tpl files during the dual-theme rollout.
+$overrides_list = [];
+foreach ($overrides_rows as $row) {
+    $row['oid']              = (int) $row['id'];
+    $row['command_or_group'] = (string) $row['name'];
+    $overrides_list[]        = $row;
+}
+
+\Sbpp\View\Renderer::render($theme, new \Sbpp\View\AdminOverridesView(
+    permission_addadmin: $userbank->HasAccess(ADMIN_OWNER | ADMIN_ADD_ADMINS),
+    overrides_error: $overrides_error,
+    overrides_save_success: $overrides_save_success,
+    overrides_list: $overrides_list,
+));

--- a/web/themes/sbpp2026/page_admin_overrides.tpl
+++ b/web/themes/sbpp2026/page_admin_overrides.tpl
@@ -1,6 +1,135 @@
-<div class="card">
-    <div class="card__body">
-        <h1>{$title}</h1>
-        <p class="text-muted">This page hasn't been redesigned yet.</p>
+{*
+    SourceBans++ 2026 — page_admin_overrides.tpl
+
+    SourceMod command/group overrides editor. Pair: Sbpp\View\AdminOverridesView.
+
+    Behavior parity with web/themes/default/page_admin_overrides.tpl:
+      - Existing rows show editable type/name/flags + a hidden `override_id[]`.
+      - Blanking out the name on an existing row deletes it on POST
+        (parity with the legacy handler in admin.overrides.php).
+      - The bottom "add" row maps to `new_override_*` POST fields.
+      - {csrf_field} is required because the dispatcher invokes
+        CSRF::rejectIfInvalid() on every POST.
+*}
+<div class="tabcontent" id="Overrides">
+{if not $permission_addadmin}
+    <div class="card">
+        <div class="card__body">
+            <p class="text-muted m-0">Access denied.</p>
+        </div>
     </div>
+{else}
+    {if $overrides_error != ""}
+        <div class="card mb-4" role="alert" style="border-color:var(--danger);background:var(--danger-bg)">
+            <div class="card__body" style="color:#b91c1c">
+                <strong>Error</strong>
+                {* nofilter: $overrides_error is built by the handler from Exception::getMessage(); any user-controlled override name embedded in it is run through htmlspecialchars(addslashes(...)) in admin.overrides.php before concatenation, and the surrounding wrapper is server-built static HTML — same provenance as the legacy ShowBox() path *}
+                <div class="mt-2 text-sm" data-testid="overrides-error">{$overrides_error nofilter}</div>
+            </div>
+        </div>
+    {/if}
+    {if $overrides_save_success}
+        <div class="card mb-4" role="status" style="border-color:var(--success);background:var(--success-bg)">
+            <div class="card__body" style="color:#047857" data-testid="overrides-success">
+                <strong>Saved.</strong> The override changes have been applied.
+            </div>
+        </div>
+    {/if}
+
+    <form method="post" action="index.php?p=admin&amp;c=admins" data-testid="overrides-form">
+        {csrf_field}
+
+        <div class="card mb-4">
+            <div class="card__header">
+                <div>
+                    <h3>Command &amp; group overrides</h3>
+                    <p>
+                        Override the flags required to run any SourceMod command, globally
+                        or per-group, without editing plugin source. Blank out a name to
+                        delete that override on save.
+                        See <a href="https://wiki.alliedmods.net/Overriding_Command_Access_%28SourceMod%29"
+                              target="_blank" rel="noopener noreferrer">overriding command access</a>
+                        in the AlliedModders wiki for a flag reference.
+                    </p>
+                </div>
+            </div>
+            <div class="card__body">
+                <table class="table" data-testid="overrides-table">
+                    <thead>
+                        <tr>
+                            <th style="width:8rem">Type</th>
+                            <th>Name</th>
+                            <th style="width:14rem">Flags</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {foreach from=$overrides_list item=override}
+                            <tr data-testid="override-row" data-id="{$override.oid}">
+                                <td>
+                                    <select class="select" name="override_type[]" aria-label="Override type">
+                                        <option value="command"{if $override.type == "command"} selected="selected"{/if}>Command</option>
+                                        <option value="group"{if $override.type == "group"} selected="selected"{/if}>Group</option>
+                                    </select>
+                                    <input type="hidden" name="override_id[]" value="{$override.oid}" />
+                                </td>
+                                <td>
+                                    <input class="input font-mono" name="override_name[]"
+                                           value="{$override.command_or_group}"
+                                           aria-label="Override name (blank to delete)" />
+                                </td>
+                                <td>
+                                    <input class="input font-mono" name="override_flags[]"
+                                           value="{$override.flags}"
+                                           aria-label="Override flags" />
+                                </td>
+                            </tr>
+                        {foreachelse}
+                            <tr data-testid="overrides-empty">
+                                <td colspan="3" class="text-muted text-sm" style="text-align:center;padding:1.5rem">
+                                    No overrides configured yet — add one below.
+                                </td>
+                            </tr>
+                        {/foreach}
+                    </tbody>
+                </table>
+            </div>
+        </div>
+
+        <div class="card mb-4">
+            <div class="card__header">
+                <div>
+                    <h3>Add an override</h3>
+                    <p>Pick a type, give it a command/group name and the flags admins need to run it.</p>
+                </div>
+            </div>
+            <div class="card__body">
+                <div class="grid gap-3" style="grid-template-columns:8rem 1fr 14rem">
+                    <div>
+                        <label class="label" for="addoverride-type">Type</label>
+                        <select class="select" id="addoverride-type" name="new_override_type"
+                                data-testid="addoverride-type">
+                            <option value="command">Command</option>
+                            <option value="group">Group</option>
+                        </select>
+                    </div>
+                    <div>
+                        <label class="label" for="addoverride-name">Name</label>
+                        <input class="input font-mono" id="addoverride-name" name="new_override_name"
+                               data-testid="addoverride-name" autocomplete="off" />
+                    </div>
+                    <div>
+                        <label class="label" for="addoverride-flags">Flags</label>
+                        <input class="input font-mono" id="addoverride-flags" name="new_override_flags"
+                               data-testid="addoverride-flags" autocomplete="off" />
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <div class="flex justify-end gap-2">
+            <a class="btn btn--ghost" href="javascript:history.go(-1);" data-testid="overrides-back">Back</a>
+            <button class="btn btn--primary" type="submit" data-testid="overrides-save">Save changes</button>
+        </div>
+    </form>
+{/if}
 </div>


### PR DESCRIPTION
## Summary

Phase B17 of the #1123 sbpp2026 theme migration. Extracts the
SourceMod command/group overrides editor out of `admin.admins.php`'s
tab grab-bag into a single-template, single-View unit so each Phase B
ticket maps cleanly to one `Sbpp\View\*` DTO and one `.tpl` per
theme.

- New `web/pages/admin.overrides.php` holds the POST save/delete/dup
  logic (verbatim from the legacy block) and renders via
  `Sbpp\View\Renderer` with the new `AdminOverridesView` DTO.
- `web/pages/admin.admins.php` delegates the overrides tab to the
  new file via a top-level `require`, so the existing AdminTabs URL
  (`?p=admin&c=admins`) keeps its three-tab layout unchanged for
  both themes (no routing change).
- `web/includes/View/AdminOverridesView.php` declares the four
  template variables (`permission_addadmin`, `overrides_error`,
  `overrides_save_success`, `overrides_list`) the legacy default
  template still needs, so `SmartyTemplateRule` matches both themes.
  Each row carries both the legacy `id`/`name` keys and the
  redesigned `oid`/`command_or_group` aliases so the same DTO
  satisfies both `.tpl` files during the dual-theme rollout.
- `web/themes/sbpp2026/page_admin_overrides.tpl` replaces the A1
  stub with a real redesign (cards, inputs, table) that:
  - calls `{csrf_field}` on the form,
  - tags each row with `data-testid="override-row"` +
    `data-id="{$override.oid}"`,
  - tags the add-row inputs with `data-testid="addoverride-{type,name,flags}"`,
  - keeps every `{nofilter}` (just the `$overrides_error` HTML)
    behind the canonical safety comment per AGENTS.md.

## Local gates

| Gate | Result |
| --- | --- |
| `./sbpp.sh phpstan` (default theme) | OK No errors (175 files) |
| `SBPP_PHPSTAN_THEME=sbpp2026 ... phpstan-sbpp2026.neon` | OK No errors (175 files) |
| `./sbpp.sh ts-check` | OK |
| `./sbpp.sh composer api-contract` | clean diff (no handler changes) |
| `./sbpp.sh test --filter='AdminFlowTest|AdminsTest|PermissionMatrixTest'` | OK (79 tests, 311 assertions) |

The full test suite was noisy on this worker due to multiple parallel
B-task agents sharing the same dev DB volume (race conditions on
`Fixture::install()` dropping/recreating `sourcebans_test` between
them); the targeted admin-suite + matrix run above is the relevant
slice and is clean.

## Manual smoke

Hit `?p=admin&c=admins` on both themes against the worker's local
stack (`http://localhost:8390`) after seeding two override rows:

- Default theme: legacy `page_admin_overrides.tpl` still renders with
  the existing copy and form fields (no behavioural diff).
- sbpp2026 theme: renders the redesigned card layout, two
  `<tr data-testid="override-row" data-id="1">` /
  `data-id="2"` rows with the right type/name/flags pre-filled, and
  the add-row with `data-testid="addoverride-type|name|flags"` hooks.

## Test plan

- [ ] CI: PHPStan (default + sbpp2026 matrix) green
- [ ] CI: PHPUnit green (this PR doesn't touch any handler so the
      shared DB races above shouldn't recur on a clean runner)
- [ ] CI: ts-check green
- [ ] CI: api-contract green (no diff expected)
- [ ] Reviewer manual: switch a test admin to `sbpp2026` theme, hit
      `?p=admin&c=admins`, click the **Overrides** tab, add / edit / delete
      rows, confirm the success/error banners render and that
      blanking out a name still deletes that override on save (parity
      with the legacy default-theme tab).