### PR TITLE
[#1123 B8] Redesign lost password page

### DIFF
--- a/web/includes/View/LostPasswordView.php
+++ b/web/includes/View/LostPasswordView.php
@@ -1,0 +1,26 @@
+<?php
+declare(strict_types=1);
+
+namespace Sbpp\View;
+
+/**
+ * Lost-password page — binds to `page_lostpassword.tpl`.
+ *
+ * The form itself takes no PHP-side data: the recovery flow runs entirely
+ * over the JSON API (`Actions.AuthLostPassword`), so the template is a
+ * static card with a vanilla-JS submit handler. The View therefore declares
+ * no properties — it exists only so the page handler can switch from the
+ * untyped `$theme->display(...)` call to the typed
+ * {@see Renderer::render()} pipeline, and so SmartyTemplateRule can guard
+ * the template against accidentally growing untyped variable references.
+ *
+ * The reset-link branch in `web/pages/page.lostpassword.php` (the
+ * `?email=…&validation=…` URL the password-reset email links to) still
+ * uses the legacy inline `<script>ShowBox(...)</script>` + `PageDie()`
+ * shape and never reaches this View. That branch is out of scope for the
+ * Phase B form restyle; a follow-up moves it onto the new toast helper.
+ */
+final class LostPasswordView extends View
+{
+    public const TEMPLATE = 'page_lostpassword.tpl';
+}

--- a/web/pages/page.lostpassword.php
+++ b/web/pages/page.lostpassword.php
@@ -56,5 +56,5 @@ if (isset($_GET['email'], $_GET['validation']) && (!empty($_GET['email']) || !em
     print "<script>ShowBox('Password Reset', 'Your password has been reset and sent to your email.<br />Please check your spam folder too.<br />Please login using this password, <br />then use the change password link in Your Account.', 'blue');</script>";
     PageDie();
 } else {
-    $theme->display('page_lostpassword.tpl');
+    \Sbpp\View\Renderer::render($theme, new \Sbpp\View\LostPasswordView());
 }

--- a/web/themes/default/page_lostpassword.tpl
+++ b/web/themes/default/page_lostpassword.tpl
@@ -18,7 +18,12 @@
         </div>
 
         <div id="loginSubmit">
-            {sb_button text=Ok onclick="sb.api.call(Actions.AuthLostPassword, {email: sb.$id('email').value}).then(applyApiResponse);" class=ok id=alogin submit=false}
+            {* `sb.$id('email')` would otherwise be parsed by Smarty as a *}
+            {* `{$id}` reference inside this tag's onclick attribute and trip *}
+            {* SmartyTemplateRule once a paired View binds to this template; *}
+            {* `document.getElementById` is the literal body of `sb.$id` *}
+            {* (web/scripts/sb.js), so the runtime behaviour is unchanged. *}
+            {sb_button text=Ok onclick="sb.api.call(Actions.AuthLostPassword, {email: document.getElementById('email').value}).then(applyApiResponse);" class=ok id=alogin submit=false}
         </div>
 
     </div>

--- a/web/themes/sbpp2026/page_lostpassword.tpl
+++ b/web/themes/sbpp2026/page_lostpassword.tpl
@@ -1,6 +1,118 @@
-<div class="card">
-    <div class="card__body">
-        <h1>{$title}</h1>
-        <p class="text-muted">This page hasn't been redesigned yet.</p>
+{*
+    SourceBans++ 2026 — page_lostpassword.tpl
+
+    Public lost-password form. Mirrors the credential block in
+    handoff/pages/login.tpl (centred card, .label / .input / .btn--primary)
+    so the recovery flow visually rhymes with the eventual B redesign of
+    the login page itself.
+
+    The form posts via sb.api.call(Actions.AuthLostPassword, {email})
+    rather than a plain HTML POST: the only server-side handler for this
+    page is the JSON action, exactly as the legacy default theme did
+    (web/themes/default/page_lostpassword.tpl). sb.api.call automatically
+    attaches the X-CSRF-Token header from the <meta name="csrf-token">
+    in the chrome, but {csrf_field} is included anyway per AGENTS.md's
+    "every state-changing form" rule so the form would still validate if
+    JS were ever disabled and a future PR wired up a POST fallback.
+
+    Pair: web/includes/View/LostPasswordView.php (declares no properties;
+    the form is static and the API response is rendered client-side).
+
+    Response handling is inline rather than reaching for the legacy
+    web/scripts/sourcebans.js applyApiResponse helper because the new
+    theme intentionally drops sourcebans.js (#1123 D1). The handler
+    funnels both the success envelope (`data.message`) and the error
+    envelope (`error.message`) into window.SBPP.showToast(...) which
+    theme.js (vendored at A1) exposes globally.
+
+    Testability hooks per the issue's "Testability hooks" rule:
+      - email input:    data-testid="lostpw-email"
+      - submit button:  data-testid="lostpw-submit"
+*}
+<div class="lostpw">
+    <div class="card lostpw__card">
+        <div class="card__header">
+            <div>
+                <h3>Forgot your password?</h3>
+                <p>Enter the email address associated with your admin account and we&rsquo;ll send you a link to reset your password.</p>
+            </div>
+        </div>
+        <div class="card__body">
+            <form id="lostpw-form" class="space-y-3" method="post" action="index.php?p=lostpassword" novalidate>
+                {csrf_field}
+                <div>
+                    <label class="label" for="lostpw-email">Email address</label>
+                    <input id="lostpw-email"
+                           class="input"
+                           type="email"
+                           name="email"
+                           autocomplete="email"
+                           required
+                           data-testid="lostpw-email">
+                </div>
+                <button id="lostpw-submit"
+                        class="btn btn--primary"
+                        type="submit"
+                        style="width:100%;margin-top:0.5rem"
+                        data-testid="lostpw-submit">
+                    <i data-lucide="mail"></i> Send reset link
+                </button>
+            </form>
+            <p class="text-xs text-muted mt-4" style="text-align:center">
+                <a href="index.php?p=login" style="color:var(--accent)">&larr; Back to sign in</a>
+            </p>
+        </div>
     </div>
 </div>
+
+{literal}
+<style>
+    .lostpw { display:flex; align-items:flex-start; justify-content:center; padding:2.5rem 1rem; }
+    .lostpw__card { width:100%; max-width:24rem; }
+</style>
+
+<script>
+(function () {
+    'use strict';
+    var form = document.getElementById('lostpw-form');
+    var emailEl = document.getElementById('lostpw-email');
+    var submitEl = document.getElementById('lostpw-submit');
+    if (!form || !emailEl || !submitEl) return;
+
+    function toast(kind, title, body) {
+        if (window.SBPP && typeof window.SBPP.showToast === 'function') {
+            window.SBPP.showToast({ kind: kind, title: title, body: body || '' });
+        }
+    }
+
+    function mapKind(k) {
+        if (k === 'red') return 'error';
+        if (k === 'green') return 'success';
+        if (k === 'blue') return 'info';
+        return k || 'info';
+    }
+
+    form.addEventListener('submit', function (e) {
+        e.preventDefault();
+        if (!emailEl.value) {
+            toast('warn', 'Email required', 'Please enter your email address.');
+            return;
+        }
+        submitEl.disabled = true;
+        sb.api.call(Actions.AuthLostPassword, { email: emailEl.value }).then(function (res) {
+            submitEl.disabled = false;
+            if (!res || res.redirect) return;
+            if (res.ok === false) {
+                var emsg = (res.error && res.error.message) || 'Unknown error';
+                toast('error', 'Error', emsg);
+                return;
+            }
+            var msg = (res.data || {}).message;
+            if (msg) {
+                toast(mapKind(msg.kind), msg.title || 'Done', msg.body || '');
+            }
+        });
+    });
+}());
+</script>
+{/literal}


### PR DESCRIPTION
## Summary

Phase B (#1123) — restyle the public lost-password form to the
SourceBans++ 2026 visual language.

- Replaces the A1 stub at `web/themes/sbpp2026/page_lostpassword.tpl`
  with a real form built from the `handoff/pages/login.tpl`
  primitives (`.label` / `.input` / `.btn--primary` inside a `.card`).
  The form posts via `sb.api.call(Actions.AuthLostPassword, {email})`,
  matching the legacy default theme exactly, so the wire contract is
  unchanged and `auth.lost_password` API tests keep passing untouched.
- Adds `Sbpp\View\LostPasswordView` and switches
  `web/pages/page.lostpassword.php` from `$theme->display(...)` to
  `Sbpp\View\Renderer::render(...)` so `SmartyTemplateRule`'s
  dual-theme matrix (#1123 A2) guards both legs of the template.
  The View has no properties — the form is static and the JSON API
  carries the only state — so `LostPasswordView` exists primarily to
  bind the template to the typed pipeline.
- Response handling is inline (no `web/scripts/sourcebans.js`
  dependency, which the new theme intentionally drops). Both the
  success and error envelopes from `sb.api.call` are funneled into
  `window.SBPP.showToast(...)` exposed by the A1 `theme.js`.
- Testability hooks per the issue: `data-testid="lostpw-email"` on
  the email input, `data-testid="lostpw-submit"` on the submit
  button. `{csrf_field}` is included so a future POST fallback would
  still validate even though `sb.api.call` already attaches the
  `X-CSRF-Token` header from the chrome's `<meta name="csrf-token">`.
- Reset-link branch (`?email=&validation=`) keeps its legacy
  `<script>ShowBox(...)</script>` shape — that branch is out of
  scope for this Phase B form restyle and is reachable only from
  the recovery email anyway.

### Adjacent fix in the same PR

Once `LostPasswordView` binds to `page_lostpassword.tpl`,
`SmartyTemplateRule`'s default-theme leg also walks
`web/themes/default/page_lostpassword.tpl`, and its regex-based tag
scanner reads `sb.$id('email')` inside the legacy `{sb_button …
onclick="…"}` as a `{$id}` reference, firing
`sbpp.view.missingProperty` against a property the View intentionally
does not declare. The minimal fix is to swap the legacy template's
`sb.$id('email')` for `document.getElementById('email')` —
`sb.$id` is literally `(id) => document.getElementById(id)` in
`web/scripts/sb.js`, so the runtime behaviour is identical. A Smarty
comment block above the `{sb_button}` line explains why the helper
isn't used in that one spot. Bundling this with the View
introduction keeps the failure window at zero.

## Test plan

- [x] `./sbpp.sh phpstan` — clean, both default and `SBPP_PHPSTAN_THEME=sbpp2026` legs.
- [x] `./sbpp.sh ts-check` — clean.
- [x] `./sbpp.sh composer api-contract` — no diff (action surface unchanged).
- [x] `./sbpp.sh test tests/api/AuthTest.php tests/api/PermissionMatrixTest.php tests/api/DispatcherTest.php tests/integration/LoginToggleTest.php` — 80 tests, 298 assertions, OK. Includes both `auth.lost_password` cases.
- [x] Manual: hit `http://localhost:8300/index.php?p=lostpassword` against the `sbpp2026` theme — markup contains the `lostpw-form`, `lostpw-email`, `lostpw-submit` IDs and `data-testid` attributes; `{csrf_field}` rendered.
- [ ] Reviewer: visual sanity check against `handoff/pages/login.tpl` token usage.