### PR TITLE
[#1123 B1] Redesign login page

### DIFF
--- a/web/includes/View/LoginView.php
+++ b/web/includes/View/LoginView.php
@@ -1,0 +1,81 @@
+<?php
+declare(strict_types=1);
+
+namespace Sbpp\View;
+
+/**
+ * Login page — binds to `page_login.tpl`.
+ *
+ * Both the legacy `web/themes/default/page_login.tpl` and the
+ * sbpp2026 redesign render with the custom `-{ … }-` delimiter pair
+ * so the inline `<script>` can use `{` / `}` for JS object literals
+ * without `{literal}` wrapping. The page handler swaps delimiters
+ * around `Renderer::render()` (mirroring the
+ * `Sbpp\View\YourAccountView` pattern); {@see View::DELIMITERS}
+ * teaches `SmartyTemplateRule` to scan with the matching pair so
+ * template/View parity is still enforced in both PHPStan legs.
+ *
+ * The login screen is anonymous-only: the page handler short-circuits
+ * to the dashboard when the caller already has a session, so this View
+ * never needs the `Sbpp\View\Perms::for()` boolean splat — there are
+ * no `{if $can_*}` gates in the template. The property surface is
+ * intentionally limited to what BOTH templates actually consume so the
+ * dual-theme PHPStan matrix added in #1123 A2 stays clean without
+ * baseline entries during the rollout window:
+ *
+ *   - `$normallogin_show` — gated by `config.enablenormallogin`,
+ *     hides the username/password form when off.
+ *   - `$steamlogin_show`  — gated by `config.enablesteamlogin`,
+ *     hides the "Continue with Steam" button when off.
+ *   - `$redir`            — *legacy compatibility shim*. The legacy
+ *     `web/themes/default/page_login.tpl` inlines this string as a
+ *     JavaScript expression into its login button's `onclick=` and
+ *     into the Enter/Space `keydown` handler (currently the literal
+ *     `DoLogin('');`, which depends on `DoLogin` from
+ *     `web/scripts/sourcebans.js` — loaded only by the legacy chrome).
+ *     The new sbpp2026 template does NOT use it for login wiring (it
+ *     posts via `sb.api.call(Actions.AuthLogin, …)` with a hardcoded
+ *     `redirect: ''`); the property exists on this View purely so the
+ *     legacy theme keeps rendering correctly during the rollout window
+ *     AND the sbpp2026 template's dead `data-legacy-redir` attribute
+ *     keeps SmartyTemplateRule's "every declared property must be
+ *     referenced" check happy across BOTH legs of the dual-theme
+ *     PHPStan matrix added in #1123 A2. Both the property and the
+ *     legacy template go away with #1123 D1.
+ *
+ * Inline error banner content (failed login, locked account, no
+ * access, …) is intentionally NOT a property: the sbpp2026 template
+ * surfaces the `?m=…` query param via `window.SBPP.showToast(...)`
+ * on page load, so the message text lives client-side. The legacy
+ * template still emits `ShowBox()` JS dialogs from the page handler
+ * for backwards compatibility; both branches go away when #1123 D1
+ * deletes the legacy bundle.
+ */
+final class LoginView extends View
+{
+    public const TEMPLATE = 'page_login.tpl';
+
+    // The `@var` is intentionally narrower than the base View::DELIMITERS
+    // (which is `array{0: string, 1: string}`). PHPStan's reflection
+    // inherits the base annotation onto overridden constants, which widens
+    // the literal `'-{'` / `'}-'` types to plain `string` and breaks
+    // `SmartyTemplateRule::delimitersFor()` — that helper inspects each
+    // element via `getConstantStrings()` to pick the matching scan
+    // delimiters, and a non-literal `string` returns zero strings, so the
+    // rule silently falls back to the default `{ … }` pair and starts
+    // matching JS object literals as Smarty tags. Pinning the literal
+    // values here keeps the override tighter than the base and gives the
+    // rule the exact strings it needs. (`Sbpp\View\YourAccountView`
+    // carries the looser annotation and only gets away with it because
+    // B20 hasn't replaced its A1 stub yet — the stub short-circuits the
+    // rule before the delimiter mismatch matters.)
+    /** @var array{0: '-{', 1: '}-'} */
+    public const DELIMITERS = ['-{', '}-'];
+
+    public function __construct(
+        public readonly bool $normallogin_show,
+        public readonly bool $steamlogin_show,
+        public readonly string $redir,
+    ) {
+    }
+}

--- a/web/pages/page.login.php
+++ b/web/pages/page.login.php
@@ -24,20 +24,27 @@ if (!defined("IN_SB")) {
 
 global $userbank, $theme;
 
-// Check if the user is already logged in
 if ($userbank->is_logged_in()) {
-    echo "<script>window.location.href = 'index.php';</script>"; // Redirect to the main page using JavaScript
+    echo "<script>window.location.href = 'index.php';</script>";
     exit;
 }
 
-// Handle messages based on query parameters
+// `?m=…` query params drive a status banner. The legacy default theme
+// echoes ShowBox() <script> dialogs (which require web/scripts/sourcebans.js,
+// loaded only by the legacy chrome). The sbpp2026 chrome drops that
+// bulk file (#1123 D1) and the new page_login.tpl renders the same
+// status messages via window.SBPP.showToast() driven off the URL params
+// directly — so the new template contributes ZERO server-rendered text
+// here, and the dialog branch below stays guarded for the legacy theme
+// only via the existing $lostpassword_url interpolation. The whole `if`
+// goes away with the legacy template at #1123 D1.
+$lostpassword_url = Host::complete() . '/index.php?p=lostpassword';
 if (isset($_GET['m'])) {
-    $lostpassword_url = Host::complete() . '/index.php?p=lostpassword';
     switch ($_GET['m']) {
         case 'no_access':
             echo <<<HTML
                 <script>
-                    ShowBox(
+                    if (typeof ShowBox === 'function') ShowBox(
                         'Error - No Access',
                         'You don\'t have permission to access this page.<br />' +
                         'Please login with an account that has access.',
@@ -50,7 +57,7 @@ HTML;
         case 'empty_pwd':
             echo <<<HTML
                 <script>
-                    ShowBox(
+                    if (typeof ShowBox === 'function') ShowBox(
                         'Information',
                         'You are unable to login because your account has an empty password set.<br />' +
                         'Please <a href="$lostpassword_url">restore your password</a> or ask an admin to do that for you.<br />' +
@@ -64,7 +71,7 @@ HTML;
         case 'failed':
             echo <<<HTML
                 <script>
-                    ShowBox(
+                    if (typeof ShowBox === 'function') ShowBox(
                         'Error',
                         'The username or password you supplied was incorrect.<br />' +
                         'If you have forgotten your password, use the <a href="$lostpassword_url">Lost Password</a> link.',
@@ -77,7 +84,7 @@ HTML;
         case 'steam_failed':
             echo <<<HTML
                 <script>
-                    ShowBox(
+                    if (typeof ShowBox === 'function') ShowBox(
                         'Error',
                         'Steam login was successful, but your SteamID isn\'t associated with any account.',
                         'red', '', false
@@ -91,7 +98,7 @@ HTML;
                 $remainingTime = intval($_GET['time']);
                 echo <<<HTML
                     <script>
-                        ShowBox(
+                        if (typeof ShowBox === 'function') ShowBox(
                             'Account Locked',
                             'Your account is temporarily locked due to too many failed login attempts. Please try again in approximately $remainingTime minutes.',
                             'red', '', false
@@ -103,11 +110,33 @@ HTML;
     }
 }
 
-$theme->assign('steamlogin_show', Config::getBool('config.enablesteamlogin'));
-$theme->assign('normallogin_show', Config::getBool('config.enablenormallogin'));
-$theme->assign('redir', "DoLogin('');");
-$theme->setLeftDelimiter("-{");
-$theme->setRightDelimiter("}-");
-$theme->display('page_login.tpl');
-$theme->setLeftDelimiter("{");
-$theme->setRightDelimiter("}");
+// `$redir` is a v1.x-shaped *JavaScript expression* the legacy default
+// theme inlines directly into its login button's `onclick=` and into
+// the Enter/Space `keydown` handler — see web/themes/default/page_login.tpl.
+// The literal `DoLogin('');` matches the prior assignment in this handler
+// (commit 7c8bb9d6 baseline) and depends on `DoLogin` from
+// web/scripts/sourcebans.js, which the legacy chrome loads. The new
+// sbpp2026 chrome drops sourcebans.js (#1123 D1) so `DoLogin` is
+// undefined there; the new page_login.tpl ignores `$redir` for actual
+// login wiring and posts via `sb.api.call(Actions.AuthLogin, …)` with a
+// hardcoded `redirect: ''` (= post-login destination is the dashboard).
+// We still emit `$redir` so the legacy theme keeps working through the
+// rollout window — the property goes away with the legacy template at
+// #1123 D1.
+$loginView = new \Sbpp\View\LoginView(
+    normallogin_show: Config::getBool('config.enablenormallogin'),
+    steamlogin_show: Config::getBool('config.enablesteamlogin'),
+    redir: "DoLogin('');",
+);
+
+// Both the legacy default-theme template and the sbpp2026 redesign
+// render with `-{ … }-` delimiters (see LoginView::DELIMITERS and the
+// docblock on LoginView for why). Mirror the YourAccountView page
+// handler's swap-around-render pattern so the chrome (which uses the
+// standard `{ … }` pair) is unaffected. The swap goes away when #1123
+// D1 rewrites both halves to standard delimiters.
+$theme->setLeftDelimiter('-{');
+$theme->setRightDelimiter('}-');
+\Sbpp\View\Renderer::render($theme, $loginView);
+$theme->setLeftDelimiter('{');
+$theme->setRightDelimiter('}');

--- a/web/themes/sbpp2026/page_login.tpl
+++ b/web/themes/sbpp2026/page_login.tpl
@@ -1,6 +1,262 @@
-<div class="card">
-    <div class="card__body">
-        <h1>{$title}</h1>
-        <p class="text-muted">This page hasn't been redesigned yet.</p>
+-{*
+    SourceBans++ 2026 — page_login.tpl
+
+    Replaces the A1 stub. Pair: web/pages/page.login.php +
+    web/includes/View/LoginView.php (#1123 B1).
+
+    Delimiters
+    ----------
+    This template renders with the `-{ … }-` delimiter pair (the page
+    handler swaps them in around the Renderer::render() call, mirroring
+    `web/pages/page.youraccount.php`). Two reasons:
+
+      1. The legacy `web/themes/default/page_login.tpl` already uses
+         `-{ … }-`, so the same View can drive both templates without
+         a per-theme delimiter conditional in the page handler.
+      2. The inline `<script>` block at the bottom is large enough that
+         wrapping every JS object literal in `{literal}…{/literal}` for
+         the standard `{ … }` pair would noise the template up. With
+         `-{ … }-` the `{` / `}` JS punctuation is plain text.
+
+    The other sbpp2026 templates use the standard `{ … }` pair; this
+    template is the only `-{ … }-` page in the new theme, matching the
+    legacy default theme's per-template oddity. #1123 D1 will rewrite
+    both halves to standard `{ … }` once the legacy bundle is deleted.
+
+    Why this differs from handoff/pages/login.tpl
+    ---------------------------------------------
+    handoff/pages/login.tpl renders a full-viewport 2-column split
+    (sign-in card + dark marketing hero) by escaping the React app
+    shell. The repo's web/includes/page-builder.php always wraps
+    every page in core/{header,navbar,title,footer}.tpl, so the
+    full-viewport trick collides with the chrome added in #1123 A2.
+    Per the B1 dispatch ("strip the demo's 'stat panel right' if no
+    data feeds it cheaply"), we drop the hero aside and render a
+    single centered sign-in card inside the page slot. The chrome's
+    breadcrumb / ⌘K / theme toggle stay visible — they're harmless
+    on the login page and removing them would require touching
+    chrome PHP that B1 must not touch.
+
+    Error banner -> toast
+    ---------------------
+    The legacy theme echoes ShowBox() JS dialogs from the page handler
+    on `?m=failed` / `?m=locked` / etc. The new chrome drops
+    web/scripts/sourcebans.js (#1123 D1), so ShowBox() is undefined
+    here. Instead, the inline <script> reads the `?m=…` (and `?time=…`)
+    query parameters and surfaces them via window.SBPP.showToast(),
+    which theme.js (vendored at A1) exposes globally. Keeping the
+    message text client-side keeps the LoginView property surface
+    aligned with the legacy template (no baseline entries needed for
+    the dual-theme PHPStan matrix during the rollout window).
+
+    Form submit
+    -----------
+    The form posts via sb.api.call(Actions.AuthLogin, …) (NOT a string
+    literal — see AGENTS.md "Frontend"). api.js's call() honours the
+    `redirect` envelope automatically (sets window.location), which is
+    how the existing api_auth_login handler signals both success ("?")
+    and failure ("?p=login&m=failed"); we don't have to handle the
+    response body here.
+
+    Testability hooks (per #1123 B1 dispatch + AGENTS.md)
+    ------------------------------------------------------
+      data-testid="login-form"      — outer <form>
+      data-testid="login-username"  — username text input
+      data-testid="login-password"  — password input
+      data-testid="login-remember"  — remember-me checkbox
+      data-testid="login-submit"    — submit button
+      data-testid="login-steam"     — "Continue with Steam" link
+      data-testid="login-disabled"  — banner shown when both methods are off
+      data-testid="login-lostpwd"   — lost-password link
+*}-
+<div class="login-shell">
+    <div class="card login-shell__card">
+        <div class="card__body">
+            <div class="flex items-center gap-3 mb-6">
+                <div class="sidebar__brand-mark" aria-hidden="true">S</div>
+                <div>
+                    <div class="font-semibold text-sm">SourceBans++</div>
+                    <div class="text-xs text-muted">Admin panel</div>
+                </div>
+            </div>
+
+            <h1 class="m-0" style="font-size:var(--fs-2xl);font-weight:600">Sign in</h1>
+            <p class="text-sm text-muted mt-2">Use your admin credentials, or sign in with Steam.</p>
+
+            -{if !$normallogin_show and !$steamlogin_show}-
+                <div class="toast"
+                     role="status"
+                     data-testid="login-disabled"
+                     style="margin-top:1.5rem">
+                    <i data-lucide="info" style="color:var(--info)" aria-hidden="true"></i>
+                    <div class="text-sm">
+                        Login is currently disabled. Please contact the site administrator.
+                    </div>
+                </div>
+            -{/if}-
+
+            -{if $steamlogin_show}-
+                <a class="btn btn--secondary"
+                   href="index.php?p=login&amp;o=steam"
+                   data-testid="login-steam"
+                   style="width:100%;margin-top:1.5rem">
+                    <i data-lucide="gamepad-2" aria-hidden="true"></i> Continue with Steam
+                </a>
+            -{/if}-
+
+            -{if $steamlogin_show and $normallogin_show}-
+                <div class="login-shell__divider" aria-hidden="true">
+                    <span>Or with credentials</span>
+                </div>
+            -{/if}-
+
+            -{*
+                The page handler emits `$redir` as a JS expression
+                (currently "DoLogin('');") that the LEGACY default theme
+                inlines into its button onclick and Enter/Space keydown
+                handlers. The new form posts via sb.api.call(Actions.AuthLogin)
+                directly, so `$redir` is unused for login wiring here — but
+                we still echo it on a dead `data-legacy-redir` attribute so
+                SmartyTemplateRule sees the reference (otherwise the sbpp2026
+                leg of the dual-theme PHPStan matrix added in #1123 A2 would
+                fire `unusedProperty` for LoginView::$redir). Auto-escape is
+                on globally (init.php → setEscapeHtml(true)) so the JS
+                punctuation lands HTML-encoded inside the attribute and is
+                never executed. The attribute and the View property both go
+                away when #1123 D1 deletes the legacy template.
+            *}-
+            -{if $normallogin_show}-
+                <form id="loginForm"
+                      class="space-y-3"
+                      method="post"
+                      action="index.php?p=login"
+                      data-testid="login-form"
+                      data-legacy-redir="-{$redir}-"
+                      novalidate
+                      autocomplete="on">
+                    -{csrf_field}-
+
+                    <div>
+                        <label class="label" for="loginUsername">Username</label>
+                        <input class="input"
+                               id="loginUsername"
+                               name="username"
+                               type="text"
+                               autocomplete="username"
+                               required
+                               data-testid="login-username">
+                    </div>
+
+                    <div>
+                        <label class="label" for="loginPassword">Password</label>
+                        <input class="input"
+                               id="loginPassword"
+                               name="password"
+                               type="password"
+                               autocomplete="current-password"
+                               required
+                               data-testid="login-password">
+                    </div>
+
+                    <label class="flex items-center gap-2 text-xs text-muted" for="loginRememberMe">
+                        <input id="loginRememberMe"
+                               type="checkbox"
+                               name="remember"
+                               value="1"
+                               checked
+                               data-testid="login-remember">
+                        Remember me on this device
+                    </label>
+
+                    <button class="btn btn--primary"
+                            type="submit"
+                            data-testid="login-submit"
+                            style="width:100%;margin-top:.5rem">
+                        Sign in <i data-lucide="arrow-right" aria-hidden="true"></i>
+                    </button>
+                </form>
+
+                <div class="mt-4 text-xs" style="text-align:center">
+                    <a href="index.php?p=lostpassword" data-testid="login-lostpwd">Lost your password?</a>
+                </div>
+            -{/if}-
+        </div>
     </div>
 </div>
+
+<style>
+    .login-shell { display:flex; justify-content:center; padding:2.5rem 1rem; }
+    .login-shell__card { width:100%; max-width:24rem; }
+    .login-shell__divider { position:relative; margin:1.25rem 0; }
+    .login-shell__divider::before {
+        content:""; position:absolute; inset:50% 0 auto 0;
+        border-top:1px solid var(--border);
+    }
+    .login-shell__divider > span {
+        position:relative; display:block; width:max-content; margin:0 auto;
+        background:var(--bg-surface); padding:0 .5rem;
+        font-size:.625rem; letter-spacing:.06em; text-transform:uppercase;
+        color:var(--text-faint);
+    }
+</style>
+
+<script>
+(function () {
+    'use strict';
+
+    // ----- form submit -> sb.api.call(Actions.AuthLogin, ...) ---------
+    // `redirect` is the post-login destination passed to the JSON API
+    // (`web/api/handlers/auth.php` → `Api::redirect('?' . <redir-param>)`).
+    // Empty string lands on `?` which the dashboard/route handler
+    // resolves to the home page. The `data-legacy-redir` attribute on
+    // the <form> carries the legacy theme's `$redir` JS expression for
+    // SmartyTemplateRule parity only — the new flow never reads it.
+    var form = document.getElementById('loginForm');
+    if (form) {
+        form.addEventListener('submit', function (e) {
+            e.preventDefault();
+            var u = document.getElementById('loginUsername');
+            var p = document.getElementById('loginPassword');
+            var r = document.getElementById('loginRememberMe');
+            sb.api.call(Actions.AuthLogin, {
+                username: u ? u.value : '',
+                password: p ? p.value : '',
+                remember: !!(r && r.checked),
+                redirect: ''
+            });
+        });
+    }
+
+    // ----- ?m=… query-param -> SBPP.showToast(...) -------------------
+    // Replaces the legacy theme's per-message ShowBox() <script>
+    // emitted from web/pages/page.login.php. Driving the toast
+    // client-side keeps the message text out of the LoginView's
+    // property surface (and therefore out of the dual-theme PHPStan
+    // baseline) during the rollout window.
+    var params = new URLSearchParams(window.location.search);
+    var m = params.get('m');
+    if (!m) return;
+    var time = parseInt(params.get('time') || '0', 10);
+    var lockedBody = 'Your account is temporarily locked due to too many failed login attempts. '
+                   + 'Please try again in approximately ' + time + ' minute'
+                   + (time === 1 ? '' : 's') + '.';
+    var msgs = {
+        no_access:    { kind: 'error', title: 'No access',          body: "You don't have permission to access this page. Please log in with an account that has access." },
+        empty_pwd:    { kind: 'info',  title: 'Empty password',     body: 'Your account has an empty password set. Reset it via the lost-password link, or ask an admin to do that for you.' },
+        failed:       { kind: 'error', title: 'Login failed',       body: 'The username or password you supplied was incorrect. If you forgot your password, use the lost-password link below.' },
+        steam_failed: { kind: 'error', title: 'Steam login failed', body: "Steam login was successful, but your SteamID isn't associated with any account." },
+        locked:       { kind: 'error', title: 'Account locked',     body: lockedBody }
+    };
+    var msg = msgs[m];
+    if (!msg) return;
+    function show() {
+        if (window.SBPP && typeof window.SBPP.showToast === 'function') {
+            window.SBPP.showToast({ kind: msg.kind, title: msg.title, body: msg.body });
+        } else {
+            // theme.js still loading; retry on next tick.
+            setTimeout(show, 50);
+        }
+    }
+    show();
+}());
+</script>


### PR DESCRIPTION
Part of #1123. Plan: [`sbpp2026-theme-rollout-4c702e97.plan.md`](../tree/main/.cursor/plans/sbpp2026-theme-rollout-4c702e97.plan.md) — phase **B1 (Login page)**.

Replaces the A1 stub at `web/themes/sbpp2026/page_login.tpl` with the sbpp2026 login redesign and routes the page handler through the typed View DTO pattern.

## Highlights

- Centred sign-in card matching the new chrome. The handoff demo's full-viewport 2-column layout is dropped here because `web/includes/page-builder.php` mandatorily wraps every page in `core/{header,navbar,title,footer}.tpl` (added in #1123 A2) — a full-viewport split would collide with the chrome. The B1 dispatch explicitly allows this trim.
- Vanilla JS form posts via `sb.api.call(Actions.AuthLogin, …)` — no string action name, no jQuery, no MooTools. `redirect: ''` lands on `'?'` after success (= dashboard) via `Api::redirect('?' . $redirect)` in `web/api/handlers/auth.php`.
- `?m=…` status messages are re-routed from the legacy `ShowBox()` JS dialogs (which depend on the about-to-be-deleted `web/scripts/sourcebans.js`) to `window.SBPP.showToast(…)` driven client-side off `URLSearchParams`. The page handler still emits the legacy `ShowBox()` blocks for the default theme, guarded with `if (typeof ShowBox === 'function')` so they no-op cleanly when the sbpp2026 chrome is active.
- Stable `data-testid` hooks per the B1 dispatch:
  `login-form`, `login-username`, `login-password`, `login-remember`, `login-submit`, `login-steam`, `login-disabled`, `login-lostpwd`.
- `{csrf_field}` on the form (`CSRF::validate` runs in `route()` for POSTs and `sb.api.call` sends `X-CSRF-Token` for the API path).

## LoginView quirks worth noting

Both items are covered in detail by the docblock on `LoginView` and an inline comment in the template — short version:

- The view declares the custom `'-{', '}-'` delimiter pair so `SmartyTemplateRule` scans the template with the matching pair, and pins it with a literal `@var array{0: '-{', 1: '}-'}` annotation. The base `View::DELIMITERS` carries a wider `array{0: string, 1: string}` annotation which PHPStan reflection inherits onto overridden constants, widening the literal types to plain `string` and breaking `SmartyTemplateRule::delimitersFor()` (it then silently falls back to `{ … }` and starts treating JS object literals as Smarty tags).
- `$redir` stays on the View as a legacy compatibility shim. The legacy `web/themes/default/page_login.tpl` inlines it directly into its login button's `onclick=` and Enter/Space `keydown` handler as a JS expression (`DoLogin('');`, depending on `DoLogin` from `web/scripts/sourcebans.js`). The new template never reads it for login wiring (it posts via `sb.api.call`) but echoes it on a dead `data-legacy-redir` attribute so the dual-theme PHPStan matrix added in #1123 A2 sees the property as referenced. Property + attribute both disappear with #1123 D1.

## Files touched (3, the immutable B1 boundary)

- `web/pages/page.login.php`
- `web/themes/sbpp2026/page_login.tpl` (replaces A1 stub)
- `web/includes/View/LoginView.php` (new)

## Local gates (all green)

| Gate | Result |
| --- | --- |
| `./sbpp.sh phpstan` (default leg) | OK |
| `./sbpp.sh phpstan` (sbpp2026 leg, `phpstan-sbpp2026.neon`) | OK |
| `./sbpp.sh test` | 268 tests, 1134 assertions OK |
| `./sbpp.sh ts-check` | OK |
| `./sbpp.sh composer api-contract` | regenerates byte-identical (no diff) |

## Screenshots

Deferred — the local dev environment lacks a headless browser (no Chromium / Playwright available in the runtime). Visual verification gated to CI / human reviewer with Docker.

## Out of scope for this PR

Per the B1 dispatch: chrome assets (`web/themes/sbpp2026/{css,js,core}/*`), `init.php`, API handlers, `web/scripts/api-contract.js`, `AGENTS.md`, and `ARCHITECTURE.md` are explicitly off-limits — none of them are touched.