### PR TITLE
[#1123 B3] Redesign public dashboard

### DIFF
--- a/web/includes/View/HomeDashboardView.php
+++ b/web/includes/View/HomeDashboardView.php
@@ -4,11 +4,29 @@ declare(strict_types=1);
 namespace Sbpp\View;
 
 /**
- * Home dashboard page — binds to `page_dashboard.tpl`, which in turn
- * `{include file='page_servers.tpl'}`s the server list view. Because the
- * dashboard renders the server list without exiting and re-entering the
- * Smarty context, every variable used by `page_servers.tpl` also has to be
- * declared here (the transitive include is resolved by SmartyTemplateRule).
+ * Home dashboard page — binds to `page_dashboard.tpl`.
+ *
+ * Two themes consume this view side-by-side during the v2.0.0 rollout
+ * (#1123): the legacy `web/themes/default/page_dashboard.tpl` (which
+ * `{include file='page_servers.tpl'}`s the server list) and the new
+ * `web/themes/sbpp2026/page_dashboard.tpl` (which renders inline server
+ * tiles + a stats card grid). Because `SmartyTemplateRule` enforces
+ * one-to-one parity between properties and template references for the
+ * theme it scans, this View declares the *union* of variables both
+ * templates need:
+ *
+ *   - Legacy-only fields (`access_bans`, `IN_SERVERS_PAGE`,
+ *     `opened_server`) stay so the legacy template + transitively
+ *     included `page_servers.tpl` continue to type-check on the
+ *     `default` PHPStan leg.
+ *   - New stat-grid fields (`active_bans`, `total_servers`) are
+ *     consumed by the sbpp2026 template's stat cards. They have no
+ *     legacy use; the legacy template ignores extra Smarty assignments.
+ *
+ * D1's hard cutover deletes the legacy template and renames the
+ * sbpp2026 directory into `default/`; at that point this View loses the
+ * legacy-only fields in a follow-up cleanup PR (tracked by the D2 docs
+ * sweep).
  */
 final class HomeDashboardView extends View
 {
@@ -28,10 +46,12 @@ final class HomeDashboardView extends View
         public readonly int $total_blocked,
         public readonly array $players_banned,
         public readonly int $total_bans,
+        public readonly int $active_bans,
         public readonly array $players_commed,
         public readonly int $total_comms,
         public readonly bool $access_bans,
         public readonly array $server_list,
+        public readonly int $total_servers,
         public readonly bool $IN_SERVERS_PAGE,
         public readonly int $opened_server,
     ) {

--- a/web/pages/page.home.php
+++ b/web/pages/page.home.php
@@ -147,10 +147,13 @@ foreach ($rows as $row) {
 
     // sbpp2026 fields, derived from the same row so the new template
     // reads handoff-style keys without re-querying. The legacy template
-    // ignores extras.
+    // ignores extras. Stored raw — Smarty's global auto-escape
+    // (init.php: $theme->setEscapeHtml(true)) handles HTML-escaping at
+    // emit time; pre-escaping here would double-encode `&`/`<`/`>` in
+    // ban reasons (AGENTS.md: "Store raw, escape on display").
     $info['bid']          = (int) $row['bid'];
-    $info['reason']       = htmlspecialchars((string) $row['reason'], ENT_QUOTES, 'UTF-8');
-    $info['sname']        = htmlspecialchars((string) ($row['server_addr'] ?? ''), ENT_QUOTES, 'UTF-8');
+    $info['reason']       = (string) ($row['reason'] ?? '');
+    $info['sname']        = (string) ($row['server_addr'] ?? '');
     $info['length_human'] = $info['length'];
     $info['banned_human'] = $info['created'];
     // 'expired' (natural end) vs 'unbanned' (explicit D/U removal) so
@@ -217,10 +220,11 @@ foreach ($rows as $row) {
         $info['unbanned'] = false;
     }
 
-    // sbpp2026 fields, mirroring the bans loop above.
+    // sbpp2026 fields, mirroring the bans loop above (raw — Smarty
+    // escapes on display).
     $info['bid']          = (int) $row['bid'];
-    $info['reason']       = htmlspecialchars((string) $row['reason'], ENT_QUOTES, 'UTF-8');
-    $info['sname']        = htmlspecialchars((string) ($row['server_addr'] ?? ''), ENT_QUOTES, 'UTF-8');
+    $info['reason']       = (string) ($row['reason'] ?? '');
+    $info['sname']        = (string) ($row['server_addr'] ?? '');
     $info['length_human'] = $info['length'];
     $info['banned_human'] = $info['created'];
     // Lucide icon name. ba.type=2 is text-chat block, otherwise voice.

--- a/web/pages/page.home.php
+++ b/web/pages/page.home.php
@@ -26,9 +26,11 @@ define('IN_HOME', true);
 
 $totalstopped = (int) $GLOBALS['PDO']->query("SELECT count(name) AS cnt FROM `:prefix_banlog`")->single()['cnt'];
 
-$rows = $GLOBALS['PDO']->query("SELECT bl.name, time, bl.sid, bl.bid, b.type, b.authid, b.ip
+$rows = $GLOBALS['PDO']->query("SELECT bl.name, time, bl.sid, bl.bid, b.type, b.authid, b.ip,
+                                CONCAT(se.ip,':',se.port) AS server_addr
 								FROM `:prefix_banlog` AS bl
 								LEFT JOIN `:prefix_bans` AS b ON b.bid = bl.bid
+								LEFT JOIN `:prefix_servers` AS se ON se.sid = bl.sid
 								ORDER BY time DESC LIMIT 10")->resultset();
 
 $GLOBALS['server_qry'] = "";
@@ -68,11 +70,25 @@ foreach ($rows as $row) {
 
     $GLOBALS['server_qry'] .= "LoadServerHostProperty(" . $row['sid'] . ", 'block_" . $row['sid'] . "_$blcount', 'title', 100);";
 
+    // sbpp2026 fields. Stored alongside the legacy keys above so the
+    // new dashboard template reads `$player.bid` / `$player.sname`
+    // without breaking the legacy template (which simply ignores extra
+    // keys). Both themes share this view during the v2.0.0 rollout.
+    $info['bid']           = (int) ($row['bid'] ?? 0);
+    $info['sname']         = (string) ($row['server_addr'] ?? '');
+    $info['blocked_human'] = $info['date'];
+
     $stopped []= $info;
     ++$blcount;
 }
 
 $BanCount = (int) $GLOBALS['PDO']->query("SELECT count(bid) AS cnt FROM `:prefix_bans`")->single()['cnt'];
+
+$ActiveBanCount = (int) $GLOBALS['PDO']
+    ->query("SELECT count(bid) AS cnt FROM `:prefix_bans`
+             WHERE RemoveType IS NULL
+               AND (length = 0 OR ends > UNIX_TIMESTAMP())")
+    ->single()['cnt'];
 
 $rows = $GLOBALS['PDO']->query("SELECT bid, ba.ip, ba.authid, ba.name, created, ends, length, reason, ba.aid, ba.sid AS ba_sid, ad.user, CONCAT(se.ip,':',se.port) AS server_addr, se.sid AS se_sid, mo.icon, ba.RemoveType, ba.type
 			    				FROM `:prefix_bans` AS ba
@@ -119,17 +135,32 @@ foreach ($rows as $row) {
     $info['short_name'] = trunc($cleaned_name, 40);
 
     if ($row['RemoveType'] == 'D' || $row['RemoveType'] == 'U' || $row['RemoveType'] == 'E' || ($row['length'] && $row['ends'] < time())) {
-        $info['unbanned'] = true;
-
-        if ($row['RemoveType'] == 'D') {
-            $info['ub_reason'] = 'D';
-        } elseif ($row['RemoveType'] == 'U') {
-            $info['ub_reason'] = 'U';
-        } else {
-            $info['ub_reason'] = 'E';
-        }
+        $info['unbanned']  = true;
+        $info['ub_reason'] = match (true) {
+            $row['RemoveType'] === 'D' => 'D',
+            $row['RemoveType'] === 'U' => 'U',
+            default                    => 'E',
+        };
     } else {
         $info['unbanned'] = false;
+    }
+
+    // sbpp2026 fields, derived from the same row so the new template
+    // reads handoff-style keys without re-querying. The legacy template
+    // ignores extras.
+    $info['bid']          = (int) $row['bid'];
+    $info['reason']       = htmlspecialchars((string) $row['reason'], ENT_QUOTES, 'UTF-8');
+    $info['sname']        = htmlspecialchars((string) ($row['server_addr'] ?? ''), ENT_QUOTES, 'UTF-8');
+    $info['length_human'] = $info['length'];
+    $info['banned_human'] = $info['created'];
+    // 'expired' (natural end) vs 'unbanned' (explicit D/U removal) so
+    // .pill / .ban-row state classes can render them differently.
+    if ($info['unbanned']) {
+        $info['state'] = $info['ub_reason'] === 'E' ? 'expired' : 'unbanned';
+    } elseif ($info['perm']) {
+        $info['state'] = 'permanent';
+    } else {
+        $info['state'] = 'active';
     }
 
     array_push($bans, $info);
@@ -176,17 +207,30 @@ foreach ($rows as $row) {
     $info['type']        = $row['type'] == 2 ? "fas fa-comment-slash fa-lg" : "fas fa-microphone-slash fa-lg";
 
     if ($row['RemoveType'] == 'D' || $row['RemoveType'] == 'U' || $row['RemoveType'] == 'E' || ($row['length'] && $row['ends'] < time())) {
-        $info['unbanned'] = true;
-
-        if ($row['RemoveType'] == 'D') {
-            $info['ub_reason'] = 'D';
-        } elseif ($row['RemoveType'] == 'U') {
-            $info['ub_reason'] = 'U';
-        } else {
-            $info['ub_reason'] = 'E';
-        }
+        $info['unbanned']  = true;
+        $info['ub_reason'] = match (true) {
+            $row['RemoveType'] === 'D' => 'D',
+            $row['RemoveType'] === 'U' => 'U',
+            default                    => 'E',
+        };
     } else {
         $info['unbanned'] = false;
+    }
+
+    // sbpp2026 fields, mirroring the bans loop above.
+    $info['bid']          = (int) $row['bid'];
+    $info['reason']       = htmlspecialchars((string) $row['reason'], ENT_QUOTES, 'UTF-8');
+    $info['sname']        = htmlspecialchars((string) ($row['server_addr'] ?? ''), ENT_QUOTES, 'UTF-8');
+    $info['length_human'] = $info['length'];
+    $info['banned_human'] = $info['created'];
+    // Lucide icon name. ba.type=2 is text-chat block, otherwise voice.
+    $info['lucide_icon']  = $row['type'] == 2 ? 'message-square-off' : 'mic-off';
+    if ($info['unbanned']) {
+        $info['state'] = $info['ub_reason'] === 'E' ? 'expired' : 'unbanned';
+    } elseif ($info['perm']) {
+        $info['state'] = 'permanent';
+    } else {
+        $info['state'] = 'active';
     }
 
     array_push($comms, $info);
@@ -206,10 +250,12 @@ require(TEMPLATES_PATH . "/page.servers.php"); //populates $serversView
     total_blocked: $totalstopped,
     players_banned: $bans,
     total_bans: $BanCount,
+    active_bans: $ActiveBanCount,
     players_commed: $comms,
     total_comms: $CommCount,
     access_bans: $serversView->access_bans,
     server_list: $serversView->server_list,
+    total_servers: count($serversView->server_list),
     IN_SERVERS_PAGE: $serversView->IN_SERVERS_PAGE,
     opened_server: $serversView->opened_server,
 ));

--- a/web/phpstan-baseline.neon
+++ b/web/phpstan-baseline.neon
@@ -163,6 +163,25 @@ parameters:
 			path: includes/View/HomeDashboardView.php
 
 		-
+			# active_bans/total_servers are sbpp2026-only stat-card fields
+			# (#1123 B3). The legacy `default/page_dashboard.tpl` doesn't
+			# render them; the sbpp2026 leg of the dual-theme PHPStan
+			# matrix runs with reportUnmatchedIgnoredErrors=false so
+			# these baseline entries auto-skip when the new template
+			# does reference them. D1 deletes the legacy template and
+			# both entries collapse into the property cleanup PR.
+			message: '#^Property Sbpp\\View\\HomeDashboardView\:\:\$active_bans is never referenced in template "page_dashboard\.tpl"\.$#'
+			identifier: sbpp.view.unusedProperty
+			count: 1
+			path: includes/View/HomeDashboardView.php
+
+		-
+			message: '#^Property Sbpp\\View\\HomeDashboardView\:\:\$total_servers is never referenced in template "page_dashboard\.tpl"\.$#'
+			identifier: sbpp.view.unusedProperty
+			count: 1
+			path: includes/View/HomeDashboardView.php
+
+		-
 			message: '#^Property Sbpp\\View\\ServersView\:\:\$opened_server is never referenced in template "page_servers\.tpl"\.$#'
 			identifier: sbpp.view.unusedProperty
 			count: 1

--- a/web/themes/sbpp2026/page_dashboard.tpl
+++ b/web/themes/sbpp2026/page_dashboard.tpl
@@ -1,6 +1,253 @@
-<div class="card">
-    <div class="card__body">
-        <h1>{$title}</h1>
-        <p class="text-muted">This page hasn't been redesigned yet.</p>
+{*
+    SourceBans++ 2026 — page_dashboard.tpl
+
+    Public landing page. Renders a stat-card grid + recent activity panels
+    sourced from `:prefix_bans`, `:prefix_comms`, `:prefix_banlog`, and
+    `:prefix_servers`. View: Sbpp\View\HomeDashboardView (also shared with
+    the legacy default theme during the v2.0.0 rollout — see the View's
+    docblock for the per-theme field map).
+
+    Skipped from the handoff design per #1123 B3 brief ("directional, not
+    literal"):
+      * Bans-over-time sparkline — no per-day aggregation feed yet.
+      * Team coverage — no on-duty / response-time tracking yet.
+    Both stay open for a follow-up once the underlying data exists.
+
+    Live server status (player counts, hostname, online/offline) is the
+    other intentional omission. The legacy theme's sb-callback /
+    LoadServerHostProperty UDP probe was deleted with sourcebans.js in
+    A1's footer rewrite; re-implementing it needs a new JSON action
+    under web/api/handlers/, which Phase B is forbidden from touching.
+    The Servers card therefore renders configured-server metadata only
+    (mod icon + ip:port + sid) and links out to ?p=servers.
+*}
+<div class="p-6 space-y-6" style="max-width:1400px;margin:0 auto;width:100%">
+
+    {* -- Page header -------------------------------------------------- *}
+    <header data-testid="dashboard-header">
+        <h1 style="font-size:var(--fs-2xl);font-weight:600;margin:0">
+            {if $dashboard_title}{$dashboard_title}{else}Dashboard{/if}
+        </h1>
+        <p class="text-sm text-muted m-0 mt-2">Activity across your servers.</p>
+    </header>
+
+    {* -- Optional admin-authored intro (Markdown) --------------------- *}
+    {if $dashboard_text}
+    <section class="card" data-testid="dashboard-intro">
+        <div class="card__body">
+            {* nofilter: rendered by IntroRenderer (CommonMark, html_input=escape, allow_unsafe_links=false); never raw user input *}
+            {$dashboard_text nofilter}
+        </div>
+    </section>
+    {/if}
+
+    {* -- Stat cards (4-up; collapses to 2-up then 1-up) --------------- *}
+    <div class="grid gap-4" style="grid-template-columns:repeat(auto-fit,minmax(180px,1fr))">
+
+        <div class="card p-5" data-testid="dashboard-stat-total-bans">
+            <div class="flex items-start justify-between">
+                <div class="text-xs font-medium text-muted" style="text-transform:uppercase;letter-spacing:0.06em">Total bans</div>
+                <i data-lucide="ban" style="color:var(--text-faint)"></i>
+            </div>
+            <div class="tabular-nums" style="font-size:1.875rem;font-weight:600;margin-top:0.5rem">{$total_bans|number_format}</div>
+            <div class="text-xs text-muted">all time</div>
+        </div>
+
+        <div class="card p-5" data-testid="dashboard-stat-active-bans">
+            <div class="flex items-start justify-between">
+                <div class="text-xs font-medium text-muted" style="text-transform:uppercase;letter-spacing:0.06em">Active bans</div>
+                <i data-lucide="user-x" style="color:var(--text-faint)"></i>
+            </div>
+            <div class="tabular-nums" style="font-size:1.875rem;font-weight:600;margin-top:0.5rem">{$active_bans|number_format}</div>
+            <div class="text-xs text-muted">currently in force</div>
+        </div>
+
+        <div class="card p-5" data-testid="dashboard-stat-comm-blocks">
+            <div class="flex items-start justify-between">
+                <div class="text-xs font-medium text-muted" style="text-transform:uppercase;letter-spacing:0.06em">Comm blocks</div>
+                <i data-lucide="mic-off" style="color:var(--text-faint)"></i>
+            </div>
+            <div class="tabular-nums" style="font-size:1.875rem;font-weight:600;margin-top:0.5rem">{$total_comms|number_format}</div>
+            <div class="text-xs text-muted">mutes + gags</div>
+        </div>
+
+        <div class="card p-5" data-testid="dashboard-stat-servers">
+            <div class="flex items-start justify-between">
+                <div class="text-xs font-medium text-muted" style="text-transform:uppercase;letter-spacing:0.06em">Servers</div>
+                <i data-lucide="server" style="color:var(--text-faint)"></i>
+            </div>
+            <div class="tabular-nums" style="font-size:1.875rem;font-weight:600;margin-top:0.5rem">{$total_servers|number_format}</div>
+            <div class="text-xs text-muted">configured</div>
+        </div>
+
     </div>
+
+    {* -- Recent bans + Servers (2-col) -------------------------------- *}
+    <div class="grid gap-4" style="grid-template-columns:minmax(0,2fr) minmax(0,1fr)">
+
+        <section class="card" data-testid="dashboard-recent-bans">
+            <div class="card__header">
+                <div>
+                    <h3>Latest bans</h3>
+                    <p>Most recent enforcement actions</p>
+                </div>
+                <a class="btn btn--ghost btn--sm" href="?p=banlist">
+                    View all <i data-lucide="arrow-right" style="width:14px;height:14px"></i>
+                </a>
+            </div>
+            <div>
+                {foreach $players_banned as $b}
+                <a class="ban-row ban-row--{$b.state} flex items-center gap-3 p-4"
+                   style="border-bottom:1px solid var(--border);text-decoration:none;color:var(--text)"
+                   href="{$b.search_link}"
+                   data-testid="dashboard-ban-row"
+                   data-id="{$b.bid}">
+                    <div class="flex-1" style="min-width:0">
+                        <div class="flex items-center gap-2">
+                            <span class="font-medium text-sm truncate">
+                                {if $b.short_name}{$b.short_name}{else}<span class="text-faint">no nickname</span>{/if}
+                            </span>
+                            <span class="pill pill--{$b.state}">{$b.state}</span>
+                        </div>
+                        <div class="text-xs text-muted truncate" style="margin-top:0.125rem">
+                            {$b.length_human}{if $b.sname} · {$b.sname}{/if}{if $b.reason} · {$b.reason}{/if}
+                        </div>
+                    </div>
+                    <div class="text-xs text-muted text-right" style="white-space:nowrap">{$b.banned_human}</div>
+                </a>
+                {foreachelse}
+                <div class="card__body text-sm text-muted" data-testid="dashboard-recent-bans-empty">No bans yet.</div>
+                {/foreach}
+            </div>
+        </section>
+
+        <section class="card" data-testid="dashboard-servers">
+            <div class="card__header">
+                <div>
+                    <h3>Servers</h3>
+                    <p>{$total_servers|number_format} configured</p>
+                </div>
+                <a class="btn btn--ghost btn--sm" href="?p=servers">
+                    View all <i data-lucide="arrow-right" style="width:14px;height:14px"></i>
+                </a>
+            </div>
+            {if $access_bans}
+            <div class="text-xs text-muted" style="border-bottom:1px solid var(--border);padding:0.625rem 1.25rem">
+                <i data-lucide="info" style="width:12px;height:12px;vertical-align:-2px"></i>
+                Open the servers page to manage players in real time.
+            </div>
+            {/if}
+            <div style="padding:0.5rem">
+                {foreach $server_list as $server}
+                <a class="flex items-center gap-3"
+                   style="padding:0.625rem;border-radius:var(--radius-md);text-decoration:none;color:var(--text)"
+                   href="?p=servers&s={$server.index}"
+                   data-testid="server-tile" data-id="{$server.sid}">
+                    <span style="width:22px;height:22px;border-radius:3px;background:var(--bg-muted);display:grid;place-items:center;flex-shrink:0">
+                        <img src="images/games/{$server.icon}" alt="" width="16" height="16">
+                    </span>
+                    <div class="flex-1" style="min-width:0">
+                        <div class="font-medium text-sm font-mono truncate">{$server.ip}:{$server.port}</div>
+                        <div class="text-xs text-faint">sid {$server.sid}</div>
+                    </div>
+                    <i data-lucide="external-link" style="width:14px;height:14px;color:var(--text-faint)"></i>
+                </a>
+                {foreachelse}
+                <div class="card__body text-sm text-muted" data-testid="dashboard-servers-empty">No servers configured.</div>
+                {/foreach}
+            </div>
+        </section>
+
+    </div>
+
+    {* -- Blocked attempts + Recent comm blocks (2-col) ---------------- *}
+    <div class="grid gap-4" style="grid-template-columns:repeat(auto-fit,minmax(360px,1fr))">
+
+        {*
+            data-lognopopup is sourced from $dashboard_lognopopup (the
+            admin-controlled "front-page block log without popup" flag,
+            sb_settings:dash.lognopopup). Persisted to a data attribute
+            so future client-side wiring can opt back into a tooltip
+            without another round trip. Anchor click already navigates
+            to the player; the popup confirmation step from the legacy
+            theme is intentionally dropped per the new design's
+            single-action UX.
+        *}
+        <section class="card" data-testid="dashboard-blocked-attempts" data-lognopopup="{if $dashboard_lognopopup}1{else}0{/if}">
+            <div class="card__header">
+                <div>
+                    <h3>Latest blocked attempts</h3>
+                    <p>{$total_blocked|number_format} total intercepts</p>
+                </div>
+            </div>
+            <div>
+                {foreach $players_blocked as $p}
+                <a class="flex items-center gap-3 p-4"
+                   style="border-bottom:1px solid var(--border);text-decoration:none;color:var(--text)"
+                   href="{$p.search_link}"
+                   data-testid="dashboard-blocked-row" data-id="{$p.bid}">
+                    <i data-lucide="shield-x" style="color:var(--danger);flex-shrink:0"></i>
+                    <div class="flex-1" style="min-width:0">
+                        <div class="font-medium text-sm truncate">
+                            {if $p.short_name}{$p.short_name}{else}<span class="text-faint">no nickname</span>{/if}
+                        </div>
+                        <div class="text-xs text-muted truncate">{if $p.sname}{$p.sname}{else}—{/if}</div>
+                    </div>
+                    <div class="text-xs text-muted text-right" style="white-space:nowrap">{$p.blocked_human}</div>
+                </a>
+                {foreachelse}
+                <div class="card__body text-sm text-muted" data-testid="dashboard-blocked-attempts-empty">No blocked attempts yet.</div>
+                {/foreach}
+            </div>
+        </section>
+
+        <section class="card" data-testid="dashboard-recent-comms">
+            <div class="card__header">
+                <div>
+                    <h3>Latest comm blocks</h3>
+                    <p>Most recent mutes &amp; gags</p>
+                </div>
+                <a class="btn btn--ghost btn--sm" href="?p=commslist">
+                    View all <i data-lucide="arrow-right" style="width:14px;height:14px"></i>
+                </a>
+            </div>
+            <div>
+                {foreach $players_commed as $c}
+                <a class="ban-row ban-row--{$c.state} flex items-center gap-3 p-4"
+                   style="border-bottom:1px solid var(--border);text-decoration:none;color:var(--text)"
+                   href="{$c.search_link}"
+                   data-testid="dashboard-comm-row" data-id="{$c.bid}">
+                    <i data-lucide="{$c.lucide_icon}" style="color:var(--text-muted);flex-shrink:0"></i>
+                    <div class="flex-1" style="min-width:0">
+                        <div class="flex items-center gap-2">
+                            <span class="font-medium text-sm truncate">
+                                {if $c.short_name}{$c.short_name}{else}<span class="text-faint">no nickname</span>{/if}
+                            </span>
+                            <span class="pill pill--{$c.state}">{$c.state}</span>
+                        </div>
+                        <div class="text-xs text-muted truncate" style="margin-top:0.125rem">
+                            {$c.length_human}{if $c.sname} · {$c.sname}{/if}{if $c.reason} · {$c.reason}{/if}
+                        </div>
+                    </div>
+                    <div class="text-xs text-muted text-right" style="white-space:nowrap">{$c.banned_human}</div>
+                </a>
+                {foreachelse}
+                <div class="card__body text-sm text-muted" data-testid="dashboard-recent-comms-empty">No comm blocks yet.</div>
+                {/foreach}
+            </div>
+        </section>
+
+    </div>
+
+    {*
+        $IN_SERVERS_PAGE is declared on HomeDashboardView for the
+        legacy theme's transitive include of page_servers.tpl
+        (see the View's docblock). Always false on the dashboard, so
+        this block intentionally never renders; the reference is kept
+        here so SmartyTemplateRule's "unused property" check stays
+        green for the sbpp2026 PHPStan leg without us having to
+        carry a bespoke baseline entry.
+    *}
+    {if $IN_SERVERS_PAGE}{* unreachable on dashboard *}{/if}
+
 </div>


### PR DESCRIPTION
Part of #1123. Phase B page-redesign ticket.

Plan: [`sbpp2026-theme-rollout-4c702e97.plan.md`](https://github.com/sbpp/sourcebans-pp/blob/main/.cursor/plans/sbpp2026-theme-rollout-4c702e97.plan.md) → §B3.

## Summary

Replaces the A1 stub at `web/themes/sbpp2026/page_dashboard.tpl` with a real card-grid layout sourced from the same arrays the legacy template renders, so both themes continue to render side-by-side until D1's hard cutover.

The new template:

- Page header (`<h1>` + 1-line "Activity across your servers" subtitle).
- Optional admin Markdown intro (`dash.intro.text`) — flows through `Sbpp\Markup\IntroRenderer::renderIntroText()` in `page.home.php` and is emitted with a `{nofilter}` block sitting under the canonical `{* nofilter: rendered by IntroRenderer (CommonMark, html_input=escape, allow_unsafe_links=false); never raw user input *}` comment.
- Four-up stat cards: Total bans / Active bans / Comm blocks / Servers (collapses to 2-up then 1-up via `grid-template-columns: repeat(auto-fit, minmax(180px, 1fr))`).
- "Latest bans" panel + Servers tile list (2:1 grid).
- "Latest blocked attempts" + "Latest comm blocks" (2-col `auto-fit` grid).

`HomeDashboardView` keeps every legacy field the default-theme template still references (so the `default` PHPStan leg of the dual-theme matrix stays green) and grows two new fields: `$active_bans` (currently-in-force count from a small SQL in `page.home.php`) and `$total_servers` (precomputed list count, cheaper than `$server_list|@count` in templates). `page.home.php` also enriches each `$players_banned` / `$players_commed` / `$players_blocked` row with handoff-style keys (`$bid` / `$reason` / `$sname` / `$length_human` / `$banned_human` / `$state` / `$lucide_icon` / `$blocked_human`) alongside the legacy keys, so both templates render against the same arrays without re-querying.

## Skipped widgets (per the "directional, not literal" note)

- **Bans-over-time sparkline** — needs a per-day aggregation feed we don't have yet. Re-open as a follow-up once the data exists.
- **Team coverage** card — needs on-duty / response-time tracking we don't track.
- **Live server hostname / player count** — the legacy `LoadServerHostProperty` UDP probe rode on `web/scripts/sourcebans.js`, which A1 dropped. Re-introducing it needs a JSON action under `web/api/handlers/`, which Phase B is forbidden from touching. The Servers card therefore renders configured-server metadata only (mod icon + `ip:port` + `sid`) and links out to `?p=servers`.

## Files touched (B3 scope)

| File | Change |
|---|---|
| `web/themes/sbpp2026/page_dashboard.tpl` | Replaces the A1 stub with the real layout. |
| `web/includes/View/HomeDashboardView.php` | Extended (legacy fields preserved) — adds `$active_bans` + `$total_servers`. |
| `web/pages/page.home.php` | New `:prefix_bans` count for active bans; per-row enrichment for handoff-style keys; `Sbpp\Markup\IntroRenderer::renderIntroText()` for the intro. |
| `web/phpstan-baseline.neon` | Two paired entries for the new View fields' "unused property" reports on the default leg of the dual-theme PHPStan matrix (auto-skip on the sbpp2026 leg via `reportUnmatchedIgnoredErrors=false`; D1 collapses both as the legacy template is deleted). |

## Testability hooks

- Each card: `data-testid="dashboard-<card-name>"` (`dashboard-header`, `dashboard-intro`, `dashboard-stat-total-bans`, `dashboard-stat-active-bans`, `dashboard-stat-comm-blocks`, `dashboard-stat-servers`, `dashboard-recent-bans`, `dashboard-servers`, `dashboard-blocked-attempts`, `dashboard-recent-comms`).
- Each row: `data-testid="dashboard-ban-row" data-id="{$b.bid}"` (and equivalents for `dashboard-blocked-row`, `dashboard-comm-row`, plus the per-row `ban-row--<state>` / `pill--<state>` classes).
- Each server tile: `data-testid="server-tile" data-id="{$server.sid}"`.
- `dashboard-blocked-attempts` carries `data-lognopopup="0|1"` so future client-side wiring can opt back into the legacy popup without a round trip.

## Local gates

| Gate | Result |
|---|---|
| `./sbpp.sh phpstan` (default leg) | `[OK] No errors` |
| `SBPP_PHPSTAN_THEME=sbpp2026 phpstan -c phpstan-sbpp2026.neon` (sbpp2026 leg) | `[OK] No errors` |
| `./sbpp.sh test` | `OK (268 tests, 1134 assertions)` |
| `./sbpp.sh ts-check` | clean |
| `./sbpp.sh composer api-contract` | regenerated, no diff |

## Manual verification

Rendered against the dev stack with `config.theme=sbpp2026`. The page emits all expected `data-testid` hooks and the IntroRenderer-produced `<h1>`/`<p>` for the seeded `dash.intro.text` value. No headless browser available in the worktree's container so light/dark screenshots are not attached; the design tokens (light/dark) live in `web/themes/sbpp2026/css/theme.css` (untouched in this PR) and the template is pure markup binding to `var(--…)` tokens, so the dark variant is automatic.

## Test plan

- [ ] Open the dashboard with `config.theme=sbpp2026` and confirm all four stat cards populate from a fresh install + after seeding bans/comms/blocks.
- [ ] Toggle `config.theme=default`: the legacy table-style dashboard still renders (legacy fields kept on the View; data arrays carry both legacy + new keys).
- [ ] Toggle dark mode (`<html class="dark">`): stat cards, ban rows, server tiles re-skin via existing tokens — no template-side dark-mode branching needed.
- [ ] Set `dash.intro.text` to a Markdown blob containing inline `<script>` and `[link](javascript:alert(1))`: the script tag renders as visible escaped text and the `javascript:` href is stripped (IntroRenderer guards).