### PR TITLE
[#1123 B4] Redesign public comms list

### DIFF
--- a/web/includes/View/CommsListView.php
+++ b/web/includes/View/CommsListView.php
@@ -1,0 +1,117 @@
+<?php
+declare(strict_types=1);
+
+namespace Sbpp\View;
+
+/**
+ * Public communications-blocklist (mute/gag) page — binds to
+ * `page_comms.tpl`. New in #1123 B4 alongside the sbpp2026 redesign of
+ * the public comms list.
+ *
+ * Dual-theme bridge (Phase B). The legacy `themes/default/page_comms.tpl`
+ * renders both a public block list AND an inline comment-edit drawer
+ * (`{if $comment} … {else}{$ban_list} … {/if}`); the new
+ * `themes/sbpp2026/page_comms.tpl` only shows the block list (the comment
+ * editor will get its own redesign post-B4 — see the new template's
+ * header docblock for the deferred-scope list). This view declares the
+ * union of variables both templates consume so `SmartyTemplateRule`
+ * passes against either theme:
+ *
+ *   - sbpp2026-only properties: $ban_list (with the slim handoff-style
+ *     row keys), $filters, $servers, $pagination, $hide_inactive(_toggle_url),
+ *     $can_{add,edit,unmute_gag,delete}_comm.
+ *   - legacy-only properties: $ban_nav, $hidetext, $hideadminname,
+ *     $view_bans, $view_comments, plus the comment-drawer set
+ *     ($comment, $commenttype, $commenttext, $ctype, $cid, $page,
+ *     $othercomments, $canedit). The default theme reads these
+ *     directly; the sbpp2026 template ignores them. Each is captured in
+ *     the `unusedProperty` block of `phpstan-baseline.neon` so the
+ *     default-leg PHPStan run still fails on *new* drift while the
+ *     sbpp2026-leg run (with `reportUnmatchedIgnoredErrors=false`) is
+ *     unaffected. D1 deletes the legacy theme + drops the unused
+ *     properties + the corresponding baseline entries in one shot.
+ *
+ * Per-row shape (each entry of `$ban_list`) — sbpp2026 keys layered on
+ * top of every legacy key already present (mod_icon, banlength, ban_date,
+ * view_*, …) so both themes render off the same row source:
+ *   - cid           int    block id (legacy `bid`)
+ *   - name          string player nickname (already cleaned + slashed)
+ *   - steam         string SteamID2
+ *   - type          string 'mute' | 'gag' | 'silence' | 'unknown'
+ *   - length_human  string e.g. "Permanent" | "1 day" (already
+ *                          SecondsToString-formatted by the handler)
+ *   - started_human string Config::time-formatted display
+ *   - started_iso   string ISO-8601 timestamp for <time datetime>
+ *   - state         string 'active' | 'expired' | 'unmuted' | 'permanent'
+ *   - sname         string server hostname / "Web Block" label
+ *   - admin         string admin nickname (or false if hidden / deleted)
+ *   - avatar_hue    int    0–359 HSL hue derived from `crc32(name . steam)`
+ *                          for the row's avatar tile (sbpp2026 only)
+ *   - edit_url      string admin edit URL
+ *   - unmute_url    string|null URL to unmute/ungag, null if N/A
+ *   - delete_url    string admin delete URL
+ */
+final class CommsListView extends View
+{
+    public const TEMPLATE = 'page_comms.tpl';
+
+    /**
+     * @param list<array<string,mixed>> $ban_list Comm rows. See class
+     *     docblock for the per-row shape.
+     * @param array{
+     *     search: string,
+     *     server: string,
+     *     time: string,
+     *     state: string,
+     *     type: string,
+     * } $filters Current filter state — drives the sticky filter bar +
+     *     active chip highlighting (sbpp2026 only).
+     * @param list<array{sid: int, name: string}> $servers Server list
+     *     for the "All servers" dropdown filter (sbpp2026 only).
+     * @param array{
+     *     from: int,
+     *     to: int,
+     *     total: int,
+     *     prev_url: ?string,
+     *     next_url: ?string,
+     * } $pagination Page navigation data (sbpp2026 only). `prev_url` /
+     *     `next_url` are `null` at the page boundaries so the template
+     *     can `disabled` them.
+     * @param list<array<string,mixed>> $othercomments Sibling comments
+     *     in the comment-edit drawer (legacy default theme only).
+     */
+    public function __construct(
+        public readonly int $total_bans,
+        public readonly string $searchlink,
+        public readonly array $ban_list,
+        public readonly array $filters,
+        public readonly array $servers,
+        public readonly array $pagination,
+        public readonly bool $hide_inactive,
+        public readonly string $hide_inactive_toggle_url,
+        public readonly bool $can_add_comm,
+        public readonly bool $can_edit_comm,
+        public readonly bool $can_unmute_gag,
+        public readonly bool $can_delete_comm,
+        // Legacy default-theme template variables. Kept on the View
+        // (rather than left as raw $theme->assign() calls in the
+        // handler) so SmartyTemplateRule can verify both themes end up
+        // with every variable they reference. Each of these is
+        // ignored by `themes/sbpp2026/page_comms.tpl` and disappears
+        // at D1 cutover.
+        public readonly bool|int|string $comment,
+        public readonly string $commenttype,
+        public readonly bool $canedit,
+        public readonly string $commenttext,
+        public readonly string $ctype,
+        public readonly int|string $cid,
+        public readonly int $page,
+        public readonly array $othercomments,
+        public readonly string $ban_nav,
+        public readonly string $hidetext,
+        public readonly bool $hideadminname,
+        public readonly bool $view_comments,
+        public readonly bool $view_bans,
+    ) {
+    }
+}

--- a/web/pages/page.commslist.php
+++ b/web/pages/page.commslist.php
@@ -713,6 +713,90 @@ foreach ($res as $row) {
     $data['view_edit']   = ($userbank->HasAccess(ADMIN_OWNER | ADMIN_EDIT_ALL_BANS) || ($userbank->HasAccess(ADMIN_EDIT_OWN_BANS) && $row['aid'] == $userbank->GetAid()) || ($userbank->HasAccess(ADMIN_EDIT_GROUP_BANS) && $row['gid'] == $userbank->GetProperty('gid')));
     $data['view_unban']  = ($userbank->HasAccess(ADMIN_OWNER | ADMIN_UNBAN) || ($userbank->HasAccess(ADMIN_UNBAN_OWN_BANS) && $row['aid'] == $userbank->GetAid()) || ($userbank->HasAccess(ADMIN_UNBAN_GROUP_BANS) && $row['gid'] == $userbank->GetProperty('gid')));
     $data['view_delete'] = ($userbank->HasAccess(ADMIN_OWNER | ADMIN_DELETE_BAN));
+
+    // === sbpp2026 row augmentation (#1123 B4) =============================
+    // Layer the slim handoff-style keys ($comm.cid / .name / .steam /
+    // .type / .length_human / .started_human / .started_iso / .state /
+    // .sname / .admin / .reason / .{edit,unmute,delete}_url) onto the
+    // same $data row the legacy theme already consumes. Doing it inside
+    // the original loop is what lets us read raw SQL columns (row_type,
+    // ban_server, server_ip, ban_created) that don't survive into
+    // $data otherwise.
+    $rowTypeStr   = isset($row['row_type']) ? (string) $row['row_type'] : '';
+    $banLengthInt = (int) $row['ban_length'];
+    $banEndsInt   = (int) $row['ban_ends'];
+    $cTimeInt     = (int) $row['c_time'];
+    if ($rowTypeStr === 'D' || $rowTypeStr === 'U') {
+        $state2026 = 'unmuted';
+    } elseif ($rowTypeStr === 'E' || ($banLengthInt > 0 && $banEndsInt < $cTimeInt)) {
+        $state2026 = 'expired';
+    } elseif ($banLengthInt === 0) {
+        $state2026 = 'permanent';
+    } else {
+        $state2026 = 'active';
+    }
+
+    $typeInt = (int) $row['type'];
+    switch ($typeInt) {
+        case 1:
+            $typeLabel = 'mute';
+            break;
+        case 2:
+            $typeLabel = 'gag';
+            break;
+        case 3:
+            // SourceComms forks sometimes assign 3 to the combined
+            // "silence" (mute+gag); display it the same way regardless
+            // of whether a write path actually emits the row.
+            $typeLabel = 'silence';
+            break;
+        default:
+            $typeLabel = 'unknown';
+    }
+
+    $banServerInt = (int) $row['ban_server'];
+    if ($banServerInt === 0) {
+        $sname2026 = 'Web Block';
+    } else {
+        $sname2026 = !empty($row['server_ip'])
+            ? (string) $row['server_ip']
+            : 'Server #' . $banServerInt;
+    }
+
+    $startedTs = (int) $row['ban_created'];
+    $key       = (string) ($_SESSION['banlist_postkey'] ?? '');
+
+    $data['cid']           = (int) $row['ban_id'];
+    $data['name']          = stripslashes((string) $data['player']);
+    $data['steam']         = (string) $data['steamid'];
+    // Stable per-name hue for the row's avatar tile. crc32 keeps
+    // identically-named players coloured the same across sessions
+    // without any storage; the modulo into 360 gives an HSL hue.
+    $data['avatar_hue']    = (int) (sprintf('%u', crc32($data['name'] . $data['steam'])) % 360);
+    // Kept as a string label for the new theme's pill/icon switch. The
+    // legacy default theme only reads `type_icon` (HTML-rendered above)
+    // so overwriting `type` is safe — see the dual-theme audit in the
+    // CommsListView class docblock.
+    $data['type']          = $typeLabel;
+    $data['length_human']  = (string) $data['ban_length'];
+    $data['started_human'] = (string) $data['ban_date'];
+    // ISO 8601 (`c`) so the new theme's <time datetime="…"> hooks give
+    // the browser a parseable absolute timestamp regardless of the
+    // admin-configured `config.dateformat`.
+    $data['started_iso']   = date('c', $startedTs);
+    $data['state']         = $state2026;
+    $data['sname']         = $sname2026;
+    $data['edit_url']      = 'index.php?p=admin&c=comms&o=edit&id=' . (int) $row['ban_id'] . '&key=' . urlencode($key);
+    $data['delete_url']    = 'index.php?p=commslist&a=delete&id=' . (int) $row['ban_id'] . '&key=' . urlencode($key);
+    if ($state2026 === 'active' || $state2026 === 'permanent') {
+        $verb              = $typeInt === 1 ? 'unmute' : ($typeInt === 2 ? 'ungag' : null);
+        $data['unmute_url'] = $verb !== null
+            ? 'index.php?p=commslist&a=' . $verb . '&id=' . (int) $row['ban_id'] . '&key=' . urlencode($key)
+            : null;
+    } else {
+        $data['unmute_url'] = null;
+    }
+
     array_push($bans, $data);
 }
 
@@ -771,17 +855,30 @@ if ($pages > 1) {
 
 //COMMENT STUFF
 //----------------------------------------
+// Comment-drawer locals. The legacy default theme renders the editor
+// when {if $comment} is truthy; the sbpp2026 redesign defers the
+// editor to a follow-up ticket, so the new theme just ignores all of
+// these. We compute them into PHP locals here (instead of the legacy
+// `$theme->assign(...)` calls) so they can be threaded into the View
+// constructor below — Renderer copies every public property onto
+// $theme, which keeps the legacy template rendering off the same
+// source of truth as the new one.
+$commenttype2026  = '';
+$commenttext2026  = '';
+$ctype2026        = '';
+$cid2026          = '';
+$page2026         = -1;
+$othercomments2026 = [];
 if (isset($_GET["comment"])) {
-    $theme->assign('commenttype', (isset($_GET["cid"]) ? "Edit" : "Add"));
+    $commenttype2026 = isset($_GET["cid"]) ? "Edit" : "Add";
     if (isset($_GET["cid"])) {
         $GLOBALS['PDO']->query("SELECT * FROM `:prefix_comments` WHERE cid = :cid");
         $GLOBALS['PDO']->bind(':cid', (int) $_GET["cid"]);
         $ceditdata      = $GLOBALS['PDO']->single();
-        $ctext          = html_entity_decode($ceditdata['commenttxt'], ENT_QUOTES | ENT_HTML5, 'UTF-8');
+        $commenttext2026 = html_entity_decode($ceditdata['commenttxt'], ENT_QUOTES | ENT_HTML5, 'UTF-8');
         $cotherdataedit = " AND cid != '" . (int) $_GET["cid"] . "'";
     } else {
         $cotherdataedit = "";
-        $ctext          = "";
     }
     $cotherdata = $GLOBALS['PDO']->query("SELECT cid, aid, commenttxt, added, edittime,
 											(SELECT user FROM `:prefix_admins` WHERE aid = C.aid) AS comname,
@@ -792,7 +889,6 @@ if (isset($_GET["comment"])) {
         $_GET["comment"]
     ));
 
-    $ocomments = [];
     foreach ($cotherdata as $cdrow) {
         $coment               = [];
         $coment['comname']    = $cdrow['comname'];
@@ -808,34 +904,112 @@ if (isset($_GET["comment"])) {
             $coment['editname'] = "";
             $coment['edittime'] = "";
         }
-        array_push($ocomments, $coment);
+        array_push($othercomments2026, $coment);
     }
 
-    $theme->assign('page', (isset($_GET["page"]) ? $_GET["page"] : -1));
-    $theme->assign('othercomments', $ocomments);
-    $theme->assign('commenttext', (isset($ctext) ? $ctext : ""));
-    $theme->assign('ctype', $_GET["ctype"]);
-    $theme->assign('cid', (isset($_GET["cid"]) ? $_GET["cid"] : ""));
-    $theme->assign('canedit', $userbank->is_admin());
+    $page2026 = isset($_GET["page"]) ? (int) $_GET["page"] : -1;
+    $ctype2026 = (string) $_GET["ctype"];
+    $cid2026   = isset($_GET["cid"]) ? (int) $_GET["cid"] : '';
 }
-$theme->assign('view_comments', $view_comments);
-$theme->assign('comment', (isset($_GET["comment"]) && $view_comments ? $_GET["comment"] : false));
+$comment2026 = (isset($_GET["comment"]) && $view_comments) ? (int) $_GET["comment"] : false;
 //----------------------------------------
 
 unset($_SESSION['CountryFetchHndl']);
 
-$theme->assign('searchlink', $searchlink);
-$theme->assign('hidetext', $hidetext);
-$theme->assign('total_bans', $BanCount);
-$theme->assign('active_bans', $BanCount);
+// `searchlink` is conditionally assigned in the search/advSearch/no-search
+// branches above. Normalise it before any sbpp2026 code reads it so we
+// don't widen the existing `Variable $searchlink might not be defined`
+// baseline entry that catches the legacy `$theme->assign('searchlink', …)`
+// reference in the original code path.
+$searchlink = $searchlink ?? '';
 
-$theme->assign('ban_nav', $ban_nav);
-$theme->assign('ban_list', $bans);
 $theme->assign('admin_nick', $userbank->GetProperty("user"));
-
 $theme->assign('admin_postkey', $_SESSION['banlist_postkey']);
-$theme->assign('hideadminname', (Config::getBool('banlist.hideadminname') && !$userbank->is_admin()));
+$theme->assign('active_bans', $BanCount);
 $theme->assign('general_unban', $userbank->HasAccess(ADMIN_OWNER | ADMIN_UNBAN | ADMIN_UNBAN_OWN_BANS | ADMIN_UNBAN_GROUP_BANS));
 $theme->assign('can_delete', $userbank->HasAccess(ADMIN_OWNER | ADMIN_DELETE_BAN));
-$theme->assign('view_bans', ($userbank->HasAccess(ADMIN_OWNER | ADMIN_EDIT_ALL_BANS | ADMIN_EDIT_OWN_BANS | ADMIN_EDIT_GROUP_BANS | ADMIN_UNBAN | ADMIN_UNBAN_OWN_BANS | ADMIN_UNBAN_GROUP_BANS | ADMIN_DELETE_BAN)));
-$theme->display('page_comms.tpl');
+
+$hideAdminName2026 = Config::getBool('banlist.hideadminname') && !$userbank->is_admin();
+$viewBans2026      = (bool) $userbank->HasAccess(ADMIN_OWNER | ADMIN_EDIT_ALL_BANS | ADMIN_EDIT_OWN_BANS | ADMIN_EDIT_GROUP_BANS | ADMIN_UNBAN | ADMIN_UNBAN_OWN_BANS | ADMIN_UNBAN_GROUP_BANS | ADMIN_DELETE_BAN);
+
+// === sbpp2026 view bag (#1123 B4) =====================================
+// Server filter dropdown — small list (one row per enabled server). The
+// schema has no hostname column, so the legacy `LoadServerHost` JS
+// resolves names lazily; the filter dropdown just shows ip:port and a
+// follow-up ticket can swap in a sb.api.call-driven resolver.
+$server_rows_2026 = $GLOBALS['PDO']->query(
+    "SELECT sid, ip, port FROM `:prefix_servers` WHERE enabled = 1 ORDER BY ip"
+)->resultset();
+$servers_2026 = [];
+foreach ($server_rows_2026 as $sr) {
+    $servers_2026[] = [
+        'sid'  => (int) $sr['sid'],
+        'name' => (string) $sr['ip'] . ':' . (int) $sr['port'],
+    ];
+}
+
+$filters_2026 = [
+    'search' => isset($_GET['searchText']) ? (string) $_GET['searchText'] : '',
+    'server' => isset($_GET['server']) ? (string) $_GET['server'] : '',
+    'time'   => isset($_GET['time']) ? (string) $_GET['time'] : '',
+    'state'  => isset($_GET['state']) ? (string) $_GET['state'] : '',
+    'type'   => isset($_GET['type']) ? (string) $_GET['type'] : '',
+];
+
+$pagination_2026 = [
+    'from'     => $BanCount === 0 ? 0 : $BansStart + 1,
+    'to'       => $BansEnd,
+    'total'    => $BanCount,
+    'prev_url' => $page > 1
+        ? 'index.php?p=commslist&page=' . ($page - 1) . $searchlink
+        : null,
+    'next_url' => $BansEnd < $BanCount
+        ? 'index.php?p=commslist&page=' . ($page + 1) . $searchlink
+        : null,
+];
+
+$hideInactive2026       = isset($_SESSION['hideinactive']);
+$hideInactive2026Toggle = 'index.php?p=commslist&hideinactive=' . ($hideInactive2026 ? 'false' : 'true') . $searchlink;
+
+// Aggregate permission flags. Each precomputed via Perms::for($userbank)
+// so the template's {if $can_*} reads stay opinion-free about the bit
+// math — see the AGENTS.md "Permissions" section + Perms::for() docblock.
+$perms2026             = \Sbpp\View\Perms::for($userbank);
+$can_add_comm_2026     = $perms2026['can_owner'] || $perms2026['can_add_ban'];
+$can_edit_comm_2026    = $perms2026['can_owner']
+    || $perms2026['can_edit_all_bans']
+    || $perms2026['can_edit_own_bans']
+    || $perms2026['can_edit_group_bans'];
+$can_unmute_gag_2026   = $perms2026['can_owner']
+    || $perms2026['can_unban']
+    || $perms2026['can_unban_own_bans']
+    || $perms2026['can_unban_group_bans'];
+$can_delete_comm_2026  = $perms2026['can_owner'] || $perms2026['can_delete_ban'];
+
+\Sbpp\View\Renderer::render($theme, new \Sbpp\View\CommsListView(
+    total_bans:               $BanCount,
+    searchlink:               $searchlink,
+    ban_list:                 $bans,
+    filters:                  $filters_2026,
+    servers:                  $servers_2026,
+    pagination:               $pagination_2026,
+    hide_inactive:            $hideInactive2026,
+    hide_inactive_toggle_url: $hideInactive2026Toggle,
+    can_add_comm:             $can_add_comm_2026,
+    can_edit_comm:            $can_edit_comm_2026,
+    can_unmute_gag:           $can_unmute_gag_2026,
+    can_delete_comm:          $can_delete_comm_2026,
+    comment:                  $comment2026,
+    commenttype:              $commenttype2026,
+    canedit:                  $userbank->is_admin(),
+    commenttext:              $commenttext2026,
+    ctype:                    $ctype2026,
+    cid:                      $cid2026,
+    page:                     $page2026,
+    othercomments:            $othercomments2026,
+    ban_nav:                  $ban_nav,
+    hidetext:                 $hidetext,
+    hideadminname:            $hideAdminName2026,
+    view_comments:            (bool) $view_comments,
+    view_bans:                $viewBans2026,
+));

--- a/web/phpstan-baseline.neon
+++ b/web/phpstan-baseline.neon
@@ -144,6 +144,69 @@ parameters:
 			count: 1
 			path: includes/View/AdminBansGroupsView.php
 
+		# CommsListView declares the union of variables both
+		# `themes/default/page_comms.tpl` (legacy) and
+		# `themes/sbpp2026/page_comms.tpl` (#1123 B4 redesign) reference;
+		# the new theme doesn't render the legacy comment-edit drawer or
+		# pagination HTML, so its sbpp2026-only properties fire as
+		# "unused" against the default-theme template. The phpstan-sbpp2026
+		# leg disables `reportUnmatchedIgnoredErrors` so these baseline
+		# entries don't have to fire there. D1 deletes the legacy theme
+		# and these entries collapse with it.
+		-
+			message: '#^Property Sbpp\\View\\CommsListView\:\:\$can_add_comm is never referenced in template "page_comms\.tpl"\.$#'
+			identifier: sbpp.view.unusedProperty
+			count: 1
+			path: includes/View/CommsListView.php
+
+		-
+			message: '#^Property Sbpp\\View\\CommsListView\:\:\$can_delete_comm is never referenced in template "page_comms\.tpl"\.$#'
+			identifier: sbpp.view.unusedProperty
+			count: 1
+			path: includes/View/CommsListView.php
+
+		-
+			message: '#^Property Sbpp\\View\\CommsListView\:\:\$can_edit_comm is never referenced in template "page_comms\.tpl"\.$#'
+			identifier: sbpp.view.unusedProperty
+			count: 1
+			path: includes/View/CommsListView.php
+
+		-
+			message: '#^Property Sbpp\\View\\CommsListView\:\:\$can_unmute_gag is never referenced in template "page_comms\.tpl"\.$#'
+			identifier: sbpp.view.unusedProperty
+			count: 1
+			path: includes/View/CommsListView.php
+
+		-
+			message: '#^Property Sbpp\\View\\CommsListView\:\:\$filters is never referenced in template "page_comms\.tpl"\.$#'
+			identifier: sbpp.view.unusedProperty
+			count: 1
+			path: includes/View/CommsListView.php
+
+		-
+			message: '#^Property Sbpp\\View\\CommsListView\:\:\$hide_inactive is never referenced in template "page_comms\.tpl"\.$#'
+			identifier: sbpp.view.unusedProperty
+			count: 1
+			path: includes/View/CommsListView.php
+
+		-
+			message: '#^Property Sbpp\\View\\CommsListView\:\:\$hide_inactive_toggle_url is never referenced in template "page_comms\.tpl"\.$#'
+			identifier: sbpp.view.unusedProperty
+			count: 1
+			path: includes/View/CommsListView.php
+
+		-
+			message: '#^Property Sbpp\\View\\CommsListView\:\:\$pagination is never referenced in template "page_comms\.tpl"\.$#'
+			identifier: sbpp.view.unusedProperty
+			count: 1
+			path: includes/View/CommsListView.php
+
+		-
+			message: '#^Property Sbpp\\View\\CommsListView\:\:\$servers is never referenced in template "page_comms\.tpl"\.$#'
+			identifier: sbpp.view.unusedProperty
+			count: 1
+			path: includes/View/CommsListView.php
+
 		-
 			message: '#^Property Sbpp\\View\\AdminServersAddView\:\:\$modid is never referenced in template "page_admin_servers_add\.tpl"\.$#'
 			identifier: sbpp.view.unusedProperty
@@ -535,12 +598,6 @@ parameters:
 			path: pages/page.commslist.php
 
 		-
-			message: '#^Variable \$ctext in isset\(\) always exists and is not nullable\.$#'
-			identifier: isset.variable
-			count: 1
-			path: pages/page.commslist.php
-
-		-
 			message: '#^Variable \$prev might not be defined\.$#'
 			identifier: variable.undefined
 			count: 1
@@ -548,12 +605,6 @@ parameters:
 
 		-
 			message: '#^Variable \$res might not be defined\.$#'
-			identifier: variable.undefined
-			count: 1
-			path: pages/page.commslist.php
-
-		-
-			message: '#^Variable \$searchlink might not be defined\.$#'
 			identifier: variable.undefined
 			count: 1
 			path: pages/page.commslist.php

--- a/web/themes/sbpp2026/page_comms.tpl
+++ b/web/themes/sbpp2026/page_comms.tpl
@@ -305,3 +305,26 @@
     <input type="hidden" form="comms-filters" name="_searchlink" value="{$searchlink|escape}" data-testid="comms-searchlink-shadow">
 
 </div>
+
+{* ============================================================
+   Manifest of properties only consumed by themes/default/page_comms.tpl.
+   Mirrors the dual-theme bridging pattern established by #1123 B2's
+   themes/sbpp2026/page_bans.tpl: the `CommsListView` declares the
+   union of variables both themes consume, and SmartyTemplateRule's
+   "every declared property is referenced" check applies per theme.
+   Without the references below, the sbpp2026 leg of the dual-theme
+   PHPStan matrix (#1123 A2) would flag every legacy-only property on
+   the View as unused.
+
+   {if false} blocks render to nothing — the parser still walks the
+   tag bodies, so the variable refs are seen, but no output is
+   produced. Putting them in the shared phpstan-baseline.neon would
+   instead break the default leg, where these properties are
+   referenced naturally and the entry would fire 0 times
+   (`reportUnmatchedIgnoredErrors` is on for the default leg).
+
+   D1 deletes themes/default/, the legacy template stops needing
+   these props, this manifest stops being necessary, and the View
+   drops them. Until then, keep this block at EOF.
+   ============================================================ *}
+{if false}{$ban_nav}{$canedit}{$cid}{$comment}{$commenttext}{$commenttype}{$ctype}{$hideadminname}{$hidetext}{$othercomments}{$page}{$view_bans}{$view_comments}{/if}

--- a/web/themes/sbpp2026/page_comms.tpl
+++ b/web/themes/sbpp2026/page_comms.tpl
@@ -1,6 +1,307 @@
-<div class="card">
-    <div class="card__body">
-        <h1>{$title}</h1>
-        <p class="text-muted">This page hasn't been redesigned yet.</p>
+{*
+    SourceBans++ 2026 — page_comms.tpl
+
+    Public communications-blocklist page. Mirrors the new banlist shape
+    from B2 (handoff/pages/banlist.tpl) with comms-specific columns:
+    type (mute/gag/silence) replaces the IP column, length + started
+    replace the long ban-reason banner, and the row state vocabulary is
+    `unmuted` instead of `unbanned`. View: Sbpp\View\CommsListView.
+
+    Skipped from the design / handoff for B4 (each open for follow-up):
+      * Comment edit drawer — the `?comment=` flow stays on the legacy
+        theme; the new theme list-only page just exposes the row's edit
+        URL. Wiring the new comment editor needs its own template.
+      * Live-server hostname resolution — the schema has no hostname
+        column; sname renders ip:port (or "Web Block" for sid=0) until
+        a future ticket re-implements the LoadServerHost equivalent
+        via sb.api.call.
+      * Fully-wired filter chips — `?type=` and `?state=` URL params
+        round-trip into the filter bar so the chips highlight, but the
+        SQL backend isn't filtered on them yet (legacy `advSearch`
+        still works). Active is derived from the existing
+        hideinactive session toggle.
+
+    Testability hooks (`data-testid`) match the B4 spec: comm-row /
+    filter-chip-* / row-action-* / page-prev / page-next / comms-search.
+*}
+<div class="p-6 space-y-4" style="max-width:1400px;margin:0 auto;width:100%">
+
+    {* -- Page header --------------------------------------------------- *}
+    <header class="flex items-center justify-between gap-4" style="flex-wrap:wrap" data-testid="comms-header">
+        <div>
+            <h1 style="font-size:var(--fs-2xl);font-weight:600;margin:0">Comm blocks</h1>
+            <p class="text-sm text-muted m-0 mt-2">
+                <span class="tabular-nums" data-testid="comms-count">{$ban_list|@count|number_format}</span>
+                of <span class="tabular-nums">{$total_bans|number_format}</span> blocks
+            </p>
+        </div>
+        <div class="flex gap-2">
+            <a class="btn btn--secondary btn--sm"
+               href="{$hide_inactive_toggle_url|escape}"
+               data-testid="toggle-hide-inactive">
+                <i data-lucide="{if $hide_inactive}eye{else}eye-off{/if}"></i>
+                {if $hide_inactive}Show inactive{else}Hide inactive{/if}
+            </a>
+            {if $can_add_comm}
+            <a class="btn btn--primary btn--sm"
+               href="index.php?p=admin&amp;c=comms"
+               data-testid="comms-add-button">
+                <i data-lucide="plus"></i> Add comm block
+            </a>
+            {/if}
+        </div>
+    </header>
+
+    {* -- Sticky filter bar -------------------------------------------- *}
+    <form method="get" action="index.php"
+          id="comms-filters"
+          style="position:sticky;top:3.5rem;z-index:20;background:var(--bg-page);padding:0.75rem 0;border-bottom:1px solid var(--border)">
+        <input type="hidden" name="p" value="commslist">
+        <div class="flex gap-3" style="flex-wrap:wrap">
+            <div style="flex:1;min-width:14rem;max-width:24rem;position:relative">
+                <i data-lucide="search"
+                   style="position:absolute;left:0.625rem;top:50%;transform:translateY(-50%);color:var(--text-faint);width:14px;height:14px"></i>
+                <input class="input input--with-icon"
+                       type="search"
+                       name="searchText"
+                       value="{$filters.search|escape}"
+                       placeholder="Player, SteamID, or reason…"
+                       data-testid="comms-search">
+            </div>
+            <select class="select" name="server" style="width:auto;min-width:11rem" data-testid="comms-server-filter">
+                <option value="">All servers</option>
+                {foreach $servers as $s}
+                    <option value="{$s.sid}" {if $filters.server == $s.sid}selected{/if}>{$s.name|escape}</option>
+                {/foreach}
+            </select>
+            <select class="select" name="time" style="width:auto" data-testid="comms-time-filter">
+                <option value="">All time</option>
+                <option value="1d" {if $filters.time == '1d'}selected{/if}>Today</option>
+                <option value="7d" {if $filters.time == '7d'}selected{/if}>Last 7 days</option>
+                <option value="30d" {if $filters.time == '30d'}selected{/if}>Last 30 days</option>
+            </select>
+            <button class="btn btn--secondary btn--sm" type="submit" data-testid="comms-filter-apply">
+                <i data-lucide="filter"></i> Apply
+            </button>
+        </div>
+
+        {* Filter chips. The active chip reflects URL state (?type= /
+           ?state=); active also lights up when the hideinactive
+           session toggle is set so the chip mirrors the toggle button
+           above. Each chip submits the form so the rest of the filter
+           state (search/server/time) is preserved. *}
+        <div class="flex items-center gap-2 mt-2 scroll-x" role="group" aria-label="Quick filters">
+            <button class="chip" type="submit" name="type" value=""
+                    aria-pressed="{if $filters.type == '' && $filters.state == ''}true{else}false{/if}"
+                    data-testid="filter-chip-all">
+                All
+            </button>
+            <button class="chip" type="submit" name="state" value="active"
+                    aria-pressed="{if $hide_inactive || $filters.state == 'active'}true{else}false{/if}"
+                    data-testid="filter-chip-active">
+                <span class="chip__dot" style="background:#f59e0b"></span> Active
+            </button>
+            <button class="chip" type="submit" name="type" value="mute"
+                    aria-pressed="{if $filters.type == 'mute'}true{else}false{/if}"
+                    data-testid="filter-chip-mute">
+                <i data-lucide="mic-off" style="width:12px;height:12px"></i> Mute
+            </button>
+            <button class="chip" type="submit" name="type" value="gag"
+                    aria-pressed="{if $filters.type == 'gag'}true{else}false{/if}"
+                    data-testid="filter-chip-gag">
+                <i data-lucide="message-square-off" style="width:12px;height:12px"></i> Gag
+            </button>
+            <button class="chip" type="submit" name="type" value="silence"
+                    aria-pressed="{if $filters.type == 'silence'}true{else}false{/if}"
+                    data-testid="filter-chip-silence">
+                <i data-lucide="volume-x" style="width:12px;height:12px"></i> Silence
+            </button>
+        </div>
+    </form>
+
+    {* -- Desktop table ------------------------------------------------ *}
+    <div class="card" style="overflow:hidden">
+        <table class="table" data-testid="comms-table">
+            <thead>
+                <tr>
+                    <th>Type</th>
+                    <th>Player</th>
+                    <th>SteamID</th>
+                    <th>Length</th>
+                    <th>Server</th>
+                    <th>Admin</th>
+                    <th>Started</th>
+                    <th>Status</th>
+                    <th aria-label="Actions"></th>
+                </tr>
+            </thead>
+            <tbody>
+                {foreach $ban_list as $comm}
+                    <tr class="ban-row ban-row--{$comm.state}"
+                        data-testid="comm-row"
+                        data-id="{$comm.cid}"
+                        data-state="{$comm.state}"
+                        data-type="{$comm.type}">
+                        <td>
+                            <span class="pill pill--{$comm.state}" style="text-transform:capitalize">
+                                <i data-lucide="{if $comm.type == 'mute'}mic-off{elseif $comm.type == 'gag'}message-square-off{elseif $comm.type == 'silence'}volume-x{else}help-circle{/if}"
+                                   style="width:12px;height:12px"></i>
+                                {$comm.type|escape}
+                            </span>
+                        </td>
+                        <td>
+                            <div class="flex items-center gap-3" style="min-width:0">
+                                <span class="avatar"
+                                      style="width:28px;height:28px;background:hsl({$comm.avatar_hue} 55% 45%);font-size:10px">
+                                    {$comm.name|truncate:2:'':true|upper|escape}
+                                </span>
+                                {if $comm.name}
+                                    <span class="font-medium truncate">{$comm.name|escape}</span>
+                                {else}
+                                    <span class="text-faint">no nickname</span>
+                                {/if}
+                            </div>
+                        </td>
+                        <td class="font-mono text-xs text-muted">{$comm.steam|escape}</td>
+                        <td class="tabular-nums text-muted">{$comm.length_human|escape}</td>
+                        <td class="text-muted">{$comm.sname|escape}</td>
+                        <td class="text-muted">
+                            {if $comm.admin}
+                                {$comm.admin|escape}
+                            {else}
+                                <span class="text-faint">—</span>
+                            {/if}
+                        </td>
+                        <td class="text-muted text-xs">
+                            <time datetime="{$comm.started_iso|escape}">{$comm.started_human|escape}</time>
+                        </td>
+                        <td>
+                            <span class="pill pill--{$comm.state}" style="text-transform:capitalize">{$comm.state|escape}</span>
+                        </td>
+                        <td>
+                            <div class="row-actions">
+                                {if $can_edit_comm}
+                                    <a class="btn--ghost btn--icon"
+                                       href="{$comm.edit_url|escape}"
+                                       title="Edit"
+                                       data-testid="row-action-edit">
+                                        <i data-lucide="pencil"></i>
+                                    </a>
+                                {/if}
+                                {if $can_unmute_gag && $comm.unmute_url}
+                                    <a class="btn--ghost btn--icon"
+                                       href="{$comm.unmute_url|escape}"
+                                       title="{if $comm.type == 'mute'}Unmute{elseif $comm.type == 'gag'}Ungag{else}Lift block{/if}"
+                                       data-testid="row-action-unmute">
+                                        <i data-lucide="check"></i>
+                                    </a>
+                                {/if}
+                                {if $can_delete_comm}
+                                    <a class="btn--ghost btn--icon"
+                                       href="{$comm.delete_url|escape}"
+                                       title="Delete"
+                                       data-testid="row-action-delete">
+                                        <i data-lucide="trash-2"></i>
+                                    </a>
+                                {/if}
+                            </div>
+                        </td>
+                    </tr>
+                {foreachelse}
+                    <tr>
+                        <td colspan="9"
+                            style="text-align:center;padding:3rem;color:var(--text-muted)"
+                            data-testid="comms-empty">
+                            No comm blocks match those filters.
+                        </td>
+                    </tr>
+                {/foreach}
+            </tbody>
+        </table>
+
+        {* -- Mobile cards --------------------------------------------- *}
+        <div class="ban-cards">
+            {foreach $ban_list as $comm}
+                <a class="ban-row ban-row--{$comm.state} flex items-center gap-3 p-4"
+                   style="border-bottom:1px solid var(--border);text-decoration:none;color:var(--text)"
+                   href="?p=commslist&amp;searchText={$comm.steam|escape:'url'}"
+                   data-testid="comm-card"
+                   data-id="{$comm.cid}">
+                    <span class="avatar"
+                          style="width:36px;height:36px;background:hsl({$comm.avatar_hue} 55% 45%);font-size:12px">
+                        {$comm.name|truncate:2:'':true|upper|escape}
+                    </span>
+                    <div style="flex:1;min-width:0">
+                        <div class="flex items-center gap-2">
+                            <span class="font-medium text-sm truncate">
+                                {if $comm.name}{$comm.name|escape}{else}<span class="text-faint">no nickname</span>{/if}
+                            </span>
+                            <span class="pill pill--{$comm.state}">{$comm.state|escape}</span>
+                        </div>
+                        <div class="text-xs text-muted truncate" style="margin-top:0.125rem">
+                            <span style="text-transform:capitalize">{$comm.type|escape}</span>
+                            · {$comm.length_human|escape}
+                            {if $comm.sname} · {$comm.sname|escape}{/if}
+                        </div>
+                        <div class="font-mono text-xs text-faint truncate" style="margin-top:0.125rem">{$comm.steam|escape}</div>
+                    </div>
+                    <i data-lucide="chevron-right"></i>
+                </a>
+            {/foreach}
+        </div>
     </div>
+
+    {* -- Pagination --------------------------------------------------- *}
+    <div class="flex items-center justify-between text-xs text-muted" data-testid="comms-pagination">
+        <div>
+            Showing
+            <span class="font-medium tabular-nums" style="color:var(--text)">{$pagination.from|number_format}–{$pagination.to|number_format}</span>
+            of
+            <span class="font-medium tabular-nums" style="color:var(--text)">{$pagination.total|number_format}</span>
+        </div>
+        <div class="flex gap-1">
+            {if $pagination.prev_url}
+                <a class="btn btn--secondary btn--sm"
+                   href="{$pagination.prev_url|escape}"
+                   data-testid="page-prev">
+                    <i data-lucide="chevron-left"></i> Prev
+                </a>
+            {else}
+                <span class="btn btn--secondary btn--sm"
+                      aria-disabled="true"
+                      style="opacity:0.5;pointer-events:none"
+                      data-testid="page-prev">
+                    <i data-lucide="chevron-left"></i> Prev
+                </span>
+            {/if}
+            {if $pagination.next_url}
+                <a class="btn btn--secondary btn--sm"
+                   href="{$pagination.next_url|escape}"
+                   data-testid="page-next">
+                    Next <i data-lucide="chevron-right"></i>
+                </a>
+            {else}
+                <span class="btn btn--secondary btn--sm"
+                      aria-disabled="true"
+                      style="opacity:0.5;pointer-events:none"
+                      data-testid="page-next">
+                    Next <i data-lucide="chevron-right"></i>
+                </span>
+            {/if}
+        </div>
+    </div>
+
+    {* `searchlink` is the URL fragment (e.g. `&searchText=foo`) the
+       handler builds to preserve the active query across navigation.
+       It is already woven into `pagination.prev_url` /
+       `pagination.next_url` and `hide_inactive_toggle_url` above, so
+       the only reason we mention it here is to keep
+       SmartyTemplateRule's parity check happy without a baseline
+       entry — the View must declare it so the legacy default theme
+       (which embeds `{$searchlink}` literally) keeps rendering, and
+       the rule needs to see at least one reference in the new theme
+       too. The hidden input below also makes the chip-submit form
+       carry the search text forward when a chip is clicked. *}
+    <input type="hidden" form="comms-filters" name="_searchlink" value="{$searchlink|escape}" data-testid="comms-searchlink-shadow">
+
 </div>


### PR DESCRIPTION
Part of #1123 (v2.0.0 theme rollout — Phase B, ticket B4).

## Summary

Replaces the A1 stub at `web/themes/sbpp2026/page_comms.tpl` with the
full sbpp2026-shaped public comm-blocklist page. Mirrors B2's banlist
shape with comms-specific columns (mute / gag / silence type pill and
icon, length, server, started, state) plus the redesign's standard
sticky filter bar (search + server + time + chips), state-tinted
left-border row, mobile cards, and structured pagination.

The handler `web/pages/page.commslist.php` now builds a
`Sbpp\View\CommsListView` and renders it via `Renderer::render`. The
View declares **the union** of variables both themes consume — the
new sbpp2026 set (`ban_list` with the slim handoff-style row keys,
`filters`, `servers`, `pagination`, `hide_inactive(_toggle_url)`,
four aggregate `$can_*` booleans) and the legacy default-theme set
(`comment`, `commenttype`, `canedit`, `commenttext`, `ctype`, `cid`,
`page`, `othercomments`, `ban_nav`, `hidetext`, `hideadminname`,
`view_comments`, `view_bans`). A small block of
`phpstan-baseline.neon` `unusedProperty` entries bridges the
sbpp2026-only properties for the legacy-leg PHPStan run; the new
theme's leg disables `reportUnmatchedIgnoredErrors` so the entries
don't fire double. **D1 deletes the legacy theme + drops these entries
in one shot** — see the View class docblock for the full audit.

Permissions are precomputed via `Perms::for($userbank)` into four
aggregate booleans (`$can_add_comm`, `$can_edit_comm`,
`$can_unmute_gag`, `$can_delete_comm`); the template uses
`{if $can_*}` only. Per-row state is derived from `RemoveType` +
`length` + `ends` so the state pill matches the
`unmuted/expired/permanent/active` vocabulary the spec calls out.

Per-row avatar tile colour uses `crc32(name . steam) % 360` as the
HSL hue so identically-named players get the same colour without any
storage and without needing a Smarty `md5` modifier (Smarty 5
doesn't ship one).

Plan link: <https://github.com/sbpp/sourcebans-pp/issues/1123>

## Files touched

- `web/themes/sbpp2026/page_comms.tpl` — replaces the A1 stub.
- `web/includes/View/CommsListView.php` — new View DTO.
- `web/pages/page.commslist.php` — switches to `Renderer::render`.
- `web/phpstan-baseline.neon` — adds 9 sbpp2026-only `unusedProperty`
  bridge entries; removes two handler entries (`Variable $ctext in
  isset() always exists` and `Variable $searchlink might not be
  defined`) that the refactor naturally retired.

Out of scope for B4 (open for a follow-up):

- Comment edit drawer (`?comment=` flow stays on the default theme;
  the new theme list-only page just exposes the row's edit URL).
- Live-server hostname resolution (sname renders ip:port; a future
  ticket can swap in a `sb.api.call`-driven resolver to match the
  legacy `LoadServerHost` JS).
- SQL filter wiring for the new `?type=` / `?state=` URL params (chips
  highlight via URL state but the legacy `advSearch` path still drives
  actual filtering).

## Testability hooks

Per the B4 spec — every required `data-testid` is wired:

```text
filter-chip-{all,active,mute,gag,silence}
comm-row + data-id="{$comm.cid}"  (and comm-card on mobile)
row-action-{edit,unmute,delete}
page-prev / page-next
comms-search
comms-empty / comms-table / comms-pagination
comms-{header,count,server-filter,time-filter,filter-apply,searchlink-shadow}
toggle-hide-inactive / comms-add-button
```

Plus `<time datetime="…">` on every started column (handler emits the
ISO-8601 form into `$comm.started_iso`).

## Test plan

- [x] `./sbpp.sh phpstan` (default-theme leg) — clean.
- [x] `./sbpp.sh phpstan -c phpstan-sbpp2026.neon` with
  `SBPP_PHPSTAN_THEME=sbpp2026` — clean.
- [x] `./sbpp.sh ts-check` — clean.
- [x] `./sbpp.sh composer api-contract` — no diff (handler is
  page-side; no API surface change).
- [x] `./sbpp.sh test` — 268 tests, 1130 assertions; one flaky
  pre-existing isolation error (`Account::checkPasswordMatches`,
  `Duplicate entry '0' for key 'PRIMARY'` in `Fixture.php`) that
  passes when re-run alone (`./sbpp.sh test --filter=checkPasswordMatches`
  → green) and isn't related to this change.
- [x] Smoke-rendered `?p=commslist` against four seed rows
  (mute/gag/permanent/unmuted) on the dev stack — page renders 26 KB
  with all required `data-testid` hooks. The dev `MariaDB 10.11`
  stack has a known pre-existing `LIMIT '0','30'` PDO bind issue
  affecting **all** list pages (banlist + commslist) — out of B4
  scope to fix; CI's PDO config doesn't hit it.

## Out-of-scope dev-stack note

The local `./sbpp.sh up` MariaDB 10.11 + PHP 8.2 stack rejects
`LIMIT '0','30'` (PDO binds array params as `PDO::PARAM_STR`,
modern MariaDB no longer coerces) on every paginated list page —
including `?p=banlist` on `main`. That's pre-existing and out of B4
scope; CI's environment doesn't trigger it. Smoke-rendering this
PR's template required a one-line throwaway tweak in
`web/includes/Database.php` (toggling `PDO::ATTR_EMULATE_PREPARES`
+ rebinding LIMIT params with `PDO::PARAM_INT`); that tweak is
**not** part of this PR.