### PR TITLE
[#1123 B5] Redesign public servers list

### DIFF
--- a/web/includes/View/ServersView.php
+++ b/web/includes/View/ServersView.php
@@ -4,9 +4,47 @@ declare(strict_types=1);
 namespace Sbpp\View;
 
 /**
- * Server list page — binds to `page_servers.tpl`, which is also pulled in
- * transitively by the dashboard (see {@see HomeDashboardView}). This view
- * only covers the standalone-display case from `page.servers.php`.
+ * Server list page — binds to `page_servers.tpl`.
+ *
+ * Two themes consume this view side-by-side during the v2.0.0 rollout
+ * (#1123): the legacy `web/themes/default/page_servers.tpl` (table +
+ * accordion + xajax-style live polling helpers from sourcebans.js) and
+ * the new `web/themes/sbpp2026/page_servers.tpl` (card grid that
+ * progressively populates each card via inline `sb.api.call(
+ * Actions.ServersHostPlayers, …)`). Both legs of the dual-theme PHPStan
+ * matrix scan this view; the SmartyTemplateRule baseline carries any
+ * legacy-only properties so the matrix stays clean.
+ *
+ * The dashboard page (`page.home.php`) `require`s `page.servers.php` to
+ * reuse the server list data and reads the populated $serversView's
+ * public properties when constructing its own {@see HomeDashboardView}.
+ * Adding a new property here means HomeDashboardView either has to
+ * forward it (legacy default theme transitively `{include}`s
+ * page_servers.tpl from page_dashboard.tpl) or ignore it (sbpp2026's
+ * dashboard renders its own server tile inline and never includes
+ * page_servers.tpl). Removing or renaming an existing property would
+ * break either the dashboard or the legacy template — only ADD here.
+ *
+ * `$server_list` row shape (set by `page.servers.php`):
+ *   - sid    int     Stable server id (DB primary key).
+ *   - ip     string  Hostname or numeric IP, as configured.
+ *   - port   int     Game port.
+ *   - dns    string  Resolved IPv4 (gethostbyname($ip)) for the
+ *                    `steam://connect/{dns}:{port}` URL — the legacy
+ *                    template uses it; the sbpp2026 template uses it for
+ *                    the same Connect button.
+ *   - icon   string  Filename in `web/images/games/` for the mod icon.
+ *   - mod    string  Mod display name from `:prefix_mods.name`. Empty
+ *                    string when the server's modid doesn't resolve
+ *                    (deleted/renamed mod row). Added in #1123 B5 for
+ *                    the sbpp2026 card label; the legacy template
+ *                    ignores extra row keys.
+ *   - index  int     0-based offset into the unsorted result set used
+ *                    by the dashboard `?p=servers&s={index}` deep links
+ *                    (matches `opened_server` semantics).
+ *   - evOnClick string Inline JS navigating to ?p=servers&s={index};
+ *                    only set when `IN_SERVERS_PAGE` is false (i.e.
+ *                    the dashboard is rendering this row). Legacy-only.
  */
 final class ServersView extends View
 {

--- a/web/pages/page.servers.php
+++ b/web/pages/page.servers.php
@@ -31,7 +31,11 @@ if (!defined('IN_HOME')) {
     }
 }
 
-$rows = $GLOBALS['PDO']->query("SELECT se.sid, se.ip, se.port, se.modid, se.rcon, md.icon FROM `:prefix_servers` se LEFT JOIN `:prefix_mods` md ON md.mid=se.modid WHERE se.sid > 0 AND se.enabled = 1 ORDER BY se.modid, se.sid")->resultset();
+// `md.name` (mod display name) is added for the sbpp2026 card label
+// (#1123 B5). The legacy default theme ignores extra row keys; the new
+// theme renders it next to the mod icon as a short tag (e.g. "TF2") so
+// the card is meaningful before the live UDP query lands.
+$rows = $GLOBALS['PDO']->query("SELECT se.sid, se.ip, se.port, se.modid, se.rcon, md.icon, md.name AS mod_name FROM `:prefix_servers` se LEFT JOIN `:prefix_mods` md ON md.mid=se.modid WHERE se.sid > 0 AND se.enabled = 1 ORDER BY se.modid, se.sid")->resultset();
 $servers = [];
 $i       = 0;
 foreach ($rows as $row) {
@@ -41,6 +45,7 @@ foreach ($rows as $row) {
     $info['dns']   = gethostbyname($row['ip']);
     $info['port']  = $row['port'];
     $info['icon']  = $row['icon'];
+    $info['mod']   = (string) ($row['mod_name'] ?? '');
     $info['index'] = $i;
     if (defined('IN_HOME')) {
         $info['evOnClick'] = "window.location = 'index.php?p=servers&s=" . $info['index'] . "';";

--- a/web/themes/sbpp2026/page_servers.tpl
+++ b/web/themes/sbpp2026/page_servers.tpl
@@ -1,6 +1,427 @@
-<div class="card">
-    <div class="card__body">
-        <h1>{$title}</h1>
-        <p class="text-muted">This page hasn't been redesigned yet.</p>
+{*
+    SourceBans++ 2026 — page_servers.tpl
+
+    Public servers list. Replaces the A1 stub. Pair:
+    web/pages/page.servers.php + web/includes/View/ServersView.php
+    (#1123 B5).
+
+    Why this differs from handoff/pages/servers.tpl
+    -----------------------------------------------
+    The handoff card grid is treated as the visual reference for the
+    layout shell (mod-letter avatar, hostname + ip:port, status pill,
+    players bar, map row), not as a 1:1 markup port:
+
+      * The handoff renders an "Add server" button and per-row "RCON" /
+        "Players" admin shortcuts gated on SourceMod char-flags
+        (`$user.srv_flags|strpos:'z'`). The legacy public servers page
+        carries neither — both belong on the admin servers list page
+        (#1123 B15). Reproducing them here would require Perms / SM
+        char-flag plumbing the public View doesn't need today, so
+        they're intentionally cut.
+      * The handoff's status (online/offline) is set server-side from a
+        precomputed `$s.online`. We don't have that cheaply: each card
+        starts in a loading state and progressively flips to
+        online/offline as the inline `sb.api.call(
+        Actions.ServersHostPlayers, …)` per-card response lands. This
+        mirrors the legacy `LoadServerHost(...)` UDP-poll flow.
+
+    Live data flow
+    --------------
+    SourceQuery (xpaw/php-source-query-class) is a UDP probe — the
+    server may be down, behind NAT, or rate-limiting. The handler
+    returns `{ error: 'connect', ip, port, is_owner }` on failure
+    instead of throwing, so each card has to handle three terminal
+    states: `loading` (initial), `online` (data came back clean),
+    `offline` (handler returned `error: 'connect'` or the call itself
+    failed). Status is persisted in the `data-status` attribute so
+    Playwright (and humans) can assert state without reading computed
+    CSS — see #1123 issue body's "State in attributes, not just
+    styling" rule.
+
+    Auto-expand
+    -----------
+    Mirrors the legacy `?p=servers&s={index}` pattern: when the page
+    handler sets `opened_server >= 0`, the matching card auto-expands
+    its player list once the live response lands. The expansion fetches
+    no additional data — the same `Actions.ServersHostPlayers`
+    response already includes `player_list[]`.
+
+    Per-row JS without ./scripts/sourcebans.js
+    ------------------------------------------
+    sourcebans.js is dropped at #1123 D1, so we can't use the legacy
+    `LoadServerHost()` / `InitAccordion()` helpers; they'd be undefined
+    here. The card markup carries `data-sid` / `data-index` /
+    `data-status` and the inline `<script>` walks
+    `[data-testid="server-tile"]` directly. `sb.api.call` and the
+    `Actions.*` constants come from the chrome's
+    api.js + api-contract.js (loaded by core/header.tpl).
+
+    Testability hooks (per #1123 issue + B5 brief)
+    ----------------------------------------------
+      data-testid="servers-list"   — outer container
+      data-testid="server-tile"    — each card (one per server)
+      data-testid="server-toggle"  — expand/collapse trigger
+      data-testid="server-connect" — steam:// connect button
+      data-id=$server.sid          — stable integer (NOT the index)
+      data-status="loading|online|offline" — terminal state on each card
+      data-index=$server.index     — 0-based offset for the dashboard
+                                     ?p=servers&s=N deep link
+*}
+<div class="p-6 space-y-4" style="max-width:1400px;margin:0 auto;width:100%">
+
+    <header class="flex items-end justify-between gap-3" style="flex-wrap:wrap">
+        <div>
+            <h1 style="font-size:var(--fs-2xl);font-weight:600;margin:0">Servers</h1>
+            <p class="text-sm text-muted m-0 mt-2"
+               data-testid="servers-summary"
+               data-total="{$server_list|@count}">
+                {$server_list|@count} configured
+                <span data-online-count>&middot; <span data-online-num>0</span> online</span>
+            </p>
+        </div>
+        {if $IN_SERVERS_PAGE && $access_bans}
+            <p class="text-xs text-muted m-0"
+               role="note"
+               data-testid="servers-rcon-hint"
+               style="max-width:24rem;text-align:right">
+                <i data-lucide="info" style="width:12px;height:12px;vertical-align:-2px"></i>
+                Right-click a player on an expanded card to kick, ban, or message them.
+            </p>
+        {/if}
+    </header>
+
+    {if $server_list|@count == 0}
+        <div class="card" data-testid="servers-empty">
+            <div class="card__body text-sm text-muted">
+                No servers are configured yet.
+            </div>
+        </div>
+    {else}
+    <div class="grid gap-4"
+         data-testid="servers-list"
+         data-opened-index="{$opened_server}"
+         style="grid-template-columns:repeat(auto-fill,minmax(20rem,1fr))">
+        {foreach $server_list as $server}
+        <article class="card"
+                 data-testid="server-tile"
+                 data-id="{$server.sid}"
+                 data-index="{$server.index}"
+                 data-status="loading"
+                 data-expanded="false">
+            <div class="card__body">
+                <div class="flex items-start gap-3">
+                    <span class="server-tile__mod"
+                          aria-hidden="true"
+                          style="width:36px;height:36px;border-radius:var(--radius-sm);background:var(--bg-muted);display:grid;place-items:center;flex-shrink:0;overflow:hidden">
+                        {if $server.icon}
+                            <img src="images/games/{$server.icon}"
+                                 alt=""
+                                 width="20"
+                                 height="20"
+                                 style="display:block">
+                        {else}
+                            <i data-lucide="server" style="width:18px;height:18px;color:var(--text-muted)"></i>
+                        {/if}
+                    </span>
+                    <div style="flex:1;min-width:0">
+                        <div class="font-semibold truncate"
+                             data-testid="server-host"
+                             data-fallback="{$server.ip}:{$server.port}"
+                             title="{$server.ip}:{$server.port}">
+                            {$server.ip}:{$server.port}
+                        </div>
+                        <div class="font-mono text-xs text-faint truncate" style="margin-top:0.125rem">
+                            {if $server.mod}{$server.mod} &middot; {/if}{$server.ip}:{$server.port}
+                        </div>
+                    </div>
+                    <span class="pill pill--offline"
+                          data-testid="server-status"
+                          aria-live="polite">
+                        <i data-lucide="loader" style="width:10px;height:10px"></i>
+                        <span data-status-label>Loading</span>
+                    </span>
+                </div>
+
+                <dl class="grid gap-2 text-xs"
+                    style="grid-template-columns:auto 1fr;align-items:center;margin-top:1rem;margin-bottom:0">
+                    <dt class="text-muted flex items-center gap-1" style="margin:0">
+                        <i data-lucide="map" style="width:13px;height:13px"></i> Map
+                    </dt>
+                    <dd class="font-mono text-faint" data-testid="server-map" style="margin:0">&mdash;</dd>
+
+                    <dt class="text-muted flex items-center gap-1" style="margin:0">
+                        <i data-lucide="users" style="width:13px;height:13px"></i> Players
+                    </dt>
+                    <dd class="tabular-nums font-medium"
+                        data-testid="server-players"
+                        style="margin:0;color:var(--text)">&mdash;</dd>
+                </dl>
+
+                <div class="server-tile__bar"
+                     aria-hidden="true"
+                     style="margin-top:0.5rem;height:6px;border-radius:var(--radius-full);background:var(--bg-muted);overflow:hidden">
+                    <div data-players-bar
+                         style="height:100%;background:var(--brand-600);width:0%;transition:width .25s ease"></div>
+                </div>
+
+                <div class="flex gap-2"
+                     style="margin-top:1rem;border-top:1px solid var(--border);padding-top:0.75rem">
+                    <a class="btn btn--primary btn--sm"
+                       data-testid="server-connect"
+                       href="steam://connect/{$server.dns}:{$server.port}">
+                        <i data-lucide="play" style="width:13px;height:13px"></i>
+                        Connect
+                    </a>
+                    <button type="button"
+                            class="btn btn--secondary btn--sm"
+                            data-testid="server-toggle"
+                            data-action="toggle-players"
+                            aria-expanded="false"
+                            aria-controls="server-players-{$server.sid}"
+                            disabled>
+                        <i data-lucide="chevron-down" style="width:13px;height:13px"></i>
+                        Players
+                    </button>
+                    <button type="button"
+                            class="btn btn--ghost btn--sm"
+                            data-testid="server-refresh"
+                            data-action="refresh"
+                            title="Re-query this server"
+                            aria-label="Refresh server status">
+                        <i data-lucide="refresh-cw" style="width:13px;height:13px"></i>
+                    </button>
+                </div>
+            </div>
+
+            <div id="server-players-{$server.sid}"
+                 class="server-tile__players"
+                 data-testid="server-players-panel"
+                 hidden
+                 style="border-top:1px solid var(--border);padding:0.75rem 1.25rem">
+                <p class="text-xs text-muted m-0" data-empty-message>No players currently connected.</p>
+                <ul class="m-0" data-player-list style="list-style:none;padding:0;display:none"></ul>
+            </div>
+        </article>
+        {/foreach}
     </div>
+    {/if}
 </div>
+
+{*
+    Inline initializer — finds every server tile, fires one
+    sb.api.call per card, and patches the DOM in place. No external
+    deps beyond the chrome's api.js + sb.js. We avoid touching
+    web/scripts/* per the Phase B "NEVER touch" list, so the wiring
+    lives in the template that owns it.
+
+    Variables interpolated by Smarty are restricted to numeric
+    `opened_server` (cast to int by the View) and the `Actions`
+    JS-side namespace from api-contract.js — no user input flows
+    through this <script>. Wrapped in {literal} so Smarty doesn't try
+    to parse the JS object literals.
+*}
+<script>
+{literal}
+(function () {
+    'use strict';
+    if (typeof sb === 'undefined' || !sb || !sb.api || typeof Actions === 'undefined') {
+        return;
+    }
+
+    /** @type {NodeListOf<HTMLElement>} */
+    var tiles = document.querySelectorAll('[data-testid="server-tile"]');
+    if (tiles.length === 0) return;
+
+    var listEl = document.querySelector('[data-testid="servers-list"]');
+    var summary = document.querySelector('[data-testid="servers-summary"]');
+    var openedIndex = listEl ? Number(listEl.getAttribute('data-opened-index')) : -1;
+    var onlineCount = 0;
+
+    function updateOnlineCount(delta) {
+        onlineCount += delta;
+        if (summary) {
+            var num = summary.querySelector('[data-online-num]');
+            if (num) num.textContent = String(onlineCount);
+        }
+    }
+
+    /**
+     * @param {HTMLElement} tile
+     * @param {string} status loading|online|offline
+     * @param {string} label
+     */
+    function setStatus(tile, status, label) {
+        var prev = tile.getAttribute('data-status');
+        tile.setAttribute('data-status', status);
+        var pill = tile.querySelector('[data-testid="server-status"]');
+        if (pill) {
+            pill.classList.remove('pill--online', 'pill--offline');
+            pill.classList.add(status === 'online' ? 'pill--online' : 'pill--offline');
+            var lbl = pill.querySelector('[data-status-label]');
+            if (lbl) lbl.textContent = label;
+            var icon = pill.querySelector('i');
+            if (icon) {
+                icon.setAttribute('data-lucide',
+                    status === 'online' ? 'check-circle-2'
+                    : status === 'offline' ? 'x-circle'
+                    : 'loader');
+            }
+        }
+        if (prev !== 'online' && status === 'online') updateOnlineCount(+1);
+        if (prev === 'online' && status !== 'online') updateOnlineCount(-1);
+    }
+
+    /**
+     * @param {HTMLElement} tile
+     * @param {{hostname?: string, players?: number, maxplayers?: number, map?: string, player_list?: Array<{name: string, frags: number, time_f: string}>, error?: string}} d
+     */
+    function applyData(tile, d) {
+        if (d.error === 'connect') {
+            setStatus(tile, 'offline', 'Offline');
+            var hostFb = tile.querySelector('[data-testid="server-host"]');
+            if (hostFb) hostFb.textContent = (hostFb.getAttribute('data-fallback') || '');
+            var toggleOff = tile.querySelector('[data-testid="server-toggle"]');
+            if (toggleOff instanceof HTMLButtonElement) toggleOff.disabled = true;
+            return;
+        }
+
+        setStatus(tile, 'online', 'Online');
+
+        var host = tile.querySelector('[data-testid="server-host"]');
+        if (host && d.hostname) {
+            // d.hostname is htmlspecialchars()'d server-side
+            // (web/api/handlers/servers.php → api_servers_host_players),
+            // so setHTML mirrors the legacy LoadServerHost() behaviour.
+            sb.setHTML(host.id || (host.id = 'server-host-' + tile.getAttribute('data-id')), d.hostname);
+        }
+
+        var mapEl = tile.querySelector('[data-testid="server-map"]');
+        if (mapEl) mapEl.textContent = d.map || '';
+
+        var players = Number(d.players || 0);
+        var maxp = Number(d.maxplayers || 0);
+        var pl = tile.querySelector('[data-testid="server-players"]');
+        if (pl) pl.textContent = players + '/' + maxp;
+        var bar = tile.querySelector('[data-players-bar]');
+        if (bar instanceof HTMLElement && maxp > 0) {
+            var pct = Math.min(100, Math.max(0, (players / maxp) * 100));
+            bar.style.width = pct + '%';
+        }
+
+        var toggle = tile.querySelector('[data-testid="server-toggle"]');
+        if (toggle instanceof HTMLButtonElement) toggle.disabled = false;
+
+        // Cache the player list on the tile for cheap re-render on toggle.
+        if (Array.isArray(d.player_list)) {
+            tile.__sbppPlayers = d.player_list;
+            renderPlayers(tile);
+        }
+    }
+
+    /**
+     * @param {HTMLElement} tile
+     */
+    function renderPlayers(tile) {
+        var panel = tile.querySelector('[data-testid="server-players-panel"]');
+        if (!panel) return;
+        var ul = panel.querySelector('[data-player-list]');
+        var empty = panel.querySelector('[data-empty-message]');
+        var list = (tile.__sbppPlayers || []);
+        if (!ul) return;
+        if (!list.length) {
+            ul.style.display = 'none';
+            if (empty instanceof HTMLElement) empty.style.display = '';
+            return;
+        }
+        if (empty instanceof HTMLElement) empty.style.display = 'none';
+        ul.style.display = '';
+        ul.innerHTML = '';
+        list.forEach(function (p) {
+            var li = document.createElement('li');
+            li.style.display = 'flex';
+            li.style.alignItems = 'center';
+            li.style.justifyContent = 'space-between';
+            li.style.gap = '0.5rem';
+            li.style.padding = '0.25rem 0';
+            li.style.borderBottom = '1px solid var(--border)';
+            li.setAttribute('data-testid', 'server-player');
+
+            var name = document.createElement('span');
+            name.className = 'truncate text-sm';
+            name.textContent = String(p.name || '');
+            li.appendChild(name);
+
+            var meta = document.createElement('span');
+            meta.className = 'text-xs text-muted font-mono tabular-nums';
+            meta.textContent = (p.frags != null ? String(p.frags) : '0') + ' \u00B7 ' + String(p.time_f || '');
+            li.appendChild(meta);
+
+            ul.appendChild(li);
+        });
+    }
+
+    /**
+     * @param {HTMLElement} tile
+     * @param {boolean} open
+     */
+    function setExpanded(tile, open) {
+        tile.setAttribute('data-expanded', open ? 'true' : 'false');
+        var toggle = tile.querySelector('[data-testid="server-toggle"]');
+        if (toggle) toggle.setAttribute('aria-expanded', open ? 'true' : 'false');
+        var panel = tile.querySelector('[data-testid="server-players-panel"]');
+        if (panel instanceof HTMLElement) {
+            if (open) panel.removeAttribute('hidden'); else panel.setAttribute('hidden', '');
+        }
+    }
+
+    /**
+     * @param {HTMLElement} tile
+     */
+    function loadTile(tile) {
+        var sid = Number(tile.getAttribute('data-id'));
+        if (!sid) return;
+        setStatus(tile, 'loading', 'Loading');
+        sb.api.call(Actions.ServersHostPlayers, { sid: sid, trunchostname: 70 }).then(function (r) {
+            if (!r || !r.ok || !r.data) {
+                setStatus(tile, 'offline', 'Offline');
+                return;
+            }
+            applyData(tile, r.data);
+            var idx = Number(tile.getAttribute('data-index'));
+            if (openedIndex >= 0 && openedIndex === idx && tile.getAttribute('data-status') === 'online') {
+                setExpanded(tile, true);
+            }
+        }, function () {
+            setStatus(tile, 'offline', 'Offline');
+        });
+    }
+
+    Array.prototype.forEach.call(tiles, function (tile) {
+        loadTile(tile);
+
+        var toggle = tile.querySelector('[data-testid="server-toggle"]');
+        if (toggle) {
+            toggle.addEventListener('click', function (ev) {
+                ev.preventDefault();
+                if (toggle instanceof HTMLButtonElement && toggle.disabled) return;
+                var open = tile.getAttribute('data-expanded') !== 'true';
+                setExpanded(tile, open);
+            });
+        }
+
+        var refresh = tile.querySelector('[data-testid="server-refresh"]');
+        if (refresh) {
+            refresh.addEventListener('click', function (ev) {
+                ev.preventDefault();
+                loadTile(tile);
+            });
+        }
+    });
+
+    // Re-render Lucide icons we just swapped via setAttribute('data-lucide').
+    if (typeof window.lucide !== 'undefined' && typeof window.lucide.createIcons === 'function') {
+        window.lucide.createIcons();
+    }
+})();
+{/literal}
+</script>


### PR DESCRIPTION
Part of #1123 (Phase B, ticket B5).

## Summary

Replaces the A1 stub at `web/themes/sbpp2026/page_servers.tpl` with a
responsive card grid sourced from `handoff/pages/servers.tpl`. Pairs
with a docblock-only extension to `Sbpp\View\ServersView` and a
one-liner enrichment to `web/pages/page.servers.php` so the template
has a `mod` display name to render before the live UDP query lands.

- **Card grid** (auto-fill `minmax(20rem, 1fr)`) — one card per
  configured server, mod icon + hostname + ip:port + status pill +
  map + players row + Connect/Players/Refresh actions. Inline JS
  walks every `[data-testid="server-tile"]` and fires
  `sb.api.call(Actions.ServersHostPlayers, ...)` per card to
  progressively populate live data; mirrors the legacy
  `LoadServerHost(...)` flow without depending on
  `web/scripts/sourcebans.js` (which D1 deletes).
- **Live state** — each tile starts at `data-status="loading"` and
  flips to `online` or `offline` based on the handler's
  `{ error: 'connect' }` envelope. Status lives on the
  `data-status` attribute (per #1123 "state in attributes, not
  styling"); the same hook drives the loading/online/offline pill.
- **Auto-expand** — `?p=servers&s={index}` keeps working: the matching
  card auto-expands its player panel once the live response lands.
  No additional fetch — the same `Actions.ServersHostPlayers`
  response already includes `player_list[]`.
- **Permissions** — `$access_bans` (legacy field, unchanged) gates
  the right-click hint at the top of the page. Per-server admin
  shortcuts (RCON, Players-as-admin) from the handoff are
  intentionally cut — they live on the admin servers list (B15).
- **Empty state** — friendly card when no servers are configured.

## Files

- `web/themes/sbpp2026/page_servers.tpl` — replaces A1 stub.
- `web/includes/View/ServersView.php` — docblock-only extension; no
  property changes (preserves the parity B3's `HomeDashboardView`
  relies on while reusing this view's `$server_list`).
- `web/pages/page.servers.php` — adds `md.name AS mod_name` to the
  SELECT and exposes it as `$info['mod']` for the new card label.
  `Renderer::render` was already in place from earlier theme
  groundwork.

## Hard rules

- Touched only the 3 in-scope files.
- No edits to chrome (`core/*`), `init.php`, `api/handlers/*`,
  `api-contract.js`, `AGENTS.md`, or `ARCHITECTURE.md`.
- Variable naming follows the handoff's `$server.{sid,name,host,port,
  players,map,mod,...}` shape; new keys added, none renamed/removed
  (B3's dashboard transitively reads `$server_list` row entries).
- No `{nofilter}` introduced.
- Vanilla JS only (`{literal}` block; relies on the chrome's
  `api-contract.js` + `sb.js` + `api.js`).
- All SQL via `:prefix_` literal placeholder; no inline prefix.
- Testability hooks: `data-testid="servers-list"`,
  `data-testid="server-tile"`, `data-id={sid}`, `data-index={index}`,
  `data-status="loading|online|offline"`, plus per-element ids on
  status / host / map / players / panel / toggle / connect /
  refresh.
- Source query data handled gracefully when offline — preserves
  legacy behaviour (UDP probe may time out; row falls back to
  Offline pill).

## Plan link

#1123 issue body, Phase B, ticket B5 ("public servers").

## Local gates

| Gate | Result |
| --- | --- |
| `./sbpp.sh phpstan` (default theme leg) | Same 4 baseline-mismatch errors as clean `main` (pre-existing). No new errors from this PR. |
| `SBPP_PHPSTAN_THEME=sbpp2026 ... phpstan-sbpp2026.neon` | Same 3 pre-existing `Database` constructor type errors as clean `main` (`init.php`, `CUserManager.php`, `install/template/page.6.php`). No new errors from this PR. |
| `./sbpp.sh ts-check` | Clean. |
| `./sbpp.sh test --testsuite api` | 238 tests, 874 assertions, all green. |
| `./sbpp.sh composer api-contract` | No diff. |

## Screenshots

Hosted on the disposable orphan branch `screenshots-b5-1154` (never
merged). Light-mode initial render, with the inline
`sb.api.call(Actions.ServersHostPlayers, ...)` probe still in flight:

![Public servers — initial loading state](https://raw.githubusercontent.com/sbpp/sourcebans-pp/screenshots-b5-1154/screenshots/b5-public-light.png)

After the probe lands, with the API mocked to return online responses
for three of the four configured servers (the fourth's mock returned
`{ error: 'connect' }`, demonstrating the offline pill and the
disabled Players button):

![Public servers — online state with players + map populated](https://raw.githubusercontent.com/sbpp/sourcebans-pp/screenshots-b5-1154/screenshots/b5-public-online.png)

Same online state with the first card's player panel expanded (clicking
the Players toggle reveals the cached `player_list[]` from the same
API response — no extra fetch):

![Public servers — expanded player panel](https://raw.githubusercontent.com/sbpp/sourcebans-pp/screenshots-b5-1154/screenshots/b5-public-expanded.png)

Real offline state (every configured server is unreachable, so every
card flips to Offline; Players button stays disabled, Connect link
stays valid since `steam://` resolution is the client's job):

![Public servers — all servers offline](https://raw.githubusercontent.com/sbpp/sourcebans-pp/screenshots-b5-1154/screenshots/b5-public-offline.png)

Dark mode — `localStorage.sbpp-theme = 'dark'` applied via the topbar
theme toggle (the Connect button rendering as neutral instead of brand
in dark mode is a CSS-specificity quirk inherited from the A1 vendored
`theme.css`, not something this PR introduces):

![Public servers — dark mode](https://raw.githubusercontent.com/sbpp/sourcebans-pp/screenshots-b5-1154/screenshots/b5-public-dark.png)

Mobile width (~420px) — sidebar collapses, cards stack to a single
column:

![Public servers — mobile width](https://raw.githubusercontent.com/sbpp/sourcebans-pp/screenshots-b5-1154/screenshots/b5-public-mobile.png)

Empty state — no enabled servers configured:

![Public servers — empty state](https://raw.githubusercontent.com/sbpp/sourcebans-pp/screenshots-b5-1154/screenshots/b5-public-empty.png)

## Test plan

- [ ] Visit `?p=servers` with no servers configured → "No servers are
      configured yet." card renders.
- [ ] Visit `?p=servers` with several servers → grid of cards, each
      starting in loading then degrading to offline (for unreachable
      hosts) or online with hostname + map + player count.
- [ ] Click a card's Players button on an online server → expands and
      lists players (name + frags + time) inline.
- [ ] Click Refresh on a card → re-fires the live query, status flips
      back to loading then resolves.
- [ ] `?p=servers&s={index}` deep-links → card with that index
      auto-expands its player panel after the live response.
- [ ] Mobile width (~360px–420px) → cards stack to single column,
      sidebar collapses.
- [ ] Toggle dark mode (theme toggle in topbar) → contrast / borders
      hold up.