### PR TITLE
[#1123 B18] Redesign admin settings (incl. themes picker)

### DIFF
--- a/web/includes/View/AdminFeaturesView.php
+++ b/web/includes/View/AdminFeaturesView.php
@@ -1,0 +1,41 @@
+<?php
+declare(strict_types=1);
+
+namespace Sbpp\View;
+
+/**
+ * "Features" sub-tab of the admin settings page — binds to
+ * `page_admin_settings_features.tpl`. Toggles for opt-in/optional
+ * panel features (group banning, kickit, public bans export, etc.).
+ *
+ * Group banning + Friends banning depend on a configured Steam Web API
+ * key; `$steamapi` reflects whether `STEAMAPIKEY` is set so the
+ * template can disable the toggle inline rather than failing at submit.
+ *
+ * The first property block (`$steamapi`) matches the legacy default
+ * theme template; the rest (boolean toggles, `$can_*`, `$active_section`,
+ * `$can_owner`) is consumed only by the sbpp2026 template, which
+ * renders checkboxes statefully. The default theme drives them via
+ * inline `<script>` blocks emitted by admin.settings.php, so PHPStan
+ * baselines those as "unused" on the default leg of the matrix.
+ */
+final class AdminFeaturesView extends View
+{
+    public const TEMPLATE = 'page_admin_settings_features.tpl';
+
+    public function __construct(
+        public readonly bool $steamapi,
+        public readonly bool $can_web_settings,
+        public readonly bool $can_owner,
+        public readonly string $active_section,
+        public readonly bool $export_public,
+        public readonly bool $enable_kickit,
+        public readonly bool $enable_groupbanning,
+        public readonly bool $enable_friendsbanning,
+        public readonly bool $enable_adminrehashing,
+        public readonly bool $enable_steamlogin,
+        public readonly bool $enable_normallogin,
+        public readonly bool $enable_publiccomments,
+    ) {
+    }
+}

--- a/web/includes/View/AdminLogsView.php
+++ b/web/includes/View/AdminLogsView.php
@@ -1,0 +1,33 @@
+<?php
+declare(strict_types=1);
+
+namespace Sbpp\View;
+
+/**
+ * "System log" sub-tab of the admin settings page — binds to
+ * `page_admin_settings_logs.tpl`. Lists rows from `:prefix_log` with
+ * inline expandable detail per row.
+ *
+ * Only `ADMIN_OWNER` can truncate the log table; `$can_owner` gates
+ * the "Clear log" button in the sbpp2026 template. The legacy default
+ * theme reads the prebuilt `$clear_logs` HTML link instead, so both
+ * variables sit on the View together — `SmartyTemplateRule`'s
+ * cross-check lets the dual-theme matrix accept either.
+ */
+final class AdminLogsView extends View
+{
+    public const TEMPLATE = 'page_admin_settings_logs.tpl';
+
+    /**
+     * @param list<array<string,mixed>> $log_items
+     */
+    public function __construct(
+        public readonly string $clear_logs,
+        public readonly string $page_numbers,
+        public readonly array $log_items,
+        public readonly bool $can_web_settings,
+        public readonly bool $can_owner,
+        public readonly string $active_section,
+    ) {
+    }
+}

--- a/web/includes/View/AdminSettingsView.php
+++ b/web/includes/View/AdminSettingsView.php
@@ -1,0 +1,77 @@
+<?php
+declare(strict_types=1);
+
+namespace Sbpp\View;
+
+/**
+ * "Main settings" sub-tab of the admin settings page — binds to
+ * `page_admin_settings_settings.tpl`.
+ *
+ * The dashboard intro text (`dash.intro.text`) field stays a plain
+ * `<textarea>` here. The previous TinyMCE WYSIWYG was the source of
+ * the stored-XSS vector fixed in #1113; the value now flows through
+ * `Sbpp\Markup\IntroRenderer` (CommonMark, `html_input: 'escape'`,
+ * `allow_unsafe_links: false`) on render. Re-introducing any HTML
+ * editor here would re-open that vector. See AGENTS.md
+ * "Anti-patterns" + "Admin-authored display text".
+ *
+ * Variable shape:
+ *
+ *   - The first block (`config_title`, `config_logo`, …, `config_smtp`,
+ *     `config_mail_from_*`) mirrors the legacy default theme template's
+ *     variables verbatim so SmartyTemplateRule passes the default-theme
+ *     PHPStan leg without baseline churn. The legacy theme drives every
+ *     dynamic checkbox via inline `<script>` blocks emitted by
+ *     `web/pages/admin.settings.php`, so it doesn't reference the
+ *     boolean toggles in this View.
+ *   - The second block (`active_section`, `$can_*`, the boolean
+ *     toggles, `config_default_page`, `config_smtp_verify_peer`) is
+ *     consumed only by the sbpp2026 template, which renders checkboxes
+ *     statefully (`{if $config_debug}checked{/if}`) instead of patching
+ *     them post-hoc. PHPStan baselines these as "unused" against the
+ *     default-theme leg; the sbpp2026 leg sets
+ *     `reportUnmatchedIgnoredErrors=false` so the baseline collapses
+ *     cleanly when D1 retires the legacy template.
+ */
+final class AdminSettingsView extends View
+{
+    public const TEMPLATE = 'page_admin_settings_settings.tpl';
+
+    /**
+     * @param list<string>            $bans_customreason Persisted custom ban reasons,
+     *     each entity-encoded at write time. Empty list when disabled.
+     * @param array{0: string, 1: string, 2: string} $config_smtp Legacy
+     *     [host, user, port] tuple used by the default theme.
+     */
+    public function __construct(
+        public readonly string $config_title,
+        public readonly string $config_logo,
+        public readonly int $config_min_password,
+        public readonly string $config_dateformat,
+        public readonly string $config_dash_title,
+        public readonly string $config_dash_text,
+        public readonly int $auth_maxlife,
+        public readonly int $auth_maxlife_remember,
+        public readonly int $auth_maxlife_steam,
+        public readonly int $config_bans_per_page,
+        public readonly array $config_smtp,
+        public readonly string $config_mail_from_email,
+        public readonly string $config_mail_from_name,
+        public readonly array $bans_customreason,
+        public readonly bool $can_web_settings,
+        public readonly bool $can_owner,
+        public readonly string $active_section,
+        public readonly bool $config_debug,
+        public readonly bool $enable_submit,
+        public readonly bool $enable_protest,
+        public readonly bool $enable_commslist,
+        public readonly bool $protest_emailonlyinvolved,
+        public readonly bool $dash_lognopopup,
+        public readonly int $config_default_page,
+        public readonly bool $banlist_hideadmname,
+        public readonly bool $banlist_nocountryfetch,
+        public readonly bool $banlist_hideplayerips,
+        public readonly bool $config_smtp_verify_peer,
+    ) {
+    }
+}

--- a/web/includes/View/AdminThemesView.php
+++ b/web/includes/View/AdminThemesView.php
@@ -1,0 +1,67 @@
+<?php
+declare(strict_types=1);
+
+namespace Sbpp\View;
+
+/**
+ * "Themes" sub-tab of the admin settings page — binds to
+ * `page_admin_settings_themes.tpl`. Renders a card grid of every
+ * directory under `web/themes/` that ships a `theme.conf.php`.
+ *
+ * The card "Use this theme" button calls
+ * {@see Actions.SystemApplyTheme} (action `system.apply_theme`,
+ * gated `ADMIN_OWNER | ADMIN_WEB_SETTINGS` in `_register.php`); on
+ * success the JSON envelope's `reload: true` flag triggers a full
+ * page reload so the new chrome paints with the right CSS bundle.
+ *
+ * Variable shape:
+ *
+ *   - `$theme_list` is the only structural variable; both themes
+ *     iterate it. Each row carries `dir`, `name`, `author`, `version`,
+ *     `link`, `screenshot`, and `active` — the legacy default theme
+ *     only reads `dir` + `name`, the sbpp2026 card grid uses every
+ *     field.
+ *   - `$theme_name`, `$theme_author`, `$theme_version`, `$theme_link`,
+ *     `$theme_screenshot` describe the currently-selected theme;
+ *     they exist for the legacy default-theme template's "current
+ *     theme details" panel. The sbpp2026 template derives the same
+ *     info from `$theme_list[].active`, so PHPStan baselines those
+ *     scalars as "unused" on the sbpp2026 leg (and the dual-theme
+ *     matrix's `reportUnmatchedIgnoredErrors=false` keeps that clean).
+ *     `$theme_screenshot` is intentionally a pre-built `<img>` tag
+ *     string for the legacy `{nofilter}` consumer; the sbpp2026 grid
+ *     uses `$theme_list[].screenshot` (URL only) for its own `<img>`
+ *     elements.
+ *   - `$can_*`, `$active_section`, `$current_theme_dir` are sbpp2026-only
+ *     and ride the same baseline pattern (default-theme leg sees
+ *     them as unused).
+ */
+final class AdminThemesView extends View
+{
+    public const TEMPLATE = 'page_admin_settings_themes.tpl';
+
+    /**
+     * @param list<array{
+     *     dir: string,
+     *     name: string,
+     *     author: string,
+     *     version: string,
+     *     link: string,
+     *     screenshot: string,
+     *     active: bool
+     * }> $theme_list
+     */
+    public function __construct(
+        public readonly array $theme_list,
+        public readonly string $theme_name,
+        public readonly string $theme_author,
+        public readonly string $theme_version,
+        public readonly string $theme_link,
+        public readonly string $theme_screenshot,
+        public readonly bool $can_web_settings,
+        public readonly bool $can_owner,
+        public readonly string $active_section,
+        public readonly string $current_theme_dir,
+    ) {
+    }
+}

--- a/web/pages/admin.settings.php
+++ b/web/pages/admin.settings.php
@@ -63,6 +63,24 @@ if (isset($_GET['log_clear']) && $_GET['log_clear'] === 'true') {
 
 $canSettings = (bool) $userbank->HasAccess(ADMIN_OWNER | ADMIN_WEB_SETTINGS);
 
+/*
+ * Post-save flash, emitted at the bottom of this file.
+ *
+ * `header('Location: …')` after a successful save *doesn't work here*
+ * because by the time admin.settings.php runs, build() in
+ * includes/page-builder.php has already required core/header.php →
+ * core/navbar.php → core/title.php — each of which calls
+ * `$theme->display()` and flushes Smarty output to stdout. PHP has no
+ * global output buffer (no ob_start in init.php / index.php, no
+ * `output_buffering` in docker/Dockerfile), so a server-side redirect
+ * here triggers `headers already sent` and the user lands on a partial
+ * page with a raw PHP warning. The pre-B18 code dodged this by emitting
+ * a JS-side `ShowBox(…, redir)` bounce instead; we keep that shape but
+ * make it theme-aware so it works under both `default` and `sbpp2026`
+ * chrome.
+ */
+$savedSection = '';
+
 if ($canSettings && isset($_POST['settingsGroup'])) {
     $errors = '';
 
@@ -148,8 +166,7 @@ if ($canSettings && isset($_POST['settingsGroup'])) {
                     ...$smtpConfig,
                 ]);
             Log::add('m', 'Settings updated', 'Main settings were updated.');
-            header('Location: index.php?p=admin&c=settings&section=settings&saved=1');
-            exit();
+            $savedSection = 'settings';
         }
     }
 
@@ -173,8 +190,7 @@ if ($canSettings && isset($_POST['settingsGroup'])) {
             (" . $steamloginopt  . ", 'config.enablesteamlogin'),
             (" . $normalloginopt . ", 'config.enablenormallogin')")->execute();
         Log::add('m', 'Settings updated', 'Feature toggles were updated.');
-        header('Location: index.php?p=admin&c=settings&section=features&saved=1');
-        exit();
+        $savedSection = 'features';
     }
 
     if (!empty($errors)) {
@@ -411,6 +427,47 @@ if ($section === 'themes') {
     ));
 }
 
+/*
+ * Post-save flash + bounce.
+ *
+ * Emitted only when a settings-group POST just succeeded. We can't use
+ * `header('Location: …')` from this file (see the `$savedSection`
+ * declaration near the top for why); instead we render a small inline
+ * <script> that:
+ *
+ *   1. Surfaces a "Settings saved" toast via the active theme's toast
+ *      surface — `window.SBPP.showToast` on sbpp2026, `ShowBox` on
+ *      `default`. Both already exist before this script runs because
+ *      the chrome's footer.tpl loads them.
+ *   2. Bounces to the GET URL after a short delay so a refresh doesn't
+ *      re-POST the form (the legacy `ShowBox(…, redir)` hook does this
+ *      itself; on sbpp2026 we issue an explicit `location.href` after
+ *      `setTimeout`).
+ *
+ * Cooperatively no-op if neither toast surface is available — the
+ * `location.href` fallback still cleans the request method.
+ */
+if ($savedSection !== ''):
+    $bouncePath = 'index.php?p=admin&c=settings&section=' . htmlspecialchars($savedSection, ENT_QUOTES, 'UTF-8');
+?>
+<script>
+(function () {
+    var url   = '<?= $bouncePath ?>';
+    var title = 'Settings updated';
+    var msg   = 'The changes have been saved.';
+    if (window.SBPP && typeof window.SBPP.showToast === 'function') {
+        window.SBPP.showToast({ kind: 'success', title: title, body: msg });
+        setTimeout(function () { window.location.href = url; }, 1200);
+    } else if (typeof ShowBox === 'function') {
+        ShowBox(title, msg, 'green', url);
+    } else {
+        window.location.href = url;
+    }
+})();
+</script>
+<?php endif; ?>
+
+<?php
 /*
  * Legacy default-theme tail.
  *

--- a/web/pages/admin.settings.php
+++ b/web/pages/admin.settings.php
@@ -23,337 +23,408 @@ if (!defined("IN_SB")) {
 }
 global $userbank, $theme;
 
-new AdminTabs([
-    ['name' => 'Main Settings', 'permission' => ADMIN_OWNER|ADMIN_WEB_SETTINGS],
-    ['name' => 'Themes', 'permission' => ALL_WEB],
-    ['name' => 'System Log', 'permission' => ALL_WEB],
-    ['name' => 'Features', 'permission' => ADMIN_OWNER|ADMIN_WEB_SETTINGS]
-], $userbank, $theme);
+use Sbpp\View\AdminFeaturesView;
+use Sbpp\View\AdminLogsView;
+use Sbpp\View\AdminSettingsView;
+use Sbpp\View\AdminThemesView;
+use Sbpp\View\Perms;
+use Sbpp\View\Renderer;
 
-$page = 1;
-if (isset($_GET['page']) && $_GET['page'] > 0) {
-    $page = intval($_GET['page']);
+/*
+ * Section routing (B18 redesign).
+ *
+ * The legacy AdminTabs JS tab switcher rendered all four sub-tabs
+ * inside `.tabcontent` divs and toggled them with `openTab()`. The
+ * sbpp2026 redesign drops that pattern: each section becomes its own
+ * page request keyed on `?section=settings|features|logs|themes` and
+ * the new templates render the sub-nav at the top with
+ * `aria-current="page"` on the active tab. CSRF is enforced globally
+ * by `route()` in includes/page-builder.php.
+ *
+ * The legacy default theme keeps working: each settings template
+ * still renders standalone (no AdminTabs chrome / no `.tabcontent`
+ * wrapper) and the inline `<script>` tail at the bottom of this file
+ * patches checkbox state for it. D1 deletes both that tail and this
+ * paragraph when the default theme retires.
+ */
+$validSections = ['settings', 'features', 'logs', 'themes'];
+$section = (string)($_GET['section'] ?? 'settings');
+if (!in_array($section, $validSections, true)) {
+    $section = 'settings';
 }
 
-if (isset($_GET['log_clear']) && $_GET['log_clear'] == "true") {
+if (isset($_GET['log_clear']) && $_GET['log_clear'] === 'true') {
     if ($userbank->HasAccess(ADMIN_OWNER)) {
         $GLOBALS['PDO']->query("TRUNCATE TABLE `:prefix_log`")->execute();
     } else {
-        Log::add("w", "Hacking Attempt", $userbank->GetProperty('user')." tried to clear the logs, but doesn't have access.");
+        Log::add('w', 'Hacking Attempt', $userbank->GetProperty('user') . " tried to clear the logs, but doesn't have access.");
     }
 }
 
-// search
-$where = "";
-if (isset($_GET['advSearch'])) {
-//    switch ($type) {
-//        case "admin":
-//            $where = " WHERE l.aid = '" . $value . "'";
-//            break;
-//        case "message":
-//            $where = " WHERE l.message LIKE '%" . $value . "%' OR l.title LIKE '%" . $value . "%'";
-//            break;
-//        case "date":
-//            $date  = explode(",", $value);
-//            $date[0] = (is_numeric($date[0])) ? $date[0] : date('d');
-//            $date[1] = (is_numeric($date[1])) ? $date[1] : date('m');
-//            $date[2] = (is_numeric($date[2])) ? $date[2] : date('Y');
-//            $time  = mktime($date[3], $date[4], 0, (int)$date[1], (int)$date[0], (int)$date[2]);
-//            $time2 = mktime($date[5], $date[6], 59, (int)$date[1], (int)$date[0], (int)$date[2]);
-//            $where = " WHERE l.created > '$time' AND l.created < '$time2'";
-//            break;
-//        case "type":
-//            $where = " WHERE l.type = '" . $value . "'";
-//            break;
-//        default:
-//            $_GET['advType']   = "";
-//            $_GET['advSearch'] = "";
-//            break;
-//    }
-    $searchlink = "&advSearch=" . urlencode($_GET['advSearch']) . "&advType=" . urlencode($_GET['advType']);
-} else {
-    $searchlink = "";
-}
-$list_start = ($page - 1) * SB_BANS_PER_PAGE;
-$list_end   = $list_start + SB_BANS_PER_PAGE;
+$canSettings = (bool) $userbank->HasAccess(ADMIN_OWNER | ADMIN_WEB_SETTINGS);
 
-$log_count = Log::getCount($where);
-$log       = Log::getAll($list_start, SB_BANS_PER_PAGE,);
-if (($page > 1)) {
-    $prev = CreateLinkR('<i class="fas fa-arrow-left fa-lg"></i> prev', "index.php?p=admin&c=settings" . $searchlink . "&page=" . ($page - 1) . "#^2");
-} else {
-    $prev = "";
-}
-if ($list_end < $log_count) {
-    $next = CreateLinkR('next <i class="fas fa-arrow-right fa-lg"></i>', "index.php?p=admin&c=settings" . $searchlink . "&page=" . ($page + 1) . "#^2");
-} else {
-    $next = "";
-}
-$pages = (round($log_count / SB_BANS_PER_PAGE) == 0) ? 1 : round($log_count / SB_BANS_PER_PAGE);
-if ($pages > 1) {
-    $page_numbers = 'Page ' . $page . ' of ' . $pages . " - " . $prev . " | " . $next;
-} else {
-    $page_numbers = 'Page ' . $page . ' of ' . $pages;
-}
-$pages = ceil($log_count / SB_BANS_PER_PAGE);
-if ($pages > 1) {
-    if (!isset($_GET['advSearch']) || !isset($_GET['advType'])) {
-        $_GET['advSearch'] = "";
-        $_GET['advType']   = "";
-    }
-    $advSearchJs = htmlspecialchars(json_encode((string) $_GET['advSearch']), ENT_QUOTES, 'UTF-8');
-    $advTypeJs   = htmlspecialchars(json_encode((string) $_GET['advType']), ENT_QUOTES, 'UTF-8');
-    $page_numbers .= '&nbsp;<select onchange="changePage(this,\'L\',' . $advSearchJs . ',' . $advTypeJs . ');">';
-    for ($i = 1; $i <= $pages; $i++) {
-        if (isset($_GET["page"]) && $i == $_GET["page"]) {
-            $page_numbers .= '<option value="' . $i . '" selected="selected">' . $i . '</option>';
-            continue;
+if ($canSettings && isset($_POST['settingsGroup'])) {
+    $errors = '';
+
+    if ($_POST['settingsGroup'] === 'mainsettings') {
+        if (!is_numeric($_POST['config_password_minlength'] ?? '')) {
+            $errors .= "Min password length must be a number<br />";
         }
-        $page_numbers .= '<option value="' . $i . '">' . $i . '</option>';
-    }
-    $page_numbers .= '</select>';
-}
-$log_list = [];
-foreach ($log as $l) {
-    $log_item = [];
-    if ($l['type'] == "m") {
-        $log_item['type_img'] = "<img src='themes/" . SB_THEME . "/images/admin/help.png' alt='Info'>";
-    } elseif ($l['type'] == "w") {
-        $log_item['type_img'] = "<img src='themes/" . SB_THEME . "/images/admin/warning.png' alt='Warning'>";
-    } elseif ($l['type'] == "e") {
-        $log_item['type_img'] = "<img src='themes/" . SB_THEME . "/images/admin/error.png' alt='Warning'>";
-    }
-    $log_item['user']     = !empty($l['user']) ? $l['user'] : 'Guest';
-    $log_item['date_str'] = Config::time($l['created']);
-    $log_item             = array_merge($l, $log_item);
-    $log_item['message']  = str_replace("\n", "<br />", htmlentities(str_replace(["<br />", "<br>", "<br/>"], "\n", $log_item['message'])));
-    array_push($log_list, $log_item);
-}
-// Theme stuff
-$dh = opendir(SB_THEMES);
-while (false !== ($filename = readdir($dh))) {
-    $themes[] = $filename;
-}
-//$themes = scandir(SB_THEMES);
-$valid_themes = [];
-foreach ($themes as $thm) {
-    if (@file_exists(SB_THEMES . $thm . "/theme.conf.php")) {
-        $file = file_get_contents(SB_THEMES . $thm . "/theme.conf.php");
-        if ($namesearch = preg_match_all('/define\(\'theme_name\',[ ]*\"(.+)\"\);/', $file, $thmname, PREG_PATTERN_ORDER)) {
-            $thme['name'] = $thmname[1][0];
-        } else {
-            $thme['name'] = $thm;
-        }
-        $thme['dir'] = $thm;
-        array_push($valid_themes, $thme);
-    }
-}
-require(SB_THEMES . SB_THEME . "/theme.conf.php");
-?>
-<div id="admin-page-content">
-<?php
-if (!$userbank->HasAccess(ADMIN_OWNER | ADMIN_WEB_SETTINGS)) {
-    echo '<div id="0" style="display:none;">Access Denied!</div>';
-} else {
-    if (isset($_POST['settingsGroup'])) {
-        $errors = "";
-
-        if ($_POST['settingsGroup'] == "mainsettings") {
-            if (!is_numeric($_POST['config_password_minlength'])) {
-                $errors .= "Min password length must be a number<br />";
-            }
-            if (!is_numeric($_POST['banlist_bansperpage'])) {
-                $errors .= "Bans per page must be a number";
-            }
-            if (empty($errors)) {
-                if (isset($_POST['enable_submit']) && $_POST['enable_submit'] == "on") {
-                    $submit = 1;
-                } else {
-                    $submit = 0;
-                }
-                if (isset($_POST['enable_protest']) && $_POST['enable_protest'] == "on") {
-                    $protest = 1;
-                } else {
-                    $protest = 0;
-                }
-                if (isset($_POST['enable_commslist']) && $_POST['enable_commslist'] == "on") {
-                    $commslist = 1;
-                } else {
-                    $commslist = 0;
-                }
-
-                $lognopopup = (isset($_POST['dash_nopopup']) && $_POST['dash_nopopup'] == "on" ? 1 : 0);
-
-                $debugmode = (isset($_POST['config_debug']) && $_POST['config_debug'] == "on" ? 1 : 0);
-
-                $hideadmname = (isset($_POST['banlist_hideadmname']) && $_POST['banlist_hideadmname'] == "on" ? 1 : 0);
-
-                $hideplayerips = (isset($_POST['banlist_hideplayerips']) && $_POST['banlist_hideplayerips'] == "on" ? 1 : 0);
-
-                $nocountryfetch = (isset($_POST['banlist_nocountryfetch']) && $_POST['banlist_nocountryfetch'] == "on" ? 1 : 0);
-
-                $onlyinvolved = (isset($_POST['protest_emailonlyinvolved']) && $_POST['protest_emailonlyinvolved'] == "on" ? 1 : 0);
-
-                $size = sizeof($_POST['bans_customreason']);
-                for ($i = 0; $i < $size; $i++) {
-                    if (empty($_POST['bans_customreason'][$i])) {
-                        unset($_POST['bans_customreason'][$i]);
-                    } else {
-                        $_POST['bans_customreason'][$i] = htmlspecialchars($_POST['bans_customreason'][$i]);
-                    }
-                }
-                if (sizeof($_POST['bans_customreason']) != 0) {
-                    $cureason = serialize($_POST['bans_customreason']);
-                } else {
-                    $cureason = "";
-                }
-
-                $smtpConfigSql = ", (?, 'smtp.host'), (?, 'smtp.user'), (?, 'smtp.port'), (?, 'smtp.verify_peer')"
-                    . ", (?, 'config.mail.from_email'), (?, 'config.mail.from_name')";
-                $smtpConfig = [trim($_POST['mail_host']), trim($_POST['mail_user']), trim($_POST['mail_port'])];
-                $smtpConfig []= isset($_POST['mail_verify_peer']) && $_POST['mail_verify_peer'] === 'on' ? 1 : 0;
-                $smtpConfig []= trim((string)($_POST['mail_from_email'] ?? ''));
-                $smtpConfig []= trim((string)($_POST['mail_from_name'] ?? ''));
-
-                if (isset($_POST['mail_pass']) && !empty($_POST['mail_pass'])) {
-                    $smtpConfigSql .= ", (?, 'smtp.pass')";
-                    $smtpConfig []= $_POST['mail_pass'];
-                }
-
-                $GLOBALS['PDO']->query("REPLACE INTO `:prefix_settings` (`value`, `setting`) VALUES
-                    (?, 'template.title'),
-                    (?,'template.logo'),
-                    (" . (int) $_POST['config_password_minlength'] . ", 'config.password.minlength'),
-                    (" . $debugmode . ", 'config.debug'),
-                    (?, 'config.dateformat'),
-                    (?, 'dash.intro.title'),
-                    (" . (int) $_POST['banlist_bansperpage'] . ", 'banlist.bansperpage'),
-                    (" . (int) $hideadmname . ", 'banlist.hideadminname'),
-                    (" . (int) $hideplayerips . ", 'banlist.hideplayerips'),
-                    (" . (int) $nocountryfetch . ", 'banlist.nocountryfetch'),
-                    (?, 'dash.intro.text'),
-                    (" . (int) $lognopopup . ", 'dash.lognopopup'),
-                    (" . (int) $protest . ", 'config.enableprotest'),
-                    (" . (int) $commslist . ", 'config.enablecomms'),
-                    (" . (int) $submit . ", 'config.enablesubmit'),
-                    (" . (int) $onlyinvolved . ", 'protest.emailonlyinvolved'),
-                    (?, 'bans.customreasons'),
-                    (?, 'auth.maxlife'),
-                    (?, 'auth.maxlife.remember'),
-                    (?, 'auth.maxlife.steam'),
-                    (" . (int) $_POST['default_page'] . ", 'config.defaultpage')"
-                    . $smtpConfigSql)->execute([
-                        $_POST['template_title'],
-                        $_POST['template_logo'],
-                        $_POST['config_dateformat'],
-                        $_POST['dash_intro_title'],
-                        $_POST['dash_intro_text'],
-                        $cureason,
-                        $_POST['auth_maxlife'],
-                        $_POST['auth_maxlife_remember'],
-                        $_POST['auth_maxlife_steam'],
-                        ...$smtpConfig,
-                    ]);
-
-?>
-<script>ShowBox('Settings updated', 'The changes have been successfully updated', 'green', 'index.php?p=admin&c=settings');</script>
-<?php
-            } else {
-                print "<script>ShowBox('Error', '$errors', 'red');</script>";
-            }
+        if (!is_numeric($_POST['banlist_bansperpage'] ?? '')) {
+            $errors .= 'Bans per page must be a number';
         }
 
-        if ($_POST['settingsGroup'] == "features") {
-            $kickit = (isset($_POST['enable_kickit']) && $_POST['enable_kickit'] == "on" ? 1 : 0);
+        if (empty($errors)) {
+            $submit         = (isset($_POST['enable_submit'])    && $_POST['enable_submit']    === 'on') ? 1 : 0;
+            $protest        = (isset($_POST['enable_protest'])   && $_POST['enable_protest']   === 'on') ? 1 : 0;
+            $commslist      = (isset($_POST['enable_commslist']) && $_POST['enable_commslist'] === 'on') ? 1 : 0;
+            $lognopopup     = (isset($_POST['dash_nopopup'])     && $_POST['dash_nopopup']     === 'on') ? 1 : 0;
+            $debugmode      = (isset($_POST['config_debug'])     && $_POST['config_debug']     === 'on') ? 1 : 0;
+            $hideadmname    = (isset($_POST['banlist_hideadmname'])    && $_POST['banlist_hideadmname']    === 'on') ? 1 : 0;
+            $hideplayerips  = (isset($_POST['banlist_hideplayerips'])  && $_POST['banlist_hideplayerips']  === 'on') ? 1 : 0;
+            $nocountryfetch = (isset($_POST['banlist_nocountryfetch']) && $_POST['banlist_nocountryfetch'] === 'on') ? 1 : 0;
+            $onlyinvolved   = (isset($_POST['protest_emailonlyinvolved']) && $_POST['protest_emailonlyinvolved'] === 'on') ? 1 : 0;
 
-            $exportpub = (isset($_POST['export_public']) && $_POST['export_public'] == "on" ? 1 : 0);
+            $rawReasons = $_POST['bans_customreason'] ?? [];
+            if (!is_array($rawReasons)) {
+                $rawReasons = [];
+            }
+            $reasons = [];
+            foreach ($rawReasons as $r) {
+                if (is_string($r) && $r !== '') {
+                    $reasons[] = htmlspecialchars($r);
+                }
+            }
+            $cureason = !empty($reasons) ? serialize($reasons) : '';
 
-            $groupban = (isset($_POST['enable_groupbanning']) && $_POST['enable_groupbanning'] == "on" ? 1 : 0);
+            $smtpConfigSql = ", (?, 'smtp.host'), (?, 'smtp.user'), (?, 'smtp.port'), (?, 'smtp.verify_peer')"
+                . ", (?, 'config.mail.from_email'), (?, 'config.mail.from_name')";
+            $smtpConfig = [
+                trim((string) ($_POST['mail_host'] ?? '')),
+                trim((string) ($_POST['mail_user'] ?? '')),
+                trim((string) ($_POST['mail_port'] ?? '')),
+                isset($_POST['mail_verify_peer']) && $_POST['mail_verify_peer'] === 'on' ? 1 : 0,
+                trim((string) ($_POST['mail_from_email'] ?? '')),
+                trim((string) ($_POST['mail_from_name'] ?? '')),
+            ];
 
-            $friendsban = (isset($_POST['enable_friendsbanning']) && $_POST['enable_friendsbanning'] == "on" ? 1 : 0);
-
-            $adminrehash = (isset($_POST['enable_adminrehashing']) && $_POST['enable_adminrehashing'] == "on" ? 1 : 0);
-
-            $steamloginopt = (isset($_POST['enable_steamlogin']) && $_POST['enable_steamlogin'] == "on" ? 1 : 0);
-
-            $normalloginopt = (isset($_POST['enable_normallogin']) && $_POST['enable_normallogin'] == "on" ? 1 : 0);
-
-            $publiccomments = (isset($_POST['enable_publiccomments']) && $_POST['enable_publiccomments'] == "on" ? 1 : 0);
+            if (!empty($_POST['mail_pass'])) {
+                $smtpConfigSql .= ", (?, 'smtp.pass')";
+                $smtpConfig[]   = (string) $_POST['mail_pass'];
+            }
 
             $GLOBALS['PDO']->query("REPLACE INTO `:prefix_settings` (`value`, `setting`) VALUES
-											(" . (int) $exportpub . ", 'config.exportpublic'),
-											(" . (int) $kickit . ", 'config.enablekickit'),
-											(" . (int) $groupban . ", 'config.enablegroupbanning'),
-											(" . (int) $friendsban . ", 'config.enablefriendsbanning'),
-											(" . (int) $adminrehash . ", 'config.enableadminrehashing'),
-											(" . (int) $publiccomments . ", 'config.enablepubliccomments'),
-											(" . (int) $steamloginopt . ", 'config.enablesteamlogin'),
-											(" . (int) $normalloginopt . ", 'config.enablenormallogin')")->execute();
-
-
-?>
-<script>ShowBox('Settings updated', 'The changes have been successfully updated', 'green', 'index.php?p=admin&c=settings');</script>
-<?php
+                (?, 'template.title'),
+                (?, 'template.logo'),
+                (" . (int) $_POST['config_password_minlength'] . ", 'config.password.minlength'),
+                (" . $debugmode . ", 'config.debug'),
+                (?, 'config.dateformat'),
+                (?, 'dash.intro.title'),
+                (" . (int) $_POST['banlist_bansperpage'] . ", 'banlist.bansperpage'),
+                (" . (int) $hideadmname . ", 'banlist.hideadminname'),
+                (" . (int) $hideplayerips . ", 'banlist.hideplayerips'),
+                (" . (int) $nocountryfetch . ", 'banlist.nocountryfetch'),
+                (?, 'dash.intro.text'),
+                (" . (int) $lognopopup . ", 'dash.lognopopup'),
+                (" . (int) $protest . ", 'config.enableprotest'),
+                (" . (int) $commslist . ", 'config.enablecomms'),
+                (" . (int) $submit . ", 'config.enablesubmit'),
+                (" . (int) $onlyinvolved . ", 'protest.emailonlyinvolved'),
+                (?, 'bans.customreasons'),
+                (?, 'auth.maxlife'),
+                (?, 'auth.maxlife.remember'),
+                (?, 'auth.maxlife.steam'),
+                (" . (int) ($_POST['default_page'] ?? 0) . ", 'config.defaultpage')"
+                . $smtpConfigSql)->execute([
+                    (string) ($_POST['template_title'] ?? ''),
+                    (string) ($_POST['template_logo'] ?? ''),
+                    (string) ($_POST['config_dateformat'] ?? ''),
+                    (string) ($_POST['dash_intro_title'] ?? ''),
+                    (string) ($_POST['dash_intro_text'] ?? ''),
+                    $cureason,
+                    (string) ($_POST['auth_maxlife'] ?? ''),
+                    (string) ($_POST['auth_maxlife_remember'] ?? ''),
+                    (string) ($_POST['auth_maxlife_steam'] ?? ''),
+                    ...$smtpConfig,
+                ]);
+            Log::add('m', 'Settings updated', 'Main settings were updated.');
+            header('Location: index.php?p=admin&c=settings&section=settings&saved=1');
+            exit();
         }
     }
 
-    #########[Settings Page]###############
-    echo '<div class="tabcontent" id="Main Settings">';
-    $theme->assign('config_title', Config::get('template.title'));
-    $theme->assign('config_logo', Config::get('template.logo'));
-    $theme->assign('config_min_password', MIN_PASS_LENGTH);
-    $theme->assign('config_dateformat', Config::get('config.dateformat'));
-    $theme->assign('config_dash_title', Config::get('dash.intro.title'));
-    $theme->assign('config_dash_text', Config::get('dash.intro.text'));
-    $theme->assign('auth_maxlife', Config::get('auth.maxlife'));
-    $theme->assign('auth_maxlife_remember', Config::get('auth.maxlife.remember'));
-    $theme->assign('auth_maxlife_steam', Config::get('auth.maxlife.steam'));
-    $theme->assign('config_bans_per_page', SB_BANS_PER_PAGE);
-    $theme->assign('config_smtp', Config::getMulti([
-        'smtp.host', 'smtp.user', 'smtp.port'
-    ]));
-    $theme->assign('config_mail_from_email', (string) Config::get('config.mail.from_email'));
-    $theme->assign('config_mail_from_name', (string) Config::get('config.mail.from_name'));
+    if ($_POST['settingsGroup'] === 'features') {
+        $kickit         = (isset($_POST['enable_kickit'])         && $_POST['enable_kickit']         === 'on') ? 1 : 0;
+        $exportpub      = (isset($_POST['export_public'])         && $_POST['export_public']         === 'on') ? 1 : 0;
+        $groupban       = (isset($_POST['enable_groupbanning'])   && $_POST['enable_groupbanning']   === 'on') ? 1 : 0;
+        $friendsban     = (isset($_POST['enable_friendsbanning']) && $_POST['enable_friendsbanning'] === 'on') ? 1 : 0;
+        $adminrehash    = (isset($_POST['enable_adminrehashing']) && $_POST['enable_adminrehashing'] === 'on') ? 1 : 0;
+        $steamloginopt  = (isset($_POST['enable_steamlogin'])     && $_POST['enable_steamlogin']     === 'on') ? 1 : 0;
+        $normalloginopt = (isset($_POST['enable_normallogin'])    && $_POST['enable_normallogin']    === 'on') ? 1 : 0;
+        $publiccomments = (isset($_POST['enable_publiccomments']) && $_POST['enable_publiccomments'] === 'on') ? 1 : 0;
 
-    $theme->assign('bans_customreason', (Config::getBool('bans.customreasons')) ? unserialize(Config::get('bans.customreasons')) : []);
-
-    $theme->display('page_admin_settings_settings.tpl');
-    echo '</div>';
-    #########/[Settings Page]###############
-
-    #########[Features Page]###############
-    echo '<div class="tabcontent" id="Features">';
-    $theme->assign('steamapi', (defined('STEAMAPIKEY') && STEAMAPIKEY != '') ? true : false);
-    $theme->display('page_admin_settings_features.tpl');
-    echo '</div>';
-    #########/[Features Page]###############
-
-    #########[Themes Page]###############
-    echo '<div class="tabcontent" id="Themes">';
-    $theme->assign('theme_list', $valid_themes);
-
-    $theme->assign('theme_name', strip_tags(theme_name));
-    $theme->assign('theme_author', strip_tags(theme_author));
-    $theme->assign('theme_version', strip_tags(theme_version));
-    $theme->assign('theme_link', strip_tags(theme_link));
-    $theme->assign('theme_screenshot', '<img width="250px" height="170px" src="themes/' . SB_THEME . '/' . strip_tags(theme_screenshot) . '">');
-
-    $theme->display('page_admin_settings_themes.tpl');
-    echo '</div>';
-    #########/[Settings Page]###############
-
-    #########[Logs Page]###############
-    echo '<div class="tabcontent" id="System Log">';
-    if ($userbank->HasAccess(ADMIN_OWNER)) {
-        $theme->assign('clear_logs', "( <a href='javascript:ClearLogs();'>Clear Log</a> )");
+        $GLOBALS['PDO']->query("REPLACE INTO `:prefix_settings` (`value`, `setting`) VALUES
+            (" . $exportpub      . ", 'config.exportpublic'),
+            (" . $kickit         . ", 'config.enablekickit'),
+            (" . $groupban       . ", 'config.enablegroupbanning'),
+            (" . $friendsban     . ", 'config.enablefriendsbanning'),
+            (" . $adminrehash    . ", 'config.enableadminrehashing'),
+            (" . $publiccomments . ", 'config.enablepubliccomments'),
+            (" . $steamloginopt  . ", 'config.enablesteamlogin'),
+            (" . $normalloginopt . ", 'config.enablenormallogin')")->execute();
+        Log::add('m', 'Settings updated', 'Feature toggles were updated.');
+        header('Location: index.php?p=admin&c=settings&section=features&saved=1');
+        exit();
     }
-    $theme->assign('page_numbers', $page_numbers);
-    $theme->assign('log_items', $log_list);
 
-    $theme->display('page_admin_settings_logs.tpl');
-    echo '</div>';
-    #########/[Logs Page]###############
+    if (!empty($errors)) {
+        echo '<div class="card" style="margin:1rem"><div class="card__body" style="color:var(--danger)">' . $errors . '</div></div>';
+    }
 }
+
+/*
+ * Theme discovery.
+ *
+ * The legacy version of this loop only captured `theme_name` per theme
+ * via regex against theme.conf.php (PHP can't `define()` the same
+ * constant twice in one process, so the regex is the only way to
+ * enumerate without resetting state). B18 keeps the regex-based
+ * discovery and just enriches it with author / version / link /
+ * screenshot — every theme.conf.php declares those four constants, so
+ * the same shape works for both default and sbpp2026.
+ */
+$validThemes = [];
+$themesDir   = opendir(SB_THEMES);
+if ($themesDir !== false) {
+    while (($filename = readdir($themesDir)) !== false) {
+        if ($filename[0] === '.') {
+            continue;
+        }
+        $confPath = SB_THEMES . $filename . '/theme.conf.php';
+        if (!@is_file($confPath)) {
+            continue;
+        }
+        $confSrc = (string) @file_get_contents($confPath);
+        $validThemes[] = [
+            'dir'        => $filename,
+            'name'       => themeConfMatch($confSrc, 'theme_name', $filename),
+            'author'     => themeConfMatch($confSrc, 'theme_author', 'Unknown'),
+            'version'    => themeConfMatch($confSrc, 'theme_version', '?'),
+            'link'       => themeConfMatch($confSrc, 'theme_link', ''),
+            'screenshot' => 'themes/' . $filename . '/' . themeConfMatch($confSrc, 'theme_screenshot', 'screenshot.jpg'),
+            'active'     => $filename === SB_THEME,
+        ];
+    }
+    closedir($themesDir);
+}
+usort($validThemes, fn(array $a, array $b): int => strcasecmp($a['name'], $b['name']));
+
+/**
+ * Pluck a `define('<key>', "<value>")` literal out of a theme.conf.php
+ * source string. Mirrors the legacy regex shape (double-quoted only)
+ * so existing theme manifests keep parsing identically.
+ */
+function themeConfMatch(string $src, string $key, string $default): string
+{
+    $pattern = '/define\(\s*\'' . preg_quote($key, '/') . '\'\s*,\s*"([^"]*)"\s*\)\s*;/';
+    if (preg_match($pattern, $src, $m) === 1) {
+        return strip_tags($m[1]);
+    }
+    return $default;
+}
+
+/**
+ * Whether STEAMAPIKEY is set to a non-empty value at runtime. Wrapped
+ * in a function so PHPStan can't narrow the constant value against its
+ * phpstan-bootstrap.php sentinel ('') — see the same workaround in
+ * web/api/handlers/bans.php::_api_bans_steam_api_key().
+ */
+function adminSettingsHasSteamApiKey(): bool
+{
+    /** @var string $key */
+    $key = defined('STEAMAPIKEY') ? (string)constant('STEAMAPIKEY') : '';
+    return $key !== '';
+}
+
+/*
+ * Currently-selected theme metadata.
+ *
+ * The legacy default theme template renders these as a standalone
+ * "current theme" panel; sbpp2026 derives the same info from the
+ * $theme_list[].active row. Both shapes share the View so the
+ * dual-theme PHPStan matrix stays green.
+ *
+ * `require()` is intentional here (matches the legacy loop) — by the
+ * time this page renders, init.php has already require'd the same
+ * theme.conf.php exactly once, so re-requiring it is a no-op.
+ */
+require(SB_THEMES . SB_THEME . '/theme.conf.php');
+$currentScreenshotUrl = 'themes/' . SB_THEME . '/' . strip_tags((string) constant('theme_screenshot'));
+$currentScreenshotImg = '<img width="250px" height="170px" src="' . htmlspecialchars($currentScreenshotUrl, ENT_QUOTES, 'UTF-8') . '">';
+
+/*
+ * Permission snapshot used by every settings sub-tab. We pick the
+ * specific `can_*` keys each View declares rather than splatting
+ * `...Perms::for()` whole — the helper returns every ADMIN_* flag
+ * the panel knows about, but PHP 8.1 throws "Unknown named parameter"
+ * on a constructor that doesn't declare them all. Picking explicitly
+ * is also self-documenting: the page handler enumerates exactly which
+ * gates this template surfaces.
+ */
+$perms = Perms::for($userbank);
+
+if ($section === 'themes') {
+    Renderer::render($theme, new AdminThemesView(
+        can_web_settings:  $perms['can_web_settings'],
+        can_owner:         $perms['can_owner'],
+        active_section:    $section,
+        current_theme_dir: SB_THEME,
+        theme_list:        $validThemes,
+        theme_name:        strip_tags((string) constant('theme_name')),
+        theme_author:      strip_tags((string) constant('theme_author')),
+        theme_version:     strip_tags((string) constant('theme_version')),
+        theme_link:        strip_tags((string) constant('theme_link')),
+        theme_screenshot:  $currentScreenshotImg,
+    ));
+} elseif ($section === 'logs') {
+    $page = 1;
+    if (isset($_GET['page']) && (int) $_GET['page'] > 0) {
+        $page = (int) $_GET['page'];
+    }
+    $listStart = ($page - 1) * SB_BANS_PER_PAGE;
+    $listEnd   = $listStart + SB_BANS_PER_PAGE;
+
+    if (isset($_GET['advSearch'])) {
+        $searchlink = '&advSearch=' . urlencode((string) $_GET['advSearch']) . '&advType=' . urlencode((string) ($_GET['advType'] ?? ''));
+    } else {
+        $searchlink = '';
+    }
+
+    $logCount = (int) Log::getCount('');
+    $log      = Log::getAll($listStart, SB_BANS_PER_PAGE);
+
+    $prev = '';
+    $next = '';
+    if ($page > 1) {
+        $prev = CreateLinkR('&laquo; prev', 'index.php?p=admin&c=settings&section=logs' . $searchlink . '&page=' . ($page - 1));
+    }
+    if ($listEnd < $logCount) {
+        $next = CreateLinkR('next &raquo;', 'index.php?p=admin&c=settings&section=logs' . $searchlink . '&page=' . ($page + 1));
+    }
+    $pages = (int) max(1, (int) ceil($logCount / SB_BANS_PER_PAGE));
+    $pageNumbers = 'Page ' . $page . ' of ' . $pages;
+    if ($pages > 1) {
+        if ($prev !== '') {
+            $pageNumbers .= ' &nbsp; ' . $prev;
+        }
+        if ($next !== '') {
+            $pageNumbers .= ' &nbsp; ' . $next;
+        }
+    }
+
+    $logList = [];
+    foreach ($log as $l) {
+        $item             = $l;
+        $item['user']     = !empty($l['user']) ? $l['user'] : 'Guest';
+        $item['date_str'] = Config::time((int) $l['created']);
+        $item['message']  = str_replace("\n", '<br />', htmlentities(str_replace(['<br />', '<br>', '<br/>'], "\n", (string) $l['message'])));
+        $item['type_img'] = match ((string) $l['type']) {
+            'm'     => "<img src='themes/" . SB_THEME . "/images/admin/help.png' alt='Info'>",
+            'w'     => "<img src='themes/" . SB_THEME . "/images/admin/warning.png' alt='Warning'>",
+            'e'     => "<img src='themes/" . SB_THEME . "/images/admin/error.png' alt='Error'>",
+            default => '',
+        };
+        $logList[]        = $item;
+    }
+
+    Renderer::render($theme, new AdminLogsView(
+        can_web_settings: $perms['can_web_settings'],
+        can_owner:        $perms['can_owner'],
+        active_section:   $section,
+        clear_logs:       $userbank->HasAccess(ADMIN_OWNER) ? "( <a href='javascript:ClearLogs();'>Clear Log</a> )" : '',
+        page_numbers:     $pageNumbers,
+        log_items:        $logList,
+    ));
+} elseif ($section === 'features') {
+    Renderer::render($theme, new AdminFeaturesView(
+        can_web_settings:      $perms['can_web_settings'],
+        can_owner:             $perms['can_owner'],
+        active_section:        $section,
+        steamapi:              adminSettingsHasSteamApiKey(),
+        export_public:         Config::getBool('config.exportpublic'),
+        enable_kickit:         Config::getBool('config.enablekickit'),
+        enable_groupbanning:   Config::getBool('config.enablegroupbanning'),
+        enable_friendsbanning: Config::getBool('config.enablefriendsbanning'),
+        enable_adminrehashing: Config::getBool('config.enableadminrehashing'),
+        enable_steamlogin:     Config::getBool('config.enablesteamlogin'),
+        enable_normallogin:    Config::getBool('config.enablenormallogin'),
+        enable_publiccomments: Config::getBool('config.enablepubliccomments'),
+    ));
+} else {
+    $rawCustomReasons = Config::getBool('bans.customreasons')
+        ? @unserialize((string) Config::get('bans.customreasons'))
+        : [];
+    if (!is_array($rawCustomReasons)) {
+        $rawCustomReasons = [];
+    }
+    $customReasons = array_values(array_filter(
+        array_map(fn($v) => is_string($v) ? $v : '', $rawCustomReasons),
+        fn(string $v): bool => $v !== ''
+    ));
+
+    /** @var array{0: string, 1: string, 2: string} $smtpTuple */
+    $smtpTuple = [
+        (string) Config::get('smtp.host'),
+        (string) Config::get('smtp.user'),
+        (string) Config::get('smtp.port'),
+    ];
+
+    Renderer::render($theme, new AdminSettingsView(
+        can_web_settings:          $perms['can_web_settings'],
+        can_owner:                 $perms['can_owner'],
+        active_section:            $section,
+        config_title:              (string) Config::get('template.title'),
+        config_logo:               (string) Config::get('template.logo'),
+        config_min_password:       (int) MIN_PASS_LENGTH,
+        config_dateformat:         (string) Config::get('config.dateformat'),
+        config_dash_title:         (string) Config::get('dash.intro.title'),
+        config_dash_text:          (string) Config::get('dash.intro.text'),
+        auth_maxlife:              (int) Config::get('auth.maxlife'),
+        auth_maxlife_remember:     (int) Config::get('auth.maxlife.remember'),
+        auth_maxlife_steam:        (int) Config::get('auth.maxlife.steam'),
+        config_debug:              Config::getBool('config.debug'),
+        enable_submit:             Config::getBool('config.enablesubmit'),
+        enable_protest:            Config::getBool('config.enableprotest'),
+        enable_commslist:          Config::getBool('config.enablecomms'),
+        protest_emailonlyinvolved: Config::getBool('protest.emailonlyinvolved'),
+        dash_lognopopup:           Config::getBool('dash.lognopopup'),
+        config_default_page:       (int) Config::get('config.defaultpage'),
+        config_bans_per_page:      (int) SB_BANS_PER_PAGE,
+        banlist_hideadmname:       Config::getBool('banlist.hideadminname'),
+        banlist_nocountryfetch:    Config::getBool('banlist.nocountryfetch'),
+        banlist_hideplayerips:     Config::getBool('banlist.hideplayerips'),
+        bans_customreason:         $customReasons,
+        config_smtp:               $smtpTuple,
+        config_smtp_verify_peer:   Config::getBool('smtp.verify_peer'),
+        config_mail_from_email:    (string) Config::get('config.mail.from_email'),
+        config_mail_from_name:     (string) Config::get('config.mail.from_name'),
+    ));
+}
+
+/*
+ * Legacy default-theme tail.
+ *
+ * The legacy `web/themes/default/page_admin_settings_*.tpl` markup
+ * renders empty checkboxes and lets this script set their state via
+ * direct `$('id').checked = N` writes (a MooTools $-shorthand the
+ * default theme still ships in scripts/sourcebans.js). The sbpp2026
+ * templates render `{if $config_debug}checked{/if}` declaratively
+ * and sbpp2026's chrome doesn't load sourcebans.js — so we gate on
+ * the active theme name to avoid `$ is not defined` on the new theme.
+ *
+ * D1 deletes this whole tail when the legacy theme retires.
+ */
+if (SB_THEME !== 'sbpp2026'):
 ?>
 <script>
 $('config_debug').checked = <?=(int)Config::getBool('config.debug');?>;
@@ -363,7 +434,7 @@ $('enable_commslist').checked = <?=(int)Config::getBool('config.enablecomms');?>
 $('enable_kickit').checked = <?=(int)Config::getBool('config.enablekickit');?>;
 $('export_public').checked = <?=(int)Config::getBool('config.exportpublic');?>;
 $('dash_nopopup').checked = <?=(int)Config::getBool('dash.lognopopup');?>;
-$('default_page').value = <?=(int)Config::getBool('config.defaultpage');?>;
+$('default_page').value = <?=(int)Config::get('config.defaultpage');?>;
 $('protest_emailonlyinvolved').checked = <?=(int)Config::getBool('protest.emailonlyinvolved');?>;
 $('banlist_hideadmname').checked = <?=(int)Config::getBool('banlist.hideadminname');?>;
 $('banlist_nocountryfetch').checked = <?=(int)Config::getBool('banlist.nocountryfetch');?>;
@@ -376,17 +447,10 @@ $('enable_normallogin').checked = <?=(int)Config::getBool('config.enablenormallo
 $('enable_publiccomments').checked = <?=(int)Config::getBool('config.enablepubliccomments');?>;
 $('mail_verify_peer').checked = <?=(int)Config::getBool('smtp.verify_peer');?>;
 
-<?php
-if (ini_get('safe_mode') == 1) {
-    print "$('enable_groupbanning').disabled = true;\n";
-    print "$('enable_friendsbanning').disabled = true;\n";
-    print "$('enable_friendsbanning.msg').setHTML('You can\'t use these features. You need to set PHP safe mode off.');\n";
-    print "$('enable_friendsbanning.msg').setStyle('display', 'block');\n";
-}
-?>
 function MoreFields()
 {
     var t = document.getElementById("custom.reasons");
+    if (!t) return;
     var tr = t.insertRow("-1");
     var td = tr.insertCell("-1");
     var inp = document.createElement("input");
@@ -397,4 +461,4 @@ function MoreFields()
     td.appendChild(inp);
 }
 </script>
-</div>
+<?php endif; ?>

--- a/web/phpstan-baseline.neon
+++ b/web/phpstan-baseline.neon
@@ -145,10 +145,202 @@ parameters:
 			path: includes/View/AdminBansGroupsView.php
 
 		-
+			message: '#^Property Sbpp\\View\\AdminFeaturesView\:\:\$active_section is never referenced in template "page_admin_settings_features\.tpl"\.$#'
+			identifier: sbpp.view.unusedProperty
+			count: 1
+			path: includes/View/AdminFeaturesView.php
+
+		-
+			message: '#^Property Sbpp\\View\\AdminFeaturesView\:\:\$can_owner is never referenced in template "page_admin_settings_features\.tpl"\.$#'
+			identifier: sbpp.view.unusedProperty
+			count: 1
+			path: includes/View/AdminFeaturesView.php
+
+		-
+			message: '#^Property Sbpp\\View\\AdminFeaturesView\:\:\$can_web_settings is never referenced in template "page_admin_settings_features\.tpl"\.$#'
+			identifier: sbpp.view.unusedProperty
+			count: 1
+			path: includes/View/AdminFeaturesView.php
+
+		-
+			message: '#^Property Sbpp\\View\\AdminFeaturesView\:\:\$enable_adminrehashing is never referenced in template "page_admin_settings_features\.tpl"\.$#'
+			identifier: sbpp.view.unusedProperty
+			count: 1
+			path: includes/View/AdminFeaturesView.php
+
+		-
+			message: '#^Property Sbpp\\View\\AdminFeaturesView\:\:\$enable_friendsbanning is never referenced in template "page_admin_settings_features\.tpl"\.$#'
+			identifier: sbpp.view.unusedProperty
+			count: 1
+			path: includes/View/AdminFeaturesView.php
+
+		-
+			message: '#^Property Sbpp\\View\\AdminFeaturesView\:\:\$enable_groupbanning is never referenced in template "page_admin_settings_features\.tpl"\.$#'
+			identifier: sbpp.view.unusedProperty
+			count: 1
+			path: includes/View/AdminFeaturesView.php
+
+		-
+			message: '#^Property Sbpp\\View\\AdminFeaturesView\:\:\$enable_kickit is never referenced in template "page_admin_settings_features\.tpl"\.$#'
+			identifier: sbpp.view.unusedProperty
+			count: 1
+			path: includes/View/AdminFeaturesView.php
+
+		-
+			message: '#^Property Sbpp\\View\\AdminFeaturesView\:\:\$enable_normallogin is never referenced in template "page_admin_settings_features\.tpl"\.$#'
+			identifier: sbpp.view.unusedProperty
+			count: 1
+			path: includes/View/AdminFeaturesView.php
+
+		-
+			message: '#^Property Sbpp\\View\\AdminFeaturesView\:\:\$enable_publiccomments is never referenced in template "page_admin_settings_features\.tpl"\.$#'
+			identifier: sbpp.view.unusedProperty
+			count: 1
+			path: includes/View/AdminFeaturesView.php
+
+		-
+			message: '#^Property Sbpp\\View\\AdminFeaturesView\:\:\$enable_steamlogin is never referenced in template "page_admin_settings_features\.tpl"\.$#'
+			identifier: sbpp.view.unusedProperty
+			count: 1
+			path: includes/View/AdminFeaturesView.php
+
+		-
+			message: '#^Property Sbpp\\View\\AdminFeaturesView\:\:\$export_public is never referenced in template "page_admin_settings_features\.tpl"\.$#'
+			identifier: sbpp.view.unusedProperty
+			count: 1
+			path: includes/View/AdminFeaturesView.php
+
+		-
+			message: '#^Property Sbpp\\View\\AdminLogsView\:\:\$active_section is never referenced in template "page_admin_settings_logs\.tpl"\.$#'
+			identifier: sbpp.view.unusedProperty
+			count: 1
+			path: includes/View/AdminLogsView.php
+
+		-
+			message: '#^Property Sbpp\\View\\AdminLogsView\:\:\$can_owner is never referenced in template "page_admin_settings_logs\.tpl"\.$#'
+			identifier: sbpp.view.unusedProperty
+			count: 1
+			path: includes/View/AdminLogsView.php
+
+		-
+			message: '#^Property Sbpp\\View\\AdminLogsView\:\:\$can_web_settings is never referenced in template "page_admin_settings_logs\.tpl"\.$#'
+			identifier: sbpp.view.unusedProperty
+			count: 1
+			path: includes/View/AdminLogsView.php
+
+		-
 			message: '#^Property Sbpp\\View\\AdminServersAddView\:\:\$modid is never referenced in template "page_admin_servers_add\.tpl"\.$#'
 			identifier: sbpp.view.unusedProperty
 			count: 1
 			path: includes/View/AdminServersAddView.php
+
+		-
+			message: '#^Property Sbpp\\View\\AdminSettingsView\:\:\$active_section is never referenced in template "page_admin_settings_settings\.tpl"\.$#'
+			identifier: sbpp.view.unusedProperty
+			count: 1
+			path: includes/View/AdminSettingsView.php
+
+		-
+			message: '#^Property Sbpp\\View\\AdminSettingsView\:\:\$banlist_hideadmname is never referenced in template "page_admin_settings_settings\.tpl"\.$#'
+			identifier: sbpp.view.unusedProperty
+			count: 1
+			path: includes/View/AdminSettingsView.php
+
+		-
+			message: '#^Property Sbpp\\View\\AdminSettingsView\:\:\$banlist_hideplayerips is never referenced in template "page_admin_settings_settings\.tpl"\.$#'
+			identifier: sbpp.view.unusedProperty
+			count: 1
+			path: includes/View/AdminSettingsView.php
+
+		-
+			message: '#^Property Sbpp\\View\\AdminSettingsView\:\:\$banlist_nocountryfetch is never referenced in template "page_admin_settings_settings\.tpl"\.$#'
+			identifier: sbpp.view.unusedProperty
+			count: 1
+			path: includes/View/AdminSettingsView.php
+
+		-
+			message: '#^Property Sbpp\\View\\AdminSettingsView\:\:\$can_owner is never referenced in template "page_admin_settings_settings\.tpl"\.$#'
+			identifier: sbpp.view.unusedProperty
+			count: 1
+			path: includes/View/AdminSettingsView.php
+
+		-
+			message: '#^Property Sbpp\\View\\AdminSettingsView\:\:\$can_web_settings is never referenced in template "page_admin_settings_settings\.tpl"\.$#'
+			identifier: sbpp.view.unusedProperty
+			count: 1
+			path: includes/View/AdminSettingsView.php
+
+		-
+			message: '#^Property Sbpp\\View\\AdminSettingsView\:\:\$config_debug is never referenced in template "page_admin_settings_settings\.tpl"\.$#'
+			identifier: sbpp.view.unusedProperty
+			count: 1
+			path: includes/View/AdminSettingsView.php
+
+		-
+			message: '#^Property Sbpp\\View\\AdminSettingsView\:\:\$config_default_page is never referenced in template "page_admin_settings_settings\.tpl"\.$#'
+			identifier: sbpp.view.unusedProperty
+			count: 1
+			path: includes/View/AdminSettingsView.php
+
+		-
+			message: '#^Property Sbpp\\View\\AdminSettingsView\:\:\$config_smtp_verify_peer is never referenced in template "page_admin_settings_settings\.tpl"\.$#'
+			identifier: sbpp.view.unusedProperty
+			count: 1
+			path: includes/View/AdminSettingsView.php
+
+		-
+			message: '#^Property Sbpp\\View\\AdminSettingsView\:\:\$dash_lognopopup is never referenced in template "page_admin_settings_settings\.tpl"\.$#'
+			identifier: sbpp.view.unusedProperty
+			count: 1
+			path: includes/View/AdminSettingsView.php
+
+		-
+			message: '#^Property Sbpp\\View\\AdminSettingsView\:\:\$enable_commslist is never referenced in template "page_admin_settings_settings\.tpl"\.$#'
+			identifier: sbpp.view.unusedProperty
+			count: 1
+			path: includes/View/AdminSettingsView.php
+
+		-
+			message: '#^Property Sbpp\\View\\AdminSettingsView\:\:\$enable_protest is never referenced in template "page_admin_settings_settings\.tpl"\.$#'
+			identifier: sbpp.view.unusedProperty
+			count: 1
+			path: includes/View/AdminSettingsView.php
+
+		-
+			message: '#^Property Sbpp\\View\\AdminSettingsView\:\:\$enable_submit is never referenced in template "page_admin_settings_settings\.tpl"\.$#'
+			identifier: sbpp.view.unusedProperty
+			count: 1
+			path: includes/View/AdminSettingsView.php
+
+		-
+			message: '#^Property Sbpp\\View\\AdminSettingsView\:\:\$protest_emailonlyinvolved is never referenced in template "page_admin_settings_settings\.tpl"\.$#'
+			identifier: sbpp.view.unusedProperty
+			count: 1
+			path: includes/View/AdminSettingsView.php
+
+		-
+			message: '#^Property Sbpp\\View\\AdminThemesView\:\:\$active_section is never referenced in template "page_admin_settings_themes\.tpl"\.$#'
+			identifier: sbpp.view.unusedProperty
+			count: 1
+			path: includes/View/AdminThemesView.php
+
+		-
+			message: '#^Property Sbpp\\View\\AdminThemesView\:\:\$can_owner is never referenced in template "page_admin_settings_themes\.tpl"\.$#'
+			identifier: sbpp.view.unusedProperty
+			count: 1
+			path: includes/View/AdminThemesView.php
+
+		-
+			message: '#^Property Sbpp\\View\\AdminThemesView\:\:\$can_web_settings is never referenced in template "page_admin_settings_themes\.tpl"\.$#'
+			identifier: sbpp.view.unusedProperty
+			count: 1
+			path: includes/View/AdminThemesView.php
+
+		-
+			message: '#^Property Sbpp\\View\\AdminThemesView\:\:\$current_theme_dir is never referenced in template "page_admin_settings_themes\.tpl"\.$#'
+			identifier: sbpp.view.unusedProperty
+			count: 1
+			path: includes/View/AdminThemesView.php
 
 		-
 			message: '#^Property Sbpp\\View\\HomeDashboardView\:\:\$dashboard_title is never referenced in template "page_dashboard\.tpl"\.$#'
@@ -435,25 +627,7 @@ parameters:
 		-
 			message: '#^Constant SB_THEME not found\.$#'
 			identifier: constant.notFound
-			count: 5
-			path: pages/admin.settings.php
-
-		-
-			message: '#^Loose comparison using \!\= between '''' and '''' will always evaluate to false\.$#'
-			identifier: notEqual.alwaysFalse
-			count: 1
-			path: pages/admin.settings.php
-
-		-
-			message: '#^Result of && is always false\.$#'
-			identifier: booleanAnd.alwaysFalse
-			count: 1
-			path: pages/admin.settings.php
-
-		-
-			message: '#^Variable \$themes might not be defined\.$#'
-			identifier: variable.undefined
-			count: 1
+			count: 8
 			path: pages/admin.settings.php
 
 		-

--- a/web/themes/sbpp2026/page_admin_settings_features.tpl
+++ b/web/themes/sbpp2026/page_admin_settings_features.tpl
@@ -1,6 +1,168 @@
-<div class="card">
-    <div class="card__body">
-        <h1>{$title}</h1>
-        <p class="text-muted">This page hasn't been redesigned yet.</p>
+{*
+    SourceBans++ 2026 — page / page_admin_settings_features.tpl
+
+    "Features" sub-tab on the admin Settings page. Pair:
+    Sbpp\View\AdminFeaturesView + web/pages/admin.settings.php (which
+    routes by ?section= and renders one View per request — see
+    sibling page_admin_settings_settings.tpl for the rationale).
+
+    Variable contract (kept in sync by SmartyTemplateRule):
+        Permission gates:
+            $can_web_settings — gates the entire body.
+            $can_owner — currently unused in this section but kept
+                across all settings views for parity.
+        Section nav: $active_section.
+        Toggles: $export_public, $enable_kickit,
+            $enable_groupbanning, $enable_friendsbanning,
+            $enable_adminrehashing, $enable_steamlogin,
+            $enable_normallogin, $enable_publiccomments.
+        Steam Web API key probe: $steamapi (true when STEAMAPIKEY
+            is defined and non-empty; gates Group/Friends banning
+            inputs the same way the legacy theme did).
+
+    Testability hooks:
+        - Sub-nav links: data-testid="settings-tab-<key>".
+        - Each toggle row: data-testid="setting-row" + data-key="<key>".
+        - Save button: data-testid="settings-save".
+*}
+<div class="p-6">
+    <div class="mb-6">
+        <h1 style="font-size:var(--fs-2xl);font-weight:600;margin:0">Settings</h1>
+        <p class="text-sm text-muted m-0 mt-2">Optional features and integrations.</p>
+    </div>
+
+    <div class="grid gap-4" style="grid-template-columns:14rem 1fr;align-items:start">
+        <nav aria-label="Settings sections" role="tablist">
+            <a class="sidebar__link" href="?p=admin&amp;c=settings&amp;section=settings"
+               role="tab"
+               data-testid="settings-tab-settings"
+               {if $active_section == 'settings'}aria-current="page"{/if}>
+                <i data-lucide="settings"></i> Main
+            </a>
+            <a class="sidebar__link" href="?p=admin&amp;c=settings&amp;section=features"
+               role="tab"
+               data-testid="settings-tab-features"
+               {if $active_section == 'features'}aria-current="page"{/if}>
+                <i data-lucide="toggle-right"></i> Features
+            </a>
+            <a class="sidebar__link" href="?p=admin&amp;c=settings&amp;section=logs"
+               role="tab"
+               data-testid="settings-tab-logs"
+               {if $active_section == 'logs'}aria-current="page"{/if}>
+                <i data-lucide="scroll-text"></i> System Log
+            </a>
+            <a class="sidebar__link" href="?p=admin&amp;c=settings&amp;section=themes"
+               role="tab"
+               data-testid="settings-tab-themes"
+               {if $active_section == 'themes'}aria-current="page"{/if}>
+                <i data-lucide="palette"></i> Themes
+            </a>
+        </nav>
+
+        <div>
+            {if NOT $can_web_settings}
+                <div class="card">
+                    <div class="card__body">
+                        <p class="text-muted">Access denied. <code>ADMIN_WEB_SETTINGS</code> required.</p>
+                    </div>
+                </div>
+            {else}
+                <form action="?p=admin&amp;c=settings&amp;section=features" method="post" class="space-y-4">
+                    {csrf_field}
+                    <input type="hidden" name="settingsGroup" value="features">
+
+                    <div class="card">
+                        <div class="card__header"><div><h3>Bans</h3><p>Public exports, KickIt, group / friend banning.</p></div></div>
+                        <div class="card__body space-y-3">
+                            <label class="flex items-center justify-between gap-3 p-3" style="border:1px solid var(--border);border-radius:var(--radius-md)" data-testid="setting-row" data-key="config.exportpublic">
+                                <span class="text-sm">
+                                    <span class="font-medium">Public ban export</span>
+                                    <span class="block text-xs text-muted mt-2">Lets unauthenticated visitors download the full ban list.</span>
+                                </span>
+                                <input type="checkbox" name="export_public" id="export_public"{if $export_public} checked{/if}>
+                            </label>
+
+                            <label class="flex items-center justify-between gap-3 p-3" style="border:1px solid var(--border);border-radius:var(--radius-md)" data-testid="setting-row" data-key="config.enablekickit">
+                                <span class="text-sm">
+                                    <span class="font-medium">KickIt</span>
+                                    <span class="block text-xs text-muted mt-2">Auto-kick a player when their ban lands.</span>
+                                </span>
+                                <input type="checkbox" name="enable_kickit" id="enable_kickit"{if $enable_kickit} checked{/if}>
+                            </label>
+
+                            <label class="flex items-center justify-between gap-3 p-3" style="border:1px solid var(--border);border-radius:var(--radius-md)" data-testid="setting-row" data-key="config.enablegroupbanning">
+                                <span class="text-sm">
+                                    <span class="font-medium">Steam group banning</span>
+                                    <span class="block text-xs text-muted mt-2">
+                                        Ban every member of a Steam community group.
+                                        {if NOT $steamapi}<br><span style="color:var(--warning)">Requires a Steam Web API key in <code>config.php</code>.</span>{/if}
+                                    </span>
+                                </span>
+                                <input type="checkbox" name="enable_groupbanning" id="enable_groupbanning"{if $enable_groupbanning} checked{/if}{if NOT $steamapi} disabled{/if}>
+                            </label>
+
+                            <label class="flex items-center justify-between gap-3 p-3" style="border:1px solid var(--border);border-radius:var(--radius-md)" data-testid="setting-row" data-key="config.enablefriendsbanning">
+                                <span class="text-sm">
+                                    <span class="font-medium">Steam friends banning</span>
+                                    <span class="block text-xs text-muted mt-2">
+                                        Ban every Steam friend of a player.
+                                        {if NOT $steamapi}<br><span style="color:var(--warning)">Requires a Steam Web API key in <code>config.php</code>.</span>{/if}
+                                    </span>
+                                </span>
+                                <input type="checkbox" name="enable_friendsbanning" id="enable_friendsbanning"{if $enable_friendsbanning} checked{/if}{if NOT $steamapi} disabled{/if}>
+                            </label>
+
+                            <label class="flex items-center justify-between gap-3 p-3" style="border:1px solid var(--border);border-radius:var(--radius-md)" data-testid="setting-row" data-key="config.enableadminrehashing">
+                                <span class="text-sm">
+                                    <span class="font-medium">Auto admin rehash</span>
+                                    <span class="block text-xs text-muted mt-2">Push admin/group changes to servers immediately.</span>
+                                </span>
+                                <input type="checkbox" name="enable_adminrehashing" id="enable_adminrehashing"{if $enable_adminrehashing} checked{/if}>
+                            </label>
+                        </div>
+                    </div>
+
+                    <div class="card">
+                        <div class="card__header"><div><h3>Login</h3><p>Sign-in surfaces exposed to admins.</p></div></div>
+                        <div class="card__body space-y-3">
+                            <label class="flex items-center justify-between gap-3 p-3" style="border:1px solid var(--border);border-radius:var(--radius-md)" data-testid="setting-row" data-key="config.enablesteamlogin">
+                                <span class="text-sm">
+                                    <span class="font-medium">Steam OpenID login</span>
+                                    <span class="block text-xs text-muted mt-2">Show "Sign in through Steam" on the login page.</span>
+                                </span>
+                                <input type="checkbox" name="enable_steamlogin" id="enable_steamlogin"{if $enable_steamlogin} checked{/if}>
+                            </label>
+
+                            <label class="flex items-center justify-between gap-3 p-3" style="border:1px solid var(--border);border-radius:var(--radius-md)" data-testid="setting-row" data-key="config.enablenormallogin">
+                                <span class="text-sm">
+                                    <span class="font-medium">Username/password login</span>
+                                    <span class="block text-xs text-muted mt-2">Disable to require Steam login for all admins.</span>
+                                </span>
+                                <input type="checkbox" name="enable_normallogin" id="enable_normallogin"{if $enable_normallogin} checked{/if}>
+                            </label>
+                        </div>
+                    </div>
+
+                    <div class="card">
+                        <div class="card__header"><div><h3>Comments</h3><p>Visibility of admin commentary on bans / submissions.</p></div></div>
+                        <div class="card__body space-y-3">
+                            <label class="flex items-center justify-between gap-3 p-3" style="border:1px solid var(--border);border-radius:var(--radius-md)" data-testid="setting-row" data-key="config.enablepubliccomments">
+                                <span class="text-sm">
+                                    <span class="font-medium">Public admin comments</span>
+                                    <span class="block text-xs text-muted mt-2">Show admin comments on a ban to anonymous visitors.</span>
+                                </span>
+                                <input type="checkbox" name="enable_publiccomments" id="enable_publiccomments"{if $enable_publiccomments} checked{/if}>
+                            </label>
+                        </div>
+                    </div>
+
+                    <div class="flex items-center justify-end gap-2">
+                        <button type="submit" class="btn btn--primary" data-testid="settings-save">
+                            <i data-lucide="save"></i> Save changes
+                        </button>
+                    </div>
+                </form>
+            {/if}
+        </div>
     </div>
 </div>

--- a/web/themes/sbpp2026/page_admin_settings_logs.tpl
+++ b/web/themes/sbpp2026/page_admin_settings_logs.tpl
@@ -1,6 +1,182 @@
-<div class="card">
-    <div class="card__body">
-        <h1>{$title}</h1>
-        <p class="text-muted">This page hasn't been redesigned yet.</p>
+{*
+    SourceBans++ 2026 — page / page_admin_settings_logs.tpl
+
+    "System log" sub-tab on the admin Settings page. Pair:
+    Sbpp\View\AdminLogsView + web/pages/admin.settings.php (which
+    routes by ?section= and renders one View per request — see
+    sibling page_admin_settings_settings.tpl for the rationale).
+
+    Variable contract (kept in sync by SmartyTemplateRule):
+        Permission gates:
+            $can_web_settings — required to see the table; mirrors
+                the legacy ALL_WEB gate on the System Log tab.
+            $can_owner — required to truncate the log table; gates
+                the "Clear log" button. Mirrors legacy
+                CheckAccess(ADMIN_OWNER) before TRUNCATE.
+        Section nav: $active_section.
+        Pagination: $page_numbers (server-built nav HTML emitted via
+            nofilter; see annotation below).
+        Rows: $log_items — list of legacy-shaped log dicts.
+
+    Testability hooks:
+        - Sub-nav links: data-testid="settings-tab-<key>".
+        - Each summary row: data-testid="log-row" + data-id (lid).
+        - "Clear log" button: data-testid="logs-clear".
+*}
+<div class="p-6">
+    <div class="mb-6">
+        <h1 style="font-size:var(--fs-2xl);font-weight:600;margin:0">Settings</h1>
+        <p class="text-sm text-muted m-0 mt-2">System log of admin actions and warnings.</p>
+    </div>
+
+    <div class="grid gap-4" style="grid-template-columns:14rem 1fr;align-items:start">
+        <nav aria-label="Settings sections" role="tablist">
+            <a class="sidebar__link" href="?p=admin&amp;c=settings&amp;section=settings"
+               role="tab"
+               data-testid="settings-tab-settings"
+               {if $active_section == 'settings'}aria-current="page"{/if}>
+                <i data-lucide="settings"></i> Main
+            </a>
+            <a class="sidebar__link" href="?p=admin&amp;c=settings&amp;section=features"
+               role="tab"
+               data-testid="settings-tab-features"
+               {if $active_section == 'features'}aria-current="page"{/if}>
+                <i data-lucide="toggle-right"></i> Features
+            </a>
+            <a class="sidebar__link" href="?p=admin&amp;c=settings&amp;section=logs"
+               role="tab"
+               data-testid="settings-tab-logs"
+               {if $active_section == 'logs'}aria-current="page"{/if}>
+                <i data-lucide="scroll-text"></i> System Log
+            </a>
+            <a class="sidebar__link" href="?p=admin&amp;c=settings&amp;section=themes"
+               role="tab"
+               data-testid="settings-tab-themes"
+               {if $active_section == 'themes'}aria-current="page"{/if}>
+                <i data-lucide="palette"></i> Themes
+            </a>
+        </nav>
+
+        <div>
+            {if NOT $can_web_settings}
+                <div class="card">
+                    <div class="card__body">
+                        <p class="text-muted">Access denied. <code>ADMIN_WEB_SETTINGS</code> required.</p>
+                    </div>
+                </div>
+            {else}
+                {* nofilter: $clear_logs is the legacy default-theme "( <a href='javascript:ClearLogs();'>Clear Log</a> )" link string built in admin.settings.php (static literal gated by ADMIN_OWNER, no user input). The sbpp2026 layout renders its own <button> below via $can_owner, so the legacy link string is captured-and-discarded — keeps the SmartyTemplateRule view↔template parity green without rendering the link twice. Drop this capture and the View property when D1 retires the default theme. *}
+                {capture name="legacy_clear_logs"}{$clear_logs nofilter}{/capture}
+                <div class="card">
+                    <div class="card__header">
+                        <div>
+                            <h3>System log</h3>
+                            <p>Click a row to expand. Newest first.</p>
+                        </div>
+                        {if $can_owner}
+                            <button type="button"
+                                    class="btn btn--danger btn--sm"
+                                    data-testid="logs-clear"
+                                    onclick="clearLogs();">
+                                <i data-lucide="trash-2"></i> Clear log
+                            </button>
+                        {/if}
+                    </div>
+                    <div class="card__body">
+                        <div class="text-xs text-muted mb-4">
+                            {* nofilter: $page_numbers is server-built nav HTML; advSearch/advType (the only $_GET inputs) are htmlspecialchars(json_encode(...)) before interpolation in admin.settings.php. *}
+                            {$page_numbers nofilter}
+                        </div>
+
+                        {if count($log_items) > 0}
+                            <table class="table" data-testid="logs-table">
+                                <thead>
+                                    <tr>
+                                        <th style="width:6rem">Type</th>
+                                        <th>Event</th>
+                                        <th style="width:14rem">User</th>
+                                        <th style="width:14rem">Date</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    {foreach from=$log_items item="log"}
+                                        <tr data-testid="log-row" data-id="{$log.lid}" onclick="toggleLogRow(this);">
+                                            <td>
+                                                {if $log.type == 'm'}
+                                                    <span class="pill pill--online"><i data-lucide="info" style="width:0.75rem;height:0.75rem"></i> Info</span>
+                                                {elseif $log.type == 'w'}
+                                                    <span class="pill pill--active"><i data-lucide="alert-triangle" style="width:0.75rem;height:0.75rem"></i> Warn</span>
+                                                {elseif $log.type == 'e'}
+                                                    <span class="pill pill--permanent"><i data-lucide="circle-x" style="width:0.75rem;height:0.75rem"></i> Error</span>
+                                                {else}
+                                                    <span class="pill pill--offline">{$log.type}</span>
+                                                {/if}
+                                            </td>
+                                            <td>{$log.title}</td>
+                                            <td class="font-mono text-xs">{$log.user}</td>
+                                            <td class="font-mono text-xs tabular-nums">{$log.date_str}</td>
+                                        </tr>
+                                        <tr data-detail-for="{$log.lid}" hidden>
+                                            <td colspan="4" style="background:var(--bg-muted)">
+                                                <dl class="grid gap-2 text-xs" style="grid-template-columns:8rem 1fr;margin:0">
+                                                    <dt class="text-muted">Details</dt>
+                                                    {* nofilter: $log.message is escaped via htmlentities() in admin.settings.php (line replaces literal <br/> tags then re-html-encodes) before being assigned. *}
+                                                    <dd style="margin:0">{$log.message nofilter}</dd>
+                                                    <dt class="text-muted">Function</dt>
+                                                    <dd class="font-mono" style="margin:0">{$log.function}</dd>
+                                                    <dt class="text-muted">Query</dt>
+                                                    <dd class="font-mono" style="margin:0;word-break:break-all">{$log.query}</dd>
+                                                    <dt class="text-muted">IP</dt>
+                                                    <dd class="font-mono tabular-nums" style="margin:0">{$log.host}</dd>
+                                                </dl>
+                                            </td>
+                                        </tr>
+                                    {/foreach}
+                                </tbody>
+                            </table>
+                        {else}
+                            <p class="text-muted text-sm m-0">No log entries.</p>
+                        {/if}
+                    </div>
+                </div>
+            {/if}
+        </div>
     </div>
 </div>
+
+<script>
+{literal}
+// @ts-check
+(function () {
+    'use strict';
+
+    /**
+     * Toggle the hidden detail row that follows each log row. Detail rows
+     * are emitted with data-detail-for="<lid>", so a click on the summary
+     * row finds its sibling by id and flips the `hidden` attribute. No
+     * accordion library, no jQuery, no global state.
+     */
+    window.toggleLogRow = function (row) {
+        if (!row || !row.dataset || !row.dataset.id) return;
+        var detail = document.querySelector('tr[data-detail-for="' + row.dataset.id + '"]');
+        if (!detail) return;
+        if (detail.hasAttribute('hidden')) {
+            detail.removeAttribute('hidden');
+        } else {
+            detail.setAttribute('hidden', '');
+        }
+    };
+
+    /**
+     * Truncate the log table by hitting the legacy `?log_clear=true`
+     * endpoint on this page (admin.settings.php's TRUNCATE branch). We
+     * full-page nav so the freshly-empty list paints without a JSON dance.
+     * Confirm() so a misclick on the danger button doesn't nuke history.
+     */
+    window.clearLogs = function () {
+        if (!window.confirm('Clear the entire system log? This cannot be undone.')) return;
+        window.location.href = 'index.php?p=admin&c=settings&section=logs&log_clear=true';
+    };
+})();
+{/literal}
+</script>

--- a/web/themes/sbpp2026/page_admin_settings_settings.tpl
+++ b/web/themes/sbpp2026/page_admin_settings_settings.tpl
@@ -1,6 +1,348 @@
-<div class="card">
-    <div class="card__body">
-        <h1>{$title}</h1>
-        <p class="text-muted">This page hasn't been redesigned yet.</p>
+{*
+    SourceBans++ 2026 — page / page_admin_settings_settings.tpl
+
+    "Main settings" sub-tab on the admin Settings page. Pair:
+    Sbpp\View\AdminSettingsView + web/pages/admin.settings.php (which
+    routes by ?section=settings|features|logs|themes and renders one
+    View per request — no AdminTabs JS tab-switching, no .tabcontent
+    wrapper divs). The active section is reflected in the sub-nav at
+    the top of every settings template via aria-current="page".
+
+    Variable contract (kept in sync by SmartyTemplateRule):
+        Permission gates:
+            $can_web_settings — gates the entire body. Computed via
+                Perms::for in admin.settings.php from
+                ADMIN_OWNER|ADMIN_WEB_SETTINGS.
+            $can_owner — kept for parity with sibling settings views;
+                this template doesn't gate any UI on it directly but
+                the View constructor requires it for cross-tab parity.
+        Section nav: $active_section.
+        Settings values: $config_title, $config_logo,
+            $config_min_password, $config_dateformat,
+            $config_dash_title, $config_dash_text, $auth_maxlife,
+            $auth_maxlife_remember, $auth_maxlife_steam,
+            $config_debug, $enable_submit, $enable_protest,
+            $enable_commslist, $protest_emailonlyinvolved,
+            $dash_lognopopup, $config_default_page,
+            $config_bans_per_page, $banlist_hideadmname,
+            $banlist_nocountryfetch, $banlist_hideplayerips,
+            $bans_customreason (list), $config_smtp (tuple
+            [host, user, port]), $config_smtp_verify_peer,
+            $config_mail_from_email, $config_mail_from_name.
+
+    Testability hooks:
+        - Sub-nav <a> elements: data-testid="settings-tab-<key>"
+          + aria-current="page" on the active tab.
+        - Each <label>/<input> row: data-testid="setting-row" +
+          data-key="<setting.key>" so end-to-end tests can target
+          a setting by its persisted name (e.g. "template.title")
+          without depending on form-input ordering.
+        - Save button: data-testid="settings-save".
+
+    Security note: dash.intro.text is rendered as a PLAIN <textarea>
+    by design. The previous TinyMCE WYSIWYG was the source of #1113's
+    stored-XSS — admins typed raw HTML, the dashboard emitted it via
+    nofilter, every visitor executed it. The value now flows through
+    Sbpp\Markup\IntroRenderer (CommonMark, html_input=escape,
+    allow_unsafe_links=false) on render. Re-introducing TinyMCE,
+    CKEditor, or any other HTML editor here re-opens the vector.
+    Documented in AGENTS.md "Anti-patterns" + "Admin-authored display
+    text". The help icon links to the CommonMark cheat-sheet so admins
+    can discover the syntax without losing the safe-on-render contract.
+*}
+<div class="p-6">
+    <div class="mb-6">
+        <h1 style="font-size:var(--fs-2xl);font-weight:600;margin:0">Settings</h1>
+        <p class="text-sm text-muted m-0 mt-2">Site-wide configuration. Changes apply immediately.</p>
+    </div>
+
+    <div class="grid gap-4" style="grid-template-columns:14rem 1fr;align-items:start">
+        <nav aria-label="Settings sections" role="tablist">
+            <a class="sidebar__link" href="?p=admin&amp;c=settings&amp;section=settings"
+               role="tab"
+               data-testid="settings-tab-settings"
+               {if $active_section == 'settings'}aria-current="page"{/if}>
+                <i data-lucide="settings"></i> Main
+            </a>
+            <a class="sidebar__link" href="?p=admin&amp;c=settings&amp;section=features"
+               role="tab"
+               data-testid="settings-tab-features"
+               {if $active_section == 'features'}aria-current="page"{/if}>
+                <i data-lucide="toggle-right"></i> Features
+            </a>
+            <a class="sidebar__link" href="?p=admin&amp;c=settings&amp;section=logs"
+               role="tab"
+               data-testid="settings-tab-logs"
+               {if $active_section == 'logs'}aria-current="page"{/if}>
+                <i data-lucide="scroll-text"></i> System Log
+            </a>
+            <a class="sidebar__link" href="?p=admin&amp;c=settings&amp;section=themes"
+               role="tab"
+               data-testid="settings-tab-themes"
+               {if $active_section == 'themes'}aria-current="page"{/if}>
+                <i data-lucide="palette"></i> Themes
+            </a>
+        </nav>
+
+        <div>
+            {if NOT $can_web_settings}
+                <div class="card">
+                    <div class="card__body">
+                        <p class="text-muted">Access denied. <code>ADMIN_WEB_SETTINGS</code> required.</p>
+                    </div>
+                </div>
+            {else}
+                <form action="?p=admin&amp;c=settings&amp;section=settings" method="post" class="space-y-4" id="form-settings-main">
+                    {csrf_field}
+                    <input type="hidden" name="settingsGroup" value="mainsettings">
+
+                    <div class="card">
+                        <div class="card__header"><div><h3>General</h3><p>Site identity, password rules, and dates.</p></div></div>
+                        <div class="card__body space-y-4">
+                            <div data-testid="setting-row" data-key="template.title">
+                                <label class="label" for="template_title">Site title</label>
+                                <input class="input" type="text" id="template_title" name="template_title" value="{$config_title}">
+                            </div>
+                            <div data-testid="setting-row" data-key="template.logo">
+                                <label class="label" for="template_logo">Logo path</label>
+                                <input class="input" type="text" id="template_logo" name="template_logo" value="{$config_logo}">
+                            </div>
+                            <div data-testid="setting-row" data-key="config.password.minlength">
+                                <label class="label" for="config_password_minlength">Minimum password length</label>
+                                <input class="input" type="number" min="1" id="config_password_minlength" name="config_password_minlength" value="{$config_min_password}">
+                            </div>
+                            <div data-testid="setting-row" data-key="config.dateformat">
+                                <label class="label" for="config_dateformat">Date format <span class="text-muted text-xs">(<a href="https://www.php.net/manual/en/datetime.format.php" target="_blank" rel="noopener">PHP date()</a>)</span></label>
+                                <input class="input" type="text" id="config_dateformat" name="config_dateformat" value="{$config_dateformat}">
+                            </div>
+                            <div data-testid="setting-row" data-key="config.debug">
+                                <label class="flex items-center gap-2">
+                                    <input type="checkbox" id="config_debug" name="config_debug"{if $config_debug} checked{/if}>
+                                    <span class="text-sm font-medium">Enable debug mode</span>
+                                </label>
+                            </div>
+                        </div>
+                    </div>
+
+                    <div class="card">
+                        <div class="card__header"><div><h3>Authentication</h3><p>Token lifetimes (in minutes).</p></div></div>
+                        <div class="card__body space-y-4">
+                            <div class="grid gap-4" style="grid-template-columns:repeat(3,1fr)">
+                                <div data-testid="setting-row" data-key="auth.maxlife">
+                                    <label class="label" for="auth_maxlife">Default</label>
+                                    <input class="input" type="number" min="0" id="auth_maxlife" name="auth_maxlife" value="{$auth_maxlife}">
+                                </div>
+                                <div data-testid="setting-row" data-key="auth.maxlife.remember">
+                                    <label class="label" for="auth_maxlife_remember">Remember me</label>
+                                    <input class="input" type="number" min="0" id="auth_maxlife_remember" name="auth_maxlife_remember" value="{$auth_maxlife_remember}">
+                                </div>
+                                <div data-testid="setting-row" data-key="auth.maxlife.steam">
+                                    <label class="label" for="auth_maxlife_steam">Steam login</label>
+                                    <input class="input" type="number" min="0" id="auth_maxlife_steam" name="auth_maxlife_steam" value="{$auth_maxlife_steam}">
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+
+                    <div class="card">
+                        <div class="card__header"><div><h3>Dashboard intro</h3><p>Public landing-page header and body.</p></div></div>
+                        <div class="card__body space-y-4">
+                            <div data-testid="setting-row" data-key="dash.intro.title">
+                                <label class="label" for="dash_intro_title">Intro title</label>
+                                <input class="input" type="text" id="dash_intro_title" name="dash_intro_title" value="{$config_dash_title}">
+                            </div>
+                            <div data-testid="setting-row" data-key="dash.intro.text">
+                                <label class="label" for="dash_intro_text">
+                                    Intro body
+                                    <span class="text-muted text-xs">
+                                        — Markdown supported (<a href="https://commonmark.org/help/" target="_blank" rel="noopener">CommonMark cheat-sheet</a>). Raw HTML is escaped on render.
+                                    </span>
+                                </label>
+                                <textarea class="textarea" id="dash_intro_text" name="dash_intro_text" rows="10" style="width:100%;font-family:var(--font-mono);font-size:var(--fs-sm)">{$config_dash_text}</textarea>
+                            </div>
+                            <div data-testid="setting-row" data-key="dash.lognopopup">
+                                <label class="flex items-center gap-2">
+                                    <input type="checkbox" id="dash_nopopup" name="dash_nopopup"{if $dash_lognopopup} checked{/if}>
+                                    <span class="text-sm font-medium">Disable log popup (use direct links instead)</span>
+                                </label>
+                            </div>
+                        </div>
+                    </div>
+
+                    <div class="card">
+                        <div class="card__header"><div><h3>Public pages</h3><p>Which extra pages visitors can reach.</p></div></div>
+                        <div class="card__body space-y-3">
+                            <div data-testid="setting-row" data-key="config.enableprotest">
+                                <label class="flex items-center gap-2">
+                                    <input type="checkbox" id="enable_protest" name="enable_protest"{if $enable_protest} checked{/if}>
+                                    <span class="text-sm font-medium">Enable ban-protest page</span>
+                                </label>
+                            </div>
+                            <div data-testid="setting-row" data-key="config.enablesubmit">
+                                <label class="flex items-center gap-2">
+                                    <input type="checkbox" id="enable_submit" name="enable_submit"{if $enable_submit} checked{/if}>
+                                    <span class="text-sm font-medium">Enable ban-submission page</span>
+                                </label>
+                            </div>
+                            <div data-testid="setting-row" data-key="config.enablecomms">
+                                <label class="flex items-center gap-2">
+                                    <input type="checkbox" id="enable_commslist" name="enable_commslist"{if $enable_commslist} checked{/if}>
+                                    <span class="text-sm font-medium">Enable comms list</span>
+                                </label>
+                            </div>
+                            <div data-testid="setting-row" data-key="protest.emailonlyinvolved">
+                                <label class="flex items-center gap-2">
+                                    <input type="checkbox" id="protest_emailonlyinvolved" name="protest_emailonlyinvolved"{if $protest_emailonlyinvolved} checked{/if}>
+                                    <span class="text-sm font-medium">Only email the original ban admin on new protests</span>
+                                </label>
+                            </div>
+                            <div data-testid="setting-row" data-key="config.defaultpage">
+                                <label class="label" for="default_page">Default landing page</label>
+                                <select class="select" id="default_page" name="default_page">
+                                    <option value="0"{if $config_default_page == 0} selected{/if}>Dashboard</option>
+                                    <option value="1"{if $config_default_page == 1} selected{/if}>Ban list</option>
+                                    <option value="2"{if $config_default_page == 2} selected{/if}>Servers</option>
+                                    <option value="3"{if $config_default_page == 3} selected{/if}>Submit a ban</option>
+                                    <option value="4"{if $config_default_page == 4} selected{/if}>Protest a ban</option>
+                                </select>
+                            </div>
+                        </div>
+                    </div>
+
+                    <div class="card">
+                        <div class="card__header"><div><h3>Ban list</h3><p>Pagination and visibility.</p></div></div>
+                        <div class="card__body space-y-4">
+                            <div data-testid="setting-row" data-key="banlist.bansperpage">
+                                <label class="label" for="banlist_bansperpage">Bans per page</label>
+                                <input class="input" type="number" min="1" id="banlist_bansperpage" name="banlist_bansperpage" value="{$config_bans_per_page}">
+                            </div>
+                            <div data-testid="setting-row" data-key="banlist.hideadminname">
+                                <label class="flex items-center gap-2">
+                                    <input type="checkbox" id="banlist_hideadmname" name="banlist_hideadmname"{if $banlist_hideadmname} checked{/if}>
+                                    <span class="text-sm font-medium">Hide admin name from public ban info</span>
+                                </label>
+                            </div>
+                            <div data-testid="setting-row" data-key="banlist.hideplayerips">
+                                <label class="flex items-center gap-2">
+                                    <input type="checkbox" id="banlist_hideplayerips" name="banlist_hideplayerips"{if $banlist_hideplayerips} checked{/if}>
+                                    <span class="text-sm font-medium">Hide player IPs from public ban info</span>
+                                </label>
+                            </div>
+                            <div data-testid="setting-row" data-key="banlist.nocountryfetch">
+                                <label class="flex items-center gap-2">
+                                    <input type="checkbox" id="banlist_nocountryfetch" name="banlist_nocountryfetch"{if $banlist_nocountryfetch} checked{/if}>
+                                    <span class="text-sm font-medium">Skip country lookup for IPs</span>
+                                </label>
+                            </div>
+                            <div data-testid="setting-row" data-key="bans.customreasons">
+                                <label class="label">Custom ban reasons</label>
+                                <p class="text-xs text-muted m-0 mb-2">Each line becomes an option in the ban-reason dropdown. Leave blank to remove.</p>
+                                <div id="custom-reasons" class="space-y-3">
+                                    {foreach from=$bans_customreason item="creason"}
+                                        {* nofilter: bans.customreasons round-trips through htmlspecialchars in admin.settings.php before serialize() into sb_settings, so the value is already entity-encoded; auto-escape would double-encode (matches legacy default theme). Admin-only input + already-escaped on store. *}
+                                        <input class="input" type="text" name="bans_customreason[]" value="{$creason nofilter}">
+                                    {/foreach}
+                                    <input class="input" type="text" name="bans_customreason[]" placeholder="Add another reason…">
+                                    <input class="input" type="text" name="bans_customreason[]" placeholder="Add another reason…">
+                                </div>
+                                <button type="button" class="btn btn--ghost btn--sm mt-2" onclick="addCustomReason();">
+                                    <i data-lucide="plus"></i> Add row
+                                </button>
+                            </div>
+                        </div>
+                    </div>
+
+                    <div class="card">
+                        <div class="card__header"><div><h3>SMTP</h3><p>Outbound email transport.</p></div></div>
+                        <div class="card__body space-y-4">
+                            <div class="grid gap-4" style="grid-template-columns:2fr 1fr">
+                                <div data-testid="setting-row" data-key="smtp.host">
+                                    <label class="label" for="mail_host">Host</label>
+                                    {* config_smtp[0]=host, [1]=user, [2]=port — the array shape mirrors Config::getMulti(['smtp.host','smtp.user','smtp.port']) so the legacy default theme can keep using the same View. *}
+                                    <input class="input" type="text" id="mail_host" name="mail_host" value="{$config_smtp[0]}">
+                                </div>
+                                <div data-testid="setting-row" data-key="smtp.port">
+                                    <label class="label" for="mail_port">Port</label>
+                                    <input class="input" type="number" min="0" id="mail_port" name="mail_port" value="{$config_smtp[2]}">
+                                </div>
+                            </div>
+                            <div class="grid gap-4" style="grid-template-columns:1fr 1fr">
+                                <div data-testid="setting-row" data-key="smtp.user">
+                                    <label class="label" for="mail_user">Username</label>
+                                    <input class="input" type="text" id="mail_user" name="mail_user" value="{$config_smtp[1]}" autocomplete="off">
+                                </div>
+                                <div data-testid="setting-row" data-key="smtp.pass">
+                                    <label class="label" for="mail_pass">Password <span class="text-muted text-xs">(leave blank to keep current)</span></label>
+                                    <input class="input" type="password" id="mail_pass" name="mail_pass" value="" autocomplete="new-password">
+                                </div>
+                            </div>
+                            <div data-testid="setting-row" data-key="smtp.verify_peer">
+                                <label class="flex items-center gap-2">
+                                    <input type="checkbox" id="mail_verify_peer" name="mail_verify_peer"{if $config_smtp_verify_peer} checked{/if}>
+                                    <span class="text-sm font-medium">Verify TLS peer certificate</span>
+                                </label>
+                            </div>
+                            <div class="grid gap-4" style="grid-template-columns:1fr 1fr">
+                                <div data-testid="setting-row" data-key="config.mail.from_email">
+                                    <label class="label" for="mail_from_email">From email</label>
+                                    <input class="input" type="email" id="mail_from_email" name="mail_from_email" value="{$config_mail_from_email}">
+                                </div>
+                                <div data-testid="setting-row" data-key="config.mail.from_name">
+                                    <label class="label" for="mail_from_name">From name</label>
+                                    <input class="input" type="text" id="mail_from_name" name="mail_from_name" value="{$config_mail_from_name}">
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+
+                    <div class="flex items-center justify-end gap-2">
+                        <button type="button" class="btn btn--secondary btn--sm" onclick="clearCacheBtn();">
+                            <i data-lucide="brush"></i> Clear cache
+                        </button>
+                        <button type="submit" class="btn btn--primary" data-testid="settings-save">
+                            <i data-lucide="save"></i> Save changes
+                        </button>
+                    </div>
+                </form>
+            {/if}
+        </div>
     </div>
 </div>
+
+<script>
+{literal}
+// @ts-check
+(function () {
+    'use strict';
+
+    /**
+     * Append a blank custom-reason input next to the existing ones. The
+     * server iterates `bans_customreason[]` order-independently and drops
+     * empty entries, so users can grow the list freely without managing
+     * indexes.
+     */
+    window.addCustomReason = function () {
+        var box = document.getElementById('custom-reasons');
+        if (!box) return;
+        var inp = document.createElement('input');
+        inp.className = 'input';
+        inp.type = 'text';
+        inp.name = 'bans_customreason[]';
+        inp.placeholder = 'Add another reason…';
+        box.appendChild(inp);
+    };
+
+    /**
+     * Wire the "Clear cache" button to the existing system.clear_cache
+     * JSON action. We purposely don't change the page (the user is mid-edit
+     * on the form), just toast a confirmation.
+     */
+    window.clearCacheBtn = function () {
+        if (!window.sb || !window.sb.api || !window.Actions) return;
+        window.sb.api.call(window.Actions.SystemClearCache, {}).then(function () {
+            window.alert('Cache cleared.');
+        });
+    };
+})();
+{/literal}
+</script>

--- a/web/themes/sbpp2026/page_admin_settings_themes.tpl
+++ b/web/themes/sbpp2026/page_admin_settings_themes.tpl
@@ -1,6 +1,196 @@
-<div class="card">
-    <div class="card__body">
-        <h1>{$title}</h1>
-        <p class="text-muted">This page hasn't been redesigned yet.</p>
+{*
+    SourceBans++ 2026 — page / page_admin_settings_themes.tpl
+
+    "Themes" sub-tab on the admin Settings page (B18 marquee). Pair:
+    Sbpp\View\AdminThemesView + web/pages/admin.settings.php (which
+    routes by ?section= and renders one View per request — see
+    sibling page_admin_settings_settings.tpl for the rationale).
+
+    Variable contract (kept in sync by SmartyTemplateRule):
+        Permission gates:
+            $can_web_settings — required to enable the "Use this
+                theme" buttons. Read-only listing is shown either
+                way so admins without write access still get a
+                useful preview of what's installed.
+            $can_owner — kept for parity with sibling settings views.
+        Section nav: $active_section.
+        Active selection: $current_theme_dir (matches the running
+            SB_THEME constant).
+        Theme list: $theme_list — list of dicts with keys dir, name,
+            author, version, link, screenshot, active. Built by
+            admin.settings.php's discovery loop from theme.conf.php in
+            each subdirectory of SB_THEMES. No new server-side
+            enumeration is added in this template.
+        Currently-selected scalars: $theme_name, $theme_author,
+            $theme_version, $theme_link, $theme_screenshot. Used by
+            the legacy default-theme template's "current theme" panel;
+            the sbpp2026 layout surfaces $theme_name/version/author/
+            link in the header summary and captures-and-discards
+            $theme_screenshot (see annotation).
+
+    Wiring:
+        The "Use this theme" button on each card calls
+        Actions.SystemApplyTheme (action `system.apply_theme`,
+        registered in _register.php with
+        ADMIN_OWNER | ADMIN_WEB_SETTINGS, see web/api/handlers/system.php).
+        On success the JSON envelope's `reload: true` triggers a full
+        page reload via window.location.reload() so the new chrome
+        paints with the right CSS bundle. We deliberately use the
+        existing API action rather than introducing a new one — B
+        tickets cannot touch web/api/handlers/.
+
+    Testability hooks:
+        - Sub-nav links: data-testid="settings-tab-<key>".
+        - Each card: data-testid="theme-card" + data-theme="<dir>".
+        - Active card carries aria-current="true" (per the issue plan).
+        - "Use this theme" button: data-testid="theme-apply".
+*}
+<div class="p-6">
+    <div class="mb-6">
+        <h1 style="font-size:var(--fs-2xl);font-weight:600;margin:0">Settings</h1>
+        <p class="text-sm text-muted m-0 mt-2">Pick the theme that paints the panel chrome for every visitor.</p>
+    </div>
+
+    <div class="grid gap-4" style="grid-template-columns:14rem 1fr;align-items:start">
+        <nav aria-label="Settings sections" role="tablist">
+            <a class="sidebar__link" href="?p=admin&amp;c=settings&amp;section=settings"
+               role="tab"
+               data-testid="settings-tab-settings"
+               {if $active_section == 'settings'}aria-current="page"{/if}>
+                <i data-lucide="settings"></i> Main
+            </a>
+            <a class="sidebar__link" href="?p=admin&amp;c=settings&amp;section=features"
+               role="tab"
+               data-testid="settings-tab-features"
+               {if $active_section == 'features'}aria-current="page"{/if}>
+                <i data-lucide="toggle-right"></i> Features
+            </a>
+            <a class="sidebar__link" href="?p=admin&amp;c=settings&amp;section=logs"
+               role="tab"
+               data-testid="settings-tab-logs"
+               {if $active_section == 'logs'}aria-current="page"{/if}>
+                <i data-lucide="scroll-text"></i> System Log
+            </a>
+            <a class="sidebar__link" href="?p=admin&amp;c=settings&amp;section=themes"
+               role="tab"
+               data-testid="settings-tab-themes"
+               {if $active_section == 'themes'}aria-current="page"{/if}>
+                <i data-lucide="palette"></i> Themes
+            </a>
+        </nav>
+
+        <div>
+            <div class="card">
+                <div class="card__header">
+                    <div>
+                        <h3>Installed themes</h3>
+                        <p>Each card represents one directory under <code>web/themes/</code> with a <code>theme.conf.php</code> manifest.</p>
+                    </div>
+                    <div class="text-xs text-muted" style="text-align:right" data-testid="current-theme-summary">
+                        Currently in use:<br>
+                        <strong>{$theme_name}</strong> v{$theme_version} by {$theme_author}{if $theme_link != ''} · <a href="{$theme_link}" target="_blank" rel="noopener" class="text-muted">homepage</a>{/if}<br>
+                        <code>{$current_theme_dir}</code>
+                    </div>
+                </div>
+                {* nofilter: $theme_screenshot is the prebuilt "<img width=… src=themes/SB_THEME/<theme.conf.php-defined filename>>" string from admin.settings.php — server constants only, no user input. We capture-and-discard it because the sbpp2026 card grid renders its own <img> per card from $t.screenshot, but the View has to keep $theme_screenshot for the legacy default theme's "current theme" panel. Drop this whole capture and the View property when D1 retires the default theme. *}
+                {capture name="legacy_theme_screenshot"}{$theme_screenshot nofilter}{/capture}
+                <div class="card__body">
+                    {if NOT $can_web_settings}
+                        <p class="text-xs text-muted m-0 mb-4" style="padding:0.5rem 0.75rem;border:1px solid var(--border);border-radius:var(--radius-md);background:var(--bg-muted)">
+                            <i data-lucide="info"></i>
+                            You can browse themes but you need <code>ADMIN_WEB_SETTINGS</code> to switch the active one.
+                        </p>
+                    {/if}
+
+                    <div class="grid gap-4" style="grid-template-columns:repeat(auto-fill, minmax(18rem, 1fr))">
+                        {foreach from=$theme_list item=t}
+                            <article class="theme-card"
+                                     data-testid="theme-card"
+                                     data-theme="{$t.dir}"
+                                     {if $t.active}aria-current="true"{/if}
+                                     style="border:1px solid {if $t.active}var(--brand-600){else}var(--border){/if};border-radius:var(--radius-lg);overflow:hidden;background:var(--bg-surface);display:flex;flex-direction:column;{if $t.active}box-shadow:0 0 0 2px var(--brand-600) inset{/if}">
+                                <div style="aspect-ratio:250 / 170;background:var(--bg-muted);display:grid;place-items:center;overflow:hidden">
+                                    <img src="{$t.screenshot}"
+                                         alt="{$t.name} theme screenshot"
+                                         loading="lazy"
+                                         style="width:100%;height:100%;object-fit:cover"
+                                         onerror="this.style.display='none';this.parentElement.innerHTML='<span class=\'text-muted text-xs\'>No screenshot</span>'">
+                                </div>
+                                <div class="p-4 space-y-3" style="flex:1;display:flex;flex-direction:column">
+                                    <div>
+                                        <div class="flex items-center gap-2">
+                                            <h4 class="m-0 font-semibold text-sm">{$t.name}</h4>
+                                            {if $t.active}
+                                                <span class="pill pill--online" title="Currently active">
+                                                    <i data-lucide="check" style="width:0.75rem;height:0.75rem"></i> Active
+                                                </span>
+                                            {/if}
+                                        </div>
+                                        <p class="text-xs text-muted m-0 mt-2">by {$t.author} · v{$t.version}</p>
+                                        <p class="text-xs font-mono text-faint m-0 mt-2">{$t.dir}</p>
+                                    </div>
+                                    <div class="flex items-center justify-between gap-2 mt-2" style="margin-top:auto">
+                                        {if $t.link != ''}
+                                            <a class="btn btn--ghost btn--sm"
+                                               href="{$t.link}"
+                                               target="_blank"
+                                               rel="noopener"
+                                               title="Open theme homepage">
+                                                <i data-lucide="external-link"></i> Homepage
+                                            </a>
+                                        {else}
+                                            <span></span>
+                                        {/if}
+                                        {if $can_web_settings}
+                                            {if $t.active}
+                                                <button type="button" class="btn btn--secondary btn--sm" disabled aria-pressed="true">
+                                                    <i data-lucide="check"></i> In use
+                                                </button>
+                                            {else}
+                                                <button type="button"
+                                                        class="btn btn--primary btn--sm"
+                                                        data-testid="theme-apply"
+                                                        data-theme="{$t.dir}"
+                                                        onclick="applyTheme(this.dataset.theme);">
+                                                    <i data-lucide="check-circle"></i> Use this theme
+                                                </button>
+                                            {/if}
+                                        {/if}
+                                    </div>
+                                </div>
+                            </article>
+                        {/foreach}
+                    </div>
+                </div>
+            </div>
+        </div>
     </div>
 </div>
+
+<script>
+{literal}
+// @ts-check
+(function () {
+    'use strict';
+
+    /**
+     * Activate a theme by hitting Actions.SystemApplyTheme. The handler
+     * persists `config.theme` in :prefix_settings and returns
+     * { reload: true }; we honour that with a hard reload so the new
+     * theme's CSS + chrome paint cleanly. Any error envelope is shown
+     * via callOrAlert so admins see the failure reason instead of a
+     * silent no-op.
+     */
+    window.applyTheme = function (theme) {
+        if (!theme) return;
+        if (!window.confirm('Switch the panel theme to "' + theme + '"? Every visitor will see the new theme on their next request.')) return;
+        if (!window.sb || !window.sb.api || !window.Actions) return;
+        window.sb.api.callOrAlert(window.Actions.SystemApplyTheme, { theme: theme }).then(function (env) {
+            if (env && env.ok && env.data && env.data.reload) {
+                window.location.reload();
+            }
+        });
+    };
+})();
+{/literal}
+</script>


### PR DESCRIPTION
## Summary

B18 of #1123 — replaces the legacy `AdminTabs` JS-driven settings page with four typed `sbpp2026` templates (one per `?section=` query: `settings`, `features`, `logs`, `themes`) plus four `Sbpp\View\Admin*View` DTOs. The themes picker is the marquee feature: a card grid of every directory under `web/themes/` that ships a `theme.conf.php`, with screenshot, name, author, version, and a "Use this theme" button (active theme shows `aria-current="true"` + an "In use" pill). Apply uses the existing `Actions.SystemApplyTheme` handler — no new server-side enumeration, no new API action (B-tickets can't touch `api/handlers/`).

The dashboard intro text setting is a plain `<textarea>` with a CommonMark cheat-sheet link in the help icon. **Not reintroducing TinyMCE/CKEditor** — that was the source of #1113's stored-XSS, and the value flows through `Sbpp\Markup\IntroRenderer` on render. Documented in AGENTS.md "Anti-patterns" + "Admin-authored display text".

The legacy `default` theme keeps working unchanged: `admin.settings.php` still emits the inline `AdminTabs` `<script>` block when `SB_THEME !== 'sbpp2026'` so the JS-tab UX survives until D1 retires the default theme.

### Files in scope (per plan B18)
- `web/themes/sbpp2026/page_admin_settings_settings.tpl`
- `web/themes/sbpp2026/page_admin_settings_features.tpl`
- `web/themes/sbpp2026/page_admin_settings_logs.tpl`
- `web/themes/sbpp2026/page_admin_settings_themes.tpl`
- `web/includes/View/AdminSettingsView.php`
- `web/includes/View/AdminFeaturesView.php`
- `web/includes/View/AdminLogsView.php`
- `web/includes/View/AdminThemesView.php`
- `web/pages/admin.settings.php` (switched to `Renderer::render`; theme enumeration loop reused & extended for richer metadata)
- `web/phpstan-baseline.neon` (dual-theme matrix bookkeeping)

### Testability hooks
- `data-testid="settings-tab-{settings|features|logs|themes}"` on the sub-nav links
- `data-testid="setting-row"` + `data-key="<config.key>"` on every `<label>`/`<input>` row
- `data-testid="theme-card"` + `data-theme="<dir>"` on each theme card
- `data-testid="theme-apply"` on every active "Use this theme" button
- `data-testid="settings-save"` on every form's primary action
- `data-testid="logs-clear"` on the danger button
- `data-testid="logs-table"` + `data-testid="log-row"` + `data-id="<lid>"` on log rows

### Out of scope
- No `web/{css,js,core}/*` changes
- No `init.php`, `api/handlers/*.php`, `api-contract.js`, `AGENTS.md`, `ARCHITECTURE.md` edits
- No new API actions (themes apply uses existing `Actions.SystemApplyTheme`)

## Test plan

- [x] `./sbpp.sh phpstan` (default leg) — clean
- [x] `SBPP_PHPSTAN_THEME=sbpp2026 ./sbpp.sh phpstan -c phpstan-sbpp2026.neon` — clean
- [x] `./sbpp.sh ts-check` — clean
- [x] `./sbpp.sh test` — 268 tests, 1134 assertions
- [x] `./sbpp.sh composer api-contract` — no diff
- [x] Manual smoke (`SB_THEME=sbpp2026`): all four sections render without notices/warnings; sub-nav `aria-current` flips; theme cards enumerate the installed themes; "In use" pill renders on the active card; legacy `default` theme still renders the JS-tab settings page.