### PR TITLE
[#1123 B9] Redesign kickit + blockit + uploadfile

### DIFF
--- a/web/includes/View/BlockitView.php
+++ b/web/includes/View/BlockitView.php
@@ -1,0 +1,36 @@
+<?php
+declare(strict_types=1);
+
+namespace Sbpp\View;
+
+/**
+ * Per-server "block this player" iframe — binds to `page_blockit.tpl`.
+ *
+ * Mirrors {@see KickitView} (same iframe contract, same `-{ … }-`
+ * delimiter rationale) but for the comm-block flow spawned by
+ * `ShowBlockBox()` in `web/scripts/sourcebans.js` after a comm block
+ * is added. The {@link api_blockit_block_player()} JSON action takes
+ * the same `check` / `sid` / `num` / `type` plus a `length` (block
+ * duration) parameter, so this view carries one extra property
+ * compared to {@see KickitView}.
+ */
+final class BlockitView extends View
+{
+    public const TEMPLATE = 'page_blockit.tpl';
+
+    /** @var array{0: string, 1: string} */
+    public const DELIMITERS = ['-{', '}-'];
+
+    /**
+     * @param list<array{num:int, ip:string, port:string|int}> $servers
+     */
+    public function __construct(
+        public readonly string $csrf_token,
+        public readonly int $total,
+        public readonly string $check,
+        public readonly int $type,
+        public readonly int $length,
+        public readonly array $servers,
+    ) {
+    }
+}

--- a/web/includes/View/KickitView.php
+++ b/web/includes/View/KickitView.php
@@ -1,0 +1,56 @@
+<?php
+declare(strict_types=1);
+
+namespace Sbpp\View;
+
+/**
+ * Per-server "kick this player" iframe — binds to `page_kickit.tpl`.
+ *
+ * Renders inside an iframe spawned by `ShowKickBox()` in
+ * `web/scripts/sourcebans.js` after a ban is added. It is a
+ * self-contained `<html>` document (no chrome shell) and uses the
+ * `-{ … }-` Smarty delimiter pair so the inline JS can keep its raw
+ * `{` / `}` tokens.
+ *
+ * The property set is the union of what the **default** and
+ * **sbpp2026** themes' `page_kickit.tpl` consume — both legs of the
+ * dual-theme PHPStan matrix (#1123 A2) scan against the same View, so
+ * mismatches between either template and this contract surface as
+ * `sbpp.view.{missingProperty,unusedProperty}` errors before merge.
+ *
+ *   - `$csrf_token`: HTML `<meta name="csrf-token">` payload — sb.api
+ *     reads it for the X-CSRF-Token header on every JSON call.
+ *   - `$total`: row count, used by the iframe-internal counter that
+ *     decides when to redirect the parent window back to the bans
+ *     admin list.
+ *   - `$check` / `$type`: pass-through query params forwarded into
+ *     {@link api_kickit_kick_player()} (steam id / ip + integer
+ *     discriminator).
+ *   - `$servers`: per-row markers for the polling JS; the
+ *     {@link api_kickit_load_servers()} JSON action refreshes the
+ *     rcon-availability flag at runtime.
+ *
+ * No `can_*` properties: the page handler dies early on missing
+ * `ADMIN_OWNER | ADMIN_ADD_BAN`, so the template never gates anything
+ * on permissions and {@see Perms::for()} would only declare unused
+ * properties.
+ */
+final class KickitView extends View
+{
+    public const TEMPLATE = 'page_kickit.tpl';
+
+    /** @var array{0: string, 1: string} */
+    public const DELIMITERS = ['-{', '}-'];
+
+    /**
+     * @param list<array{num:int, ip:string, port:string|int}> $servers
+     */
+    public function __construct(
+        public readonly string $csrf_token,
+        public readonly int $total,
+        public readonly string $check,
+        public readonly int $type,
+        public readonly array $servers,
+    ) {
+    }
+}

--- a/web/includes/View/UploadFileView.php
+++ b/web/includes/View/UploadFileView.php
@@ -1,0 +1,51 @@
+<?php
+declare(strict_types=1);
+
+namespace Sbpp\View;
+
+/**
+ * Generic "pick a file and POST it" popup — binds to
+ * `page_uploadfile.tpl`.
+ *
+ * The same template + view backs three popup-window flows opened via
+ * `window.open(...)` from the parent admin page:
+ *
+ *   - `web/pages/admin.uploadicon.php`   → mod icon (gif/jpg/png)
+ *   - `web/pages/admin.uploadmapimg.php` → server-list map image (jpg)
+ *   - `web/pages/admin.uploaddemo.php`   → demo attachment
+ *     (zip/rar/dem/7z/bz2/gz)
+ *
+ * Each handler dies early on insufficient permissions, so the template
+ * itself never gates content on `can_*` flags.
+ *
+ * Variables (one row per `{$prop}` reference in either default or
+ * sbpp2026 `page_uploadfile.tpl`):
+ *
+ *   - `$title`: window title + heading.
+ *   - `$message`: ALREADY-RENDERED HTML emitted with `nofilter`. On a
+ *     successful upload each handler builds a
+ *     `<script>window.opener.<cb>(...);self.close()</script>` blob
+ *     that JSON-encodes the admin-controlled filename with
+ *     `JSON_HEX_*` flags (#1113 fix); on a rejection the handlers
+ *     emit a hand-built `<b>…</b>` error string. The template MUST
+ *     keep the `nofilter` comment annotation in place.
+ *   - `$input_name`: the `name=` attribute of the `<input type="file">`,
+ *     so each handler reads its `$_FILES[<input_name>]` entry directly.
+ *   - `$form_name`: HTML `id` of the `<form>` (used by the popup's
+ *     callbacks to look the form up via `document.getElementById`).
+ *   - `$formats`: human-readable allowed-formats sentence ("a JPG",
+ *     "a GIF, PNG or JPG", …) shown in the help text.
+ */
+final class UploadFileView extends View
+{
+    public const TEMPLATE = 'page_uploadfile.tpl';
+
+    public function __construct(
+        public readonly string $title,
+        public readonly string $message,
+        public readonly string $input_name,
+        public readonly string $form_name,
+        public readonly string $formats,
+    ) {
+    }
+}

--- a/web/pages/admin.blockit.php
+++ b/web/pages/admin.blockit.php
@@ -21,26 +21,31 @@ include_once '../init.php';
 
 global $userbank, $theme;
 
+// See admin.kickit.php for why this chdir() is needed.
+chdir(ROOT);
+
 if (!$userbank->HasAccess(ADMIN_OWNER | ADMIN_ADD_BAN)) {
     echo "No Access";
     die();
 }
 
 $servers = $GLOBALS['PDO']->query("SELECT ip, port, rcon FROM `:prefix_servers` WHERE enabled = 1 ORDER BY modid, sid")->resultset();
-$theme->assign('total', count($servers));
 $serverlinks = [];
 $num         = 0;
 foreach ($servers as $server) {
-    $serverlinks[] = ['num' => $num, 'ip' => $server['ip'], 'port' => $server['port']];
+    $serverlinks[] = ['num' => $num, 'ip' => (string)$server['ip'], 'port' => (string)$server['port']];
     $num++;
 }
-$theme->assign('servers', $serverlinks);
-$theme->assign('check', $_GET['check'] ?? '');
-$theme->assign('type', $_GET['type'] ?? 0);
-$theme->assign('length', $_GET['length'] ?? 0);
 
 $theme->setLeftDelimiter('-{');
 $theme->setRightDelimiter('}-');
-$theme->display('page_blockit.tpl');
+\Sbpp\View\Renderer::render($theme, new \Sbpp\View\BlockitView(
+    csrf_token: CSRF::token(),
+    total: count($serverlinks),
+    check: (string) ($_GET['check'] ?? ''),
+    type: (int) ($_GET['type'] ?? 0),
+    length: (int) ($_GET['length'] ?? 0),
+    servers: $serverlinks,
+));
 $theme->setLeftDelimiter('{');
 $theme->setRightDelimiter('}');

--- a/web/pages/admin.kickit.php
+++ b/web/pages/admin.kickit.php
@@ -21,25 +21,35 @@ include_once '../init.php';
 
 global $userbank, $theme;
 
+// Apache hands this iframe page a CWD of /pages/ (the script's
+// directory), but Smarty's default compile-dir path is the relative
+// `./templates_c/` — which would resolve under /pages/ here and fail
+// because only the web-root /templates_c/ is writable. Re-chdir to
+// the web root so Smarty (and any other relative path) lines up with
+// what index.php-routed pages see. ROOT is defined by ../init.php.
+chdir(ROOT);
+
 if (!$userbank->HasAccess(ADMIN_OWNER | ADMIN_ADD_BAN)) {
     echo "No Access";
     die();
 }
 
 $servers = $GLOBALS['PDO']->query("SELECT ip, port, rcon FROM `:prefix_servers` WHERE enabled = 1 ORDER BY modid, sid")->resultset();
-$theme->assign('total', count($servers));
 $serverlinks = [];
 $num         = 0;
 foreach ($servers as $server) {
-    $serverlinks[] = ['num' => $num, 'ip' => $server['ip'], 'port' => $server['port']];
+    $serverlinks[] = ['num' => $num, 'ip' => (string)$server['ip'], 'port' => (string)$server['port']];
     $num++;
 }
-$theme->assign('servers', $serverlinks);
-$theme->assign('check', $_GET['check'] ?? '');
-$theme->assign('type', $_GET['type'] ?? 0);
 
 $theme->setLeftDelimiter('-{');
 $theme->setRightDelimiter('}-');
-$theme->display('page_kickit.tpl');
+\Sbpp\View\Renderer::render($theme, new \Sbpp\View\KickitView(
+    csrf_token: CSRF::token(),
+    total: count($serverlinks),
+    check: (string) ($_GET['check'] ?? ''),
+    type: (int) ($_GET['type'] ?? 0),
+    servers: $serverlinks,
+));
 $theme->setLeftDelimiter('{');
 $theme->setRightDelimiter('}');

--- a/web/pages/admin.uploaddemo.php
+++ b/web/pages/admin.uploaddemo.php
@@ -22,6 +22,9 @@ include_once("../init.php");
 include_once("../includes/system-functions.php");
 global $theme, $userbank;
 
+// See admin.kickit.php for why this chdir() is needed.
+chdir(ROOT);
+
 if (!$userbank->HasAccess(ADMIN_OWNER | ADMIN_ADD_BAN | ADMIN_EDIT_OWN_BANS | ADMIN_EDIT_GROUP_BANS | ADMIN_EDIT_ALL_BANS)) {
     Log::add("w", "Hacking Attempt", $userbank->GetProperty('user')." tried to upload a demo, but doesn't have access.");
     die("You don't have access to this!");
@@ -50,10 +53,10 @@ if (isset($_POST['upload'])) {
     }
 }
 
-$theme->assign("title", "Upload Demo");
-$theme->assign("message", $message);
-$theme->assign("input_name", "demo_file");
-$theme->assign("form_name", "demup");
-$theme->assign("formats", "a DEM, ZIP, RAR, 7Z, BZ2 or GZ");
-
-$theme->display('page_uploadfile.tpl');
+\Sbpp\View\Renderer::render($theme, new \Sbpp\View\UploadFileView(
+    title: 'Upload Demo',
+    message: $message,
+    input_name: 'demo_file',
+    form_name: 'demup',
+    formats: 'a DEM, ZIP, RAR, 7Z, BZ2 or GZ',
+));

--- a/web/pages/admin.uploadicon.php
+++ b/web/pages/admin.uploadicon.php
@@ -21,6 +21,9 @@ include_once("../init.php");
 include_once("../includes/system-functions.php");
 global $theme, $userbank;
 
+// See admin.kickit.php for why this chdir() is needed.
+chdir(ROOT);
+
 if (!$userbank->HasAccess(ADMIN_OWNER | ADMIN_EDIT_MODS | ADMIN_ADD_MODS)) {
     Log::add("w", "Hacking Attempt", $userbank->GetProperty('user')." tried to upload a mod icon, but doesn't have access.");
     die("You don't have access to this!");
@@ -42,10 +45,10 @@ if (isset($_POST['upload'])) {
     }
 }
 
-$theme->assign("title", "Upload Icon");
-$theme->assign("message", $message);
-$theme->assign("input_name", "icon_file");
-$theme->assign("form_name", "iconup");
-$theme->assign("formats", "a GIF, PNG or JPG");
-
-$theme->display('page_uploadfile.tpl');
+\Sbpp\View\Renderer::render($theme, new \Sbpp\View\UploadFileView(
+    title: 'Upload Icon',
+    message: $message,
+    input_name: 'icon_file',
+    form_name: 'iconup',
+    formats: 'a GIF, PNG or JPG',
+));

--- a/web/pages/admin.uploadmapimg.php
+++ b/web/pages/admin.uploadmapimg.php
@@ -21,6 +21,9 @@ include_once("../init.php");
 include_once("../includes/system-functions.php");
 global $theme, $userbank;
 
+// See admin.kickit.php for why this chdir() is needed.
+chdir(ROOT);
+
 if (!$userbank->HasAccess(ADMIN_OWNER | ADMIN_ADD_SERVER)) {
     Log::add("w", "Hacking Attempt", $userbank->GetProperty('user')." tried to upload a mapimage, but doesn't have access.");
     die("You don't have access to this!");
@@ -42,10 +45,10 @@ if (isset($_POST['upload'])) {
     }
 }
 
-$theme->assign("title", "Upload Mapimage");
-$theme->assign("message", $message);
-$theme->assign("input_name", "mapimg_file");
-$theme->assign("form_name", "mapimgup");
-$theme->assign("formats", "a JPG");
-
-$theme->display('page_uploadfile.tpl');
+\Sbpp\View\Renderer::render($theme, new \Sbpp\View\UploadFileView(
+    title: 'Upload Mapimage',
+    message: $message,
+    input_name: 'mapimg_file',
+    form_name: 'mapimgup',
+    formats: 'a JPG',
+));

--- a/web/themes/sbpp2026/page_blockit.tpl
+++ b/web/themes/sbpp2026/page_blockit.tpl
@@ -1,6 +1,133 @@
-<div class="card">
+-{*
+    SourceBans++ 2026 — page_blockit.tpl
+    Bound view: \Sbpp\View\BlockitView (web/includes/View/BlockitView.php).
+
+    Mirror of page_kickit.tpl but for the comm-block flow loaded into
+    an iframe by `ShowBlockBox()` in web/scripts/sourcebans.js after
+    a comm block is added. Variable contract, delimiter rationale,
+    parent-window dialog hooks (set_counter, height adjustment) all
+    match the kickit template — see that file for the per-block
+    explanation. The only delta on the wire is `$length` (the block
+    duration in minutes) being forwarded into Actions.BlockitBlockPlayer.
+*}-
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <meta name="csrf-token" content="-{$csrf_token}-">
+    <title>Block player</title>
+    <link rel="stylesheet" href="../themes/sbpp2026/css/theme.css">
+    <script src="../scripts/api-contract.js"></script>
+    <script src="../scripts/sb.js"></script>
+    <script src="../scripts/api.js"></script>
+</head>
+<body style="background:transparent;padding:0.5rem">
+<div id="container" class="card" data-testid="blockit-container">
+    <div class="card__header">
+        <div>
+            <h3>Searching for the player on all servers&hellip;</h3>
+            <p>Each row is polled live; rows update as servers respond.</p>
+        </div>
+    </div>
     <div class="card__body">
-        <h1>{$title}</h1>
-        <p class="text-muted">This page hasn't been redesigned yet.</p>
+        <table class="table" data-testid="blockit-results">
+            <thead>
+                <tr>
+                    <th>Server</th>
+                    <th>Status</th>
+                </tr>
+            </thead>
+            <tbody>
+                -{foreach from=$servers item=serv}-
+                <tr data-testid="blockit-row--{$serv.num}-">
+                    <td class="font-mono text-xs">
+                        <div id="srvip_-{$serv.num}-"
+                             data-testid="blockit-host--{$serv.num}-">-{$serv.ip}-:-{$serv.port}-</div>
+                    </td>
+                    <td>
+                        <div id="srv_-{$serv.num}-"
+                             class="text-xs text-muted"
+                             data-testid="blockit-status--{$serv.num}-">Waiting&hellip;</div>
+                    </td>
+                </tr>
+                -{/foreach}-
+            </tbody>
+        </table>
     </div>
 </div>
+<script>
+    (function () {
+        var TOTAL = -{$total}-;
+        var CHECK = '-{$check}-';
+        var TYPE = -{$type}-;
+        var LENGTH = -{$length}-;
+        var srvcount = 0;
+
+        function setCounter(count) {
+            srvcount += count;
+            if (srvcount === TOTAL || count === -1) {
+                var ctl = parent.document.getElementById('dialog-control');
+                if (ctl) {
+                    ctl.innerHTML = '<font color="green" style="font-size: 12px;"><b>Done searching.</b></font>' + ctl.innerHTML;
+                    ctl.style.display = 'block';
+                }
+                setTimeout(function () {
+                    var place = parent.document.getElementById('dialog-placement');
+                    if (place) place.style.display = 'none';
+                }, 5000);
+                setTimeout(function () { window.location = '../index.php?p=admin&c=comms'; }, 5000);
+            }
+        }
+
+        function processRow(sid, num) {
+            sb.api.call(Actions.BlockitBlockPlayer, { check: CHECK, sid: sid, num: num, type: TYPE, length: LENGTH })
+                .then(function (r) {
+                    if (!r || !r.ok || !r.data) {
+                        sb.setHTML('srv_' + num, "<span class='text-xs' style='color:var(--danger)'><i>Error.</i></span>");
+                        setCounter(1);
+                        return;
+                    }
+                    var d = r.data;
+                    if (d.hostname) {
+                        sb.setHTML('srvip_' + num, "<span class='font-mono text-xs' title='" + d.ip + ':' + d.port + "'>" + d.hostname + "</span>");
+                    }
+                    if (d.status === 'no_connect') {
+                        sb.setHTML('srv_' + num, "<span class='text-xs' style='color:var(--danger)'><i>Can't connect to server.</i></span>");
+                        setCounter(1);
+                    } else if (d.status === 'blocked') {
+                        sb.setHTML('srv_' + num, "<span class='text-xs font-semibold' style='color:var(--success)'><u>Player Found &amp; blocked!</u></span>");
+                        setCounter(-1);
+                    } else {
+                        sb.setHTML('srv_' + num, "<span class='text-xs text-muted'>Player not found.</span>");
+                        setCounter(1);
+                    }
+                });
+        }
+
+        window.addEventListener('load', function () {
+            var ctl = parent.document.getElementById('dialog-control');
+            if (ctl) ctl.style.display = 'none';
+
+            sb.api.call(Actions.BlockitLoadServers, {}).then(function (r) {
+                if (!r || !r.ok || !r.data) return;
+                r.data.servers.forEach(function (s) {
+                    if (s.has_rcon) {
+                        sb.setHTML('srv_' + s.num, '<span class="text-xs text-muted">Searching&hellip;</span>');
+                        processRow(s.sid, s.num);
+                    } else {
+                        sb.setHTML('srv_' + s.num, '<span class="text-xs text-faint">No rcon password.</span>');
+                        setCounter(1);
+                    }
+                });
+            });
+
+            var srvkicker = parent.document.getElementById('srvkicker');
+            if (srvkicker) {
+                srvkicker.height = (document.getElementById('container').offsetHeight + 20) + 'px';
+            }
+        });
+    })();
+</script>
+</body>
+</html>

--- a/web/themes/sbpp2026/page_kickit.tpl
+++ b/web/themes/sbpp2026/page_kickit.tpl
@@ -1,6 +1,146 @@
-<div class="card">
+-{*
+    SourceBans++ 2026 — page_kickit.tpl
+    Bound view: \Sbpp\View\KickitView (web/includes/View/KickitView.php).
+
+    Self-contained <html> doc loaded by the parent admin/bans page in
+    an iframe via `ShowKickBox()` in web/scripts/sourcebans.js. No
+    chrome shell, so we link directly to the sbpp2026 stylesheet
+    (the iframe URL is /pages/admin.kickit.php so the relative
+    `../themes/sbpp2026/css/theme.css` resolves correctly). The
+    custom `-{ … }-` delimiter pair lets the inline JS keep its raw
+    `{` / `}` tokens — see KickitView::DELIMITERS.
+
+    Variable contract is intentionally identical to the legacy
+    web/themes/default/page_kickit.tpl so the same KickitView covers
+    both legs of the dual-theme PHPStan matrix during the v2.0.0
+    rollout. The window title, return URL, and theme path are NOT
+    template variables — they're fixed for this theme/page.
+
+    Per-row JS calls Actions.KickitLoadServers + Actions.KickitKickPlayer
+    via sb.api.call (CSRF token forwarded as the X-CSRF-Token header
+    read from the <meta> tag below). No <form> on this page, so no
+    {csrf_field} needed. Per-row containers (`srv_<n>`, `srvip_<n>`)
+    preserve the IDs the legacy template used so existing
+    parent-window dialog hooks (set_counter, height adjustment) keep
+    working.
+*}-
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <meta name="csrf-token" content="-{$csrf_token}-">
+    <title>Kick player</title>
+    <link rel="stylesheet" href="../themes/sbpp2026/css/theme.css">
+    <script src="../scripts/api-contract.js"></script>
+    <script src="../scripts/sb.js"></script>
+    <script src="../scripts/api.js"></script>
+</head>
+<body style="background:transparent;padding:0.5rem">
+<div id="container" class="card" data-testid="kickit-container">
+    <div class="card__header">
+        <div>
+            <h3>Searching for the player on all servers&hellip;</h3>
+            <p>Each row is polled live; rows update as servers respond.</p>
+        </div>
+    </div>
     <div class="card__body">
-        <h1>{$title}</h1>
-        <p class="text-muted">This page hasn't been redesigned yet.</p>
+        <table class="table" data-testid="kickit-results">
+            <thead>
+                <tr>
+                    <th>Server</th>
+                    <th>Status</th>
+                </tr>
+            </thead>
+            <tbody>
+                -{foreach from=$servers item=serv}-
+                <tr data-testid="kickit-row--{$serv.num}-">
+                    <td class="font-mono text-xs">
+                        <div id="srvip_-{$serv.num}-"
+                             data-testid="kickit-host--{$serv.num}-">-{$serv.ip}-:-{$serv.port}-</div>
+                    </td>
+                    <td>
+                        <div id="srv_-{$serv.num}-"
+                             class="text-xs text-muted"
+                             data-testid="kickit-status--{$serv.num}-">Waiting&hellip;</div>
+                    </td>
+                </tr>
+                -{/foreach}-
+            </tbody>
+        </table>
     </div>
 </div>
+<script>
+    (function () {
+        var TOTAL = -{$total}-;
+        var CHECK = '-{$check}-';
+        var TYPE = -{$type}-;
+        var srvcount = 0;
+
+        function setCounter(count) {
+            srvcount += count;
+            if (srvcount === TOTAL || count === -1) {
+                var ctl = parent.document.getElementById('dialog-control');
+                if (ctl) {
+                    ctl.innerHTML = '<font color="green" style="font-size: 12px;"><b>Done searching.</b></font>' + ctl.innerHTML;
+                    ctl.style.display = 'block';
+                }
+                setTimeout(function () {
+                    var place = parent.document.getElementById('dialog-placement');
+                    if (place) place.style.display = 'none';
+                }, 5000);
+                setTimeout(function () { window.location = '../index.php?p=admin&c=bans'; }, 5000);
+            }
+        }
+
+        function processRow(sid, num) {
+            sb.api.call(Actions.KickitKickPlayer, { check: CHECK, sid: sid, num: num, type: TYPE })
+                .then(function (r) {
+                    if (!r || !r.ok || !r.data) {
+                        sb.setHTML('srv_' + num, "<span class='text-xs' style='color:var(--danger)'><i>Error.</i></span>");
+                        setCounter(1);
+                        return;
+                    }
+                    var d = r.data;
+                    if (d.hostname) {
+                        sb.setHTML('srvip_' + num, "<span class='font-mono text-xs' title='" + d.ip + ':' + d.port + "'>" + d.hostname + "</span>");
+                    }
+                    if (d.status === 'no_connect') {
+                        sb.setHTML('srv_' + num, "<span class='text-xs' style='color:var(--danger)'><i>Can't connect to server.</i></span>");
+                        setCounter(1);
+                    } else if (d.status === 'kicked') {
+                        sb.setHTML('srv_' + num, "<span class='text-xs font-semibold' style='color:var(--success)'><u>Player Found &amp; Kicked!</u></span>");
+                        setCounter(-1);
+                    } else {
+                        sb.setHTML('srv_' + num, "<span class='text-xs text-muted'>Player not found.</span>");
+                        setCounter(1);
+                    }
+                });
+        }
+
+        window.addEventListener('load', function () {
+            var ctl = parent.document.getElementById('dialog-control');
+            if (ctl) ctl.style.display = 'none';
+
+            sb.api.call(Actions.KickitLoadServers, {}).then(function (r) {
+                if (!r || !r.ok || !r.data) return;
+                r.data.servers.forEach(function (s) {
+                    if (s.has_rcon) {
+                        sb.setHTML('srv_' + s.num, '<span class="text-xs text-muted">Searching&hellip;</span>');
+                        processRow(s.sid, s.num);
+                    } else {
+                        sb.setHTML('srv_' + s.num, '<span class="text-xs text-faint">No rcon password.</span>');
+                        setCounter(1);
+                    }
+                });
+            });
+
+            var srvkicker = parent.document.getElementById('srvkicker');
+            if (srvkicker) {
+                srvkicker.height = (document.getElementById('container').offsetHeight + 20) + 'px';
+            }
+        });
+    })();
+</script>
+</body>
+</html>

--- a/web/themes/sbpp2026/page_uploadfile.tpl
+++ b/web/themes/sbpp2026/page_uploadfile.tpl
@@ -1,6 +1,76 @@
-<div class="card">
+{*
+    SourceBans++ 2026 — page_uploadfile.tpl
+    Bound view: \Sbpp\View\UploadFileView (web/includes/View/UploadFileView.php).
+
+    Self-contained popup window opened via window.open(...) from one
+    of the parent admin pages (admin.uploadicon.php,
+    admin.uploadmapimg.php, admin.uploaddemo.php). On a successful
+    upload the page handler builds a {$message} blob containing
+    `<script>window.opener.<cb>(<json-encoded args>);self.close()</script>`
+    using JSON_HEX_* flags so the admin-controlled filename is safe
+    to interpolate into both the HTML attribute and the JS string
+    layers (#1113 fix). The template is the only Phase B/C template
+    that legitimately needs `{$message nofilter}`.
+
+    Variable contract is intentionally identical to the legacy
+    web/themes/default/page_uploadfile.tpl so the same
+    UploadFileView covers both legs of the dual-theme PHPStan matrix.
+    The theme stylesheet path is hardcoded because it's
+    sbpp2026-specific — the iframe URL is /pages/admin.upload*.php so
+    `../themes/sbpp2026/css/theme.css` resolves correctly.
+*}
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <title>{$title} : SourceBans++</title>
+    <link rel="icon" href="../themes/sbpp2026/images/favicon.ico">
+    <link rel="stylesheet" href="../themes/sbpp2026/css/theme.css">
+</head>
+<body style="padding:1rem;background:var(--bg-page)">
+<div class="card" style="max-width:24rem;margin:0 auto">
+    <div class="card__header">
+        <div>
+            <h3>{$title}</h3>
+            <p>Pick a file to upload. The file must be {$formats} file format.</p>
+        </div>
+    </div>
     <div class="card__body">
-        <h1>{$title}</h1>
-        <p class="text-muted">This page hasn't been redesigned yet.</p>
+        {if $message}
+            <div class="text-xs"
+                 data-testid="uploadfile-message"
+                 style="margin-bottom:0.75rem;color:var(--text)">
+                {* nofilter: $message is server-built — either an empty string, a hand-built `<b>… file must be …</b>` rejection literal, or a popup-callback `<script>window.opener.<cb>(<json-encoded args>);self.close()</script>` blob whose admin-controlled filename was JSON_HEX_*-encoded by admin.upload{demo,icon,mapimg}.php so every special char survives both the HTML and JS layers (#1113). *}
+                {$message nofilter}
+            </div>
+        {/if}
+
+        <form action=""
+              method="POST"
+              id="{$form_name}"
+              enctype="multipart/form-data"
+              data-testid="uploadfile-form">
+            {csrf_field}
+            <input type="hidden" name="upload" value="1">
+
+            <label class="label" for="uploadfile-input">Select file</label>
+            <input type="file"
+                   id="uploadfile-input"
+                   class="input"
+                   name="{$input_name}"
+                   data-testid="uploadfile-input"
+                   required>
+
+            <div style="margin-top:0.75rem;display:flex;justify-content:flex-end">
+                <button type="submit"
+                        class="btn btn--primary btn--sm"
+                        data-testid="uploadfile-submit">
+                    Save
+                </button>
+            </div>
+        </form>
     </div>
 </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary

Phase B9 of the SourceBans++ 2026 theme rollout (#1123). This PR replaces three Phase A1 stub templates and switches the five page handlers that render them onto typed View DTOs + `Renderer::render`.

| Stub before | After (same template path) | Page handler(s) switched to `Renderer::render` |
|---|---|---|
| `web/themes/sbpp2026/page_kickit.tpl` | "Searching the player on all servers" iframe (card + table) | `web/pages/admin.kickit.php` |
| `web/themes/sbpp2026/page_blockit.tpl` | Same shape, comm-block flow | `web/pages/admin.blockit.php` |
| `web/themes/sbpp2026/page_uploadfile.tpl` | "Pick a file" popup (card + form) | `web/pages/admin.uploadicon.php`, `admin.uploadmapimg.php`, `admin.uploaddemo.php` |

New typed View DTOs:

- `Sbpp\View\KickitView` — pairs with `page_kickit.tpl` (custom `-{ … }-` delimiters)
- `Sbpp\View\BlockitView` — pairs with `page_blockit.tpl` (custom `-{ … }-` delimiters)
- `Sbpp\View\UploadFileView` — pairs with `page_uploadfile.tpl` (default delimiters)

Each View declares the **union** of variables the legacy default theme + the new sbpp2026 theme reference, so both legs of the dual-theme PHPStan matrix stay green. To keep that intersection minimal I hardcoded per-page constants (window `<title>`, theme stylesheet path, parent-window return URL) inside the sbpp2026 templates — these don't vary at runtime, so they don't need to flow through the View.

These pages live as **standalone** `<html>` documents (no chrome shell): kickit/blockit are loaded into iframes spawned by `ShowKickBox()` / `ShowBlockBox()` in `web/scripts/sourcebans.js`, and the upload flows are `window.open()` popup windows. The new theme reskins them with `.card` / `.table` / `.input` / `.btn--primary` from `theme.css`. Per-row containers (`srv_<n>`, `srvip_<n>`) keep the IDs the legacy template used so the parent dialog's `set_counter` + iframe-height shim keep working untouched.

### Testability hooks (per the issue's data-testid rule)

- `kickit-{container, results, row-N, host-N, status-N}`
- `blockit-{container, results, row-N, host-N, status-N}`
- `uploadfile-{form, input, submit, message}`

### Side fix in scope: CWD for direct-loaded handlers

`admin.kickit.php` / `admin.blockit.php` / `admin.upload*.php` are direct-loaded (Apache hands them a CWD of `/pages/`). Smarty's default compile_dir is the relative `./templates_c/`, which then resolves under `/pages/` and explodes because only the web-root `/templates_c/` is writable in the dev container (entrypoint pre-creates `${WEB_ROOT}/templates_c`). Each handler now `chdir(ROOT)` right after `init.php` so the compile dir lines up with what `index.php`-routed pages already see. The bug is pre-existing in `main` — visible the moment we exercise these pages in dev — but it's the same minimal handlers I'm already touching, so I fixed it in scope rather than leaving the rendered iframe broken on the new theme.

### nofilter discipline

Two `{nofilter}` sites, each annotated per `AGENTS.md`:

- `page_uploadfile.tpl` — `{$message nofilter}` carries the popup-callback `<script>window.opener.<cb>(<json-encoded args>);self.close()</script>` blob built by the upload handlers. Admin-controlled filename is JSON-encoded with `JSON_HEX_*` flags (the existing #1113 fix), so it survives both HTML and JS string contexts.
- The hidden CSRF input the form uses ships via the `{csrf_field}` Smarty plugin — no explicit nofilter needed.

## Files touched

```
web/includes/View/KickitView.php       (new)
web/includes/View/BlockitView.php      (new)
web/includes/View/UploadFileView.php   (new)
web/themes/sbpp2026/page_kickit.tpl
web/themes/sbpp2026/page_blockit.tpl
web/themes/sbpp2026/page_uploadfile.tpl
web/pages/admin.kickit.php
web/pages/admin.blockit.php
web/pages/admin.uploadicon.php
web/pages/admin.uploadmapimg.php
web/pages/admin.uploaddemo.php
```

No `init.php`, no `themes/{css,js,core}/*`, no `api/handlers/*`, no `scripts/api-contract.js`, no docs — Phase B "never touch" list respected.

## Local gates (sbpp-1123-b9 stack)

| Gate | Result |
|---|---|
| `./sbpp.sh phpstan` (default leg) | OK — 0 errors |
| `phpstan --configuration=phpstan-sbpp2026.neon` (sbpp2026 leg) | OK — 0 errors |
| `./sbpp.sh ts-check` | OK |
| `./sbpp.sh composer api-contract` | no diff |
| `./sbpp.sh test tests/api/KickitTest.php tests/api/BlockitTest.php` | 10/10 pass |

## Manual smoke (theme=sbpp2026, http://localhost:8310)

Seeded 3 enabled servers (10.0.0.1:27015 / 10.0.0.2:27016 / 10.0.0.3:27017, the third without rcon). Verified:

- `/pages/admin.kickit.php?check=STEAM_0:0:1&type=0` → renders the new `.card` + `.table` shell, three `<tr data-testid="kickit-row-N">` rows seeded with the right IPs, `var TOTAL = 3` / `var CHECK = 'STEAM_0:0:1'` in the inline JS, `<meta name="csrf-token">` present.
- `/pages/admin.blockit.php?check=STEAM_0:0:5&type=2&length=120` → mirror of kickit, plus `var LENGTH = 120` and the `Actions.BlockitBlockPlayer` call carrying `length`.
- `/pages/admin.uploadicon.php` → the new card+form shell, `<input id="uploadfile-input" data-testid="uploadfile-input">`, `{csrf_field}`-rendered hidden input, "Save" submit button.

(No headless browser available on the host for binary screenshots.)

## Test plan

- [ ] CI: phpstan (default + sbpp2026 matrix legs), phpunit, ts-check, api-contract
- [ ] Manual: open admin/bans → add a ban → confirm the iframe inside the "Ban Added" dialog renders the new card UI and per-row results update as the kick API responds
- [ ] Manual: open admin/comms → add a block → same as above for blockit
- [ ] Manual: open admin/bans add-ban form → "Upload a Demo" popup → drop a `.dem` file → confirm the popup closes and the parent form receives the demo hash via `window.opener.demo(...)`
- [ ] Manual: open admin/mods edit → "Upload MOD Icon" → same flow with `window.opener.icon(...)`
- [ ] Manual: open admin/servers → "Upload Map Image" → same flow with `window.opener.mapimg(...)`