### PR TITLE
[#1123 B16] Redesign admin mods group

### DIFF
--- a/web/includes/View/AdminEditModView.php
+++ b/web/includes/View/AdminEditModView.php
@@ -1,0 +1,40 @@
+<?php
+declare(strict_types=1);
+
+namespace Sbpp\View;
+
+/**
+ * Edit form for a single mod — binds to `page_admin_edit_mod.tpl`.
+ *
+ * `web/pages/admin.edit.mod.php` still drives this template via direct
+ * `$theme->assign()` calls (the page handler is out of scope for this
+ * Phase B ticket). The variable contract preserved here mirrors what
+ * that page assigns:
+ *
+ *   - `name`           — current mod name (post-store htmlspecialchars'd
+ *                        in admin.edit.mod.php; see #1113 audit).
+ *   - `folder`         — current mod folder (same caveat).
+ *   - `mod_icon`       — current icon filename (same caveat).
+ *   - `steam_universe` — first digit of STEAM_X:Y:Z (PDO returns an
+ *                        int-as-string by default; see Database.php).
+ *
+ * The `enabled` checkbox is intentionally NOT a template variable: the
+ * legacy page handler emits an inline `<script>` after the template
+ * that sets `$('enabled').checked` from the row's `enabled` column,
+ * because the .tpl is rendered before the row's checkbox state is
+ * known to Smarty. Preserving that path keeps admin.edit.mod.php out
+ * of this PR's scope; D-series can fold it in once it migrates to
+ * `Renderer::render`.
+ */
+final class AdminEditModView extends View
+{
+    public const TEMPLATE = 'page_admin_edit_mod.tpl';
+
+    public function __construct(
+        public readonly string $name,
+        public readonly string $folder,
+        public readonly string $mod_icon,
+        public readonly int|string $steam_universe,
+    ) {
+    }
+}

--- a/web/includes/View/AdminModsAddView.php
+++ b/web/includes/View/AdminModsAddView.php
@@ -1,0 +1,27 @@
+<?php
+declare(strict_types=1);
+
+namespace Sbpp\View;
+
+/**
+ * Second tab of the admin "Mods" page (add new mod) — binds to
+ * `page_admin_mods_add.tpl`. The form is wired to `Actions.ModsAdd`
+ * via the legacy `ProcessMod()` helper in `web/scripts/sourcebans.js`;
+ * the icon picker still pops `pages/admin.uploadicon.php` and writes
+ * the resulting filename back into the form via `window.opener.icon()`.
+ *
+ * `permission_add` keeps its legacy name because the default theme's
+ * `page_admin_mods_add.tpl` references `{if NOT $permission_add}`. The
+ * dual-theme PHPStan matrix (#1123 A2) cross-checks both templates
+ * against this View; renaming would force a paired edit to the
+ * default theme, which is out of this PR's scope.
+ */
+final class AdminModsAddView extends View
+{
+    public const TEMPLATE = 'page_admin_mods_add.tpl';
+
+    public function __construct(
+        public readonly bool $permission_add,
+    ) {
+    }
+}

--- a/web/includes/View/AdminModsListView.php
+++ b/web/includes/View/AdminModsListView.php
@@ -1,0 +1,41 @@
+<?php
+declare(strict_types=1);
+
+namespace Sbpp\View;
+
+/**
+ * First tab of the admin "Mods" page — binds to
+ * `page_admin_mods_list.tpl`.
+ *
+ * Each `mod_list` row is the raw `:prefix_mods` SELECT projection (mid,
+ * name, modfolder, icon, steam_universe, enabled). The View only cares
+ * that the array has the columns the template iterates; the
+ * SmartyTemplateRule check is on the View → template variable parity,
+ * not on the inner array shape.
+ *
+ * Property names keep the legacy `permission_*` shape (rather than the
+ * newer `can_*` convention `Sbpp\View\Perms::for()` produces) because
+ * the default theme's `page_admin_mods_list.tpl` still references
+ * `{$permission_listmods}` / `{$permission_editmods}` /
+ * `{$permission_deletemods}`. The dual-theme PHPStan matrix added in
+ * #1123 A2 cross-checks both templates against this single View, so
+ * both themes have to use the same variable names until D1 drops the
+ * legacy theme. See `AdminServersListView` / `AdminBansAddView` for
+ * the established Phase A→B convention.
+ */
+final class AdminModsListView extends View
+{
+    public const TEMPLATE = 'page_admin_mods_list.tpl';
+
+    /**
+     * @param list<array<string,mixed>> $mod_list
+     */
+    public function __construct(
+        public readonly bool $permission_listmods,
+        public readonly bool $permission_editmods,
+        public readonly bool $permission_deletemods,
+        public readonly int $mod_count,
+        public readonly array $mod_list,
+    ) {
+    }
+}

--- a/web/pages/admin.mods.php
+++ b/web/pages/admin.mods.php
@@ -24,32 +24,29 @@ if (!defined("IN_SB")) {
 global $userbank, $theme;
 
 new AdminTabs([
-    ['name' => 'List MODs', 'permission' => ADMIN_OWNER|ADMIN_LIST_MODS],
-    ['name' => 'Add new MOD', 'permission' => ADMIN_OWNER|ADMIN_ADD_MODS]
+    ['name' => 'List MODs',    'permission' => ADMIN_OWNER|ADMIN_LIST_MODS],
+    ['name' => 'Add new MOD',  'permission' => ADMIN_OWNER|ADMIN_ADD_MODS],
 ], $userbank, $theme);
 
-$mod_list = $GLOBALS['PDO']->query("SELECT * FROM `:prefix_mods` WHERE mid > 0 ORDER BY name ASC")->resultset();
-$query = $GLOBALS['PDO']->query("SELECT COUNT(mid) AS cnt FROM `:prefix_mods`")->single();
-$mod_count = $query['cnt'];
-?>
-<div id="admin-page-content">
-    <!-- List Mods -->
-    <div class="tabcontent" id="List MODs">
-<?php
-$theme->assign('mod_count', $mod_count);
-$theme->assign('permission_listmods', $userbank->HasAccess(ADMIN_OWNER | ADMIN_LIST_MODS));
-$theme->assign('permission_editmods', $userbank->HasAccess(ADMIN_OWNER | ADMIN_EDIT_MODS));
-$theme->assign('permission_deletemods', $userbank->HasAccess(ADMIN_OWNER | ADMIN_DELETE_MODS));
-$theme->assign('mod_list', $mod_list);
+$mod_list  = $GLOBALS['PDO']->query("SELECT * FROM `:prefix_mods` WHERE mid > 0 ORDER BY name ASC")->resultset();
+$mod_count = (int) $GLOBALS['PDO']->query("SELECT COUNT(mid) AS cnt FROM `:prefix_mods`")->single()['cnt'];
 
-$theme->display('page_admin_mods_list.tpl');
-?>
-    </div>
-    <!-- Add Mods -->
-    <div class="tabcontent" id="Add new MOD">
-<?php
-$theme->assign('permission_add', $userbank->HasAccess(ADMIN_OWNER | ADMIN_ADD_MODS));
-$theme->display('page_admin_mods_add.tpl');
-?>
-    </div>
-</div>
+echo '<div id="admin-page-content">';
+
+echo '<div class="tabcontent" id="List MODs">';
+\Sbpp\View\Renderer::render($theme, new \Sbpp\View\AdminModsListView(
+    permission_listmods:   $userbank->HasAccess(ADMIN_OWNER | ADMIN_LIST_MODS),
+    permission_editmods:   $userbank->HasAccess(ADMIN_OWNER | ADMIN_EDIT_MODS),
+    permission_deletemods: $userbank->HasAccess(ADMIN_OWNER | ADMIN_DELETE_MODS),
+    mod_count:             $mod_count,
+    mod_list:              $mod_list,
+));
+echo '</div>';
+
+echo '<div class="tabcontent" id="Add new MOD">';
+\Sbpp\View\Renderer::render($theme, new \Sbpp\View\AdminModsAddView(
+    permission_add: $userbank->HasAccess(ADMIN_OWNER | ADMIN_ADD_MODS),
+));
+echo '</div>';
+
+echo '</div>';

--- a/web/themes/sbpp2026/page_admin_edit_mod.tpl
+++ b/web/themes/sbpp2026/page_admin_edit_mod.tpl
@@ -1,6 +1,155 @@
-<div class="card">
-    <div class="card__body">
-        <h1>{$title}</h1>
-        <p class="text-muted">This page hasn't been redesigned yet.</p>
+{*
+    SourceBans++ 2026 — page / page_admin_edit_mod.tpl
+
+    Edit form for a single mod. Pair: Sbpp\View\AdminEditModView +
+    web/pages/admin.edit.mod.php (the latter is intentionally NOT in
+    this PR's scope — see AdminEditModView's docblock for why).
+
+    Variable contract (matches the $theme->assign() calls in
+    web/pages/admin.edit.mod.php):
+        - $name           — current mod name
+        - $folder         — current mod folder
+        - $mod_icon       — current icon filename
+        - $steam_universe — int-as-string from PDO
+
+    Submission flow:
+        - <form method="post" action=""> POSTs back to the same page.
+          admin.edit.mod.php inspects $_POST['name'] to decide whether
+          to validate + UPDATE the row.
+        - {csrf_field} is required; admin.edit.mod.php currently
+          relies on the existing page-level CSRF middleware, so the
+          field doubles as the explicit token for any future direct
+          POST handler.
+        - The icon picker pops pages/admin.uploadicon.php which calls
+          window.opener.icon('<filename>') on success; that wires the
+          filename into the hidden #icon_hid input that the page
+          handler reads as $_POST['icon_hid'].
+        - The "Enabled" checkbox is rendered without a `checked`
+          attribute on purpose: admin.edit.mod.php emits an inline
+          <script> AFTER this template that sets
+          $('enabled').checked from the row's `enabled` column. That
+          keeps the page handler out of this Phase B PR's scope.
+
+    Testability hooks: every interactive control carries
+    data-testid="editmod-<field>" so end-to-end tests can address it.
+    HTML form ids stay intact because admin.edit.mod.php's inline
+    error-handling script targets them by id (legacy MooTools-style
+    `$('name.msg')`).
+*}
+<form method="post"
+      action=""
+      enctype="multipart/form-data"
+      autocomplete="off"
+      data-testid="editmod-form">
+    {csrf_field}
+    <div class="card">
+        <div class="card__header">
+            <div>
+                <h3>Edit Mod</h3>
+                <p>Update the configuration for this game mod.</p>
+            </div>
+        </div>
+        <div class="card__body space-y-4" style="max-width:42rem">
+            <input type="hidden" name="insert_type" value="add">
+
+            {* nofilter: mod metadata is htmlspecialchars(strip_tags($_POST[…]))'d in admin.edit.mod.php before INSERT/UPDATE, so values pulled back out of `:prefix_mods` are already entity-encoded; auto-escaping the value attribute would double-encode (#1113 audit). The id="icon_hid" element is the channel the popup uploader writes into via window.opener.icon(). *}
+            <input type="hidden" id="icon_hid" name="icon_hid" value="{$mod_icon nofilter}">
+
+            <div>
+                <label class="label" for="name">Mod name</label>
+                {* nofilter: see the icon_hid annotation above — name is htmlspecialchars'd on store, double-encoding it in the value attribute would render literal &amp;… to admins (#1108 / #1113 audit). *}
+                <input class="input"
+                       type="text"
+                       id="name"
+                       name="name"
+                       data-testid="editmod-name"
+                       value="{$name nofilter}"
+                       required>
+                <div id="name.msg"
+                     class="text-xs"
+                     style="color:var(--danger);display:none;margin-top:0.25rem"></div>
+            </div>
+
+            <div>
+                <label class="label" for="folder">Mod folder</label>
+                {* nofilter: see the icon_hid annotation above — folder is htmlspecialchars'd on store. *}
+                <input class="input"
+                       type="text"
+                       id="folder"
+                       name="folder"
+                       data-testid="editmod-folder"
+                       value="{$folder nofilter}"
+                       required>
+                <p class="text-xs text-muted" style="margin-top:0.25rem">
+                    Folder name on disk (e.g. <span class="font-mono">cstrike</span> for Counter-Strike: Source).
+                </p>
+                <div id="folder.msg"
+                     class="text-xs"
+                     style="color:var(--danger);display:none;margin-top:0.25rem"></div>
+            </div>
+
+            <div>
+                <label class="label" for="steam_universe">Steam universe number</label>
+                <input class="input"
+                       type="number"
+                       id="steam_universe"
+                       name="steam_universe"
+                       data-testid="editmod-steam_universe"
+                       min="0"
+                       value="{$steam_universe}"
+                       style="max-width:8rem">
+                <p class="text-xs text-muted" style="margin-top:0.25rem">
+                    First digit (X) of <span class="font-mono">STEAM_X:Y:Z</span> as rendered by this mod.
+                </p>
+            </div>
+
+            <div>
+                <label class="flex items-center gap-2">
+                    <input type="checkbox"
+                           id="enabled"
+                           name="enabled"
+                           data-testid="editmod-enabled"
+                           value="1">
+                    <span class="text-sm">Enabled — assignable to bans and servers.</span>
+                </label>
+            </div>
+
+            <div>
+                <label class="label">Mod icon</label>
+                <div class="flex items-center gap-3">
+                    <button class="btn btn--secondary btn--sm"
+                            type="button"
+                            data-testid="editmod-upload"
+                            onclick="childWindow=open('pages/admin.uploadicon.php','upload','resizable=yes,width=320,height=160');">
+                        <i data-lucide="upload"></i>
+                        Upload icon
+                    </button>
+                    {if $mod_icon}
+                        <span class="text-xs text-muted">
+                            Current:
+                            {* nofilter: see the icon_hid annotation above — icon filename is htmlspecialchars'd on store. *}
+                            <span class="font-mono" data-testid="editmod-current-icon">{$mod_icon nofilter}</span>
+                        </span>
+                    {/if}
+                </div>
+                <div id="icon.msg"
+                     class="text-xs"
+                     style="color:var(--danger);margin-top:0.25rem"></div>
+            </div>
+
+            <div class="flex justify-end gap-2"
+                 style="border-top:1px solid var(--border);padding-top:1rem">
+                <a class="btn btn--ghost btn--sm"
+                   href="javascript:history.go(-1)"
+                   data-testid="editmod-cancel">Back</a>
+                <button class="btn btn--primary btn--sm"
+                        type="submit"
+                        id="editmod"
+                        data-testid="editmod-submit">
+                    <i data-lucide="save"></i>
+                    Save changes
+                </button>
+            </div>
+        </div>
     </div>
-</div>
+</form>

--- a/web/themes/sbpp2026/page_admin_mods_add.tpl
+++ b/web/themes/sbpp2026/page_admin_mods_add.tpl
@@ -1,6 +1,145 @@
-<div class="card">
-    <div class="card__body">
-        <h1>{$title}</h1>
-        <p class="text-muted">This page hasn't been redesigned yet.</p>
+{*
+    SourceBans++ 2026 — page / page_admin_mods_add.tpl
+
+    Second tab of the admin "Mods" page (add a new mod). Pair:
+    Sbpp\View\AdminModsAddView + web/pages/admin.mods.php.
+
+    Submission flow (preserved end-to-end from the legacy theme):
+        1. <button data-testid="addmod-submit"> calls ProcessMod()
+           (web/scripts/sourcebans.js), which validates the inputs and
+           POSTs the JSON payload via sb.api.call(Actions.ModsAdd, …).
+           api.js handles the CSRF header automatically; the
+           {csrf_field} hidden input is included for any future
+           server-side fallback (no-JS) submission.
+        2. The icon picker pops pages/admin.uploadicon.php in a child
+           window. On successful upload the popup calls
+           window.opener.icon('<filename>'), which sets the icname
+           closure variable that ProcessMod() reads back as the icon
+           field. The form's enctype="multipart/form-data" matches the
+           upload window's content-type so a future direct upload
+           (instead of the popup) drops in without changing markup.
+
+    Variable contract: only $permission_add. The default theme's
+    page_admin_mods_add.tpl uses the same name; the dual-theme PHPStan
+    matrix (#1123 A2) enforces the join through Sbpp\View\AdminModsAddView.
+
+    Testability hooks: every interactive control carries
+    data-testid="addmod-<field>" so end-to-end tests can address it
+    without depending on element ids (which double as JS hooks for the
+    legacy ProcessMod() function — left intact to keep the wiring
+    in this Phase B PR's scope).
+*}
+{if NOT $permission_add}
+    <div class="card">
+        <div class="card__body">
+            <p class="text-muted">Access denied.</p>
+        </div>
     </div>
-</div>
+{else}
+    <form method="post"
+          action=""
+          enctype="multipart/form-data"
+          autocomplete="off"
+          onsubmit="ProcessMod(); return false;"
+          data-testid="addmod-form">
+        {csrf_field}
+        <div class="card">
+            <div class="card__header">
+                <div>
+                    <h3>Add Mod</h3>
+                    <p>Configure a new game mod that can be assigned to bans and servers.</p>
+                </div>
+            </div>
+            <div class="card__body space-y-4" style="max-width:42rem">
+                <input type="hidden" id="fromsub" value="">
+
+                <div>
+                    <label class="label" for="name">Mod name</label>
+                    <input class="input"
+                           type="text"
+                           id="name"
+                           name="name"
+                           data-testid="addmod-name"
+                           required>
+                    <div id="name.msg"
+                         class="text-xs"
+                         style="color:var(--danger);display:none;margin-top:0.25rem"></div>
+                </div>
+
+                <div>
+                    <label class="label" for="folder">Mod folder</label>
+                    <input class="input"
+                           type="text"
+                           id="folder"
+                           name="folder"
+                           data-testid="addmod-folder"
+                           required>
+                    <p class="text-xs text-muted" style="margin-top:0.25rem">
+                        Folder name on disk (e.g. <span class="font-mono">cstrike</span> for Counter-Strike: Source).
+                    </p>
+                    <div id="folder.msg"
+                         class="text-xs"
+                         style="color:var(--danger);display:none;margin-top:0.25rem"></div>
+                </div>
+
+                <div>
+                    <label class="label" for="steam_universe">Steam universe number</label>
+                    <input class="input"
+                           type="number"
+                           id="steam_universe"
+                           name="steam_universe"
+                           data-testid="addmod-steam_universe"
+                           min="0"
+                           value="0"
+                           style="max-width:8rem">
+                    <p class="text-xs text-muted" style="margin-top:0.25rem">
+                        First digit (X) of <span class="font-mono">STEAM_X:Y:Z</span> as rendered by this mod. Default 0.
+                    </p>
+                </div>
+
+                <div>
+                    <label class="flex items-center gap-2">
+                        <input type="checkbox"
+                               id="enabled"
+                               name="enabled"
+                               data-testid="addmod-enabled"
+                               value="1"
+                               checked>
+                        <span class="text-sm">Enabled — assignable to bans and servers.</span>
+                    </label>
+                </div>
+
+                <div>
+                    <label class="label">Mod icon</label>
+                    <button class="btn btn--secondary btn--sm"
+                            type="button"
+                            data-testid="addmod-upload"
+                            onclick="childWindow=open('pages/admin.uploadicon.php','upload','resizable=yes,width=320,height=160');">
+                        <i data-lucide="upload"></i>
+                        Upload icon
+                    </button>
+                    <p class="text-xs text-muted" style="margin-top:0.25rem">
+                        16x16 GIF, PNG or JPG. Opens a popup uploader.
+                    </p>
+                    <div id="icon.msg"
+                         class="text-xs"
+                         style="color:var(--danger);margin-top:0.25rem"></div>
+                </div>
+
+                <div class="flex justify-end gap-2"
+                     style="border-top:1px solid var(--border);padding-top:1rem">
+                    <a class="btn btn--ghost btn--sm"
+                       href="javascript:history.go(-1)"
+                       data-testid="addmod-cancel">Back</a>
+                    <button class="btn btn--primary btn--sm"
+                            type="submit"
+                            id="amod"
+                            data-testid="addmod-submit">
+                        <i data-lucide="plus"></i>
+                        Add mod
+                    </button>
+                </div>
+            </div>
+        </div>
+    </form>
+{/if}

--- a/web/themes/sbpp2026/page_admin_mods_list.tpl
+++ b/web/themes/sbpp2026/page_admin_mods_list.tpl
@@ -1,6 +1,109 @@
-<div class="card">
-    <div class="card__body">
-        <h1>{$title}</h1>
-        <p class="text-muted">This page hasn't been redesigned yet.</p>
+{*
+    SourceBans++ 2026 — page / page_admin_mods_list.tpl
+
+    First tab of the admin "Mods" page. Pair: Sbpp\View\AdminModsListView
+    + web/pages/admin.mods.php (renders this and page_admin_mods_add.tpl
+    inside the AdminTabs scaffold).
+
+    Variable contract (kept in sync by SmartyTemplateRule):
+        - $permission_listmods   — gate the whole tab body.
+        - $permission_editmods   — gate the per-row "Edit" link.
+        - $permission_deletemods — gate the per-row "Delete" button.
+        - $mod_count             — total mods configured.
+        - $mod_list              — :prefix_mods rows (mid, name,
+                                   modfolder, icon, steam_universe,
+                                   enabled).
+
+    Variable names match the default theme's page_admin_mods_list.tpl
+    (legacy `permission_*` style). The dual-theme PHPStan matrix
+    (#1123 A2) cross-checks both templates against the View, so both
+    have to agree on names until D1 retires the legacy theme.
+
+    Testability hooks:
+        - Each row carries data-testid="mod-row" + data-id="{$mod.mid}"
+          so end-to-end tests can target a specific mod without parsing
+          inner markup.
+        - The Delete button uses data-mod-name / data-mod-id to feed
+          RemoveMod() so admin-controlled mod names can never escape
+          out of an inline JS string literal (#1113-style hardening).
+*}
+{if NOT $permission_listmods}
+    <div class="card">
+        <div class="card__body">
+            <p class="text-muted">Access denied.</p>
+        </div>
     </div>
-</div>
+{else}
+    <div class="card">
+        <div class="card__header">
+            <div>
+                <h3>Server Mods</h3>
+                <p>{$mod_count} configured</p>
+            </div>
+        </div>
+        {if $mod_count > 0}
+            <table class="table" data-testid="mods-table">
+                <thead>
+                    <tr>
+                        <th style="width:40%">Name</th>
+                        <th>Folder</th>
+                        <th><span title="SteamID Universe (X of STEAM_X:Y:Z)">SU</span></th>
+                        <th>Status</th>
+                        {if $permission_editmods || $permission_deletemods}
+                            <th style="text-align:right">Actions</th>
+                        {/if}
+                    </tr>
+                </thead>
+                <tbody>
+                    {foreach from=$mod_list item=mod}
+                        <tr id="mid_{$mod.mid}" data-testid="mod-row" data-id="{$mod.mid}">
+                            <td>
+                                <div class="flex items-center gap-3">
+                                    <img src="images/games/{$mod.icon}"
+                                         alt=""
+                                         width="20"
+                                         height="20"
+                                         loading="lazy"
+                                         onerror="this.style.visibility='hidden'">
+                                    <span class="font-medium">{$mod.name}</span>
+                                </div>
+                            </td>
+                            <td><span class="font-mono text-xs">{$mod.modfolder}</span></td>
+                            <td class="tabular-nums">{$mod.steam_universe}</td>
+                            <td>
+                                {if $mod.enabled}
+                                    <span class="pill pill--online">Enabled</span>
+                                {else}
+                                    <span class="pill pill--offline">Disabled</span>
+                                {/if}
+                            </td>
+                            {if $permission_editmods || $permission_deletemods}
+                                <td style="text-align:right">
+                                    <div class="flex justify-end gap-2">
+                                        {if $permission_editmods}
+                                            <a class="btn btn--ghost btn--sm"
+                                               href="index.php?p=admin&c=mods&o=edit&id={$mod.mid|escape:'url'}"
+                                               data-testid="editmod-link">Edit</a>
+                                        {/if}
+                                        {if $permission_deletemods}
+                                            <button class="btn btn--ghost btn--sm"
+                                                    type="button"
+                                                    data-testid="deletemod-btn"
+                                                    data-mod-id="{$mod.mid}"
+                                                    data-mod-name="{$mod.name}"
+                                                    onclick="RemoveMod(this.dataset.modName, this.dataset.modId);">Delete</button>
+                                        {/if}
+                                    </div>
+                                </td>
+                            {/if}
+                        </tr>
+                    {/foreach}
+                </tbody>
+            </table>
+        {else}
+            <div class="card__body">
+                <p class="text-muted">No mods configured yet.</p>
+            </div>
+        {/if}
+    </div>
+{/if}


### PR DESCRIPTION
## Summary

Phase B16 of #1123 — wires the sbpp2026 theme's admin **Mods** group
(list / add / edit) into the `Renderer::render` flow.

- New `Sbpp\View\AdminModsListView` / `AdminModsAddView` /
  `AdminEditModView` paired with the three new sbpp2026 templates;
  `SmartyTemplateRule` cross-checks property↔template variable
  parity against both themes.
- `web/pages/admin.mods.php` swaps inline `$theme->assign` +
  `$theme->display` for two typed `Renderer::render` calls (one
  per tab). The legacy `admin.edit.mod.php` page handler stays
  intact (it's out of B16 scope) — the new edit template adopts
  exactly the variables that page already assigns
  (`$name`, `$folder`, `$mod_icon`, `$steam_universe`); the
  `enabled` checkbox is still set by the inline `<script>` the
  page emits after the template (see `AdminEditModView` docblock).
- The list tab uses a card+table layout, an Enabled/Disabled
  status pill, and per-row `data-testid="mod-row"` +
  `data-id="{$mod.mid}"` hooks. Edit/Delete buttons are gated on
  `ADMIN_EDIT_MODS` / `ADMIN_DELETE_MODS`. Delete reuses the
  existing `RemoveMod()` flow (driven through `Actions.ModsRemove`).
- The add tab uses a `multipart/form-data` form (kept for the popup
  uploader and any future direct upload); `ProcessMod()` in
  `sourcebans.js` still drives `Actions.ModsAdd`. `{csrf_field}` is
  emitted for the no-JS fallback path.
- Every `{nofilter}` site has a paired `{* nofilter: <reason> *}`
  comment per the #1113 audit (mod metadata is
  `htmlspecialchars(strip_tags(...))`'d on store, so escaping in the
  `value=""` attribute would double-encode).
- Permission variable names stay `permission_*` to match the legacy
  default theme — the dual-theme PHPStan matrix (#1123 A2) cross-checks
  both themes against the same View, so renaming would force out-of-scope
  edits to `themes/default/`.

## Files in scope

- `web/includes/View/AdminModsListView.php` (new)
- `web/includes/View/AdminModsAddView.php` (new)
- `web/includes/View/AdminEditModView.php` (new)
- `web/themes/sbpp2026/page_admin_mods_list.tpl`
- `web/themes/sbpp2026/page_admin_mods_add.tpl`
- `web/themes/sbpp2026/page_admin_edit_mod.tpl`
- `web/pages/admin.mods.php`

## Test plan

- [x] `./sbpp.sh ts-check` — clean.
- [x] `./sbpp.sh composer api-contract` — no diff (PHP API surface
      untouched).
- [x] `./sbpp.sh phpstan` (default theme) — no new errors. Pre-existing
      baseline drift in `AdminBansGroupsView` / `AdminServersAddView` /
      `HomeDashboardView` / `ServersView` is reproducible on a clean
      `main` checkout in this same Docker host (other workers'
      uncomitted state on the shared db) and is unrelated to B16.
- [x] `SBPP_PHPSTAN_THEME=sbpp2026 ./sbpp.sh phpstan` — same:
      identical pre-existing drift on clean `main`, no B16 errors.
- [x] `./sbpp.sh test` mod surface — `ModsTest` (full),
      `PermissionMatrix` (`mods.add`, `mods.remove`, …),
      `DispatcherTest`, `ApiContractTest` — 65 tests / 258 assertions
      pass.
- [x] Smoke-tested all three pages against the running stack
      (`?p=admin&c=mods`, `?p=admin&c=mods&o=edit&id=2`) under the
      `sbpp2026` theme: confirmed `data-testid` hooks, `{csrf_field}`
      tokens, Enabled/Disabled pills, and form `multipart/form-data`
      enctypes render as designed.
- [ ] Full `./sbpp.sh test` suite — host is currently saturated with 80+
      sibling worker containers; `tests/api/AccountTest.php` etc. wall-clock
      out before completing. Focused scopes covering everything Mods-adjacent
      pass clean above; CI will run the full matrix.

## Out of scope (per plan)

- `web/pages/admin.edit.mod.php` (legacy page handler) is preserved
  as-is; the D-series can fold it into `Renderer::render` once the
  inline-`<script>`-after-template pattern for the `enabled` checkbox
  is reworked.
- The legacy `themes/default/` mods templates are unchanged; the
  permission variable names (`permission_listmods` / `permission_add`
  / …) are kept identical so the dual-theme PHPStan matrix stays
  green.