### PR TITLE
[#1123 followup] Redesign edit ban form (B13 follow-up; drops -{}- delims + MooTools)

### DIFF
--- a/web/includes/View/AdminBansEditView.php
+++ b/web/includes/View/AdminBansEditView.php
@@ -1,0 +1,64 @@
+<?php
+declare(strict_types=1);
+
+namespace Sbpp\View;
+
+/**
+ * Edit-existing-ban form on the admin bans page — binds to
+ * `page_admin_edit_ban.tpl`.
+ *
+ * Variable contract is the intersection the legacy
+ * `default/page_admin_edit_ban.tpl` and the new sbpp2026 redesign both
+ * consume:
+ *
+ *   - `$can_edit_ban`    Defense-in-depth template gate. The page handler
+ *                        already early-`PageDie`'s on access denial, so this
+ *                        is `true` whenever the form actually renders. The
+ *                        sbpp2026 template uses `{if NOT $can_edit_ban}` to
+ *                        render an "Access denied" card if it is ever
+ *                        reached without the gate being honoured upstream.
+ *   - `$ban_name`        Current player name on the ban row.
+ *   - `$ban_authid`      Current Steam2 authid on the ban row.
+ *   - `$ban_ip`          Current IP on the ban row.
+ *   - `$ban_demo`        Pre-built "Uploaded: <b>safename</b>" snippet
+ *                        (or empty), htmlspecialchars'd in the page handler
+ *                        per #1113. Rendered with `{nofilter}` from both
+ *                        themes; the safety annotation lives at the call
+ *                        site in the sbpp2026 template.
+ *   - `$customreason`    `false` when custom reasons are disabled, otherwise
+ *                        the list of reason strings from `bans.customreasons`.
+ *
+ * Length / type / current-reason / post-validation errors / success-redirect
+ * are NOT Smarty vars: the page handler emits a vanilla `<script>` tail
+ * after `Renderer::render` to hydrate the `<select>`s, surface per-field
+ * validation errors, and trigger the "saved" toast → redirect. This mirrors
+ * the legacy convention preserved during the v2.0.0 rollout window so the
+ * View stays narrow enough that the legacy `-{ … }-` template's variable
+ * references match the View's properties on the dual-theme PHPStan matrix
+ * (#1123 A2).
+ *
+ * The legacy template uses Smarty's custom `-{ … }-` delimiters; the
+ * sbpp2026 redesign moves to the standard `{ … }` pair so the View binds
+ * with the default {@see View::DELIMITERS}. The page handler does NOT swap
+ * delimiters per active theme — D1 deletes the legacy template outright, so
+ * carrying a per-theme conditional here would just be dead-on-arrival
+ * scaffolding (see `web/pages/admin.edit.ban.php` for the rationale).
+ */
+final class AdminBansEditView extends View
+{
+    public const TEMPLATE = 'page_admin_edit_ban.tpl';
+
+    /**
+     * @param false|list<string> $customreason `false` when custom reasons
+     *     are disabled, otherwise the list of reason strings.
+     */
+    public function __construct(
+        public readonly bool $can_edit_ban,
+        public readonly string $ban_name,
+        public readonly string $ban_authid,
+        public readonly string $ban_ip,
+        public readonly string $ban_demo,
+        public readonly false|array $customreason,
+    ) {
+    }
+}

--- a/web/pages/admin.edit.ban.php
+++ b/web/pages/admin.edit.ban.php
@@ -22,16 +22,57 @@ if (!defined("IN_SB")) {
     die();
 }
 
-global $theme;
+global $userbank, $theme;
 
 new AdminTabs([], $userbank, $theme);
 
+/**
+ * Vanilla replacement for sourcebans.js' ShowBox(): emits an inline
+ * <script> that surfaces a toast via window.SBPP.showToast (theme.js,
+ * sbpp2026) with sb.message.* (sb.js, both themes) as a fallback, then
+ * redirects after a short delay. Used in place of the legacy
+ * `<script>ShowBox(…)</script>` calls so the page works under sbpp2026
+ * (which does NOT load sourcebans.js) without losing the legacy theme.
+ *
+ * The strings are JSON-encoded so embedded quotes / newlines / non-ASCII
+ * survive the round-trip into the script body without further escaping.
+ */
+function emitEditBanToastAndRedirect(string $kind, string $title, string $body, string $redirect): void
+{
+    $kindJs = json_encode($kind, JSON_THROW_ON_ERROR | JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT);
+    $titleJs = json_encode($title, JSON_THROW_ON_ERROR | JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT);
+    $bodyJs = json_encode($body, JSON_THROW_ON_ERROR | JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT);
+    $redirectJs = json_encode($redirect, JSON_THROW_ON_ERROR | JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT);
+    echo <<<HTML
+<script>
+(function () {
+    var kind = {$kindJs};
+    var title = {$titleJs};
+    var body = {$bodyJs};
+    var redirect = {$redirectJs};
+    var SBPP = window.SBPP;
+    if (SBPP && typeof SBPP.showToast === 'function') {
+        SBPP.showToast({ kind: kind === 'red' ? 'error' : kind === 'green' ? 'success' : kind, title: title, body: body });
+    } else if (window.sb && window.sb.message) {
+        var fn = (kind === 'red') ? window.sb.message.error
+            : (kind === 'green') ? window.sb.message.success
+            : window.sb.message.info;
+        if (typeof fn === 'function') fn(title, body, redirect);
+    }
+    if (redirect) {
+        setTimeout(function () { window.location.href = redirect; }, 1500);
+    }
+})();
+</script>
+HTML;
+}
+
 if ($_GET['key'] != $_SESSION['banlist_postkey']) {
-    echo '<script>ShowBox("Error", "Possible hacking attempt (URL Key mismatch)!", "red", "index.php?p=admin&c=bans");</script>';
+    emitEditBanToastAndRedirect('red', 'Error', 'Possible hacking attempt (URL Key mismatch)!', 'index.php?p=admin&c=bans');
     PageDie();
 }
 if (!isset($_GET['id']) || !is_numeric($_GET['id'])) {
-    echo '<script>ShowBox("Error", "No ban id specified. Please only follow links!", "red", "index.php?p=admin&c=bans");</script>';
+    emitEditBanToastAndRedirect('red', 'Error', 'No ban id specified. Please only follow links!', 'index.php?p=admin&c=bans');
     PageDie();
 }
 $_GET['id'] = (int) $_GET['id'];
@@ -46,14 +87,37 @@ $GLOBALS['PDO']->query("
 $GLOBALS['PDO']->bind(':id', $_GET['id']);
 $res = $GLOBALS['PDO']->single();
 
-if (!$userbank->HasAccess(ADMIN_OWNER | ADMIN_EDIT_ALL_BANS) && (!$userbank->HasAccess(ADMIN_EDIT_OWN_BANS) && $res['aid'] != $userbank->GetAid()) && (!$userbank->HasAccess(ADMIN_EDIT_GROUP_BANS) && $res['gid'] != $userbank->GetProperty('gid'))) {
-    echo '<script>ShowBox("Error", "You don\'t have access to this!", "red", "index.php?p=admin&c=bans");</script>';
+isset($_GET["page"]) ? $pagelink = "&page=" . urlencode($_GET["page"]) : $pagelink = "";
+
+if (!$res) {
+    emitEditBanToastAndRedirect('red', 'Error', 'There was an error getting details. Maybe the ban has been deleted?', 'index.php?p=banlist' . $pagelink);
     PageDie();
 }
 
-isset($_GET["page"]) ? $pagelink = "&page=" . urlencode($_GET["page"]) : $pagelink = "";
+$canEditBan = (bool) $userbank->HasAccess(ADMIN_OWNER | ADMIN_EDIT_ALL_BANS)
+    || ($userbank->HasAccess(ADMIN_EDIT_OWN_BANS) && $res['aid'] == $userbank->GetAid())
+    || ($userbank->HasAccess(ADMIN_EDIT_GROUP_BANS) && $res['gid'] == $userbank->GetProperty('gid'));
 
-$errorScript = "";
+if (!$canEditBan) {
+    emitEditBanToastAndRedirect('red', 'Error', "You don't have access to this!", 'index.php?p=admin&c=bans');
+    PageDie();
+}
+
+/**
+ * Per-field validation errors collected during the POST step.
+ * Replayed at the bottom of the page by the tail <script>: each entry
+ * sets the matching `<id>.msg` div's textContent + reveals it via
+ * `style.display = 'block'`. Vanilla DOM only — no MooTools `setStyle()`
+ * / `setHTML()` (the sbpp2026 stack does not load sourcebans.js).
+ *
+ * @var array<string, string> $validationErrors  field id (`name`, `steam`,
+ *     `ip`, `reason`, `length`, `demo`) → message string.
+ */
+$validationErrors = [];
+
+/** Whether the current POST resulted in a successful UPDATE; drives the
+ *  success toast + redirect emitted by the tail script. */
+$postSuccess = false;
 
 if (isset($_POST['name'])) {
     $_POST['steam'] = \SteamID\SteamID::toSteam2(trim($_POST['steam']));
@@ -64,28 +128,23 @@ if (isset($_POST['name'])) {
     // If they didn't type a steamid
     if (empty($_POST['steam']) && $_POST['type'] == 0) {
         $error++;
-        $errorScript .= "$('steam.msg').innerHTML = 'You must type a Steam ID or Community ID';";
-        $errorScript .= "$('steam.msg').setStyle('display', 'block');";
+        $validationErrors['steam'] = 'You must type a Steam ID or Community ID';
     } elseif ($_POST['type'] == 0 && !\SteamID\SteamID::isValidID($_POST['steam'])) {
         $error++;
-        $errorScript .= "$('steam.msg').innerHTML = 'Please enter a valid Steam ID or Community ID';";
-        $errorScript .= "$('steam.msg').setStyle('display', 'block');";
+        $validationErrors['steam'] = 'Please enter a valid Steam ID or Community ID';
     } elseif (empty($_POST['ip']) && $_POST['type'] == 1) {
         // Didn't type an IP
         $error++;
-        $errorScript .= "$('ip.msg').innerHTML = 'You must type an IP';";
-        $errorScript .= "$('ip.msg').setStyle('display', 'block');";
+        $validationErrors['ip'] = 'You must type an IP';
     } elseif ($_POST['type'] == 1 && !filter_var($_POST['ip'], FILTER_VALIDATE_IP)) {
         $error++;
-        $errorScript .= "$('ip.msg').innerHTML = 'You must type a valid IP';";
-        $errorScript .= "$('ip.msg').setStyle('display', 'block');";
+        $validationErrors['ip'] = 'You must type a valid IP';
     }
 
     // Didn't type a custom reason
     if ($_POST['listReason'] == "other" && empty($_POST['txtReason'])) {
         $error++;
-        $errorScript .= "$('reason.msg').innerHTML = 'You must type a reason';";
-        $errorScript .= "$('reason.msg').setStyle('display', 'block');";
+        $validationErrors['reason'] = 'You must type a reason';
     }
 
     // prune any old bans
@@ -103,16 +162,14 @@ if (isset($_POST['name'])) {
 
             if ((int) $chk['count'] > 0) {
                 $error++;
-                $errorScript .= "$('steam.msg').innerHTML = 'This SteamID is already banned';";
-                $errorScript .= "$('steam.msg').setStyle('display', 'block');";
+                $validationErrors['steam'] = 'This SteamID is already banned';
             } else {
                 // Check if player is immune
                 $admchk = $userbank->GetAllAdmins();
                 foreach ($admchk as $admin) {
                     if ($admin['authid'] == $_POST['steam'] && $userbank->GetProperty('srv_immunity') < $admin['srv_immunity']) {
                         $error++;
-                        $errorScript .= "$('steam.msg').innerHTML = 'Admin " . $admin['user'] . " is immune';";
-                        $errorScript .= "$('steam.msg').setStyle('display', 'block');";
+                        $validationErrors['steam'] = 'Admin ' . $admin['user'] . ' is immune';
                         break;
                     }
                 }
@@ -128,8 +185,7 @@ if (isset($_POST['name'])) {
 
             if ((int) $chk['count'] > 0) {
                 $error++;
-                $errorScript .= "$('ip.msg').innerHTML = 'This IP is already banned';";
-                $errorScript .= "$('ip.msg').setStyle('display', 'block');";
+                $validationErrors['ip'] = 'This IP is already banned';
             }
         }
     }
@@ -213,43 +269,184 @@ if (isset($_POST['name'])) {
             Log::add("m", "Ban length edited", "Ban length for ({$lengthrev['authid']}) has been updated."
                 . " Before: {$lengthrev['length']}; Now: {$_POST['banlength']}.");
         }
-        echo '<script>ShowBox("Ban updated", "The ban has been updated successfully", "green", "index.php?p=banlist' . $pagelink . '");</script>';
+        $postSuccess = true;
     }
 }
 
-if (!$res) {
-    echo '<script>ShowBox("Error", "There was an error getting details. Maybe the ban has been deleted?", "red", "index.php?p=banlist' . $pagelink . '");</script>';
-}
+$customReason = Config::getBool('bans.customreasons')
+    ? unserialize((string) Config::get('bans.customreasons'))
+    : false;
+/** @var false|list<string> $customReason */
 
-$theme->assign('ban_name', $res['name']);
-$theme->assign('ban_reason', $res['reason']);
-$theme->assign('ban_authid', trim($res['authid']));
-$theme->assign('ban_ip', $res['ip']);
-// Issue #1113: dname is the admin-supplied original filename of the demo
-// (POST'd by whoever edited the ban + uploaded the demo, stored as
-// `:prefix_demos.origname`). It used to be interpolated raw into HTML
-// rendered with `nofilter`, so a filename like `<img src=x onerror=…>`
-// turned the edit-ban page into stored XSS for any admin viewing that ban.
-// htmlspecialchars + ENT_QUOTES so the value is safe inside both the
-// surrounding `<b>…</b>` text and the wrapping JS string the edit-ban
-// template emits it from.
-$theme->assign('ban_demo', !empty($res['dname'])
-    ? 'Uploaded: <b>' . htmlspecialchars((string) $res['dname'], ENT_QUOTES, 'UTF-8') . '</b>'
-    : '');
-$theme->assign('customreason', (Config::getBool('bans.customreasons')) ? unserialize(Config::get('bans.customreasons')) : false);
+\Sbpp\View\Renderer::render($theme, new \Sbpp\View\AdminBansEditView(
+    can_edit_ban: $canEditBan,
+    ban_name:     (string) $res['name'],
+    ban_authid:   trim((string) $res['authid']),
+    ban_ip:       (string) $res['ip'],
+    // Issue #1113: dname is the admin-supplied original filename of the
+    // demo (POST'd by whoever edited the ban + uploaded the demo, stored
+    // as `:prefix_demos.origname`). It used to be interpolated raw into
+    // HTML rendered with `nofilter`, so a filename like
+    // `<img src=x onerror=…>` turned the edit-ban page into stored XSS
+    // for any admin viewing that ban. htmlspecialchars + ENT_QUOTES so
+    // the value is safe inside both the surrounding `<b>…</b>` text and
+    // the `nofilter` render in the template.
+    ban_demo: !empty($res['dname'])
+        ? 'Uploaded: <b>' . htmlspecialchars((string) $res['dname'], ENT_QUOTES, 'UTF-8') . '</b>'
+        : '',
+    customreason: $customReason,
+));
 
-$theme->setLeftDelimiter('-{');
-$theme->setRightDelimiter('}-');
-$theme->display('page_admin_edit_ban.tpl');
-$theme->setLeftDelimiter('{');
-$theme->setRightDelimiter('}');
+// Tail script — vanilla replacements for sourcebans.js helpers the
+// sbpp2026 stack does not load. The default theme also gets this script
+// (it's idempotent / additive); the legacy MooTools-style helpers it
+// shipped (`changeReason`, `selectLengthTypeReason`, `demo`) are
+// shadowed by these vanilla declarations on a per-page basis without
+// touching `web/scripts/sourcebans.js` (which #1123 D1 deletes outright).
+//
+// Order:
+//   1. Replay POST validation errors into the per-field `*.msg` divs.
+//   2. Emit the "saved" toast + redirect on success.
+//   3. Define `changeReason`, `selectLengthTypeReason`, `demo` as
+//      vanilla functions targeting the matching DOM ids.
+//   4. Hydrate the `<select>`s with the row's current type/length/
+//      reason via `selectLengthTypeReason`.
+$validationErrorsJs = json_encode($validationErrors, JSON_THROW_ON_ERROR | JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT);
+$banLengthSeconds = (int) $res['length'];
+$banType = (int) $res['type'];
+// $res['reason'] is admin-controlled free text — JSON-encode it so any
+// quote / backslash / non-ASCII byte survives the round-trip into the
+// inline script body unmolested. The hydrator does an equality check on
+// `<option>.value` against this string, so preserving the literal byte
+// sequence matters.
+$banReasonJs = json_encode((string) $res['reason'], JSON_THROW_ON_ERROR | JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT);
+$redirectUrl = 'index.php?p=banlist' . $pagelink;
+$redirectUrlJs = json_encode($redirectUrl, JSON_THROW_ON_ERROR | JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT);
+$postSuccessJs = $postSuccess ? 'true' : 'false';
 ?>
-<script type="text/javascript">window.addEvent('domready', function(){
-<?=$errorScript?>
-});
-function changeReason(szListValue)
-{
-    $('dreason').style.display = (szListValue == "other" ? "block" : "none");
-}
-selectLengthTypeReason('<?=(int) $res['length']?>', '<?=$res['type']?>', '<?=addslashes($res['reason'])?>');
+<script>
+(function () {
+    'use strict';
+
+    /** @type {{[k: string]: string}} */
+    var validationErrors = <?=$validationErrorsJs?>;
+    var postSuccess = <?=$postSuccessJs?>;
+    var redirectUrl = <?=$redirectUrlJs?>;
+
+    function $id(id) { return document.getElementById(id); }
+    function setMsg(id, text) {
+        var el = $id(id);
+        if (!el) return;
+        if (text) {
+            el.textContent = text;
+            el.style.display = 'block';
+        } else {
+            el.textContent = '';
+            el.style.display = 'none';
+        }
+    }
+    function toast(kind, title, body) {
+        var SBPP = window.SBPP;
+        if (SBPP && typeof SBPP.showToast === 'function') {
+            SBPP.showToast({
+                kind: kind === 'red' ? 'error' : kind === 'green' ? 'success' : kind,
+                title: title,
+                body: body
+            });
+            return;
+        }
+        if (window.sb && window.sb.message) {
+            var fn = (kind === 'red') ? window.sb.message.error
+                : (kind === 'green') ? window.sb.message.success
+                : window.sb.message.info;
+            if (typeof fn === 'function') fn(title, body || '');
+        }
+    }
+
+    document.addEventListener('DOMContentLoaded', function () {
+        Object.keys(validationErrors).forEach(function (field) {
+            setMsg(field + '.msg', validationErrors[field]);
+        });
+        if (postSuccess) {
+            toast('green', 'Ban updated', 'The ban has been updated successfully');
+            setTimeout(function () { window.location.href = redirectUrl; }, 1500);
+        }
+    });
+
+    // Toggle the custom-reason textarea on/off based on the listReason
+    // dropdown. Replaces the legacy `$('dreason').style.display = …`
+    // helper that used the MooTools `$()` selector.
+    window.changeReason = function (szListValue) {
+        var dre = $id('dreason');
+        if (dre) dre.style.display = (szListValue === 'other' ? 'block' : 'none');
+    };
+
+    // Vanilla replacement for sourcebans.js' `selectLengthTypeReason`:
+    // hydrate the type / banlength / listReason <select>s with the
+    // current ban's stored values after the form has rendered. Falls
+    // back to the "Other reason" branch (revealing the textarea +
+    // pre-filling its value) when the stored reason isn't one of the
+    // hard-coded preset options or a configured custom reason.
+    window.selectLengthTypeReason = function (length, type, reason) {
+        var banlength = $id('banlength');
+        if (banlength) {
+            for (var i = 0; i < banlength.options.length; i++) {
+                if (banlength.options[i].value === String(length / 60)) {
+                    banlength.options[i].selected = true;
+                    break;
+                }
+            }
+        }
+        var ttype = $id('type');
+        if (ttype && ttype.options[type]) {
+            ttype.options[type].selected = true;
+        }
+        var list = $id('listReason');
+        if (!list) return;
+        for (var j = 0; j < list.options.length; j++) {
+            if (list.options[j].innerHTML === reason) {
+                list.options[j].selected = true;
+                return;
+            }
+            if (list.options[j].value === 'other') {
+                var txt = $id('txtReason');
+                var dre = $id('dreason');
+                if (txt) txt.value = reason;
+                if (dre) dre.style.display = 'block';
+                list.options[j].selected = true;
+                return;
+            }
+        }
+    };
+
+    // The "Upload a demo" popup (pages/admin.uploaddemo.php) calls
+    // `window.opener.demo(id, name)` after a successful upload. Update
+    // the demo-status inline banner + the hidden `did`/`dname` inputs
+    // so the next save persists the new demo.
+    //
+    // The popup escapes `id` and `name` via JSON encoding before the
+    // call (admin.uploaddemo.php), so they are JavaScript primitives
+    // here; we still treat `name` as untrusted text and write it via
+    // textContent + a leading static label so any HTML metacharacters
+    // render literally, not as markup.
+    window.demo = function (id, name) {
+        var msg = $id('demo.msg');
+        if (msg) {
+            msg.textContent = '';
+            var label = document.createTextNode('Uploaded: ');
+            var b = document.createElement('b');
+            b.textContent = String(name);
+            msg.appendChild(label);
+            msg.appendChild(b);
+        }
+        var did = $id('did');
+        var dname = $id('dname');
+        if (did) did.value = id;
+        if (dname) dname.value = name;
+    };
+
+    document.addEventListener('DOMContentLoaded', function () {
+        window.selectLengthTypeReason(<?=$banLengthSeconds?>, <?=$banType?>, <?=$banReasonJs?>);
+    });
+})();
 </script>

--- a/web/phpstan-baseline.neon
+++ b/web/phpstan-baseline.neon
@@ -138,6 +138,21 @@ parameters:
 			count: 2
 			path: includes/SteamID/calc/BCMATH.php
 
+		# AdminBansEditView declares $can_edit_ban for the sbpp2026
+		# redesign's `{if NOT $can_edit_ban}` access-denied gate; the
+		# legacy `themes/default/page_admin_edit_ban.tpl` doesn't carry
+		# that gate (the page handler PageDie's on access denial under
+		# both themes), so the property fires as "unused" on the
+		# default-theme PHPStan leg. The phpstan-sbpp2026 leg disables
+		# `reportUnmatchedIgnoredErrors` so this entry doesn't have to
+		# fire there. D1 deletes the legacy theme and this entry
+		# collapses with it. (#1123 B13 follow-up.)
+		-
+			message: '#^Property Sbpp\\View\\AdminBansEditView\:\:\$can_edit_ban is never referenced in template "page_admin_edit_ban\.tpl"\.$#'
+			identifier: sbpp.view.unusedProperty
+			count: 1
+			path: includes/View/AdminBansEditView.php
+
 		# CommsListView declares the union of variables both
 		# `themes/default/page_comms.tpl` (legacy) and
 		# `themes/sbpp2026/page_comms.tpl` (#1123 B4 redesign) reference;
@@ -735,12 +750,6 @@ parameters:
 			identifier: variable.undefined
 			count: 5
 			path: pages/admin.edit.adminservers.php
-
-		-
-			message: '#^Variable \$userbank might not be defined\.$#'
-			identifier: variable.undefined
-			count: 9
-			path: pages/admin.edit.ban.php
 
 		-
 			message: '#^Variable \$theme might not be defined\.$#'

--- a/web/themes/sbpp2026/page_admin_edit_ban.tpl
+++ b/web/themes/sbpp2026/page_admin_edit_ban.tpl
@@ -1,6 +1,254 @@
-<div class="card">
-    <div class="card__body">
-        <h1>{$title}</h1>
-        <p class="text-muted">This page hasn't been redesigned yet.</p>
+{*
+    SourceBans++ 2026 — page_admin_edit_ban.tpl
+    Bound to Sbpp\View\AdminBansEditView (validated by SmartyTemplateRule).
+
+    Edit-existing-ban form — the sister of page_admin_bans_add.tpl
+    (B13). The legacy default theme's template uses Smarty's custom
+    `-{ … }-` delimiter pair (a SourceBans-1.x oddity preserved on the
+    edit-ban page only); the sbpp2026 redesign drops that override and
+    renders with the standard `{ … }` pair. The page handler picks one
+    delimiter set unconditionally — see web/pages/admin.edit.ban.php
+    for the "no per-theme conditional" rationale (#1123 B13 follow-up).
+
+    DOM ids (`name`, `type`, `steam`, `ip`, `listReason`, `txtReason`,
+    `dreason`, `banlength`, `did`, `dname`, `nick.msg`, `steam.msg`,
+    `ip.msg`, `reason.msg`, `length.msg`, `demo.msg`, `editban`,
+    `back`) match the legacy template exactly so the page handler's
+    tail script (`changeReason`, `selectLengthTypeReason`, `demo`) can
+    target them by `document.getElementById(...)` without a per-theme
+    fork. The popup window opened by `pages/admin.uploaddemo.php` also
+    calls `window.opener.demo(id, name)` against those same ids.
+
+    sbpp2026 doesn't load `web/scripts/sourcebans.js`, so the legacy
+    `selectLengthTypeReason` / `ShowBox` helpers are unavailable. The
+    handler emits a vanilla replacement script after Renderer::render
+    (defined inline against window.SBPP.showToast / sb.message as a
+    fallback). That keeps THIS template purely declarative — no
+    inline {literal} block needed for client-side glue beyond the
+    server-emitted tail.
+
+    Form posts back to action="" (preserves the URL incl. ?id, ?key,
+    ?page); admin.edit.ban.php validates the CSRF token and writes the
+    row. Server-side validation errors (per field) are pushed into the
+    `*.msg` divs below by the handler's tail script (vanilla DOM, no
+    MooTools).
+
+    Testability hooks per the issue's "Testability hooks" rule:
+      - data-testid="editban-<field>" on every input/select.
+      - data-testid="editban-submit" / "editban-cancel" on buttons.
+
+    Permission gate: $can_edit_ban is precomputed in admin.edit.ban.php
+    (row-aware: ADMIN_OWNER | ADMIN_EDIT_ALL_BANS, or own/group ban
+    with the matching flag). The handler also early-PageDie's on
+    failure, so this template gate is defense-in-depth for the case
+    where the View is ever instantiated without that upstream check.
+*}
+{if NOT $can_edit_ban}
+    <div class="card" data-testid="editban-denied">
+        <div class="card__body">
+            <h1 style="font-size:1.25rem;font-weight:600;margin:0">Access denied</h1>
+            <p class="text-sm text-muted m-0 mt-2">You don't have permission to edit this ban.</p>
+        </div>
     </div>
-</div>
+{else}
+    <section class="p-6" data-testid="editban-section" style="max-width:48rem">
+        <div class="mb-6">
+            <h1 style="font-size:1.5rem;font-weight:600;margin:0">Edit ban</h1>
+            <p class="text-sm text-muted m-0 mt-2">
+                Update the player name, identifier, length, or reason on this ban.
+            </p>
+        </div>
+
+        <form id="editban-form"
+              class="card p-6 space-y-4"
+              method="post"
+              action=""
+              data-testid="editban-form"
+              autocomplete="off">
+            {csrf_field}
+            <input type="hidden" name="insert_type" value="add">
+
+            <div>
+                <label class="label" for="name">Player name</label>
+                <input type="text"
+                       class="input"
+                       id="name"
+                       name="name"
+                       value="{$ban_name|escape}"
+                       data-testid="editban-name">
+                <div class="text-xs mt-2"
+                     id="name.msg"
+                     style="color:var(--danger);display:none"></div>
+            </div>
+
+            <div class="grid gap-4" style="grid-template-columns:repeat(auto-fit,minmax(14rem,1fr))">
+                <div>
+                    <label class="label" for="type">Ban type</label>
+                    <select class="select"
+                            id="type"
+                            name="type"
+                            data-testid="editban-type">
+                        <option value="0">Steam ID</option>
+                        <option value="1">IP Address</option>
+                    </select>
+                </div>
+                <div>
+                    <label class="label" for="banlength">Ban length</label>
+                    <select class="select"
+                            id="banlength"
+                            name="banlength"
+                            data-testid="editban-length">
+                        <option value="0">Permanent</option>
+                        <optgroup label="Minutes">
+                            <option value="1">1 minute</option>
+                            <option value="5">5 minutes</option>
+                            <option value="10">10 minutes</option>
+                            <option value="15">15 minutes</option>
+                            <option value="30">30 minutes</option>
+                            <option value="45">45 minutes</option>
+                        </optgroup>
+                        <optgroup label="Hours">
+                            <option value="60">1 hour</option>
+                            <option value="120">2 hours</option>
+                            <option value="180">3 hours</option>
+                            <option value="240">4 hours</option>
+                            <option value="480">8 hours</option>
+                            <option value="720">12 hours</option>
+                        </optgroup>
+                        <optgroup label="Days">
+                            <option value="1440">1 day</option>
+                            <option value="2880">2 days</option>
+                            <option value="4320">3 days</option>
+                            <option value="5760">4 days</option>
+                            <option value="7200">5 days</option>
+                            <option value="8640">6 days</option>
+                        </optgroup>
+                        <optgroup label="Weeks">
+                            <option value="10080">1 week</option>
+                            <option value="20160">2 weeks</option>
+                            <option value="30240">3 weeks</option>
+                        </optgroup>
+                        <optgroup label="Months">
+                            <option value="43200">1 month</option>
+                            <option value="86400">2 months</option>
+                            <option value="129600">3 months</option>
+                            <option value="259200">6 months</option>
+                            <option value="518400">12 months</option>
+                        </optgroup>
+                    </select>
+                    <div class="text-xs mt-2"
+                         id="length.msg"
+                         style="color:var(--danger);display:none"></div>
+                </div>
+            </div>
+
+            <div>
+                <label class="label" for="steam">Steam ID / Community ID</label>
+                <input type="text"
+                       class="input font-mono"
+                       id="steam"
+                       name="steam"
+                       value="{$ban_authid|escape}"
+                       data-testid="editban-steam"
+                       placeholder="STEAM_0:1:23498765">
+                <div class="text-xs mt-2"
+                     id="steam.msg"
+                     style="color:var(--danger);display:none"></div>
+            </div>
+
+            <div>
+                <label class="label" for="ip">IP address</label>
+                <input type="text"
+                       class="input font-mono"
+                       id="ip"
+                       name="ip"
+                       value="{$ban_ip|escape}"
+                       data-testid="editban-ip"
+                       placeholder="203.0.113.10">
+                <div class="text-xs mt-2"
+                     id="ip.msg"
+                     style="color:var(--danger);display:none"></div>
+            </div>
+
+            <div>
+                <label class="label" for="listReason">Ban reason</label>
+                <select class="select"
+                        id="listReason"
+                        name="listReason"
+                        data-testid="editban-reason"
+                        onchange="changeReason(this[this.selectedIndex].value);">
+                    <option value="" selected>-- Select reason --</option>
+                    <optgroup label="Hacking">
+                        <option value="Aimbot">Aimbot</option>
+                        <option value="Antirecoil">Antirecoil</option>
+                        <option value="Wallhack">Wallhack</option>
+                        <option value="Spinhack">Spinhack</option>
+                        <option value="Multi-Hack">Multi-Hack</option>
+                        <option value="No Smoke">No Smoke</option>
+                        <option value="No Flash">No Flash</option>
+                    </optgroup>
+                    <optgroup label="Behavior">
+                        <option value="Team Killing">Team Killing</option>
+                        <option value="Team Flashing">Team Flashing</option>
+                        <option value="Spamming Mic/Chat">Spamming Mic/Chat</option>
+                        <option value="Inappropriate Spray">Inappropriate Spray</option>
+                        <option value="Inappropriate Language">Inappropriate Language</option>
+                        <option value="Inappropriate Name">Inappropriate Name</option>
+                        <option value="Ignoring Admins">Ignoring Admins</option>
+                        <option value="Team Stacking">Team Stacking</option>
+                    </optgroup>
+                    {if $customreason}
+                        <optgroup label="Custom">
+                            {foreach from=$customreason item="creason"}
+                                {* nofilter: bans.customreasons round-trips through htmlspecialchars in admin.settings.php before serialize() into sb_settings, so the value is already entity-encoded; auto-escaping would double-encode. *}
+                                <option value="{$creason nofilter}">{$creason nofilter}</option>
+                            {/foreach}
+                        </optgroup>
+                    {/if}
+                    <option value="other">Other reason</option>
+                </select>
+                <div id="dreason" class="mt-2" style="display:none">
+                    <textarea class="textarea"
+                              id="txtReason"
+                              name="txtReason"
+                              rows="4"
+                              placeholder="Explain in detail why this ban is being made."
+                              data-testid="editban-reason-custom"></textarea>
+                </div>
+                <div class="text-xs mt-2"
+                     id="reason.msg"
+                     style="color:var(--danger);display:none"></div>
+            </div>
+
+            <div>
+                <label class="label">Demo upload</label>
+                <button type="button"
+                        class="btn btn--secondary btn--sm"
+                        id="uploaddemo"
+                        data-testid="editban-demo"
+                        onclick="childWindow=open('pages/admin.uploaddemo.php','upload','resizable=no,width=300,height=130');">
+                    Upload a demo
+                </button>
+                <input type="hidden" name="did" id="did" value="">
+                <input type="hidden" name="dname" id="dname" value="">
+                {* nofilter: $ban_demo is empty-or `Uploaded: <b>` + htmlspecialchars($res['dname'], ENT_QUOTES, 'UTF-8') + `</b>` built in admin.edit.ban.php. The `<b>…</b>` literals are server-controlled; the user-supplied dname is escaped on store-side per #1113 so dropping it raw here is safe. *}
+                <div class="text-xs mt-2" id="demo.msg" style="color:#cc0000">{$ban_demo nofilter}</div>
+            </div>
+
+            <div class="flex justify-end gap-2"
+                 style="border-top:1px solid var(--border);padding-top:0.75rem">
+                <button type="button"
+                        class="btn btn--ghost"
+                        id="back"
+                        data-testid="editban-cancel"
+                        onclick="history.go(-1);">Back</button>
+                <button type="submit"
+                        class="btn btn--primary"
+                        id="editban"
+                        data-testid="editban-submit">
+                    Save changes
+                </button>
+            </div>
+        </form>
+    </section>
+{/if}


### PR DESCRIPTION
Part of #1123. Pre-flight follow-up to unblock D1.

The B13 ticket landed seven of the eight admin-bans templates in the new
sbpp2026 theme but missed `page_admin_edit_ban.tpl` — D1's pre-flight
check (`find … -name 'page_admin_edit_ban.tpl' | xargs grep -l "hasn't
been redesigned yet"`) flagged the A1 stub as still present, blocking
the cutover. This patch ships the redesign so D1 can proceed.

## Files touched

- `web/themes/sbpp2026/page_admin_edit_ban.tpl` — replaces the A1 stub
  with the redesigned form. Standard `{ }` Smarty (no `-{ }-`
  override). Mirrors the `page_admin_bans_add.tpl` shape from B13:
  card layout, vanilla form, `{csrf_field}`, every input/select/button
  carries a stable `data-testid="editban-<field>"` hook
  (`editban-name`, `editban-type`, `editban-length`, `editban-steam`,
  `editban-ip`, `editban-reason`, `editban-reason-custom`,
  `editban-demo`, `editban-submit`, `editban-cancel`). The single
  `nofilter` (the `$ban_demo` "Uploaded: <b>safename</b>" snippet)
  carries the canonical safety annotation pointing at the #1113 escape
  contract on the handler side.

- `web/includes/View/AdminBansEditView.php` — **new**. Typed View DTO
  bound to the new template via the `TEMPLATE` constant. Variable
  contract is the intersection both themes consume (`ban_name`,
  `ban_authid`, `ban_ip`, `ban_demo`, `customreason`) plus the
  `can_edit_ban` defense-in-depth gate the new template uses for the
  access-denied card. Length / type / current-reason / per-field
  validation errors / success-redirect are NOT View properties —
  they're emitted by the page handler's vanilla tail script after
  `Renderer::render` so the View stays narrow enough to satisfy
  `SmartyTemplateRule` against both the legacy `-{ … }-` template and
  the new `sbpp2026` one on the dual-theme PHPStan matrix (#1123 A2).
  Does **not** override `View::DELIMITERS`; the legacy template's
  inner `{$var}` matches the standard tag regex so the default leg
  keeps finding every property as referenced.

- `web/pages/admin.edit.ban.php` — rewritten:
  - Drops `setLeftDelimiter('-{')` / `setRightDelimiter('}-')` calls
    and the trailing `$theme->display(…)` chain. Switches to
    `Sbpp\View\Renderer::render($theme, new AdminBansEditView(…))`.
    No per-theme delimiter conditional — the B14 stopgap pattern is
    deliberately skipped because D1 will delete the legacy template
    outright (per spec).
  - Drops `<script>ShowBox(…)</script>` (lives in `web/scripts/sourcebans.js`
    which sbpp2026 doesn't load and #1123 D1 deletes outright).
    Replaces with an `emitEditBanToastAndRedirect()` helper that
    surfaces a toast via `window.SBPP.showToast` (theme.js) with
    `sb.message.{success,error}` (sb.js) as a fallback.
  - Drops the MooTools-style `$('id').setStyle(…)` /
    `$('id').setHTML(…)` `$errorScript` accumulator. Per-field
    validation errors now collect into a structured PHP array, get
    JSON-encoded into the inline tail script, and a vanilla
    `setMsg(id, text)` writes them into the matching `*.msg` divs on
    `DOMContentLoaded`.
  - Drops the call into `selectLengthTypeReason` from
    `sourcebans.js`. Inlines a self-contained vanilla replacement
    that hydrates the type / banlength / listReason `<select>`s
    post-mount with the row's stored values (mirrors B14's
    `admin.edit.comms.php` shim, adjusted for ban-edit's
    banlength-in-seconds and the type 0/1 select).
  - Drops the legacy `$('id').value = …` / `$('id').setHTML(…)`
    inside the popup `demo(id, name)` callback. The new vanilla
    version uses `textContent` + `appendChild` so any HTML
    metacharacters in the demo's original filename (admin-supplied;
    see #1113 audit) render literally instead of parsing as markup.
  - Keeps every DB op + form-validation branch identical to the
    legacy code: same SteamID validation, same duplicate-ban check,
    same admin-immunity guard, same archive-other-submissions
    update, same demo `:prefix_demos` REPLACE, same `Log::add` on
    length change, same redirect target.

- `web/phpstan-baseline.neon` — net `+15 / −6`:
  - Removes the `pages/admin.edit.ban.php` `Variable $userbank might
    not be defined` entry (count: 9). The new handler declares
    `global $userbank` so all nine occurrences resolve.
  - Adds one `AdminBansEditView::$can_edit_ban` unused-property
    entry gating the default-theme leg (the legacy template doesn't
    carry the access-denied card; the `phpstan-sbpp2026.neon` config
    disables `reportUnmatchedIgnoredErrors` so the entry doesn't
    have to fire under the sbpp2026 leg). D1 deletes the legacy
    template and this entry collapses with it.

## Hard rules satisfied

- Stub check: `find web/themes/sbpp2026 -name 'page_admin_edit_ban.tpl' | xargs grep -l "hasn't been redesigned yet"` → 0 hits.
- No `setLeftDelimiter('-{')` / `setRightDelimiter('}-')` / `-{ }-` markers in the new template, View, or handler.
- No MooTools (`setStyle`, `setHTML`, `window.addEvent`, `$('id')` selector); no `ShowBox`; no call into `selectLengthTypeReason` from `sourcebans.js`.
- Permission gate via `can_edit_ban` (computed from `ADMIN_OWNER | ADMIN_EDIT_ALL_BANS`, plus the row-aware `EDIT_OWN_BANS` / `EDIT_GROUP_BANS` branches). Template gates via `{if NOT $can_edit_ban}`.
- `{csrf_field}` on the form.
- Every `{nofilter}` carries a `{* nofilter: <reason> *}` comment immediately above it.
- All SQL uses `:prefix_` literals.

## Test plan

- [x] `./sbpp.sh phpstan` (default leg, 208 files) — green.
- [x] sbpp2026 phpstan leg (`SBPP_PHPSTAN_THEME=sbpp2026 phpstan-sbpp2026.neon`, 208 files) — green.
- [x] `./sbpp.sh test` — 280 tests / 1189 assertions, all green.
- [x] `./sbpp.sh ts-check` — green.
- [x] `./sbpp.sh composer api-contract` — no diff.
- [x] End-to-end smoke against the sbpp2026 dev stack: `GET edit-ban` renders the form populated with the row's current name/authid/ip/length/type/reason; `POST` with a valid edit updates the DB (verified `bid=1` `name`+`length`+`reason` updated) and emits the "Ban updated" toast + redirect script; `POST` with a missing custom reason replays `{"reason":"You must type a reason"}` into `#reason.msg` via vanilla DOM; bad-URL-key, missing-id, and deleted-ban paths emit the vanilla toast + redirect script (no `ShowBox`).

Refs #1123 B13.