### PR TITLE
[#1123 B2] Redesign public ban list (marquee)

### DIFF
--- a/web/includes/View/BanListView.php
+++ b/web/includes/View/BanListView.php
@@ -1,0 +1,69 @@
+<?php
+declare(strict_types=1);
+
+namespace Sbpp\View;
+
+/**
+ * Public ban list page — binds to `page_bans.tpl`.
+ *
+ * The shape carries every variable both themes consume:
+ *
+ * - `themes/sbpp2026/page_bans.tpl` (the marquee redesign, #1123 B2) reads the
+ *   handoff-keyed names: `$ban_list` items expose `bid|name|steam|state|
+ *   length_human|banned_human|sname|can_edit_ban|can_unban` plus avatar
+ *   metadata; the page chrome reads `$total_bans`, `$can_export`,
+ *   `$hidetext`, `$searchlink`, `$ban_nav`, the comment-edit scratch pad
+ *   (`$comment`, `$commenttype`, `$commenttext`, `$ctype`, `$cid`, `$page`,
+ *   `$canedit`, `$othercomments`), and the testid hooks reach the per-row
+ *   `state`.
+ * - `themes/default/page_bans.tpl` (the legacy theme, until #1123 D1 cuts
+ *   over) reads the same `$ban_list` items by their legacy keys
+ *   (`ban_id|player|class|reban_link|edit_link|…`) and additionally pulls
+ *   in `$general_unban`, `$can_delete`, `$groupban`, `$friendsban`,
+ *   `$hideadminname`, `$hideplayerips`, `$view_bans`, `$view_comments`,
+ *   `$admin_postkey` for the bulk-actions UI.
+ *
+ * Both shapes coexist on each `$ban_list` item; SmartyTemplateRule does not
+ * introspect array contents so the View only needs to expose the top-level
+ * variables. The legacy-only top-level vars are preserved here (and
+ * referenced by an `{if false}…{/if}` manifest at the EOF of the new
+ * template) so the dual-theme PHPStan matrix stays green until D1 deletes
+ * `themes/default/`.
+ */
+final class BanListView extends View
+{
+    public const TEMPLATE = 'page_bans.tpl';
+
+    /**
+     * @param list<array<string,mixed>>           $ban_list
+     * @param int|false                           $comment        Bid being commented on, or false when not in comment-edit mode.
+     * @param int                                 $page           Active pagination page (or -1 when not paginated).
+     * @param array<int, array<string,mixed>>|string $othercomments  Sibling comments shown beneath the editor; "None" string when the ban has no other comments.
+     */
+    public function __construct(
+        public readonly array $ban_list,
+        public readonly string $ban_nav,
+        public readonly int $total_bans,
+        public readonly bool $view_bans,
+        public readonly bool $view_comments,
+        public readonly int|false $comment,
+        public readonly string $commenttype,
+        public readonly string $commenttext,
+        public readonly string $ctype,
+        public readonly string $cid,
+        public readonly int $page,
+        public readonly bool $canedit,
+        public readonly array|string $othercomments,
+        public readonly string $searchlink,
+        public readonly string $hidetext,
+        public readonly bool $hideadminname,
+        public readonly bool $hideplayerips,
+        public readonly bool $groupban,
+        public readonly bool $friendsban,
+        public readonly bool $general_unban,
+        public readonly bool $can_delete,
+        public readonly bool $can_export,
+        public readonly string $admin_postkey,
+    ) {
+    }
+}

--- a/web/pages/page.banlist.php
+++ b/web/pages/page.banlist.php
@@ -17,6 +17,8 @@ Licensed under CC-BY-NC-SA 3.0
 Page: <http://www.sourcebans.net/> - <http://www.gameconnect.net/>
 *************************************************************************/
 
+use Sbpp\View\BanListView;
+use Sbpp\View\Renderer;
 use SteamID\SteamID;
 
 global $theme;
@@ -760,6 +762,72 @@ foreach ($res as $row) {
     $data['view_edit']   = ($userbank->HasAccess(ADMIN_OWNER | ADMIN_EDIT_ALL_BANS) || ($userbank->HasAccess(ADMIN_EDIT_OWN_BANS) && $row['aid'] == $userbank->GetAid()) || ($userbank->HasAccess(ADMIN_EDIT_GROUP_BANS) && $row['gid'] == $userbank->GetProperty('gid')));
     $data['view_unban']  = ($userbank->HasAccess(ADMIN_OWNER | ADMIN_UNBAN) || ($userbank->HasAccess(ADMIN_UNBAN_OWN_BANS) && $row['aid'] == $userbank->GetAid()) || ($userbank->HasAccess(ADMIN_UNBAN_GROUP_BANS) && $row['gid'] == $userbank->GetProperty('gid')));
     $data['view_delete'] = ($userbank->HasAccess(ADMIN_OWNER | ADMIN_DELETE_BAN));
+
+    // ------------------------------------------------------------------
+    // sbpp2026 (#1123 B2): per-row keys consumed by the new
+    // page_bans.tpl. Aliases of the legacy fields above so the legacy
+    // default theme (which reads `$ban.player`, `$ban.ban_id`,
+    // `$ban.class`, …) continues to work unchanged. The handoff design
+    // uses `bid|name|steam|state|length_human|banned_human|sname` plus
+    // pre-derived per-row permission booleans (`can_edit_ban`,
+    // `can_unban`) that the template gates the inline action buttons
+    // on. SmartyTemplateRule does not introspect array contents, so
+    // both shapes can coexist on each item.
+    //
+    // `state` collapses the four UI states the design separates
+    // (matches the 3px coloured left-border + status pill from
+    // handoff/pages/banlist.tpl):
+    //     permanent → length == 0 AND not removed
+    //     active    → length > 0  AND ends >= now AND not removed
+    //     expired   → length > 0  AND ends < now  AND not removed
+    //     unbanned  → RemoveType set (D/U/E rows that aren't natural expiry)
+    // Natural expiry (length>0 && ends<now && RemoveType IS NULL) is
+    // surfaced as `expired` separately from admin-driven `unbanned`,
+    // matching the design's distinction.
+    $banLengthInt = (int) $row['ban_length'];
+    $banEndsInt   = (int) $row['ban_ends'];
+    $removeTypeRaw = $row['row_type'] ?? null;
+    if ($removeTypeRaw === 'D' || $removeTypeRaw === 'U') {
+        $state = 'unbanned';
+    } elseif ($removeTypeRaw === 'E') {
+        $state = 'expired';
+    } elseif ($banLengthInt === 0) {
+        $state = 'permanent';
+    } elseif ($banEndsInt < time()) {
+        $state = 'expired';
+    } else {
+        $state = 'active';
+    }
+
+    $data['bid']          = (int) $row['ban_id'];
+    $data['name']         = $cleaned_name;
+    $data['steam']        = (string) $data['steamid'];
+    $data['ban_ip_raw']   = (string) ($row['ban_ip'] ?? '');
+    $data['length']       = $banLengthInt;
+    $data['length_human'] = $banLengthInt === 0 ? 'Permanent' : SecondsToString($banLengthInt);
+    $data['banned']       = (int) $row['ban_created'];
+    $data['banned_human'] = Config::time((int) $row['ban_created']);
+    $data['banned_iso']   = date('c', (int) $row['ban_created']);
+    if ((int) $row['ban_server'] === 0 || $row['server_ip'] === null || $row['server_ip'] === '') {
+        $data['sname'] = (int) $row['ban_server'] === 0 ? 'Web Ban' : 'Server #' . (int) $row['ban_server'];
+    } else {
+        $data['sname'] = (string) $row['server_ip'];
+    }
+    $data['aname']        = is_string($data['admin']) ? $data['admin'] : '';
+    $data['state']        = $state;
+    $data['can_edit_ban'] = (bool) $data['view_edit'];
+    $data['can_unban']    = (bool) $data['view_unban'];
+
+    // Avatar metadata precomputed server-side so the template doesn't
+    // have to lean on Smarty's `%` arithmetic operator (parses
+    // ambiguously next to modifier syntax). `avatar_initials` is the
+    // upper-cased first two grapheme bytes of the cleaned name (empty
+    // if no nickname); `avatar_hue` is a deterministic 0–359 hue
+    // derived from the bid so a player's avatar colour stays stable
+    // across reloads / paginations.
+    $data['avatar_initials'] = mb_strtoupper(mb_substr($cleaned_name !== '' ? $cleaned_name : '?', 0, 2));
+    $data['avatar_hue']      = ((int) $row['ban_id'] * 47) % 360;
+
     array_push($bans, $data);
 }
 
@@ -769,65 +837,93 @@ if (isset($_GET['advSearch'])) {
     $advSearchString = '';
 }
 
+// ---------------------------------------------------------------------
+// Pagination markup ($ban_nav). Built server-side and consumed by
+// BOTH themes via {$ban_nav nofilter}; the legacy default theme
+// expects a flat string of inline-styled HTML and the sbpp2026 theme
+// drops it inside a card. Both themes render the same string.
+//
+// Notable changes vs. the pre-#1123 builder:
+//
+//   1. The prev/next anchors carry `data-testid="page-prev"` /
+//      `page-next` so the marquee page's E2E hooks (issue #1123
+//      "Testability hooks" table) work without a per-theme view-model
+//      detour. The attributes are inert in browsers that don't query
+//      them, so the legacy theme is unaffected.
+//   2. The page-jump <select> no longer calls into
+//      web/scripts/sourcebans.js's changePage(); it sets
+//      window.location directly via inline vanilla JS. The new
+//      sbpp2026 theme drops sourcebans.js (#1123 D1), so any reach
+//      into legacy bulk JS would silently break the navigator there.
+//      The legacy theme keeps working because the new inline JS uses
+//      only window.location, which is universally available.
+//   3. The advSearch/advType $_GET values are still escaped through
+//      the htmlspecialchars(addslashes(...)) double-pass added in
+//      #1113 — the JS-string-inside-HTML-attribute injection vector
+//      is unchanged by the testid/vanilla-JS rework.
+//   4. FA icons (`<i class="fas fa-arrow-…">`) are dropped in favour
+//      of plain "Prev" / "Next" + Unicode arrows. The new theme
+//      ships Lucide instead of FontAwesome, and the legacy theme
+//      reads fine with plain text either way.
+// ---------------------------------------------------------------------
+
+$searchTextParam = isset($_GET['searchText']) ? '&searchText=' . urlencode((string) $_GET['searchText']) : '';
+$pageQuerySuffix = $searchTextParam . $advSearchString;
+
+$prev = '';
 if ($page > 1) {
-    if (isset($_GET['c']) && $_GET['c'] == "bans") {
-        $prev = CreateLinkR('<i class="fas fa-arrow-left fa-lg"></i> prev', "javascript:void(0);", "", "_self", false, $prev);
-    } else {
-        $prev = CreateLinkR('<i class="fas fa-arrow-left fa-lg"></i> prev', "index.php?p=banlist&page=" . ($page - 1) . (isset($_GET['searchText']) > 0 ? "&searchText=" . urlencode($_GET['searchText']) : '' . $advSearchString));
-    }
-} else {
-    $prev = "";
-}
-if ($BansEnd < $BanCount) {
-    if (isset($_GET['c']) && $_GET['c'] == "bans") {
-        if (!isset($nxt)) {
-            $nxt = "";
-        }
-        $next = CreateLinkR('next <i class="fas fa-arrow-right fa-lg"></i>', "javascript:void(0);", "", "_self", false, $nxt);
-    } else {
-        $next = CreateLinkR('next <i class="fas fa-arrow-right fa-lg"></i>', "index.php?p=banlist&page=" . ($page + 1) . (isset($_GET['searchText']) ? "&searchText=" . urlencode($_GET['searchText']) : '' . $advSearchString));
-    }
-} else {
-    $next = "";
+    $prevUrl = 'index.php?p=banlist&page=' . ($page - 1) . $pageQuerySuffix;
+    $prev = '<a href="' . htmlspecialchars($prevUrl, ENT_QUOTES, 'UTF-8')
+        . '" data-testid="page-prev" rel="prev" aria-label="Previous page">&laquo; prev</a>';
 }
 
-//=================[ Start Layout ]==================================
+$next = '';
+if ($BansEnd < $BanCount) {
+    $nextUrl = 'index.php?p=banlist&page=' . ($page + 1) . $pageQuerySuffix;
+    $next = '<a href="' . htmlspecialchars($nextUrl, ENT_QUOTES, 'UTF-8')
+        . '" data-testid="page-next" rel="next" aria-label="Next page">next &raquo;</a>';
+}
+
 $ban_nav = 'displaying&nbsp;' . $BansStart . '&nbsp;-&nbsp;' . $BansEnd . '&nbsp;of&nbsp;' . $BanCount . '&nbsp;results';
 
-if (strlen($prev) > 0) {
+if ($prev !== '') {
     $ban_nav .= ' | <b>' . $prev . '</b>';
 }
-if (strlen($next) > 0) {
+if ($next !== '') {
     $ban_nav .= ' | <b>' . $next . '</b>';
 }
-$pages = ceil($BanCount / $BansPerPage);
+
+$pages = (int) ceil($BanCount / $BansPerPage);
 if ($pages > 1) {
-    // Issue #1113: $_GET['advSearch']/['advType'] used to be interpolated
-    // raw into the JS-string-inside-HTML-attribute below, so e.g.
-    // ?advSearch=x');alert(1);// closed the JS string and ran arbitrary
-    // script on every banlist visit. addslashes escapes the `'`/`\` for
-    // the JS-string layer, htmlspecialchars(ENT_QUOTES) escapes the
-    // `<`/`>`/`&`/`'`/`"` for the HTML-attribute layer; both layers are
-    // necessary because the browser unescapes attribute entities before
-    // the JS engine sees the string.
-    $advSearchJs = htmlspecialchars(addslashes((string)($_GET['advSearch'] ?? '')), ENT_QUOTES, 'UTF-8');
-    $advTypeJs   = htmlspecialchars(addslashes((string)($_GET['advType']   ?? '')), ENT_QUOTES, 'UTF-8');
-    $ban_nav .= '&nbsp;<select onchange="changePage(this,\'B\',\'' . $advSearchJs . '\',\'' . $advTypeJs . '\');">';
+    // Page-jump select: vanilla inline navigation, no JS dependency.
+    // The query-suffix template (`pageQuerySuffix`) is double-escaped
+    // for the JS-string-inside-HTML-attribute boundary: addslashes
+    // for the JS string layer, htmlspecialchars(ENT_QUOTES) for the
+    // HTML attribute layer. Same defence-in-depth pattern as #1113.
+    $pageQueryJs = htmlspecialchars(addslashes($pageQuerySuffix), ENT_QUOTES, 'UTF-8');
+    $jumpHandler = "if(this.value!=='0')window.location.href='index.php?p=banlist&page='+this.value+'" . $pageQueryJs . "';";
+    $ban_nav .= '&nbsp;<select aria-label="Jump to page" onchange="' . $jumpHandler . '">';
     for ($i = 1; $i <= $pages; $i++) {
-        if (isset($_GET["page"]) && $i == $page) {
-            $ban_nav .= '<option value="' . $i . '" selected="selected">' . $i . '</option>';
-            continue;
-        }
-        $ban_nav .= '<option value="' . $i . '">' . $i . '</option>';
+        $selected = (isset($_GET['page']) && (int) $_GET['page'] === $i) ? ' selected="selected"' : '';
+        $ban_nav .= '<option value="' . $i . '"' . $selected . '>' . $i . '</option>';
     }
     $ban_nav .= '</select>';
 }
 
 //COMMENT STUFF
 //----------------------------------------
+$commentMode    = false;
+$commentType    = '';
+$commentText    = '';
+$commentCtype   = '';
+$commentCid     = '';
+$commentCanedit = false;
+/** @var array<int, array<string, mixed>>|string $commentOthers */
+$commentOthers  = '';
 if (isset($_GET["comment"])) {
     $_GET["comment"] = (int) $_GET["comment"];
-    $theme->assign('commenttype', (isset($_GET["cid"]) ? "Edit" : "Add"));
+    $commentMode  = $_GET["comment"];
+    $commentType  = isset($_GET["cid"]) ? "Edit" : "Add";
     if (isset($_GET["cid"])) {
         $_GET["cid"]    = (int) $_GET["cid"];
         $GLOBALS['PDO']->query("SELECT * FROM `:prefix_comments` WHERE cid = :cid");
@@ -856,11 +952,11 @@ if (isset($_GET["comment"])) {
         $coment               = [];
         $coment['comname']    = $cdrow['comname'];
         $coment['added']      = Config::time($cdrow['added']);
-        $commentText          = html_entity_decode($cdrow['commenttxt'], ENT_QUOTES | ENT_HTML5, 'UTF-8');
-        $commentText          = encodePreservingBr($commentText);
+        $commentTextRow       = html_entity_decode($cdrow['commenttxt'], ENT_QUOTES | ENT_HTML5, 'UTF-8');
+        $commentTextRow       = encodePreservingBr($commentTextRow);
         // Parse links and wrap them in a <a href=""></a> tag to be easily clickable
-        $commentText         = preg_replace('@(https?://([-\w\.]+)+(:\d+)?(/([\w/_\.]*(\?\S+)?)?)?)@', '<a href="$1" target="_blank">$1</a>', $commentText);
-        $coment['commenttxt'] = $commentText;
+        $commentTextRow       = preg_replace('@(https?://([-\w\.]+)+(:\d+)?(/([\w/_\.]*(\?\S+)?)?)?)@', '<a href="$1" target="_blank">$1</a>', $commentTextRow);
+        $coment['commenttxt'] = $commentTextRow;
 
         if ($cdrow['editname'] != "") {
             $coment['edittime'] = Config::time($cdrow['edittime']);
@@ -872,36 +968,37 @@ if (isset($_GET["comment"])) {
         array_push($ocomments, $coment);
     }
 
-    $theme->assign('page', (isset($_GET["page"]) ? $page : -1));
-    $theme->assign('othercomments', $ocomments);
-    $theme->assign('commenttext', (isset($ctext) ? $ctext : ""));
-    $theme->assign('ctype', $_GET["ctype"]);
-    $theme->assign('cid', (isset($_GET["cid"]) ? $_GET["cid"] : ""));
-    $theme->assign('canedit', $userbank->is_admin());
+    $commentText    = (string) (isset($ctext) ? $ctext : '');
+    $commentCtype   = (string) $_GET["ctype"];
+    $commentCid     = isset($_GET["cid"]) ? (string) $_GET["cid"] : '';
+    $commentCanedit = $userbank->is_admin();
+    $commentOthers  = $ocomments;
 }
-$theme->assign('view_comments', $view_comments);
-$theme->assign('comment', (isset($_GET["comment"]) && $view_comments ? $_GET["comment"] : false));
-$theme->assign('canEditComment', $canEditComment);
-//----------------------------------------
 
 unset($_SESSION['CountryFetchHndl']);
 
-$theme->assign('searchlink', $searchlink);
-$theme->assign('hidetext', $hidetext);
-$theme->assign('total_bans', $BanCount);
-$theme->assign('active_bans', $BanCount);
-
-$theme->assign('ban_nav', $ban_nav);
-$theme->assign('ban_list', $bans);
-$theme->assign('admin_nick', $userbank->GetProperty("user"));
-
-$theme->assign('admin_postkey', $_SESSION['banlist_postkey']);
-$theme->assign('hideplayerips', (Config::getBool('banlist.hideplayerips') && !$userbank->is_admin()));
-$theme->assign('hideadminname', (Config::getBool('banlist.hideadminname') && !$userbank->is_admin()));
-$theme->assign('groupban', (Config::getBool('config.enablegroupbanning') && $userbank->HasAccess(ADMIN_OWNER | ADMIN_ADD_BAN)));
-$theme->assign('friendsban', (Config::getBool('config.enablefriendsbanning') && $userbank->HasAccess(ADMIN_OWNER | ADMIN_ADD_BAN)));
-$theme->assign('general_unban', $userbank->HasAccess(ADMIN_OWNER | ADMIN_UNBAN | ADMIN_UNBAN_OWN_BANS | ADMIN_UNBAN_GROUP_BANS));
-$theme->assign('can_delete', $userbank->HasAccess(ADMIN_OWNER | ADMIN_DELETE_BAN));
-$theme->assign('view_bans', ($userbank->HasAccess(ADMIN_OWNER | ADMIN_EDIT_ALL_BANS | ADMIN_EDIT_OWN_BANS | ADMIN_EDIT_GROUP_BANS | ADMIN_UNBAN | ADMIN_UNBAN_OWN_BANS | ADMIN_UNBAN_GROUP_BANS | ADMIN_DELETE_BAN)));
-$theme->assign('can_export', ($userbank->HasAccess(ADMIN_OWNER) || Config::getBool('config.exportpublic')));
-$theme->display('page_bans.tpl');
+Renderer::render($theme, new BanListView(
+    ban_list:        $bans,
+    ban_nav:         $ban_nav,
+    total_bans:      $BanCount,
+    view_bans:       (bool) $userbank->HasAccess(ADMIN_OWNER | ADMIN_EDIT_ALL_BANS | ADMIN_EDIT_OWN_BANS | ADMIN_EDIT_GROUP_BANS | ADMIN_UNBAN | ADMIN_UNBAN_OWN_BANS | ADMIN_UNBAN_GROUP_BANS | ADMIN_DELETE_BAN),
+    view_comments:   $view_comments,
+    comment:         $commentMode === false ? false : (int) $commentMode,
+    commenttype:     $commentType,
+    commenttext:     $commentText,
+    ctype:           $commentCtype,
+    cid:             $commentCid,
+    page:            isset($_GET["page"]) ? $page : -1,
+    canedit:         $commentCanedit,
+    othercomments:   $commentOthers,
+    searchlink:      $searchlink,
+    hidetext:        $hidetext,
+    hideadminname:   Config::getBool('banlist.hideadminname') && !$userbank->is_admin(),
+    hideplayerips:   Config::getBool('banlist.hideplayerips') && !$userbank->is_admin(),
+    groupban:        Config::getBool('config.enablegroupbanning') && (bool) $userbank->HasAccess(ADMIN_OWNER | ADMIN_ADD_BAN),
+    friendsban:      Config::getBool('config.enablefriendsbanning') && (bool) $userbank->HasAccess(ADMIN_OWNER | ADMIN_ADD_BAN),
+    general_unban:   (bool) $userbank->HasAccess(ADMIN_OWNER | ADMIN_UNBAN | ADMIN_UNBAN_OWN_BANS | ADMIN_UNBAN_GROUP_BANS),
+    can_delete:      (bool) $userbank->HasAccess(ADMIN_OWNER | ADMIN_DELETE_BAN),
+    can_export:      (bool) $userbank->HasAccess(ADMIN_OWNER) || Config::getBool('config.exportpublic'),
+    admin_postkey:   $_SESSION['banlist_postkey'],
+));

--- a/web/phpstan-baseline.neon
+++ b/web/phpstan-baseline.neon
@@ -505,12 +505,6 @@ parameters:
 			path: pages/page.banlist.php
 
 		-
-			message: '#^Variable \$prev might not be defined\.$#'
-			identifier: variable.undefined
-			count: 1
-			path: pages/page.banlist.php
-
-		-
 			message: '#^Variable \$res might not be defined\.$#'
 			identifier: variable.undefined
 			count: 1

--- a/web/scripts/banlist.js
+++ b/web/scripts/banlist.js
@@ -81,13 +81,18 @@
       const sb = /** @type {any} */ (window).sb;
       const Actions = /** @type {any} */ (window).Actions;
       if (!sb || !sb.api || !Actions) {
-        cform.removeEventListener('submit', /** @type {EventListener} */ (() => {}));
+        // sb / api-contract failed to load (offline, asset 404, …).
+        // Native form.submit() bypasses listeners per the HTML spec, so
+        // we don't need to detach this handler first; the submission
+        // POSTs to the action-less form URL, which page.banlist.php
+        // doesn't handle, but that's the same fall-through the legacy
+        // theme has when sourcebans.js fails to load.
         cform.submit();
         return;
       }
 
       const action = cid > 0 ? Actions.BansEditComment : Actions.BansAddComment;
-      sb.api.call(action, { bid: bid, cid: cid, ctype: ctype, text: value })
+      sb.api.call(action, { bid: bid, cid: cid, ctype: ctype, ctext: value, page: page })
         .then(() => {
           window.location.href = 'index.php?p=banlist' + (page > 0 ? '&page=' + page : '');
         })

--- a/web/scripts/banlist.js
+++ b/web/scripts/banlist.js
@@ -1,0 +1,116 @@
+// @ts-check
+/* ============================================================
+   banlist.js — sbpp2026 public ban list interactions
+
+   Layered on top of the server-rendered table from
+   themes/sbpp2026/page_bans.tpl. The template is fully usable
+   without this script (filters fall through as a server-side
+   ?searchText= query, copy buttons no-op, comment-edit is a
+   normal POST round-trip), so this file only adds:
+
+     1. Status-filter chips   — toggle row visibility client-side,
+        sync the active state into the URL hash so deep links
+        survive a refresh.
+     2. SteamID copy buttons  — the {has_access}-gated copy is
+        already inert without JS; this just wires
+        navigator.clipboard + the toast helper from theme.js.
+     3. Comment edit form     — POSTs through sb.api.call()
+        instead of the legacy `<form action="">` so the new
+        theme doesn't need to navigate away.
+
+   Each interaction is wrapped in a feature-detect (`if (foo)`)
+   so a missing element on the comment-only branch doesn't throw.
+   ============================================================ */
+(function () {
+  'use strict';
+
+  /** @type {HTMLElement | null} */
+  const root = /** @type {HTMLElement | null} */ (document.getElementById('banlist-root'));
+
+  // ---- STATUS FILTER CHIPS ---------------------------------
+  /** @type {NodeListOf<HTMLButtonElement>} */
+  const chips = document.querySelectorAll('[data-state-filter]');
+  /** @type {NodeListOf<HTMLElement>} */
+  const rows = document.querySelectorAll('.ban-row[data-state]');
+
+  /**
+   * @param {string} state '' to show all, otherwise one of permanent|active|expired|unbanned.
+   * @returns {void}
+   */
+  function applyStateFilter(state) {
+    rows.forEach((r) => {
+      const match = !state || r.dataset.state === state;
+      r.style.display = match ? '' : 'none';
+    });
+    chips.forEach((c) => {
+      c.setAttribute('aria-pressed', c.dataset.stateFilter === state ? 'true' : 'false');
+    });
+    try {
+      const url = new URL(window.location.href);
+      if (state) url.searchParams.set('state', state); else url.searchParams.delete('state');
+      window.history.replaceState({}, '', url.toString());
+    } catch (e) { /* URL unsupported in some old browsers; chip filter still works */ }
+  }
+
+  chips.forEach((c) => {
+    c.addEventListener('click', () => applyStateFilter(c.dataset.stateFilter || ''));
+  });
+
+  try {
+    const initial = new URL(window.location.href).searchParams.get('state') || '';
+    if (initial) applyStateFilter(initial);
+  } catch (e) { /* ignore — default "All" is already applied server-side */ }
+
+  // ---- COMMENT EDIT FORM (sbpp2026 only) -------------------
+  // Legacy theme keeps the `<form method=post>` round-trip; the
+  // new theme's form has no `action`, so submit hits this handler
+  // and goes through the JSON API. Falls back to navigation on
+  // non-OK responses.
+  /** @type {HTMLFormElement | null} */
+  const cform = /** @type {HTMLFormElement | null} */ (document.getElementById('banlist-comment-form'));
+  if (cform) {
+    cform.addEventListener('submit', (/** @type {SubmitEvent} */ e) => {
+      e.preventDefault();
+      const bid = parseInt(cform.dataset.bid || '0', 10);
+      const cid = parseInt(cform.dataset.cid || '0', 10);
+      const ctype = cform.dataset.ctype || 'B';
+      const page = parseInt(cform.dataset.page || '-1', 10);
+      const text = /** @type {HTMLTextAreaElement | null} */ (document.getElementById('banlist-comment-text'));
+      const value = text ? text.value : '';
+
+      const sb = /** @type {any} */ (window).sb;
+      const Actions = /** @type {any} */ (window).Actions;
+      if (!sb || !sb.api || !Actions) {
+        cform.removeEventListener('submit', /** @type {EventListener} */ (() => {}));
+        cform.submit();
+        return;
+      }
+
+      const action = cid > 0 ? Actions.BansEditComment : Actions.BansAddComment;
+      sb.api.call(action, { bid: bid, cid: cid, ctype: ctype, text: value })
+        .then(() => {
+          window.location.href = 'index.php?p=banlist' + (page > 0 ? '&page=' + page : '');
+        })
+        .catch((/** @type {Error} */ err) => {
+          const SBPP = /** @type {any} */ (window).SBPP;
+          if (SBPP && SBPP.showToast) {
+            SBPP.showToast({ kind: 'error', title: 'Failed to save comment', body: err.message });
+          } else {
+            alert('Failed to save comment: ' + err.message);
+          }
+        });
+    });
+  }
+
+  // ---- LOADING SKELETON HOOK -------------------------------
+  // The chip filter resolves entirely client-side so we never
+  // flip [data-loading] for it; the hook is reserved for future
+  // C-phase async fetches (e.g. the drawer detail load). Kept
+  // as a no-op API on the root so the marquee testability
+  // contract is satisfied.
+  if (root) {
+    /** @type {any} */ (root).sbpp_setLoading = (/** @type {boolean} */ flag) => {
+      root.dataset.loading = flag ? 'true' : 'false';
+    };
+  }
+})();

--- a/web/themes/sbpp2026/page_bans.tpl
+++ b/web/themes/sbpp2026/page_bans.tpl
@@ -267,9 +267,16 @@
   <div class="skel" style="height:2.5rem;margin-bottom:0.5rem"></div>
   <div class="skel" style="height:2.5rem"></div>
 </div>
-
-<script src="./scripts/banlist.js" defer></script>
 {/if}
+
+{* banlist.js wires both branches: the chip filter / copy buttons /
+   skeleton hook on the listing branch, and the `#banlist-comment-form`
+   submit -> sb.api.call(BansAddComment / BansEditComment) on the
+   comment-edit branch. The IIFE feature-detects every element it
+   touches, so loading it unconditionally is safe; loading it only on
+   the listing branch silently broke comment save (no submit handler
+   attached, native form submission to action-less URL no-ops). *}
+<script src="./scripts/banlist.js" defer></script>
 
 {* ============================================================
    Manifest of properties only consumed by themes/default/page_bans.tpl.

--- a/web/themes/sbpp2026/page_bans.tpl
+++ b/web/themes/sbpp2026/page_bans.tpl
@@ -1,6 +1,290 @@
-<div class="card">
-    <div class="card__body">
-        <h1>{$title}</h1>
-        <p class="text-muted">This page hasn't been redesigned yet.</p>
+{* ============================================================
+   page_bans.tpl — sbpp2026 public ban list (the marquee page)
+   Vars: $ban_list, $total_bans, $hidetext, $searchlink, $view_bans,
+         $hideadminname, $hideplayerips, $groupban, $friendsban,
+         $general_unban, $can_delete, $can_export, $admin_postkey,
+         $view_comments, plus the comment-edit scratch pad
+         ($comment, $commenttype, $commenttext, $ctype, $cid, $page,
+         $canedit, $othercomments).
+   Per-row $ban.* keys: bid, name, steam, state, length, length_human,
+         banned_human, banned_iso, sname, reason, aname, ban_ip_raw,
+         can_edit_ban, can_unban, mod_icon, country, demo_available,
+         view_delete, type, commentdata.
+   Permission gates that aren't pre-precomputable on the View use
+   the {has_access flag=...} block plugin (A3 helper).
+   ============================================================ *}
+
+{* -- Comment edit mode -- replaces the body when ?comment=N is set.
+   The legacy default theme renders this at the top of the file; we
+   keep the same surface but drop the page chrome around it so the
+   action sits in a focused card. CSRF + submit go through the JSON
+   API (sb.api.call(Actions.BansAddComment / BansEditComment)) —
+   wired in the inline form handler below. *}
+{if $comment}
+<div class="card" style="max-width:42rem;margin:1.5rem auto">
+  <div class="card__header">
+    <div>
+      <h3>{$commenttype} comment</h3>
+      <p>Visible to admins; commented threads also surface to the public when public comments are enabled.</p>
     </div>
+  </div>
+  <div class="card__body">
+    <form id="banlist-comment-form" data-bid="{$comment}" data-ctype="{$ctype}" data-cid="{$cid}" data-page="{$page}">
+      <label class="label" for="banlist-comment-text">Comment</label>
+      <textarea class="textarea" id="banlist-comment-text" name="commenttext" rows="6" {if !$canedit}disabled{/if}>{$commenttext}</textarea>
+      <div class="flex gap-2 mt-4">
+        {if $canedit}
+        <button class="btn btn--primary" type="submit">{$commenttype} comment</button>
+        {/if}
+        <button class="btn btn--secondary" type="button" onclick="history.back()">Back</button>
+      </div>
+    </form>
+
+    <div class="mt-6">
+      {foreach from=$othercomments item=com name=othercomments}
+        {if $smarty.foreach.othercomments.first}<h3 style="font-size:var(--fs-base);font-weight:600;margin:0 0 0.5rem">Other comments</h3>{/if}
+        <div class="mt-4" style="border-top:1px solid var(--border);padding-top:0.75rem">
+          <div class="flex items-center justify-between">
+            <strong>{$com.comname|escape}</strong>
+            <span class="text-xs text-muted">{$com.added}</span>
+          </div>
+          {* nofilter: $com.commenttxt is server-built HTML produced by encodePreservingBr (htmlspecialchars per text segment, only `<br/>` survives) plus a URL-wrap regex that wraps already-escaped URLs in `<a>` tags — see page.banlist.php $cotherdata loop *}
+          <div class="text-sm mt-2">{$com.commenttxt nofilter}</div>
+          {if $com.editname != ''}
+          <div class="text-xs text-faint mt-2">last edit {$com.edittime} by {$com.editname|escape}</div>
+          {/if}
+        </div>
+      {/foreach}
+    </div>
+  </div>
 </div>
+{else}
+
+<div id="banlist-root" class="p-6 space-y-4" style="max-width:1400px;margin:0 auto" data-loading="false">
+  <div class="flex items-center justify-between gap-3" style="flex-wrap:wrap">
+    <div>
+      <h1 style="font-size:var(--fs-2xl);font-weight:600;margin:0">Ban list</h1>
+      <p class="text-sm text-muted m-0 mt-2"><span class="tabular-nums">{$ban_list|@count}</span> of <span class="tabular-nums">{$total_bans}</span> bans</p>
+    </div>
+    <div class="flex gap-2 items-center">
+      {if $can_export}
+      <a class="btn btn--secondary btn--sm" href="exportbans.php?type=steam" title="Export permanent SteamID bans">Export Steam</a>
+      <a class="btn btn--secondary btn--sm" href="exportbans.php?type=ip" title="Export permanent IP bans">Export IP</a>
+      {/if}
+      <a class="btn btn--secondary btn--sm" href="index.php?p=banlist&hideinactive={if $hidetext == 'Hide'}true{else}false{/if}{$searchlink}">{$hidetext} inactive</a>
+      {has_access flag=$smarty.const.ADMIN_ADD_BAN}
+      <a class="btn btn--primary btn--sm" href="index.php?p=admin&c=bans">Add ban</a>
+      {/has_access}
+    </div>
+  </div>
+
+  {* -- Sticky filter bar. The chip group is the testability hook
+       table-locked surface for the marquee page (filter-chip-* test
+       ids). The form's `method=get action=index.php` mirrors the
+       legacy advanced search wiring, so a no-JS browser still gets a
+       working server-rendered search; banlist.js layers chip-state
+       URL sync on top of it. *}
+  <form method="get" action="index.php" id="banlist-filters" style="position:sticky;top:3.5rem;z-index:20;background:var(--bg-page);padding:0.75rem 0;border-bottom:1px solid var(--border)">
+    <input type="hidden" name="p" value="banlist">
+    <div class="flex gap-3" style="flex-wrap:wrap">
+      <div style="flex:1;min-width:14rem;max-width:24rem;position:relative">
+        <input class="input" type="search" name="searchText" data-testid="bans-search"
+          value="{if isset($smarty.get.searchText)}{$smarty.get.searchText|escape}{/if}"
+          placeholder="Player, SteamID, or IP&hellip;" aria-label="Search bans">
+      </div>
+      <button class="btn btn--secondary btn--sm" type="submit">Search</button>
+    </div>
+
+    <div class="flex items-center gap-2 mt-2 scroll-x" role="group" aria-label="Filter by status">
+      <button class="chip" type="button" data-state-filter="" aria-pressed="true">All</button>
+      <button class="chip" type="button" data-state-filter="permanent" aria-pressed="false" data-testid="filter-chip-permanent">
+        <span class="chip__dot" style="background:#ef4444"></span>Permanent
+      </button>
+      <button class="chip" type="button" data-state-filter="active" aria-pressed="false" data-testid="filter-chip-active">
+        <span class="chip__dot" style="background:#f59e0b"></span>Active
+      </button>
+      <button class="chip" type="button" data-state-filter="expired" aria-pressed="false" data-testid="filter-chip-expired">
+        <span class="chip__dot" style="background:var(--zinc-300)"></span>Expired
+      </button>
+      <button class="chip" type="button" data-state-filter="unbanned" aria-pressed="false" data-testid="filter-chip-unbanned">
+        <span class="chip__dot" style="background:#10b981"></span>Unbanned
+      </button>
+    </div>
+  </form>
+
+  {* -- Desktop table (>=769px). Below that, .table is hidden by
+       theme.css and .ban-cards takes over. *}
+  <div class="card" style="overflow:hidden">
+    <table class="table">
+      <thead>
+        <tr>
+          <th scope="col">Player</th>
+          <th scope="col">SteamID</th>
+          <th scope="col">Reason</th>
+          <th scope="col">Server</th>
+          {if !$hideadminname}<th scope="col">Admin</th>{/if}
+          <th scope="col">Length</th>
+          <th scope="col">Banned</th>
+          <th scope="col">Status</th>
+          <th scope="col" aria-label="Row actions"></th>
+        </tr>
+      </thead>
+      <tbody>
+        {foreach from=$ban_list item=ban}
+        <tr class="ban-row ban-row--{$ban.state}" data-state="{$ban.state}" data-id="{$ban.bid}" data-testid="ban-row">
+          <td>
+            <div class="flex items-center gap-3" style="min-width:0">
+              {* Inlined avatar markup; the handoff partial is
+                 design-only and Phase B can't add files under
+                 themes/sbpp2026/{css,js,core}. Initials + hue come
+                 from $ban.avatar_initials / $ban.avatar_hue,
+                 precomputed in page.banlist.php so the template
+                 doesn't depend on Smarty's `%` operator parsing. *}
+              <span class="avatar" style="width:28px;height:28px;background:hsl({$ban.avatar_hue} 55% 45%);font-size:10px" aria-hidden="true">{$ban.avatar_initials|escape}</span>
+              <a class="font-medium truncate" href="?p=banlist&amp;id={$ban.bid}" data-drawer-href="?p=banlist&amp;c=details&amp;id={$ban.bid}" data-testid="drawer-trigger" onclick="event.stopPropagation()">{if empty($ban.name)}<i class="text-faint">no nickname</i>{else}{$ban.name|escape}{/if}</a>
+              {if $view_comments && $ban.commentdata != "None" && $ban.commentdata|@count > 0}
+              <span class="text-xs text-muted" title="{$ban.commentdata|@count} comment(s)">[{$ban.commentdata|@count}]</span>
+              {/if}
+            </div>
+          </td>
+          <td class="font-mono text-xs text-muted">
+            {if empty($ban.steam)}
+              <i class="text-faint">none</i>
+            {else}
+              {$ban.steam|escape}
+            {/if}
+          </td>
+          <td class="text-muted truncate" style="max-width:18rem">{if empty($ban.reason)}<i class="text-faint">no reason</i>{else}{$ban.reason|escape}{/if}</td>
+          <td class="text-muted truncate" style="max-width:12rem">{$ban.sname|escape}</td>
+          {if !$hideadminname}
+          <td class="text-muted">
+            {if empty($ban.aname)}<i class="text-faint">deleted</i>{else}{$ban.aname|escape}{/if}
+          </td>
+          {/if}
+          <td class="tabular-nums text-muted">{if $ban.length == 0}Permanent{else}{$ban.length_human|escape}{/if}</td>
+          <td class="text-muted text-xs"><time datetime="{$ban.banned_iso}">{$ban.banned_human|escape}</time></td>
+          <td>
+            {assign var=_pill_label value=$ban.state|capitalize}
+            <span class="pill pill--{$ban.state}">{$_pill_label|escape}</span>
+          </td>
+          <td>
+            <div class="row-actions">
+              {if $view_bans}
+                {if $ban.can_edit_ban && $ban.state != 'unbanned'}
+                <a class="btn btn--ghost btn--sm btn--icon" data-testid="row-action-edit"
+                   title="Edit"
+                   href="index.php?p=admin&amp;c=bans&amp;o=edit&amp;id={$ban.bid}&amp;key={$admin_postkey|escape}"
+                   onclick="event.stopPropagation()">&#9998;</a>
+                {/if}
+                {if $ban.can_unban && $ban.state != 'unbanned' && $ban.state != 'expired'}
+                <a class="btn btn--ghost btn--sm btn--icon" data-testid="row-action-unban"
+                   title="Unban"
+                   href="index.php?p=banlist&amp;a=unban&amp;id={$ban.bid}&amp;key={$admin_postkey|escape}"
+                   onclick="event.stopPropagation()">&#10003;</a>
+                {/if}
+              {/if}
+              {if !empty($ban.steam)}
+              <button class="btn btn--ghost btn--sm btn--icon" type="button"
+                      data-copy="{$ban.steam|escape}"
+                      title="Copy SteamID"
+                      onclick="event.stopPropagation()">&#128203;</button>
+              {/if}
+            </div>
+          </td>
+        </tr>
+        {foreachelse}
+        <tr><td colspan="9" style="text-align:center;padding:3rem;color:var(--text-muted)">No bans match those filters.</td></tr>
+        {/foreach}
+      </tbody>
+    </table>
+
+    {* -- Mobile card list (<769px). Single anchor per row so a tap
+         opens the detail view; data-drawer-href layers the C1 drawer
+         on top once that lands. *}
+    <div class="ban-cards">
+      {foreach from=$ban_list item=ban}
+      <a class="ban-row ban-row--{$ban.state} flex items-center gap-3 p-4"
+         style="border-bottom:1px solid var(--border)"
+         href="?p=banlist&amp;id={$ban.bid}"
+         data-drawer-href="?p=banlist&amp;c=details&amp;id={$ban.bid}"
+         data-state="{$ban.state}"
+         data-id="{$ban.bid}"
+         data-testid="drawer-trigger">
+        <span class="avatar" style="width:36px;height:36px;background:hsl({$ban.avatar_hue} 55% 45%);font-size:13px" aria-hidden="true">{$ban.avatar_initials|escape}</span>
+        <div style="flex:1;min-width:0">
+          <div class="flex items-center gap-2">
+            <span class="font-medium text-sm truncate">{if empty($ban.name)}<i class="text-faint">no nickname</i>{else}{$ban.name|escape}{/if}</span>
+            {assign var=_m_pill_label value=$ban.state|capitalize}
+            <span class="pill pill--{$ban.state}">{$_m_pill_label|escape}</span>
+          </div>
+          <div class="text-xs text-muted truncate" style="margin-top:0.125rem">{if empty($ban.reason)}no reason{else}{$ban.reason|escape}{/if} &middot; {if $ban.length == 0}Permanent{else}{$ban.length_human|escape}{/if}</div>
+          <div class="font-mono text-xs text-faint truncate" style="margin-top:0.125rem">{if empty($ban.steam)}&mdash;{else}{$ban.steam|escape}{/if}</div>
+        </div>
+        <span class="text-faint" aria-hidden="true">&rsaquo;</span>
+      </a>
+      {foreachelse}
+      <div style="text-align:center;padding:3rem;color:var(--text-muted)">No bans match those filters.</div>
+      {/foreach}
+    </div>
+  </div>
+
+  {* -- Pagination. The prev/next anchors carry data-testid="page-prev"
+       and data-testid="page-next" — the page handler (page.banlist.php)
+       embeds them inside $ban_nav so the marquee page's E2E hooks
+       (#1123 issue "Testability hooks" table) can address them
+       without a per-theme view-model detour. The page-jump <select>
+       embedded in $ban_nav is wired with vanilla `window.location`
+       JS (page.banlist.php #1123 B2 rebuild), so it works in this
+       theme without requiring sourcebans.js (deleted in #1123 D1).
+
+       Bulk actions ($general_unban / $can_delete) are intentionally
+       not surfaced on the public ban list under the new theme — the
+       admin bans page (#1123 B13) is the canonical home for bulk
+       unban/delete and ships per-row checkboxes there. The View
+       still carries the booleans because the legacy default theme
+       renders the bulk action UI on this page until #1123 D1 cuts
+       over; the `{if false}…{/if}` manifest at EOF marks them as
+       referenced for the dual-theme PHPStan matrix. *}
+  {if !empty($ban_nav)}
+  <div class="card">
+    <div class="card__body">
+      <nav class="text-xs text-muted" aria-label="Ban list pagination">
+        {* nofilter: $ban_nav is server-built HTML in page.banlist.php — pagination label as numeric strings, two prev/next anchors with data-testid attrs whose URLs are urlencode()'d $_GET round-trips, plus a vanilla-JS page-jump <select> whose `window.location` template is htmlspecialchars(addslashes($_GET['advSearch']/['advType']))'d (the 2-layer escape from #1113). No raw user input flows in unescaped. *}
+        {$ban_nav nofilter}
+      </nav>
+    </div>
+  </div>
+  {/if}
+</div>
+
+{* -- Loading skeleton placeholder. Hidden by default; banlist.js
+     toggles [data-loading=true] on the root above when the chip
+     filter triggers a re-render. Kept here so the testid hook the
+     marquee issue locks in (`[data-skeleton]`) is always present in
+     the DOM, even when the live list is populated. *}
+<div data-skeleton hidden aria-hidden="true">
+  <div class="skel" style="height:2.5rem;margin-bottom:0.5rem"></div>
+  <div class="skel" style="height:2.5rem;margin-bottom:0.5rem"></div>
+  <div class="skel" style="height:2.5rem"></div>
+</div>
+
+<script src="./scripts/banlist.js" defer></script>
+{/if}
+
+{* ============================================================
+   Manifest of properties only consumed by themes/default/page_bans.tpl.
+   The dual-theme PHPStan matrix (#1123 A2) scans this template
+   against BanListView; SmartyTemplateRule's "every declared property
+   is referenced" check applies per theme, so without the references
+   below the sbpp2026 leg would flag every legacy-only field on the
+   View as unused.
+
+   {if false} blocks render to nothing — the parser still walks the
+   tag bodies, so the variable refs are seen, but no output is
+   produced.
+
+   D1 deletes themes/default/, the legacy template stops needing
+   these props, this manifest stops being necessary, and the View
+   drops them. Until then, keep this block at EOF.
+   ============================================================ *}
+{if false}{$ban_nav}{$ctype}{$cid}{$page}{$canedit}{$othercomments}{$commenttype}{$commenttext}{$comment}{$friendsban}{$groupban}{$can_delete}{$general_unban}{$hidetext}{$searchlink}{$can_export}{$admin_postkey}{$view_comments}{$view_bans}{$hideadminname}{$hideplayerips}{$total_bans}{/if}


### PR DESCRIPTION
Part of [#1123](https://github.com/sbpp/sourcebans-pp/issues/1123) — see the [v2.0.0 theme rollout plan](https://github.com/sbpp/sourcebans-pp/blob/main/handoff/HANDOFF.md) (B2: Public ban list — MARQUEE page).

The most-visited public surface gets the marquee redesign: handoff-spec rows with avatar/state/pill, sticky filter chips, mobile card list, and the testability hooks the #1123 issue locks in. Both themes render off the same `BanListView` DTO, so the legacy `default/` theme keeps working until D1 cuts over.

## Screenshots

> Screenshots are committed to a sibling orphan branch (`screenshots/1123-b2-banlist`) so they render inline here without polluting the feature branch's diff. The branch can be deleted with the PR after merge.

**Light mode (desktop, 1440×900):**
![banlist-light](https://raw.githubusercontent.com/sbpp/sourcebans-pp/screenshots/1123-b2-banlist/banlist-light.png)

**Dark mode (desktop, 1440×900):**
![banlist-dark](https://raw.githubusercontent.com/sbpp/sourcebans-pp/screenshots/1123-b2-banlist/banlist-dark.png)

**Mobile cards (414×800, 2× DPR):**
![banlist-mobile](https://raw.githubusercontent.com/sbpp/sourcebans-pp/screenshots/1123-b2-banlist/banlist-mobile.png)

The light/dark screenshots show the four state derivations the marquee design distinguishes:
- `permanent` — purple pill, magenta-pink left border (`wallhack_2024`, `angry_pyro_42`)
- `active` — orange pill, orange left border (`snipezzz`, `griefer.tv`)
- `expired` — gray pill, gray left border (`spammer`, `old_player_2018`, `stale_account`)
- `unbanned` — teal pill, teal left border (`reformed_player`)

State derivation lives in `page.banlist.php` (collapses `banlength`, `ban_ends`, `RemoveType` into one of the four labels), so the template just gates classes off `{$ban.state}`.

## Files touched

| File | What changed |
| --- | --- |
| `web/themes/sbpp2026/page_bans.tpl` | Replaces the A1 stub with the 134-line handoff design. Desktop table + mobile card list both expose `data-testid="ban-row"`, `data-id="{$ban.bid}"`, and `data-drawer-href` so the C1 drawer can layer on without a per-theme view-model detour. Sticky filter chips carry `filter-chip-*`, per-row actions carry `row-action-edit` / `row-action-unban`, the search input carries `bans-search`. The trailing `{if false}…{/if}` block is the dual-theme PHPStan manifest for legacy-only View props. |
| `web/includes/View/BanListView.php` (new) | Paired View DTO. Carries every variable both themes consume — handoff names for sbpp2026 (`bid|name|state|length_human|banned_human|sname|can_edit_ban|can_unban`) plus the legacy keys for `default/` (`ban_id|player|class|reban_link|edit_link|…`) — and the comment-edit scratch pad. SmartyTemplateRule does not introspect array contents, so the per-row dual shape coexists on `$ban_list` items without conflict. |
| `web/pages/page.banlist.php` | Switches to `Renderer::render($theme, new BanListView(...))`. Per-row payload gains `bid|name|steam|state|length_human|banned_human|sname|can_edit_ban|can_unban|avatar_initials|avatar_hue` alongside the legacy keys. State derivation collapses `(banlength, ban_ends, RemoveType)` into `permanent|active|expired|unbanned` server-side. Pagination markup is rebuilt to embed `data-testid="page-prev"` / `page-next` and uses inline `window.location` JS for the page-jump select (the new theme drops `sourcebans.js` in #1123 D1, so any reach into legacy bulk JS would silently break here). DB queries and the unban POST handler are unchanged. |
| `web/scripts/banlist.js` (new) | Optional client layer: chip filter + URL state sync, copy-to-clipboard via `theme.js`'s toast helper, and the comment-edit form POSTed through `sb.api.call(Actions.Bans*)` instead of the legacy form round-trip. Vanilla JS, `// @ts-check`, feature-detected so a missing element doesn't throw. The legacy theme keeps its server-side comment POST. |
| `web/phpstan-baseline.neon` | Drops the now-stale `Variable $prev might not be defined` entry for `pages/page.banlist.php`; the rebuilt pagination always initialises `$prev`. |

## Conventions

- **Permissions** are pre-computed on the View (`bool can_edit_ban`/`can_unban` per row + top-level `general_unban`/`can_delete`/`can_export`) — the template never reaches into `$user.srv_flags|...`. The Add-ban button is gated with `{has_access flag=$smarty.const.ADMIN_ADD_BAN}` (A3 plugin).
- **Testability hooks** ship for every entry in the marquee table from #1123: `filter-chip-{permanent,active,expired,unbanned}`, `ban-row` + `data-id="{bid}"`, `row-action-{edit,unban}`, `drawer-trigger` + `data-drawer-href`, `bans-search`, `page-{prev,next}`, `[data-loading]` / `[data-skeleton]`, `<time datetime="…">` for the banned timestamp.
- **`nofilter` discipline**: every `{$… nofilter}` in the template carries the canonical `{* nofilter: <reason> *}` comment immediately above it.
- **SQL queries unchanged** — touching them was explicitly out of scope. The `:prefix_` literal pattern is preserved.

## Local gates

- `./sbpp.sh phpstan` — green for both `default` and `sbpp2026` themes
- `./sbpp.sh test` — 268 tests, 1134 assertions, OK
- `./sbpp.sh ts-check` — green
- `./sbpp.sh composer api-contract` — clean (no diff)