### PR TITLE
[#1123 B10] Redesign admin home (card grid landing)

### DIFF
--- a/web/includes/View/AdminHomeView.php
+++ b/web/includes/View/AdminHomeView.php
@@ -1,0 +1,94 @@
+<?php
+declare(strict_types=1);
+
+namespace Sbpp\View;
+
+/**
+ * Admin landing page (`?p=admin` with no `c=…`) — binds to
+ * `page_admin.tpl`. The route enforces `CheckAdminAccess(ALL_WEB)` in
+ * {@see route()} (web/includes/page-builder.php), so the only people
+ * who hit this view are admins holding *some* web flag; this View's
+ * job is then to gate the per-area cards so an admin only sees
+ * cards leading to areas they actually have rights inside.
+ *
+ * ### Dual-theme rollout
+ *
+ * Two themes consume this view side-by-side during the v2.0.0 rollout
+ * (#1123): the legacy `web/themes/default/page_admin.tpl` (table-y
+ * stats grid + access-flag-gated card list) and the new
+ * `web/themes/sbpp2026/page_admin.tpl` (8-card landing grid). Because
+ * `SmartyTemplateRule` enforces one-to-one parity between properties
+ * and template references for the theme it scans, this View declares
+ * the *union* of variables both templates need:
+ *
+ *   - New fields (`can_admins`, `can_groups`, `can_servers`,
+ *     `can_bans`, `can_mods`, `can_overrides`, `can_settings`,
+ *     `can_audit`) drive the sbpp2026 template's per-card visibility
+ *     gates. Each is a composite `OR` over the underlying `can_<flag>`
+ *     keys produced by {@see Perms::for()}, mirroring the masks the
+ *     legacy router uses in `page-builder.php` so a card visible on
+ *     the landing implies the router will let the user through.
+ *   - Legacy-only fields (`access_*`, `dev`, `demosize`, `total_*`,
+ *     `archived_*`) stay so the legacy template continues to
+ *     type-check on the `default` PHPStan leg of the dual-theme
+ *     matrix. The sbpp2026 template references them inside an
+ *     unreachable `{if false}` parity block (see the template) so the
+ *     `sbpp2026` leg's "unused property" check also stays green
+ *     without bespoke baseline entries — matching the precedent set
+ *     by `HomeDashboardView`'s `IN_SERVERS_PAGE` parity reference.
+ *
+ * ### Card list
+ *
+ * The set of cards (and therefore the list of `can_<area>` props) is
+ * the canonical 8-card admin grid for the v2.0.0 theme:
+ *   - admins, groups, servers, bans, mods, overrides, settings, audit
+ *
+ * Comms intentionally folds into the sidebar nav (`admin/comms`) — the
+ * mockup at `handoff/ui_kits/webpanel-2026/views.jsx` (`AdminPanelView`)
+ * doesn't surface a separate Comms card on the landing, matching the
+ * orchestrator's spec for #1123 B10. Audit is a forward-looking card
+ * gated to owners until a future ticket adds the `c=audit` route +
+ * page; until then the legacy router's `default:` case returns the
+ * admin landing itself, so the link is a harmless self-loop rather
+ * than a 404.
+ *
+ * D1's hard cutover deletes the legacy template and renames the
+ * sbpp2026 directory into `default/`; at that point this View loses
+ * the legacy-only fields in a follow-up cleanup PR (tracked by the D2
+ * docs sweep).
+ */
+final class AdminHomeView extends View
+{
+    public const TEMPLATE = 'page_admin.tpl';
+
+    public function __construct(
+        // sbpp2026 — composite per-area gates for the landing card grid.
+        public readonly bool $can_admins,
+        public readonly bool $can_groups,
+        public readonly bool $can_servers,
+        public readonly bool $can_bans,
+        public readonly bool $can_mods,
+        public readonly bool $can_overrides,
+        public readonly bool $can_settings,
+        public readonly bool $can_audit,
+        // legacy default theme — kept until D1 deletes the legacy template.
+        public readonly bool $access_admins,
+        public readonly bool $access_servers,
+        public readonly bool $access_bans,
+        public readonly bool $access_groups,
+        public readonly bool $access_settings,
+        public readonly bool $access_mods,
+        public readonly bool $dev,
+        public readonly string $demosize,
+        public readonly int $total_admins,
+        public readonly int $total_bans,
+        public readonly int $total_comms,
+        public readonly int $total_blocks,
+        public readonly int $total_servers,
+        public readonly int $total_protests,
+        public readonly int $archived_protests,
+        public readonly int $total_submissions,
+        public readonly int $archived_submissions,
+    ) {
+    }
+}

--- a/web/pages/page.admin.php
+++ b/web/pages/page.admin.php
@@ -2,7 +2,7 @@
 /*************************************************************************
 This file is part of SourceBans++
 
-SourceBans++ (c) 2014-2024 by SourceBans++ Dev Team
+SourceBans++ (c) 2014-2026 by SourceBans++ Dev Team
 
 The SourceBans++ Web panel is licensed under a
 Creative Commons Attribution-NonCommercial-ShareAlike 3.0 Unported License.
@@ -21,36 +21,59 @@ if (!defined("IN_SB")) {
     echo "You should not be here. Only follow links!";
     die();
 }
+
 global $userbank, $theme;
+
+// Stat counts the legacy default-theme template renders in its
+// information rows. AdminHomeView keeps these fields declared during
+// the v2.0.0 theme rollout (#1123) so the default PHPStan leg's
+// SmartyTemplateRule parity check still passes; D1's hard cutover
+// drops both the legacy template and the legacy fields together.
 $counts = $GLOBALS['PDO']->query("SELECT
-								 (SELECT COUNT(bid) FROM `:prefix_banlog`) AS blocks,
-								 (SELECT COUNT(bid) FROM `:prefix_bans`) AS bans,
-								 (SELECT COUNT(bid) FROM `:prefix_comms`) AS comms,
-								 (SELECT COUNT(aid) FROM `:prefix_admins` WHERE aid > 0) AS admins,
-								 (SELECT COUNT(subid) FROM `:prefix_submissions` WHERE archiv = '0') AS subs,
-								 (SELECT COUNT(subid) FROM `:prefix_submissions` WHERE archiv > 0) AS archiv_subs,
-								 (SELECT COUNT(pid) FROM `:prefix_protests` WHERE archiv = '0') AS protests,
-								 (SELECT COUNT(pid) FROM `:prefix_protests` WHERE archiv > 0) AS archiv_protests,
-								 (SELECT COUNT(sid) FROM `:prefix_servers`) AS servers")->single();
+                                 (SELECT COUNT(bid) FROM `:prefix_banlog`)                       AS blocks,
+                                 (SELECT COUNT(bid) FROM `:prefix_bans`)                         AS bans,
+                                 (SELECT COUNT(bid) FROM `:prefix_comms`)                        AS comms,
+                                 (SELECT COUNT(aid) FROM `:prefix_admins`  WHERE aid > 0)        AS admins,
+                                 (SELECT COUNT(subid) FROM `:prefix_submissions` WHERE archiv = '0') AS subs,
+                                 (SELECT COUNT(subid) FROM `:prefix_submissions` WHERE archiv > 0)   AS archiv_subs,
+                                 (SELECT COUNT(pid) FROM `:prefix_protests`    WHERE archiv = '0') AS protests,
+                                 (SELECT COUNT(pid) FROM `:prefix_protests`    WHERE archiv > 0)   AS archiv_protests,
+                                 (SELECT COUNT(sid) FROM `:prefix_servers`)                      AS servers")->single();
 
-$theme->assign('access_admins', $userbank->HasAccess(ADMIN_OWNER | ADMIN_LIST_ADMINS | ADMIN_ADD_ADMINS | ADMIN_EDIT_ADMINS | ADMIN_DELETE_ADMINS));
-$theme->assign('access_servers', $userbank->HasAccess(ADMIN_OWNER | ADMIN_LIST_SERVERS | ADMIN_ADD_SERVER | ADMIN_EDIT_SERVERS | ADMIN_DELETE_SERVERS));
-$theme->assign('access_bans', $userbank->HasAccess(ADMIN_OWNER | ADMIN_ADD_BAN | ADMIN_EDIT_OWN_BANS | ADMIN_EDIT_GROUP_BANS | ADMIN_EDIT_ALL_BANS | ADMIN_BAN_PROTESTS | ADMIN_BAN_SUBMISSIONS));
-$theme->assign('access_groups', $userbank->HasAccess(ADMIN_OWNER | ADMIN_LIST_GROUPS | ADMIN_ADD_GROUP | ADMIN_EDIT_GROUPS | ADMIN_DELETE_GROUPS));
-$theme->assign('access_settings', $userbank->HasAccess(ADMIN_OWNER | ADMIN_WEB_SETTINGS));
-$theme->assign('access_mods', $userbank->HasAccess(ADMIN_OWNER | ADMIN_LIST_MODS | ADMIN_ADD_MODS | ADMIN_EDIT_MODS | ADMIN_DELETE_MODS));
-
-$theme->assign('dev', SB_DEV);
-
-$theme->assign('demosize', getDirSize(SB_DEMOS));
-$theme->assign('total_admins', $counts['admins']);
-$theme->assign('total_bans', $counts['bans']);
-$theme->assign('total_comms', $counts['comms']);
-$theme->assign('total_blocks', $counts['blocks']);
-$theme->assign('total_servers', $counts['servers']);
-$theme->assign('total_protests', $counts['protests']);
-$theme->assign('archived_protests', $counts['archiv_protests']);
-$theme->assign('total_submissions', $counts['subs']);
-$theme->assign('archived_submissions', $counts['archiv_subs']);
-
-$theme->display('page_admin.tpl');
+// AdminHomeView precomputes one composite `$can_<area>` boolean per
+// landing-grid card from Sbpp\View\Perms::for($userbank). Each composite
+// OR's the per-flag booleans the legacy router gates on for that
+// sub-route in web/includes/page-builder.php — a card visible on the
+// landing implies the router will let the user through. Owner bypass is
+// already baked into every per-flag bool by Perms::for(), so a user
+// holding ADMIN_OWNER lights up every card without an extra `||
+// $can_owner` here.
+$perms = \Sbpp\View\Perms::for($userbank);
+\Sbpp\View\Renderer::render($theme, new \Sbpp\View\AdminHomeView(
+    can_admins:    $perms['can_list_admins']  || $perms['can_add_admins']  || $perms['can_edit_admins']  || $perms['can_delete_admins'],
+    can_groups:    $perms['can_list_groups']  || $perms['can_add_group']   || $perms['can_edit_groups']  || $perms['can_delete_groups'],
+    can_servers:   $perms['can_list_servers'] || $perms['can_add_server']  || $perms['can_edit_servers'] || $perms['can_delete_servers'],
+    can_bans:      $perms['can_add_ban'] || $perms['can_edit_own_bans'] || $perms['can_edit_group_bans'] || $perms['can_edit_all_bans'] || $perms['can_ban_protests'] || $perms['can_ban_submissions'] || $perms['can_delete_ban'] || $perms['can_unban'],
+    can_mods:      $perms['can_list_mods']    || $perms['can_add_mods']    || $perms['can_edit_mods']    || $perms['can_delete_mods'],
+    can_overrides: $perms['can_add_admins'],
+    can_settings:  $perms['can_web_settings'],
+    can_audit:     $perms['can_owner'],
+    // Legacy default-theme bindings; see View docblock + D1 cutover note.
+    access_admins:        $userbank->HasAccess(ADMIN_OWNER | ADMIN_LIST_ADMINS  | ADMIN_ADD_ADMINS  | ADMIN_EDIT_ADMINS  | ADMIN_DELETE_ADMINS),
+    access_servers:       $userbank->HasAccess(ADMIN_OWNER | ADMIN_LIST_SERVERS | ADMIN_ADD_SERVER  | ADMIN_EDIT_SERVERS | ADMIN_DELETE_SERVERS),
+    access_bans:          $userbank->HasAccess(ADMIN_OWNER | ADMIN_ADD_BAN | ADMIN_EDIT_OWN_BANS | ADMIN_EDIT_GROUP_BANS | ADMIN_EDIT_ALL_BANS | ADMIN_BAN_PROTESTS | ADMIN_BAN_SUBMISSIONS),
+    access_groups:        $userbank->HasAccess(ADMIN_OWNER | ADMIN_LIST_GROUPS  | ADMIN_ADD_GROUP   | ADMIN_EDIT_GROUPS  | ADMIN_DELETE_GROUPS),
+    access_settings:      $userbank->HasAccess(ADMIN_OWNER | ADMIN_WEB_SETTINGS),
+    access_mods:          $userbank->HasAccess(ADMIN_OWNER | ADMIN_LIST_MODS    | ADMIN_ADD_MODS    | ADMIN_EDIT_MODS    | ADMIN_DELETE_MODS),
+    dev:                  SB_DEV,
+    demosize:             getDirSize(SB_DEMOS),
+    total_admins:         (int) $counts['admins'],
+    total_bans:           (int) $counts['bans'],
+    total_comms:          (int) $counts['comms'],
+    total_blocks:         (int) $counts['blocks'],
+    total_servers:        (int) $counts['servers'],
+    total_protests:       (int) $counts['protests'],
+    archived_protests:    (int) $counts['archiv_protests'],
+    total_submissions:    (int) $counts['subs'],
+    archived_submissions: (int) $counts['archiv_subs'],
+));

--- a/web/phpstan-baseline.neon
+++ b/web/phpstan-baseline.neon
@@ -168,6 +168,66 @@ parameters:
 			count: 1
 			path: includes/View/ServersView.php
 
+		# AdminHomeView (#1123 B10) declares the union of variables both
+		# themes need: the new sbpp2026 `page_admin.tpl` uses 8 composite
+		# `$can_<area>` booleans for the card grid, while the legacy
+		# `web/themes/default/page_admin.tpl` keeps using the per-flag
+		# `$access_*` booleans + stat counts. The default PHPStan leg
+		# scans the legacy template, which doesn't reference any
+		# `$can_<area>` field, so these 8 entries silence the resulting
+		# `unusedProperty` errors. The sbpp2026 leg passes cleanly thanks
+		# to the parity `{if false}…{/if}` block at the bottom of
+		# `web/themes/sbpp2026/page_admin.tpl`. D1's hard cutover deletes
+		# the legacy template + the matching legacy props on
+		# AdminHomeView; these 8 entries should be removed in lockstep.
+		-
+			message: '#^Property Sbpp\\View\\AdminHomeView\:\:\$can_admins is never referenced in template "page_admin\.tpl"\.$#'
+			identifier: sbpp.view.unusedProperty
+			count: 1
+			path: includes/View/AdminHomeView.php
+
+		-
+			message: '#^Property Sbpp\\View\\AdminHomeView\:\:\$can_groups is never referenced in template "page_admin\.tpl"\.$#'
+			identifier: sbpp.view.unusedProperty
+			count: 1
+			path: includes/View/AdminHomeView.php
+
+		-
+			message: '#^Property Sbpp\\View\\AdminHomeView\:\:\$can_servers is never referenced in template "page_admin\.tpl"\.$#'
+			identifier: sbpp.view.unusedProperty
+			count: 1
+			path: includes/View/AdminHomeView.php
+
+		-
+			message: '#^Property Sbpp\\View\\AdminHomeView\:\:\$can_bans is never referenced in template "page_admin\.tpl"\.$#'
+			identifier: sbpp.view.unusedProperty
+			count: 1
+			path: includes/View/AdminHomeView.php
+
+		-
+			message: '#^Property Sbpp\\View\\AdminHomeView\:\:\$can_mods is never referenced in template "page_admin\.tpl"\.$#'
+			identifier: sbpp.view.unusedProperty
+			count: 1
+			path: includes/View/AdminHomeView.php
+
+		-
+			message: '#^Property Sbpp\\View\\AdminHomeView\:\:\$can_overrides is never referenced in template "page_admin\.tpl"\.$#'
+			identifier: sbpp.view.unusedProperty
+			count: 1
+			path: includes/View/AdminHomeView.php
+
+		-
+			message: '#^Property Sbpp\\View\\AdminHomeView\:\:\$can_settings is never referenced in template "page_admin\.tpl"\.$#'
+			identifier: sbpp.view.unusedProperty
+			count: 1
+			path: includes/View/AdminHomeView.php
+
+		-
+			message: '#^Property Sbpp\\View\\AdminHomeView\:\:\$can_audit is never referenced in template "page_admin\.tpl"\.$#'
+			identifier: sbpp.view.unusedProperty
+			count: 1
+			path: includes/View/AdminHomeView.php
+
 		-
 			message: '#^Call to an undefined method Lcobucci\\JWT\\Token\:\:claims\(\)\.$#'
 			identifier: method.notFound

--- a/web/themes/sbpp2026/page_admin.tpl
+++ b/web/themes/sbpp2026/page_admin.tpl
@@ -1,6 +1,231 @@
-<div class="card">
-    <div class="card__body">
-        <h1>{$title}</h1>
-        <p class="text-muted">This page hasn't been redesigned yet.</p>
-    </div>
-</div>
+{*
+    SourceBans++ 2026 — page_admin.tpl
+
+    Admin landing page (?p=admin with no c=…). Replaces the A1 stub
+    with the canonical 8-card grid from the AdminPanelView mockup
+    (handoff/ui_kits/webpanel-2026/views.jsx). Pair:
+    web/pages/page.admin.php → web/includes/View/AdminHomeView.php.
+
+    The page-builder route (`case 'admin':` default in
+    web/includes/page-builder.php) gates the page itself on
+    CheckAdminAccess(ALL_WEB), so anyone landing here already holds
+    *some* web flag. This template's job is to gate the per-area
+    cards so an admin only sees the cards that match the sub-routes
+    they can actually open.
+
+    Cards are gated by composite $can_<area> booleans precomputed by
+    the page handler from Sbpp\View\Perms::for($userbank). Each gate
+    OR's together the underlying ADMIN_* flags the legacy router
+    requires for that sub-route (see page-builder.php), so a card
+    visible here implies the router will let the user through —
+    "card visible but route 403's" can't drift between the two.
+
+    Comms folds into the sidebar nav (admin/comms) per the mockup,
+    not a card here. Audit is a forward-looking card gated to owners
+    until a future ticket adds the c=audit route + page; until then
+    the legacy router's `default:` case returns this same admin
+    landing, so the link is a harmless self-loop rather than a 404.
+
+    Testability hooks per the issue's "Testability hooks" rule:
+      - card grid carries role="list" + aria-label
+      - each card carries data-testid="admin-card-<area>"
+      - active sidebar item is set by core/navbar.tpl, not here
+
+    Card styles live in a literal-wrapped <style> block at the bottom
+    so the Phase B "Don't touch ../css/*.css" rule is honoured (the
+    shell tokens — --bg-surface, --border, --accent, etc. — come from
+    web/themes/sbpp2026/css/theme.css unchanged). Paired
+    {literal}…{/literal} prevents Smarty from interpreting CSS braces
+    as tags, matching the convention used by page_lostpassword.tpl.
+*}
+<section class="admin-home">
+    <header class="admin-home__header mb-6">
+        <h1 class="admin-home__title">Admin panel</h1>
+        <p class="admin-home__subtitle text-sm text-muted mt-2">Manage admins, groups, servers, and panel settings.</p>
+    </header>
+
+    <ul class="admin-cards" role="list" aria-label="Admin areas">
+        {if $can_admins}
+            <li>
+                <a class="admin-card"
+                   href="index.php?p=admin&amp;c=admins"
+                   data-testid="admin-card-admins">
+                    <div class="admin-card__icon" aria-hidden="true"><i data-lucide="users"></i></div>
+                    <div class="admin-card__title">Admins</div>
+                    <div class="admin-card__desc">View, add, edit, and remove panel admins.</div>
+                </a>
+            </li>
+        {/if}
+
+        {if $can_groups}
+            <li>
+                <a class="admin-card"
+                   href="index.php?p=admin&amp;c=groups"
+                   data-testid="admin-card-groups">
+                    <div class="admin-card__icon" aria-hidden="true"><i data-lucide="shield-check"></i></div>
+                    <div class="admin-card__title">Groups</div>
+                    <div class="admin-card__desc">Permission and immunity groupings for admins.</div>
+                </a>
+            </li>
+        {/if}
+
+        {if $can_servers}
+            <li>
+                <a class="admin-card"
+                   href="index.php?p=admin&amp;c=servers"
+                   data-testid="admin-card-servers">
+                    <div class="admin-card__icon" aria-hidden="true"><i data-lucide="server"></i></div>
+                    <div class="admin-card__title">Servers</div>
+                    <div class="admin-card__desc">Game servers SourceBans++ talks to.</div>
+                </a>
+            </li>
+        {/if}
+
+        {if $can_bans}
+            <li>
+                <a class="admin-card"
+                   href="index.php?p=admin&amp;c=bans"
+                   data-testid="admin-card-bans">
+                    <div class="admin-card__icon" aria-hidden="true"><i data-lucide="ban"></i></div>
+                    <div class="admin-card__title">Bans</div>
+                    <div class="admin-card__desc">Add bans, review submissions and appeals.</div>
+                </a>
+            </li>
+        {/if}
+
+        {if $can_mods}
+            <li>
+                <a class="admin-card"
+                   href="index.php?p=admin&amp;c=mods"
+                   data-testid="admin-card-mods">
+                    <div class="admin-card__icon" aria-hidden="true"><i data-lucide="puzzle"></i></div>
+                    <div class="admin-card__title">Mods</div>
+                    <div class="admin-card__desc">Game/mod entries shown across the panel.</div>
+                </a>
+            </li>
+        {/if}
+
+        {if $can_overrides}
+            <li>
+                <a class="admin-card"
+                   href="index.php?p=admin&amp;c=admins"
+                   data-testid="admin-card-overrides">
+                    <div class="admin-card__icon" aria-hidden="true"><i data-lucide="key-round"></i></div>
+                    <div class="admin-card__title">Overrides</div>
+                    <div class="admin-card__desc">Override SourceMod command flags per server or group.</div>
+                </a>
+            </li>
+        {/if}
+
+        {if $can_settings}
+            <li>
+                <a class="admin-card"
+                   href="index.php?p=admin&amp;c=settings"
+                   data-testid="admin-card-settings">
+                    <div class="admin-card__icon" aria-hidden="true"><i data-lucide="settings"></i></div>
+                    <div class="admin-card__title">Settings</div>
+                    <div class="admin-card__desc">SMTP, theme, and integration configuration.</div>
+                </a>
+            </li>
+        {/if}
+
+        {if $can_audit}
+            <li>
+                <a class="admin-card"
+                   href="index.php?p=admin&amp;c=audit"
+                   data-testid="admin-card-audit">
+                    <div class="admin-card__icon" aria-hidden="true"><i data-lucide="scroll-text"></i></div>
+                    <div class="admin-card__title">Audit log</div>
+                    <div class="admin-card__desc">Admin actions across the panel (coming soon).</div>
+                </a>
+            </li>
+        {/if}
+    </ul>
+</section>
+
+{*
+    Parity block - references the legacy default-theme variables that
+    AdminHomeView still declares so SmartyTemplateRule's "unused
+    property" check stays green for the sbpp2026 PHPStan leg without a
+    bespoke baseline entry. The if-false branch is unreachable at
+    render time, so the new theme never visibly renders the legacy
+    counts. Mirrors the unreachable parity reference HomeDashboardView
+    established (#1123 B3) using IN_SERVERS_PAGE. D1 deletes the legacy
+    theme + the matching props on AdminHomeView; this block leaves
+    with them.
+*}
+{if false}
+    {$access_admins}{$access_bans}{$access_groups}{$access_mods}
+    {$access_servers}{$access_settings}{$archived_protests}
+    {$archived_submissions}{$demosize}{$dev}{$total_admins}
+    {$total_bans}{$total_blocks}{$total_comms}{$total_protests}
+    {$total_servers}{$total_submissions}
+{/if}
+
+{literal}
+<style>
+    .admin-home { max-width: 1400px; padding: 1rem; }
+    @media (min-width: 640px) { .admin-home { padding: 1.5rem; } }
+    .admin-home__title {
+        font-size: var(--fs-2xl);
+        font-weight: 600;
+        letter-spacing: -0.02em;
+        color: var(--text);
+        margin: 0;
+    }
+    .admin-home__subtitle { margin-bottom: 0; }
+
+    .admin-cards {
+        display: grid;
+        grid-template-columns: repeat(auto-fill, minmax(15rem, 1fr));
+        gap: 1rem;
+        list-style: none;
+        margin: 0;
+        padding: 0;
+    }
+
+    .admin-card {
+        display: block;
+        background: var(--bg-surface);
+        border: 1px solid var(--border);
+        border-radius: var(--radius-xl);
+        padding: 1.25rem;
+        color: var(--text);
+        text-decoration: none;
+        transition: border-color .15s ease, box-shadow .15s ease, transform .15s ease;
+    }
+    .admin-card:hover {
+        border-color: var(--zinc-300);
+        box-shadow: var(--shadow);
+    }
+    html.dark .admin-card:hover { border-color: var(--zinc-700); }
+    .admin-card:focus-visible {
+        outline: 2px solid var(--accent);
+        outline-offset: 2px;
+    }
+
+    .admin-card__icon {
+        width: 2.25rem;
+        height: 2.25rem;
+        border-radius: var(--radius-lg);
+        background: var(--bg-muted);
+        color: var(--text);
+        display: grid;
+        place-items: center;
+        margin-bottom: 0.75rem;
+    }
+    .admin-card__icon i { width: 1rem; height: 1rem; }
+
+    .admin-card__title {
+        font-size: var(--fs-base);
+        font-weight: 600;
+        color: var(--text);
+    }
+    .admin-card__desc {
+        font-size: var(--fs-xs);
+        color: var(--text-muted);
+        margin-top: 0.25rem;
+        line-height: 1.5;
+    }
+</style>
+{/literal}


### PR DESCRIPTION
## Summary

Phase B10 of the v2.0.0 theme rollout (#1123) replaces the Phase A1 stub
for `?p=admin` with the canonical **8-card landing grid** from the
handoff `AdminPanelView` mockup, gates each card on the union of
permission flags the legacy router enforces for that sub-route, and
switches `web/pages/page.admin.php` from the legacy `$theme->assign`
chain to the typed `Renderer::render(new AdminHomeView(...))` flow.

### What's in the box

- **`Sbpp\View\AdminHomeView` (new)** — declares one composite
  `bool $can_<area>` per landing card (`admins`, `groups`, `servers`,
  `bans`, `mods`, `overrides`, `settings`, `audit`), computed in the
  page handler from `Sbpp\View\Perms::for($userbank)`. ADMIN_OWNER
  bypass is already baked into every per-flag bool by `Perms::for()`,
  so an owner lights up every card without an extra `|| $can_owner`.
  The View also keeps the legacy `$access_*` / `$total_*` / `$dev` /
  `$demosize` fields the existing `default/page_admin.tpl` renders, so
  one View serves both themes during the dual-theme rollout (D1 drops
  the legacy fields when the legacy template goes away).

- **`web/pages/page.admin.php`** — switches to `Renderer::render(...)`
  with named-arg construction. Stat-count query is unchanged; the
  composite `can_<area>` derivations are spelled out so the gating
  logic is auditable in one place. Comment links each composite to the
  legacy router mask in `web/includes/page-builder.php`.

- **`web/themes/sbpp2026/page_admin.tpl`** — the new card grid:
  `role="list"` + `aria-label="Admin areas"`, `data-testid="admin-card-<area>"`
  per the issue's testability rule, `lucide` icons matching the
  handoff, `{if $can_<area>}` gating around each card, and a
  `{literal}<style>{/literal}` block at the bottom for card styles
  (Phase B forbids touching `../css/*.css`). An unreachable
  `{if false}{$access_*}…{/if}` parity block at the bottom keeps
  `SmartyTemplateRule`'s "unused property" check green on the sbpp2026
  PHPStan leg without bespoke baseline entries — same precedent
  `HomeDashboardView`/`page_dashboard.tpl` set in B3.

- **`web/phpstan-baseline.neon`** — 8 `unusedProperty` entries for the
  new `$can_<area>` props on the **default** leg (the legacy
  `default/page_admin.tpl` doesn't reference them); the baseline +
  AdminHomeView docblock both call these out as removable in lockstep
  with D1's hard cutover.

### Permission gating

Each composite OR's the per-flag `can_*` keys produced by
`Perms::for()`, mirroring the masks the legacy router uses in
`page-builder.php`:

| Card | Composite |
| --- | --- |
| Admins | `can_list_admins ∥ can_add_admins ∥ can_edit_admins ∥ can_delete_admins` |
| Groups | `can_list_groups ∥ can_add_group ∥ can_edit_groups ∥ can_delete_groups` |
| Servers | `can_list_servers ∥ can_add_server ∥ can_edit_servers ∥ can_delete_servers` |
| Bans | `can_add_ban ∥ can_edit_*_bans ∥ can_ban_protests ∥ can_ban_submissions ∥ can_delete_ban ∥ can_unban` |
| Mods | `can_list_mods ∥ can_add_mods ∥ can_edit_mods ∥ can_delete_mods` |
| Overrides | `can_add_admins` (matches the legacy `c=admins` route's mask for the overrides sub-tab) |
| Settings | `can_web_settings` |
| Audit | `can_owner` (forward-looking; legacy router's `default:` returns the admin landing itself, so the link is a harmless self-loop until the `c=audit` route lands) |

## Test plan

Local quality gates all clean:

- [x] `./sbpp.sh phpstan` (default leg + `SBPP_THEMES=sbpp2026` leg)
- [x] `./sbpp.sh test` — 268 tests, 1134 assertions
- [x] `./sbpp.sh ts-check`
- [x] `./sbpp.sh composer api-contract` (no diff)

End-to-end verification against the `sbpp2026` theme using chromium:

- [x] Logged in as `admin/admin`, hit `?p=admin`
- [x] All 8 cards render in light **and** dark mode
- [x] Sidebar "Admin Panel" link is the active item
- [x] Every card carries its `data-testid="admin-card-<area>"`

## Out of scope

- Comms is intentionally absent from the landing per the handoff
  mockup (it folds into the sidebar nav `admin/comms`); the legacy
  `c=comms` sub-route + page are unaffected.
- Audit is the forward-looking 8th card; the actual `c=audit` route +
  page is a future ticket.
- D1 will delete the legacy `default/page_admin.tpl` and the legacy
  fields on `AdminHomeView` together with the matching baseline
  entries — leaving them here keeps this PR scope-locked to B10.