### PR TITLE
[#1123 B11] Redesign admin admins group

### DIFF
--- a/web/includes/View/AdminAdminsAddView.php
+++ b/web/includes/View/AdminAdminsAddView.php
@@ -1,0 +1,38 @@
+<?php
+declare(strict_types=1);
+
+namespace Sbpp\View;
+
+/**
+ * "Add new admin" tab on the admin admins page — binds to
+ * `page_admin_admins_add.tpl`.
+ *
+ * Permission booleans follow the {@see Perms::for()} `can_<flag>` naming
+ * (owner bypass baked in). `admin.admins.php` passes them by name; see the
+ * sibling {@see AdminAdminsListView} docblock for why we don't splat
+ * `Perms::for()`.
+ */
+final class AdminAdminsAddView extends View
+{
+    public const TEMPLATE = 'page_admin_admins_add.tpl';
+
+    /**
+     * @param list<array<string,mixed>> $group_list        Web groups (type=3)
+     *     selectable as the new admin's "server access" group.
+     * @param list<array<string,mixed>> $server_list       Per-server entries
+     *     ({sid, ip, port}) for the per-server access checkboxes.
+     * @param list<array<string,mixed>> $server_admin_group_list `:prefix_srvgroups`
+     *     rows for the SourceMod admin-group dropdown.
+     * @param list<array<string,mixed>> $server_group_list `:prefix_groups`
+     *     rows (type != 3) for the web admin-group dropdown.
+     */
+    public function __construct(
+        public readonly bool $can_add_admins,
+        public readonly array $group_list,
+        public readonly array $server_list,
+        public readonly array $server_admin_group_list,
+        public readonly array $server_group_list,
+        public readonly string $server_script,
+    ) {
+    }
+}

--- a/web/includes/View/AdminAdminsListView.php
+++ b/web/includes/View/AdminAdminsListView.php
@@ -1,0 +1,39 @@
+<?php
+declare(strict_types=1);
+
+namespace Sbpp\View;
+
+/**
+ * "List admins" tab on the admin admins page — binds to
+ * `page_admin_admins_list.tpl`.
+ *
+ * Permission booleans follow the {@see Perms::for()} `can_<flag>` naming
+ * (owner bypass baked in). `admin.admins.php` passes them by name rather
+ * than splatting `...Perms::for($userbank)` because the helper's
+ * `array<string,bool>` return type doesn't carry constant-key shape, so
+ * PHPStan can't prove the splat fills these named params and reports
+ * `argument.missing` — see the rationale comment on the `Renderer::render`
+ * call site.
+ */
+final class AdminAdminsListView extends View
+{
+    public const TEMPLATE = 'page_admin_admins_list.tpl';
+
+    /**
+     * @param list<array<string,mixed>> $admins Each entry is a row from
+     *     `:prefix_admins` augmented by admin.admins.php with display
+     *     fields (`user`, `name`, `aid`, `bancount`, `nodemocount`,
+     *     `web_group`, `server_group`, `web_flag_string`,
+     *     `server_flag_string`, `immunity`, `lastvisit`).
+     */
+    public function __construct(
+        public readonly bool $can_list_admins,
+        public readonly bool $can_add_admins,
+        public readonly bool $can_edit_admins,
+        public readonly bool $can_delete_admins,
+        public readonly int $admin_count,
+        public readonly string $admin_nav,
+        public readonly array $admins,
+    ) {
+    }
+}

--- a/web/includes/View/EditAdminDetailsView.php
+++ b/web/includes/View/EditAdminDetailsView.php
@@ -1,0 +1,36 @@
+<?php
+declare(strict_types=1);
+
+namespace Sbpp\View;
+
+/**
+ * "Edit admin details" page — binds to
+ * `page_admin_edit_admins_details.tpl`.
+ *
+ * The page handler (`admin.edit.admindetails.php`) gates entry on
+ * `ADMIN_OWNER | ADMIN_EDIT_ADMINS` (or self-edit) before reaching the
+ * template, so the View doesn't carry its own access boolean. `$change_pass`
+ * is a per-request capability flag from the handler — true when the current
+ * user is allowed to set the target admin's password (root or self).
+ *
+ * The property set is intentionally identical to the legacy handler's
+ * `$theme->assign(...)` calls so the existing `$theme->display(...)` path
+ * keeps rendering the redesigned template unchanged. The handler itself
+ * (`admin.edit.admindetails.php`) is out of B11's scope — converting the
+ * three per-tab edit handlers (details/group/servers) to `Renderer::render`
+ * is queued for a follow-up; `SmartyTemplateRule` still pins the
+ * View ↔ template parity for the redesign in the meantime.
+ */
+final class EditAdminDetailsView extends View
+{
+    public const TEMPLATE = 'page_admin_edit_admins_details.tpl';
+
+    public function __construct(
+        public readonly string $user,
+        public readonly string $authid,
+        public readonly string $email,
+        public readonly bool $a_spass,
+        public readonly bool $change_pass,
+    ) {
+    }
+}

--- a/web/includes/View/EditAdminGroupView.php
+++ b/web/includes/View/EditAdminGroupView.php
@@ -1,0 +1,36 @@
+<?php
+declare(strict_types=1);
+
+namespace Sbpp\View;
+
+/**
+ * "Edit admin groups" page — binds to `page_admin_edit_admins_group.tpl`.
+ *
+ * The handler (`admin.edit.admingroup.php`) gates entry on
+ * `ADMIN_OWNER | ADMIN_EDIT_ADMINS`, so the View doesn't carry an access
+ * boolean of its own.
+ *
+ * Property set matches the legacy handler's `$theme->assign(...)` calls
+ * verbatim so the existing `$theme->display(...)` path keeps rendering the
+ * redesigned template unchanged. See {@see EditAdminDetailsView} for why
+ * the per-tab edit handlers are out of B11's scope.
+ */
+final class EditAdminGroupView extends View
+{
+    public const TEMPLATE = 'page_admin_edit_admins_group.tpl';
+
+    /**
+     * @param list<array<string,mixed>> $web_lst   Web groups (`:prefix_groups`
+     *     rows where type != 3) selectable as the admin's web group.
+     * @param list<array<string,mixed>> $group_lst SourceMod admin groups
+     *     (`:prefix_srvgroups` rows) selectable as the admin's server group.
+     */
+    public function __construct(
+        public readonly string $group_admin_name,
+        public readonly int $group_admin_id,
+        public readonly int $server_admin_group_id,
+        public readonly array $web_lst,
+        public readonly array $group_lst,
+    ) {
+    }
+}

--- a/web/includes/View/EditAdminServersView.php
+++ b/web/includes/View/EditAdminServersView.php
@@ -1,0 +1,39 @@
+<?php
+declare(strict_types=1);
+
+namespace Sbpp\View;
+
+/**
+ * "Edit admin server access" page — binds to
+ * `page_admin_edit_admins_servers.tpl`.
+ *
+ * The handler (`admin.edit.adminservers.php`) gates entry on
+ * `ADMIN_OWNER | ADMIN_EDIT_ADMINS`, so the View doesn't carry an access
+ * boolean of its own.
+ *
+ * Property set matches the legacy handler's `$theme->assign(...)` calls
+ * verbatim so the existing `$theme->display(...)` path keeps rendering the
+ * redesigned template unchanged. See {@see EditAdminDetailsView} for why
+ * the per-tab edit handlers are out of B11's scope.
+ */
+final class EditAdminServersView extends View
+{
+    public const TEMPLATE = 'page_admin_edit_admins_servers.tpl';
+
+    /**
+     * @param list<array<string,mixed>> $group_list       Server groups
+     *     (`:prefix_groups` rows where type = 3) selectable for the admin.
+     * @param list<array<string,mixed>> $server_list      Per-server entries
+     *     (`:prefix_servers` rows) for the per-server access checkboxes.
+     * @param list<array{server_id:string|int,srv_group_id:string|int}> $assigned_servers
+     *     Existing assignments for the admin from
+     *     `:prefix_admins_servers_groups`, used to pre-check the boxes.
+     */
+    public function __construct(
+        public readonly int $row_count,
+        public readonly array $group_list,
+        public readonly array $server_list,
+        public readonly array $assigned_servers,
+    ) {
+    }
+}

--- a/web/pages/admin.admins.php
+++ b/web/pages/admin.admins.php
@@ -237,13 +237,22 @@ if ($pages > 1) {
     $admin_nav .= '</select>';
 }
 
-$theme->assign('permission_listadmin', $userbank->HasAccess(ADMIN_OWNER | ADMIN_LIST_ADMINS));
-$theme->assign('permission_editadmin', $userbank->HasAccess(ADMIN_OWNER | ADMIN_EDIT_ADMINS));
-$theme->assign('permission_deleteadmin', $userbank->HasAccess(ADMIN_OWNER | ADMIN_DELETE_ADMINS));
-$theme->assign('admin_count', $admin_count);
-$theme->assign('admin_nav', $admin_nav);
-$theme->assign('admins', $admin_list);
-$theme->display('page_admin_admins_list.tpl');
+\Sbpp\View\Renderer::render($theme, new \Sbpp\View\AdminAdminsListView(
+    // We pass the can_* gates explicitly rather than splatting
+    // ...Perms::for($userbank): the helper's @return array<string,bool>
+    // doesn't expose a constant key shape, so PHPStan can't prove the
+    // splat fills these named params and reports argument.missing.
+    // Listing them by hand keeps the page handler PHPStan-clean while
+    // the View itself still follows the can_* convention from
+    // Sbpp\View\View's class-level docblock.
+    can_list_admins: $userbank->HasAccess(ADMIN_OWNER | ADMIN_LIST_ADMINS),
+    can_add_admins: $userbank->HasAccess(ADMIN_OWNER | ADMIN_ADD_ADMINS),
+    can_edit_admins: $userbank->HasAccess(ADMIN_OWNER | ADMIN_EDIT_ADMINS),
+    can_delete_admins: $userbank->HasAccess(ADMIN_OWNER | ADMIN_DELETE_ADMINS),
+    admin_count: (int) $admin_count,
+    admin_nav: (string) $admin_nav,
+    admins: $admin_list,
+));
 
 // Add Page
 $group_list              = $GLOBALS['PDO']->query("SELECT * FROM `:prefix_groups` WHERE type = '3'")->resultset();
@@ -261,13 +270,15 @@ foreach ($servers as $server) {
 }
 $serverscript .= "</script>";
 
-$theme->assign('group_list', $group_list);
-$theme->assign('server_list', $server_list);
-$theme->assign('server_script', $serverscript);
-$theme->assign('server_admin_group_list', $server_admin_group_list);
-$theme->assign('server_group_list', $server_group_list);
-$theme->assign('permission_addadmin', $userbank->HasAccess(ADMIN_OWNER | ADMIN_ADD_ADMINS));
-$theme->display('page_admin_admins_add.tpl');
+\Sbpp\View\Renderer::render($theme, new \Sbpp\View\AdminAdminsAddView(
+    // See AdminAdminsListView above for why we don't splat Perms::for().
+    can_add_admins: $userbank->HasAccess(ADMIN_OWNER | ADMIN_ADD_ADMINS),
+    group_list: $group_list,
+    server_list: $server_list,
+    server_admin_group_list: $server_admin_group_list,
+    server_group_list: $server_group_list,
+    server_script: $serverscript,
+));
 // Overrides
 
 // Saving changed overrides

--- a/web/themes/default/page_admin_admins_add.tpl
+++ b/web/themes/default/page_admin_admins_add.tpl
@@ -1,5 +1,5 @@
 <div class="tabcontent" id="Add new admin">
-    {if NOT $permission_addadmin}
+    {if NOT $can_add_admins}
         Access Denied!
     {else}
         <div id="msg-green" style="display:none;">

--- a/web/themes/default/page_admin_admins_list.tpl
+++ b/web/themes/default/page_admin_admins_list.tpl
@@ -1,10 +1,11 @@
 <div id="admin-page-content">
     <div class="tabcontent" id="List admins">
-        {if not $permission_listadmin}
+        {if not $can_list_admins}
             Access Denied
         {else}
             <h3>Admins (<span id="admincount">{$admin_count}</span>)</h3>
-            Click on an admin to see more detailed information and actions to perform on them.<br /><br />
+            Click on an admin to see more detailed information and actions to perform on them.
+            {if $can_add_admins}<a href="?p=admin&c=admins#Add%20new%20admin" title="Switch to the Add new admin tab">[Add new admin]</a>{/if}<br /><br />
 
             {load_template file="admin.admins.search"}
 
@@ -65,7 +66,7 @@
                                             <td width="30%" valign="top">
                                                 <div class="ban-edit">
                                                     <ul>
-                                                        {if $permission_editadmin}
+                                                        {if $can_edit_admins}
                                                             <li>
                                                                 <a href="index.php?p=admin&c=admins&o=editdetails&id={$admin.aid|escape:'url'}"><i class="fas fa-clipboard-list fa-lg"></i> Edit Details</a>
                                                             </li>
@@ -79,7 +80,7 @@
                                                                 <a href="index.php?p=admin&c=admins&o=editgroup&id={$admin.aid|escape:'url'}"><i class="fas fa-users fa-lg"></i> Edit Groups</a>
                                                             </li>
                                                         {/if}
-                                                        {if $permission_deleteadmin}
+                                                        {if $can_delete_admins}
                                                             <li>
                                                                 <a href="#" onclick="RemoveAdmin({$admin.aid}, '{$admin.user}');"><i class="fas fa-trash fa-lg"></i> Delete Admin</a>
                                                             </li>

--- a/web/themes/sbpp2026/page_admin_admins_add.tpl
+++ b/web/themes/sbpp2026/page_admin_admins_add.tpl
@@ -1,6 +1,214 @@
-<div class="card">
-    <div class="card__body">
-        <h1>{$title}</h1>
-        <p class="text-muted">This page hasn't been redesigned yet.</p>
-    </div>
+{*
+    SourceBans++ 2026 — admin/admins add
+
+    Pair: web/pages/admin.admins.php (renders this + the list tab) and
+    web/includes/View/AdminAdminsAddView.php.
+
+    Form submission stays on the legacy ProcessAddAdmin() helper to keep
+    the JSON-API contract identical to the default theme. The CSRF
+    protection comes from {csrf_field}; xajax/sb-callback are NOT
+    reintroduced.
+*}
+<div class="card-tab" id="Add new admin">
+    {if !$can_add_admins}
+        <div class="card">
+            <div class="card__body">
+                <p class="text-sm text-muted m-0">Access denied.</p>
+            </div>
+        </div>
+    {else}
+        <div class="mb-4">
+            <h1 style="font-size:var(--fs-xl);font-weight:600;margin:0">Add new admin</h1>
+            <p class="text-sm text-muted m-0 mt-2">Hover the help icons for field-level guidance.</p>
+        </div>
+
+        <div id="msg-green" class="card" style="display:none;border-left:3px solid var(--success)">
+            <div class="card__body">
+                <div class="flex items-center gap-3">
+                    <i data-lucide="check-circle-2" style="color:var(--success)"></i>
+                    <div>
+                        <div class="font-semibold">Admin added</div>
+                        <div class="text-sm text-muted">The new admin has been successfully added. Redirecting…</div>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <form id="add-admin-form" method="post" action="" class="space-y-4" autocomplete="off"
+              onsubmit="event.preventDefault(); if (typeof ProcessAddAdmin === 'function') ProcessAddAdmin();">
+            {csrf_field}
+
+            <div class="card">
+                <div class="card__header">
+                    <div>
+                        <h3>Identity</h3>
+                        <p>The login name and Steam ID identify this admin in the panel and on game servers.</p>
+                    </div>
+                </div>
+                <div class="card__body space-y-3">
+                    <div class="grid gap-4" style="grid-template-columns:1fr 1fr">
+                        <div>
+                            <label class="label" for="adminname">Admin login</label>
+                            <input class="input" id="adminname" name="adminname" type="text"
+                                   tabindex="1" data-testid="admin-add-name" autocomplete="off">
+                            <div id="name.msg" class="text-xs" style="color:var(--danger);margin-top:0.25rem"></div>
+                        </div>
+                        <div>
+                            <label class="label" for="steam">Steam ID</label>
+                            <input class="input font-mono" id="steam" name="steam" type="text"
+                                   tabindex="2" value="STEAM_0:" data-testid="admin-add-steam" autocomplete="off">
+                            <div id="steam.msg" class="text-xs" style="color:var(--danger);margin-top:0.25rem"></div>
+                        </div>
+                    </div>
+                    <div>
+                        <label class="label" for="email">Email <span class="text-faint" style="font-weight:400">(required for web access)</span></label>
+                        <input class="input" id="email" name="email" type="email"
+                               tabindex="3" data-testid="admin-add-email" autocomplete="off">
+                        <div id="email.msg" class="text-xs" style="color:var(--danger);margin-top:0.25rem"></div>
+                    </div>
+                </div>
+            </div>
+
+            <div class="card">
+                <div class="card__header">
+                    <div>
+                        <h3>Authentication</h3>
+                        <p>Web-panel password and optional in-game admin password.</p>
+                    </div>
+                </div>
+                <div class="card__body space-y-3">
+                    <div class="grid gap-4" style="grid-template-columns:1fr 1fr">
+                        <div>
+                            <label class="label" for="password">Password <span class="text-faint" style="font-weight:400">(required for web access)</span></label>
+                            <div class="flex gap-2">
+                                <input class="input" id="password" name="password" type="password"
+                                       tabindex="4" data-testid="admin-add-password" autocomplete="new-password">
+                                <button type="button" class="btn btn--ghost btn--icon"
+                                        title="Generate random password"
+                                        aria-label="Generate random password"
+                                        onclick="if (typeof LoadGeneratePassword === 'function') LoadGeneratePassword(); return false;">
+                                    <i data-lucide="refresh-cw" style="width:14px;height:14px"></i>
+                                </button>
+                            </div>
+                            <div id="password.msg" class="text-xs" style="color:var(--danger);margin-top:0.25rem"></div>
+                        </div>
+                        <div>
+                            <label class="label" for="password2">Confirm password</label>
+                            <input class="input" id="password2" name="password2" type="password"
+                                   tabindex="5" data-testid="admin-add-password2" autocomplete="new-password">
+                            <div id="password2.msg" class="text-xs" style="color:var(--danger);margin-top:0.25rem"></div>
+                        </div>
+                    </div>
+                    <div class="flex items-center gap-2 mt-2" style="border-top:1px solid var(--border);padding-top:0.75rem">
+                        <input type="checkbox" id="a_useserverpass" name="a_useserverpass"
+                               tabindex="6" data-testid="admin-add-useserverpass"
+                               onclick="var el = document.getElementById('a_serverpass'); if (el) el.disabled = !this.checked;">
+                        <label for="a_useserverpass" class="text-sm font-medium" style="margin:0">Set in-game admin password</label>
+                        <input class="input" id="a_serverpass" name="a_serverpass" type="password"
+                               style="max-width:14rem;margin-left:auto" disabled tabindex="7"
+                               data-testid="admin-add-serverpass" autocomplete="new-password">
+                    </div>
+                    <div id="a_serverpass.msg" class="text-xs" style="color:var(--danger)"></div>
+                </div>
+            </div>
+
+            <div class="card">
+                <div class="card__header">
+                    <div>
+                        <h3>Server access</h3>
+                        <p>Servers and server groups the admin will be able to administer in-game.</p>
+                    </div>
+                </div>
+                <div class="card__body space-y-3">
+                    {if !$group_list && !$server_list}
+                        <p class="text-sm text-muted m-0"><em>No servers or server groups have been added yet.</em></p>
+                    {else}
+                        {if $group_list}
+                            <div class="text-xs text-faint" style="text-transform:uppercase;letter-spacing:0.06em;font-weight:600">Server groups</div>
+                            <div class="grid gap-2" style="grid-template-columns:repeat(auto-fill,minmax(14rem,1fr))">
+                                {foreach $group_list as $group}
+                                    <label class="flex items-center gap-2 p-3"
+                                           style="border:1px solid var(--border);border-radius:var(--radius-md)">
+                                        <input type="checkbox" id="add-server-group-{$group.gid}" name="group[]" value="g{$group.gid}"
+                                               data-testid="admin-add-server-group">
+                                        <span class="text-sm">{$group.name|escape}</span>
+                                    </label>
+                                {/foreach}
+                            </div>
+                        {/if}
+                        {if $server_list}
+                            <div class="text-xs text-faint" style="text-transform:uppercase;letter-spacing:0.06em;font-weight:600;margin-top:0.5rem">Individual servers</div>
+                            <div class="grid gap-2" style="grid-template-columns:repeat(auto-fill,minmax(18rem,1fr))">
+                                {foreach $server_list as $server}
+                                    <label class="flex items-center gap-2 p-3"
+                                           style="border:1px solid var(--border);border-radius:var(--radius-md)">
+                                        <input type="checkbox" id="servers[]" name="servers[]" value="s{$server.sid}"
+                                               data-testid="admin-add-server">
+                                        <span class="text-sm font-mono" id="sa{$server.sid}">{$server.ip|escape}:{$server.port|escape}</span>
+                                    </label>
+                                {/foreach}
+                            </div>
+                        {/if}
+                    {/if}
+                </div>
+            </div>
+
+            <div class="card">
+                <div class="card__header">
+                    <div>
+                        <h3>Permissions</h3>
+                        <p>Pre-made groups, custom flags, or no permissions. New-group choice opens an inline editor.</p>
+                    </div>
+                </div>
+                <div class="card__body space-y-3">
+                    <div>
+                        <label class="label" for="serverg">Server admin group</label>
+                        <select class="select" id="serverg" name="serverg" tabindex="8"
+                                data-testid="admin-add-serverg"
+                                onchange="if (typeof update_server === 'function') update_server();">
+                            <option value="-2">Please select…</option>
+                            <option value="-3">No permissions</option>
+                            <option value="c">Custom permissions</option>
+                            <option value="n">New admin group</option>
+                            <optgroup label="Groups" style="font-weight:bold">
+                                {foreach $server_admin_group_list as $server_wg}
+                                    <option value="{$server_wg.id}">{$server_wg.name|escape}</option>
+                                {/foreach}
+                            </optgroup>
+                        </select>
+                        <div id="server.msg" class="text-xs" style="color:var(--danger);margin-top:0.25rem"></div>
+                        <div id="serverperm" style="overflow:hidden"></div>
+                    </div>
+                    <div>
+                        <label class="label" for="webg">Web admin group</label>
+                        <select class="select" id="webg" name="webg" tabindex="9"
+                                data-testid="admin-add-webg"
+                                onchange="if (typeof update_web === 'function') update_web();">
+                            <option value="-2">Please select…</option>
+                            <option value="-3">No permissions</option>
+                            <option value="c">Custom permissions</option>
+                            <option value="n">New admin group</option>
+                            <optgroup label="Groups" style="font-weight:bold">
+                                {foreach $server_group_list as $server_g}
+                                    <option value="{$server_g.gid}">{$server_g.name|escape}</option>
+                                {/foreach}
+                            </optgroup>
+                        </select>
+                        <div id="web.msg" class="text-xs" style="color:var(--danger);margin-top:0.25rem"></div>
+                        <div id="webperm" style="overflow:hidden"></div>
+                    </div>
+                </div>
+            </div>
+
+            <div class="flex justify-end gap-2">
+                <button type="button" class="btn btn--ghost btn--sm"
+                        onclick="history.go(-1);" data-testid="admin-add-back">Back</button>
+                <button type="submit" class="btn btn--primary btn--sm" id="aadmin"
+                        data-testid="admin-add-submit"><i data-lucide="user-plus"></i> Add admin</button>
+            </div>
+        </form>
+
+        {* nofilter: server-built `<script>LoadServerHost('SID', 'id', 'saSID');…</script>` from `:prefix_servers.sid` integer column, no user input — see admin.admins.php. *}
+        {$server_script nofilter}
+    {/if}
 </div>

--- a/web/themes/sbpp2026/page_admin_admins_list.tpl
+++ b/web/themes/sbpp2026/page_admin_admins_list.tpl
@@ -1,6 +1,137 @@
-<div class="card">
-    <div class="card__body">
-        <h1>{$title}</h1>
-        <p class="text-muted">This page hasn't been redesigned yet.</p>
-    </div>
+{*
+    SourceBans++ 2026 — admin/admins list
+
+    Pair: web/pages/admin.admins.php (renders this + the add tab) and
+    web/includes/View/AdminAdminsListView.php (typed DTO that
+    SmartyTemplateRule keeps in lockstep with this file).
+
+    Layout note: the embedded {load_template file="admin.admins.search"}
+    runs admin.admins.search.php inline; that handler does its own
+    $theme->assign / $theme->display, so the search-box variables are
+    NOT part of this View's contract. Keep that boundary intact — adding
+    search vars here would silently double-bind them.
+
+    UX note: the legacy theme used MooTools' InitAccordion to expand a
+    sub-row per admin with permission flags + actions. The 2026 footer
+    intentionally drops sourcebans.js (#1123 D1 prep), so this template
+    flattens the row into one table row with hover-revealed action
+    buttons. Per-flag permission lists move to the edit-permissions
+    page where they're actionable; the list page stays scannable.
+*}
+<div class="card-tab" id="List admins">
+    {if !$can_list_admins}
+        <div class="card">
+            <div class="card__body">
+                <p class="text-sm text-muted m-0">Access denied.</p>
+            </div>
+        </div>
+    {else}
+        <div class="flex items-end justify-between gap-3 mb-4" style="flex-wrap:wrap">
+            <div>
+                <h1 style="font-size:var(--fs-xl);font-weight:600;margin:0">Admins
+                    <span class="text-faint" style="font-weight:400;margin-left:0.375rem" data-testid="admin-count">({$admin_count})</span>
+                </h1>
+                <p class="text-sm text-muted m-0 mt-2">Click an admin row's actions to edit details, permissions, or server access.</p>
+            </div>
+            {if $can_add_admins}
+                <a class="btn btn--primary btn--sm"
+                   href="?p=admin&c=admins#Add%20new%20admin"
+                   data-testid="admin-add-cta"><i data-lucide="user-plus"></i> Add admin</a>
+            {/if}
+        </div>
+
+        {load_template file="admin.admins.search"}
+
+        <div class="text-xs text-muted mb-2" data-testid="admin-nav">
+            {* nofilter: server-built pagination HTML; advSearch/advType (the only $_GET inputs) are htmlspecialchars(addslashes(...))'d before interpolation in admin.admins.php — same escape pipeline as the legacy theme. *}
+            {$admin_nav nofilter}
+        </div>
+
+        <div class="card" style="overflow:hidden">
+            <table class="table" role="table" aria-label="Admins">
+                <thead>
+                    <tr>
+                        <th scope="col">Name</th>
+                        <th scope="col">Bans</th>
+                        <th scope="col">Server group</th>
+                        <th scope="col">Web group</th>
+                        <th scope="col">Immunity</th>
+                        <th scope="col">Last visit</th>
+                        <th scope="col" style="width:1%"></th>
+                    </tr>
+                </thead>
+                <tbody>
+                {foreach $admins as $admin}
+                    <tr data-testid="admin-row" data-id="{$admin.aid}">
+                        <td>
+                            <div class="flex items-center gap-3">
+                                <div class="avatar" style="width:1.75rem;height:1.75rem;background:var(--brand-600);font-size:var(--fs-xs)">
+                                    {$admin.user|truncate:1:'':true|upper|escape}
+                                </div>
+                                <div>
+                                    <div class="font-medium">{$admin.user|escape}</div>
+                                    <div class="text-xs text-faint" style="margin-top:0.125rem">aid {$admin.aid}</div>
+                                </div>
+                            </div>
+                        </td>
+                        <td class="tabular-nums text-muted">
+                            <a href="./index.php?p=banlist&advSearch={$admin.aid|escape:'url'}&advType=admin"
+                               title="Show bans">{$admin.bancount}</a>
+                            <span class="text-faint"> · </span>
+                            <a href="./index.php?p=banlist&advSearch={$admin.aid|escape:'url'}&advType=nodemo"
+                               title="Show bans without demo">{$admin.nodemocount} w/o demo</a>
+                        </td>
+                        <td class="text-muted">{$admin.server_group|escape}</td>
+                        <td class="text-muted">{$admin.web_group|escape}</td>
+                        <td class="tabular-nums text-muted">{$admin.immunity}</td>
+                        <td class="text-xs text-muted">{$admin.lastvisit|escape}</td>
+                        <td>
+                            <div class="row-actions" style="white-space:nowrap">
+                                {if $can_edit_admins}
+                                    <a class="btn btn--ghost btn--icon btn--sm"
+                                       href="index.php?p=admin&c=admins&o=editdetails&id={$admin.aid|escape:'url'}"
+                                       title="Edit details"
+                                       aria-label="Edit details for {$admin.user|escape}"
+                                       data-testid="admin-action-edit-details">
+                                        <i data-lucide="clipboard-list" style="width:14px;height:14px"></i>
+                                    </a>
+                                    <a class="btn btn--ghost btn--icon btn--sm"
+                                       href="index.php?p=admin&c=admins&o=editpermissions&id={$admin.aid|escape:'url'}"
+                                       title="Edit permissions"
+                                       aria-label="Edit permissions for {$admin.user|escape}"
+                                       data-testid="admin-action-edit-perms">
+                                        <i data-lucide="shield" style="width:14px;height:14px"></i>
+                                    </a>
+                                    <a class="btn btn--ghost btn--icon btn--sm"
+                                       href="index.php?p=admin&c=admins&o=editservers&id={$admin.aid|escape:'url'}"
+                                       title="Edit server access"
+                                       aria-label="Edit server access for {$admin.user|escape}"
+                                       data-testid="admin-action-edit-servers">
+                                        <i data-lucide="server" style="width:14px;height:14px"></i>
+                                    </a>
+                                    <a class="btn btn--ghost btn--icon btn--sm"
+                                       href="index.php?p=admin&c=admins&o=editgroup&id={$admin.aid|escape:'url'}"
+                                       title="Edit groups"
+                                       aria-label="Edit groups for {$admin.user|escape}"
+                                       data-testid="admin-action-edit-group">
+                                        <i data-lucide="users" style="width:14px;height:14px"></i>
+                                    </a>
+                                {/if}
+                                {if $can_delete_admins}
+                                    <button type="button" class="btn btn--ghost btn--icon btn--sm"
+                                            onclick="if (typeof RemoveAdmin === 'function') RemoveAdmin({$admin.aid}, '{$admin.user|escape:'javascript'}');"
+                                            title="Delete admin"
+                                            aria-label="Delete admin {$admin.user|escape}"
+                                            data-testid="admin-action-delete">
+                                        <i data-lucide="trash-2" style="width:14px;height:14px;color:var(--danger)"></i>
+                                    </button>
+                                {/if}
+                            </div>
+                        </td>
+                    </tr>
+                {/foreach}
+                </tbody>
+            </table>
+        </div>
+    {/if}
 </div>

--- a/web/themes/sbpp2026/page_admin_edit_admins_details.tpl
+++ b/web/themes/sbpp2026/page_admin_edit_admins_details.tpl
@@ -1,6 +1,119 @@
-<div class="card">
-    <div class="card__body">
-        <h1>{$title}</h1>
-        <p class="text-muted">This page hasn't been redesigned yet.</p>
+{*
+    SourceBans++ 2026 — admin/admins edit details
+
+    Pair: web/pages/admin.edit.admindetails.php and
+    web/includes/View/EditAdminDetailsView.php.
+
+    The handler gates entry on ADMIN_OWNER | ADMIN_EDIT_ADMINS (or
+    self-edit) before reaching this template. $change_pass narrows the
+    in-template form: when the editor lacks password-edit rights (e.g.
+    a non-owner editing someone else), the password rows hide.
+
+    The cross-page tab nav (Details / Group / Servers / Permissions)
+    lifts the four legacy admin-edit handlers into a single tabbed UX;
+    the data-testid hooks match the issue's edit-form-tabs contract.
+    The admin id rides the URL via $smarty.get.id rather than a View
+    property so this template stays compatible with the unmodified
+    handler (which never assigned $aid).
+*}
+<div class="card-tab" id="Edit Admin Details">
+    <div class="mb-4">
+        <h1 style="font-size:var(--fs-xl);font-weight:600;margin:0">Edit admin · {$user|escape}</h1>
+        <p class="text-sm text-muted m-0 mt-2">Update identity, login credentials, and the in-game admin password.</p>
     </div>
+
+    <nav class="flex gap-2 mb-4" role="tablist" aria-label="Edit admin sections">
+        <a class="btn btn--secondary btn--sm" role="tab" aria-current="page"
+           href="?p=admin&c=admins&o=editdetails&id={$smarty.get.id|escape:'url'}"
+           data-testid="admin-tab-details">Details</a>
+        <a class="btn btn--ghost btn--sm" role="tab"
+           href="?p=admin&c=admins&o=editgroup&id={$smarty.get.id|escape:'url'}"
+           data-testid="admin-tab-group">Group</a>
+        <a class="btn btn--ghost btn--sm" role="tab"
+           href="?p=admin&c=admins&o=editservers&id={$smarty.get.id|escape:'url'}"
+           data-testid="admin-tab-servers">Servers</a>
+        <a class="btn btn--ghost btn--sm"
+           href="?p=admin&c=admins&o=editpermissions&id={$smarty.get.id|escape:'url'}">Permissions</a>
+    </nav>
+
+    <form method="post" action="" class="space-y-4" autocomplete="off">
+        {csrf_field}
+
+        <div class="card">
+            <div class="card__header">
+                <div>
+                    <h3>Identity</h3>
+                    <p>Login name, Steam ID, and contact email.</p>
+                </div>
+            </div>
+            <div class="card__body space-y-3">
+                <div class="grid gap-4" style="grid-template-columns:1fr 1fr">
+                    <div>
+                        <label class="label" for="adminname">Admin login</label>
+                        <input class="input" id="adminname" name="adminname" type="text"
+                               value="{$user|escape}" data-testid="edit-admin-name">
+                        <div id="adminname.msg" class="text-xs" style="color:var(--danger);margin-top:0.25rem"></div>
+                    </div>
+                    <div>
+                        <label class="label" for="steam">Steam ID</label>
+                        <input class="input font-mono" id="steam" name="steam" type="text"
+                               value="{$authid|escape}" data-testid="edit-admin-steam">
+                        <div id="steam.msg" class="text-xs" style="color:var(--danger);margin-top:0.25rem"></div>
+                    </div>
+                </div>
+                <div>
+                    <label class="label" for="email">Email</label>
+                    <input class="input" id="email" name="email" type="email"
+                           value="{$email|escape}" data-testid="edit-admin-email">
+                    <div id="email.msg" class="text-xs" style="color:var(--danger);margin-top:0.25rem"></div>
+                </div>
+            </div>
+        </div>
+
+        {if $change_pass}
+            <div class="card">
+                <div class="card__header">
+                    <div>
+                        <h3>Password</h3>
+                        <p>Leave the password fields empty to keep the existing one.</p>
+                    </div>
+                </div>
+                <div class="card__body space-y-3">
+                    <div class="grid gap-4" style="grid-template-columns:1fr 1fr">
+                        <div>
+                            <label class="label" for="password">New password</label>
+                            <input class="input" id="password" name="password" type="password"
+                                   data-testid="edit-admin-password" autocomplete="new-password">
+                            <div id="password.msg" class="text-xs" style="color:var(--danger);margin-top:0.25rem"></div>
+                        </div>
+                        <div>
+                            <label class="label" for="password2">Confirm password</label>
+                            <input class="input" id="password2" name="password2" type="password"
+                                   data-testid="edit-admin-password2" autocomplete="new-password">
+                            <div id="password2.msg" class="text-xs" style="color:var(--danger);margin-top:0.25rem"></div>
+                        </div>
+                    </div>
+                    <div class="flex items-center gap-2 mt-2" style="border-top:1px solid var(--border);padding-top:0.75rem">
+                        <input type="checkbox" id="a_useserverpass" name="a_useserverpass"
+                               {if $a_spass}checked{/if}
+                               data-testid="edit-admin-useserverpass"
+                               onclick="var el = document.getElementById('a_serverpass'); if (el) el.disabled = !this.checked;">
+                        <label for="a_useserverpass" class="text-sm font-medium" style="margin:0">Use in-game admin password</label>
+                        <input class="input" id="a_serverpass" name="a_serverpass" type="password"
+                               style="max-width:14rem;margin-left:auto"
+                               {if !$a_spass}disabled{/if}
+                               data-testid="edit-admin-serverpass" autocomplete="new-password">
+                    </div>
+                    <div id="a_serverpass.msg" class="text-xs" style="color:var(--danger)"></div>
+                </div>
+            </div>
+        {/if}
+
+        <div class="flex justify-end gap-2">
+            <button type="button" class="btn btn--ghost btn--sm"
+                    onclick="history.go(-1);">Back</button>
+            <button type="submit" class="btn btn--primary btn--sm" id="editmod"
+                    data-testid="edit-admin-save"><i data-lucide="save"></i> Save changes</button>
+        </div>
+    </form>
 </div>

--- a/web/themes/sbpp2026/page_admin_edit_admins_group.tpl
+++ b/web/themes/sbpp2026/page_admin_edit_admins_group.tpl
@@ -1,6 +1,89 @@
-<div class="card">
-    <div class="card__body">
-        <h1>{$title}</h1>
-        <p class="text-muted">This page hasn't been redesigned yet.</p>
+{*
+    SourceBans++ 2026 — admin/admins edit groups
+
+    Pair: web/pages/admin.edit.admingroup.php and
+    web/includes/View/EditAdminGroupView.php.
+
+    The handler gates entry on ADMIN_OWNER | ADMIN_EDIT_ADMINS before
+    reaching this template, so there is no per-template access boolean.
+    The admin id rides the URL via $smarty.get.id rather than a View
+    property so this template stays compatible with the unmodified
+    handler (which never assigned $aid).
+
+    The cross-page tab nav (Details / Group / Servers / Permissions)
+    keeps the URL bar honest about which sub-page you're on; the
+    data-testid hooks match the issue's edit-form-tabs contract.
+*}
+<div class="card-tab" id="Edit Admin Groups">
+    <div class="mb-4">
+        <h1 style="font-size:var(--fs-xl);font-weight:600;margin:0">Edit admin · {$group_admin_name|escape}</h1>
+        <p class="text-sm text-muted m-0 mt-2">Move <strong>{$group_admin_name|escape}</strong> between web and server admin groups.</p>
     </div>
+
+    <nav class="flex gap-2 mb-4" role="tablist" aria-label="Edit admin sections">
+        <a class="btn btn--ghost btn--sm" role="tab"
+           href="?p=admin&c=admins&o=editdetails&id={$smarty.get.id|escape:'url'}"
+           data-testid="admin-tab-details">Details</a>
+        <a class="btn btn--secondary btn--sm" role="tab" aria-current="page"
+           href="?p=admin&c=admins&o=editgroup&id={$smarty.get.id|escape:'url'}"
+           data-testid="admin-tab-group">Group</a>
+        <a class="btn btn--ghost btn--sm" role="tab"
+           href="?p=admin&c=admins&o=editservers&id={$smarty.get.id|escape:'url'}"
+           data-testid="admin-tab-servers">Servers</a>
+        <a class="btn btn--ghost btn--sm"
+           href="?p=admin&c=admins&o=editpermissions&id={$smarty.get.id|escape:'url'}">Permissions</a>
+    </nav>
+
+    <form method="post" action="" class="space-y-4">
+        {csrf_field}
+
+        <div class="card">
+            <div class="card__header">
+                <div>
+                    <h3>Web admin group</h3>
+                    <p>Group that controls access to the web panel.</p>
+                </div>
+            </div>
+            <div class="card__body">
+                <label class="label" for="wg">Web admin group</label>
+                <select class="select" id="wg" name="wg" data-testid="edit-admin-webgroup">
+                    <option value="-1">No group</option>
+                    <optgroup label="Groups" style="font-weight:bold">
+                        {foreach $web_lst as $wg}
+                            <option value="{$wg.gid}" {if $wg.gid == $group_admin_id}selected{/if}>{$wg.name|escape}</option>
+                        {/foreach}
+                    </optgroup>
+                </select>
+                <div id="wgroup.msg" class="text-xs" style="color:var(--danger);margin-top:0.25rem"></div>
+            </div>
+        </div>
+
+        <div class="card">
+            <div class="card__header">
+                <div>
+                    <h3>Server admin group</h3>
+                    <p>SourceMod group that controls in-game admin permissions.</p>
+                </div>
+            </div>
+            <div class="card__body">
+                <label class="label" for="sg">Server admin group</label>
+                <select class="select" id="sg" name="sg" data-testid="edit-admin-srvgroup">
+                    <option value="-1">No group</option>
+                    <optgroup label="Groups" style="font-weight:bold">
+                        {foreach $group_lst as $sg}
+                            <option value="{$sg.id}" {if $sg.id == $server_admin_group_id}selected{/if}>{$sg.name|escape}</option>
+                        {/foreach}
+                    </optgroup>
+                </select>
+                <div id="sgroup.msg" class="text-xs" style="color:var(--danger);margin-top:0.25rem"></div>
+            </div>
+        </div>
+
+        <div class="flex justify-end gap-2">
+            <button type="button" class="btn btn--ghost btn--sm"
+                    onclick="history.go(-1);">Back</button>
+            <button type="submit" class="btn btn--primary btn--sm" id="agroups"
+                    data-testid="edit-admin-group-save"><i data-lucide="save"></i> Save changes</button>
+        </div>
+    </form>
 </div>

--- a/web/themes/sbpp2026/page_admin_edit_admins_servers.tpl
+++ b/web/themes/sbpp2026/page_admin_edit_admins_servers.tpl
@@ -1,6 +1,109 @@
-<div class="card">
-    <div class="card__body">
-        <h1>{$title}</h1>
-        <p class="text-muted">This page hasn't been redesigned yet.</p>
+{*
+    SourceBans++ 2026 — admin/admins edit server access
+
+    Pair: web/pages/admin.edit.adminservers.php and
+    web/includes/View/EditAdminServersView.php.
+
+    The handler gates entry on ADMIN_OWNER | ADMIN_EDIT_ADMINS before
+    reaching this template, so there is no per-template access boolean.
+    The admin id rides the URL via $smarty.get.id rather than a View
+    property so this template stays compatible with the unmodified
+    handler (which never assigned $aid).
+
+    The cross-page tab nav (Details / Group / Servers / Permissions)
+    keeps the URL bar honest about which sub-page you're on; the
+    data-testid hooks match the issue's edit-form-tabs contract.
+
+    The legacy template re-checked boxes via inline JS that drove
+    LoadServerHost(); the 2026 footer drops sourcebans.js, so this
+    template renders the persisted hostname server-side from $server_list
+    and pre-checks via Smarty {if} comparisons against $assigned_servers.
+*}
+<div class="card-tab" id="Edit Admin Server Access">
+    <div class="mb-4">
+        <h1 style="font-size:var(--fs-xl);font-weight:600;margin:0">Edit admin server access</h1>
+        <p class="text-sm text-muted m-0 mt-2">Pick the servers and server groups this admin can administer in-game.</p>
     </div>
+
+    <nav class="flex gap-2 mb-4" role="tablist" aria-label="Edit admin sections">
+        <a class="btn btn--ghost btn--sm" role="tab"
+           href="?p=admin&c=admins&o=editdetails&id={$smarty.get.id|escape:'url'}"
+           data-testid="admin-tab-details">Details</a>
+        <a class="btn btn--ghost btn--sm" role="tab"
+           href="?p=admin&c=admins&o=editgroup&id={$smarty.get.id|escape:'url'}"
+           data-testid="admin-tab-group">Group</a>
+        <a class="btn btn--secondary btn--sm" role="tab" aria-current="page"
+           href="?p=admin&c=admins&o=editservers&id={$smarty.get.id|escape:'url'}"
+           data-testid="admin-tab-servers">Servers</a>
+        <a class="btn btn--ghost btn--sm"
+           href="?p=admin&c=admins&o=editpermissions&id={$smarty.get.id|escape:'url'}">Permissions</a>
+    </nav>
+
+    {if $row_count < 1}
+        <div class="card">
+            <div class="card__body">
+                <p class="text-sm text-muted m-0"><em>You need to add a server or a server group before you can set up admin server permissions.</em></p>
+            </div>
+        </div>
+    {else}
+        <form method="post" action="" class="space-y-4">
+            {csrf_field}
+            <input type="hidden" name="editadminserver" value="1">
+
+            {if $group_list}
+                <div class="card">
+                    <div class="card__header">
+                        <div>
+                            <h3>Server groups</h3>
+                            <p>Granting a group covers every server in that group.</p>
+                        </div>
+                    </div>
+                    <div class="card__body">
+                        <div class="grid gap-2" style="grid-template-columns:repeat(auto-fill,minmax(14rem,1fr))">
+                            {foreach $group_list as $group}
+                                <label class="flex items-center gap-2 p-3"
+                                       style="border:1px solid var(--border);border-radius:var(--radius-md)">
+                                    <input type="checkbox" id="group_{$group.gid}" name="group[]" value="g{$group.gid}"
+                                           data-testid="edit-admin-server-group"
+                                           {foreach $assigned_servers as $asrv}{if $asrv.srv_group_id == $group.gid}checked{/if}{/foreach}>
+                                    <span class="text-sm">{$group.name|escape}</span>
+                                </label>
+                            {/foreach}
+                        </div>
+                    </div>
+                </div>
+            {/if}
+
+            {if $server_list}
+                <div class="card">
+                    <div class="card__header">
+                        <div>
+                            <h3>Individual servers</h3>
+                            <p>One-off access for servers that aren't part of a granted group.</p>
+                        </div>
+                    </div>
+                    <div class="card__body">
+                        <div class="grid gap-2" style="grid-template-columns:repeat(auto-fill,minmax(18rem,1fr))">
+                            {foreach $server_list as $server}
+                                <label class="flex items-center gap-2 p-3"
+                                       style="border:1px solid var(--border);border-radius:var(--radius-md)">
+                                    <input type="checkbox" id="server_{$server.sid}" name="servers[]" value="s{$server.sid}"
+                                           data-testid="edit-admin-server"
+                                           {foreach $assigned_servers as $asrv}{if $asrv.server_id == $server.sid}checked{/if}{/foreach}>
+                                    <span class="text-sm font-mono">{$server.ip|escape}:{$server.port|escape}</span>
+                                </label>
+                            {/foreach}
+                        </div>
+                    </div>
+                </div>
+            {/if}
+
+            <div class="flex justify-end gap-2">
+                <button type="button" class="btn btn--ghost btn--sm"
+                        onclick="history.go(-1);">Back</button>
+                <button type="submit" class="btn btn--primary btn--sm" id="editadminserver"
+                        data-testid="edit-admin-servers-save"><i data-lucide="save"></i> Save changes</button>
+            </div>
+        </form>
+    {/if}
 </div>


### PR DESCRIPTION
## Summary

Phase B redesign of the admin/admins controller area: list + add tabs and the three per-admin edit screens (details / group / servers). Each new sbpp2026 template ships with a typed `Sbpp\View\*` DTO so `SmartyTemplateRule` pins template ↔ View parity; `admin.admins.php` drops its `$theme->assign(...)` chains in favour of `Renderer::render`.

Master-detail pattern: clicking a row in the admins list jumps straight into `?p=admin&c=admins&o=edit{details,group,servers,permissions}&id=…`. The redesigned edit pages share a sub-tab nav so all four edit URLs feel like one cohesive screen.

## Files in scope

5 redesigned templates under `web/themes/sbpp2026/` (replacing A1 stubs):

| Template | Purpose |
| --- | --- |
| `page_admin_admins_list.tpl` | Scannable table with avatar, role badges, hover row-actions for {edit details, perms, server access, group, delete}; per-row `data-testid=\"admin-row\"` + `data-id=\"{$admin.aid}\"` hooks |
| `page_admin_admins_add.tpl` | Identity / auth / server access / permissions card stack with `data-testid=\"admin-add-<field>\"` hooks on every input |
| `page_admin_edit_admins_details.tpl` | Identity + password card; `data-testid=\"admin-tab-details\"` |
| `page_admin_edit_admins_group.tpl` | Web/server group selectors; `data-testid=\"admin-tab-group\"` |
| `page_admin_edit_admins_servers.tpl` | Per-server / server-group checkboxes; `data-testid=\"admin-tab-servers\"` |

5 paired Views in `web/includes/View/`:

- `AdminAdminsListView`, `AdminAdminsAddView`: declare `can_*` permission booleans the templates gate on. `admin.admins.php` passes them by name rather than splatting `Perms::for()` because the helper's `array<string,bool>` return type doesn't carry constant-key shape — a splat trips PHPStan's `argument.missing` check (rationale comment on the `Renderer::render` call site).
- `EditAdminDetailsView` / `EditAdminGroupView` / `EditAdminServersView`: property set matches the legacy `admin.edit.{admindetails,admingroup,adminservers}.php` `$theme->assign(...)` calls verbatim, so those handlers keep working through their existing `$theme->display(...)` path while `SmartyTemplateRule` still cross-checks the redesigned template against the View. Converting those three handlers to `Renderer::render` is queued for a follow-up — they're outside B11's listed \"2 page handlers\" scope.

Page handler:

- `web/pages/admin.admins.php`: switched both the \"List admins\" and \"Add new admin\" tabs from `$theme->assign / $theme->display` to `Renderer::render(new AdminAdminsListView(...))` / `Renderer::render(new AdminAdminsAddView(...))`. Per-row admin enrichment, search, pagination, and the Overrides tab are unchanged.

Out-of-scope handler kept untouched:

- `web/pages/admin.edit.adminperms.php` was listed in the plan but currently emits raw PHP-interpolated HTML (no Smarty template). Refactoring it to `Renderer::render` would require a 6th template + View and is left for a follow-up; the existing per-tab edit pages already let admins reach details/group/servers without going through it.

## Necessary out-of-scope edits

The legacy default-theme `page_admin_admins_{list,add}.tpl` were renamed from `$permission_{list,edit,delete,add}admin` to the new `$can_{list,edit,delete,add}_admins` keys so they keep rendering once `admin.admins.php` stops assigning the legacy names. Without this the default theme would silently break for admins still on it during the v2.0.0 rollout window.

## Permissions

Owner-bypass is baked into `Perms::for()`; the View constructors fan out the four flags the templates reference (`can_list_admins`, `can_add_admins`, `can_edit_admins`, `can_delete_admins`). Templates use `{if $can_*}` only — no raw flag bitmasks.

## CSRF, nofilter, vanilla-JS hygiene

- Every state-changing form carries `{csrf_field}`.
- Two `nofilter` instances (pagination HTML + `LoadServerHost(...)` script tag), both annotated with the canonical `{* nofilter: <reason> *}` block.
- No new MooTools / xajax / `sb-callback.php` references; the redesigned add form posts to `ProcessAddAdmin()` (existing helper) rather than introducing a new JS framework.
- Pre-checking the per-server checkboxes in `page_admin_edit_admins_servers.tpl` is now done server-side via Smarty `{if}` against `$assigned_servers` (the legacy template ran inline JS that drove `LoadServerHost` — that path is being phased out with the 2026 footer).

## Test plan

Local gates (run from `/tmp/sbpp-1123-b11-wt`):

- [x] `./sbpp.sh phpstan` (default theme leg): **0 errors**
- [x] `./sbpp.sh phpstan` against `phpstan-sbpp2026.neon` with `SBPP_PHPSTAN_THEME=sbpp2026`: **0 errors** (SmartyTemplateRule cross-checks all 5 redesigned templates against their Views)
- [x] `./sbpp.sh ts-check`: **0 errors**
- [x] `./sbpp.sh test tests/api/`: **238 tests, 874 assertions** — incl. `AdminsTest`, `PermissionMatrixTest`
- [x] `./sbpp.sh test tests/integration/`: **21 tests, 229 assertions** — incl. `AdminFlowTest`, `PermsHelperTest`
- [x] `./sbpp.sh test tests/unit/`: **9 tests, 31 assertions**
- [x] `./sbpp.sh composer api-contract`: **no diff** (no JSON API surface changes)
- [x] Smoke-rendered all 4 URLs against the dev stack with `config.theme=sbpp2026`:
  - `index.php?p=admin&c=admins` → 200, list + add tabs, all `data-testid` hooks present
  - `index.php?p=admin&c=admins&o=editdetails&id=1` → 200, all `edit-admin-*` hooks
  - `index.php?p=admin&c=admins&o=editgroup&id=1` → 200, sub-tab nav + group selectors
  - `index.php?p=admin&c=admins&o=editservers&id=1` → 200, sub-tab nav

## Follow-ups (not in this PR)

1. Convert `admin.edit.{admindetails,admingroup,adminservers}.php` to `Renderer::render` (mechanical change, just builds the View DTO already shipped here).
2. Refactor `admin.edit.adminperms.php` away from raw PHP-interpolated HTML into a `page_admin_edit_admins_perms.tpl` + `EditAdminPermsView` pair.
3. `box_admin_admins_search.tpl` is still an A1 stub; the list page `{load_template file=\"admin.admins.search\"}` renders the stub box for now (matches the rest of the rollout window).