### PR TITLE
[#1123 followup] Redesign 4 search-box stubs (B11/B13/B14/B18 follow-up)

### DIFF
--- a/web/includes/View/AdminAdminsSearchView.php
+++ b/web/includes/View/AdminAdminsSearchView.php
@@ -1,0 +1,85 @@
+<?php
+declare(strict_types=1);
+
+namespace Sbpp\View;
+
+/**
+ * "Advanced search" panel on the admin/admins list — binds to
+ * `box_admin_admins_search.tpl`.
+ *
+ * Two themes consume this view side-by-side during the v2.0.0 rollout
+ * (#1123): the legacy `web/themes/default/box_admin_admins_search.tpl`
+ * (table layout + xajax-style live polling driven by sourcebans.js'
+ * `LoadServerHost` helper) and the new
+ * `web/themes/sbpp2026/box_admin_admins_search.tpl` (card layout that
+ * dispatches one `sb.api.call(Actions.ServersHostPlayers, …)` per
+ * server option directly from inline `{literal}<script>…{/literal}`).
+ * Both legs of the dual-theme PHPStan matrix scan this view, so it
+ * declares the union of variables both templates reference; the new
+ * template carries an `{if false}…{/if}` parity block for the legacy-
+ * only `$server_script` so SmartyTemplateRule's "unused property"
+ * check stays green for the sbpp2026 leg without bespoke baseline
+ * entries. D1's hard cutover deletes the legacy template + the
+ * legacy-only `$server_script` property here in lockstep.
+ *
+ * Permission name shape note: the boolean is `$can_editadmin` (no
+ * underscore between "edit" and "admin", and singular) to match the
+ * legacy template's literal `{if $can_editadmin}` reference. The new
+ * sbpp2026 template uses the same name. We deviate from the
+ * `Perms::for()` `can_<lowercase ADMIN_*>` convention here only to
+ * keep the dual-theme matrix happy — see {@see AdminAdminsListView}
+ * for the canonical naming on Views that don't need to share a
+ * template name across themes.
+ *
+ * Rendered inline from `web/pages/admin.admins.search.php`, which is
+ * pulled in by `page_admin_admins_list.tpl` via the
+ * `{load_template file="admin.admins.search"}` Smarty plugin.
+ *
+ * The form submits as a plain `GET` to
+ * `?p=admin&c=admins&advSearch=…&advType=…`, which is the wire format
+ * `web/pages/admin.admins.php` already parses. No CSRF field — search
+ * is read-only.
+ */
+final class AdminAdminsSearchView extends View
+{
+    public const TEMPLATE = 'box_admin_admins_search.tpl';
+
+    /**
+     * @param list<array{sid: int, ip: string, port: int}> $server_list
+     *     Per-server entries for the "Search by server" dropdown.
+     * @param string $server_script Server-built `<script>` blob that
+     *     fires one `sb.api.call(Actions.ServersHostPlayers, {sid})`
+     *     per option to populate the `<option id="ssSID">` text — the
+     *     vanilla replacement for the legacy `LoadServerHost('SID', …)`
+     *     calls (sourcebans.js helper, deleted at #1123 D1). Consumed
+     *     by the legacy default-theme template only; the new sbpp2026
+     *     template inlines its own per-tile script and carries an
+     *     `{if false}…{/if}` parity reference so SmartyTemplateRule
+     *     stays green.
+     * @param list<array{gid: int|string, name: string}>  $webgroup_list
+     *     `:prefix_groups` rows where `type=1` (web groups).
+     * @param list<array{name: string}>                   $srvadmgroup_list
+     *     `:prefix_srvgroups` rows (SourceMod admin groups).
+     * @param list<array{gid: int|string, name: string}>  $srvgroup_list
+     *     `:prefix_groups` rows where `type=3` (server groups).
+     * @param list<array{name: string, flag: string}>     $admwebflag_list
+     *     Web permission flags as {label, ADMIN_* constant name} pairs
+     *     for the "Search by web permission" multi-select. Submitted as
+     *     a comma-joined `ADMIN_*` constant-name string the consumer
+     *     handler resolves with `constant()`.
+     * @param list<array{name: string, flag: string}>     $admsrvflag_list
+     *     SourceMod permission flags as {label, SM_* constant name}
+     *     pairs for the "Search by server permission" multi-select.
+     */
+    public function __construct(
+        public readonly bool $can_editadmin,
+        public readonly array $server_list,
+        public readonly string $server_script,
+        public readonly array $webgroup_list,
+        public readonly array $srvadmgroup_list,
+        public readonly array $srvgroup_list,
+        public readonly array $admwebflag_list,
+        public readonly array $admsrvflag_list,
+    ) {
+    }
+}

--- a/web/includes/View/AdminBansSearchView.php
+++ b/web/includes/View/AdminBansSearchView.php
@@ -1,0 +1,68 @@
+<?php
+declare(strict_types=1);
+
+namespace Sbpp\View;
+
+/**
+ * "Advanced search" panel for the public ban list — binds to
+ * `box_admin_bans_search.tpl`.
+ *
+ * Two themes consume this view side-by-side during the v2.0.0 rollout
+ * (#1123): the legacy `web/themes/default/box_admin_bans_search.tpl`
+ * (table layout + xajax-style live polling driven by sourcebans.js'
+ * `LoadServerHost` helper) and the new
+ * `web/themes/sbpp2026/box_admin_bans_search.tpl` (card layout that
+ * dispatches one `sb.api.call(Actions.ServersHostPlayers, …)` per
+ * server option directly from inline `{literal}<script>…{/literal}`).
+ * Both legs of the dual-theme PHPStan matrix scan this view, so it
+ * declares the union of variables both templates reference; the new
+ * template carries an `{if false}…{/if}` parity block for the legacy-
+ * only `$server_script` so SmartyTemplateRule's "unused property"
+ * check stays green for the sbpp2026 leg without bespoke baseline
+ * entries. D1's hard cutover deletes the legacy template + the
+ * legacy-only `$server_script` property here in lockstep.
+ *
+ * The form submits as a plain `GET` to
+ * `?p=banlist&advSearch=…&advType=…`, which is the wire format
+ * `web/pages/page.banlist.php` already parses. No CSRF field — search
+ * is read-only.
+ */
+final class AdminBansSearchView extends View
+{
+    public const TEMPLATE = 'box_admin_bans_search.tpl';
+
+    /**
+     * @param list<array<string,mixed>> $admin_list  Each entry is a row
+     *     from `:prefix_admins` with at minimum `aid` and `user`. Only
+     *     consumed when `$hideadminname` is false.
+     * @param list<array{sid: int, ip: string, port: int}> $server_list
+     *     Per-server entries for the `Server` dropdown.
+     * @param string $server_script Server-built `<script>` blob that
+     *     fires one `sb.api.call(Actions.ServersHostPlayers, {sid})`
+     *     per option to populate the `<option id="ssSID">` text — the
+     *     vanilla replacement for the legacy `LoadServerHost('SID', …)`
+     *     calls (sourcebans.js helper, deleted at #1123 D1). Consumed
+     *     by the legacy default-theme template only; the new sbpp2026
+     *     template inlines its own per-option script and carries an
+     *     `{if false}…{/if}` parity reference so SmartyTemplateRule
+     *     stays green.
+     * @param bool $hideplayerips
+     *     `Config::getBool('banlist.hideplayerips')` for non-admins.
+     *     Mirrors the legacy default-theme gate on the "Search by IP" row.
+     * @param bool $hideadminname
+     *     `Config::getBool('banlist.hideadminname')` for non-admins.
+     *     Mirrors the legacy gate on the "Search by admin" row.
+     * @param bool $is_admin
+     *     `$userbank->is_admin()`. Gates the "Search by comment" row
+     *     (admin notes are not surfaced to the public).
+     */
+    public function __construct(
+        public readonly array $admin_list,
+        public readonly array $server_list,
+        public readonly string $server_script,
+        public readonly bool $hideplayerips,
+        public readonly bool $hideadminname,
+        public readonly bool $is_admin,
+    ) {
+    }
+}

--- a/web/includes/View/AdminCommsSearchView.php
+++ b/web/includes/View/AdminCommsSearchView.php
@@ -1,0 +1,65 @@
+<?php
+declare(strict_types=1);
+
+namespace Sbpp\View;
+
+/**
+ * "Advanced search" panel for the public comms (mute / gag) list — binds
+ * to `box_admin_comms_search.tpl`.
+ *
+ * Two themes consume this view side-by-side during the v2.0.0 rollout
+ * (#1123): the legacy `web/themes/default/box_admin_comms_search.tpl`
+ * (table layout + xajax-style live polling driven by sourcebans.js'
+ * `LoadServerHost` helper) and the new
+ * `web/themes/sbpp2026/box_admin_comms_search.tpl` (card layout that
+ * dispatches one `sb.api.call(Actions.ServersHostPlayers, …)` per
+ * server option directly from inline `{literal}<script>…{/literal}`).
+ * Both legs of the dual-theme PHPStan matrix scan this view, so it
+ * declares the union of variables both templates reference; the new
+ * template carries an `{if false}…{/if}` parity block for the legacy-
+ * only `$server_script` so SmartyTemplateRule's "unused property"
+ * check stays green for the sbpp2026 leg without bespoke baseline
+ * entries. D1's hard cutover deletes the legacy template + the
+ * legacy-only `$server_script` property here in lockstep.
+ *
+ * The form submits as a plain `GET` to
+ * `?p=commslist&advSearch=…&advType=…`, which is the wire format
+ * `web/pages/page.commslist.php` already parses. No CSRF field —
+ * search is read-only.
+ */
+final class AdminCommsSearchView extends View
+{
+    public const TEMPLATE = 'box_admin_comms_search.tpl';
+
+    /**
+     * @param list<array<string,mixed>> $admin_list  Each entry is a row
+     *     from `:prefix_admins` with at minimum `aid` and `user`. Only
+     *     consumed when `$hideadminname` is false.
+     * @param list<array{sid: int, ip: string, port: int}> $server_list
+     *     Per-server entries for the `Server` dropdown.
+     * @param string $server_script Server-built `<script>` blob that
+     *     fires one `sb.api.call(Actions.ServersHostPlayers, {sid})`
+     *     per option to populate the `<option id="ssSID">` text — the
+     *     vanilla replacement for the legacy `LoadServerHost('SID', …)`
+     *     calls (sourcebans.js helper, deleted at #1123 D1). Consumed
+     *     by the legacy default-theme template only; the new sbpp2026
+     *     template inlines its own per-option script and carries an
+     *     `{if false}…{/if}` parity reference so SmartyTemplateRule
+     *     stays green.
+     * @param bool $hideadminname
+     *     `Config::getBool('banlist.hideadminname')` for non-admins.
+     *     Mirrors the legacy default-theme gate on the "Search by admin"
+     *     row.
+     * @param bool $is_admin
+     *     `$userbank->is_admin()`. Gates the "Search by comment" row
+     *     (admin notes are not surfaced to the public).
+     */
+    public function __construct(
+        public readonly array $admin_list,
+        public readonly array $server_list,
+        public readonly string $server_script,
+        public readonly bool $hideadminname,
+        public readonly bool $is_admin,
+    ) {
+    }
+}

--- a/web/includes/View/AdminLogSearchView.php
+++ b/web/includes/View/AdminLogSearchView.php
@@ -1,0 +1,33 @@
+<?php
+declare(strict_types=1);
+
+namespace Sbpp\View;
+
+/**
+ * "Advanced search" panel for the admin System Log sub-tab — binds to
+ * `box_admin_log_search.tpl`.
+ *
+ * Rendered inline from `web/pages/admin.log.search.php`, which is itself
+ * pulled in by the consumer page (`page_admin_settings_logs.tpl`) via
+ * the `{load_template file="admin.log.search"}` Smarty plugin.
+ *
+ * The submitted search form is a plain `GET` to `?p=admin&c=settings`
+ * with `section=logs`, `advSearch=<value>` and `advType=<key>` query
+ * params, mirroring the legacy `search_log()` URL shape that
+ * `web/pages/admin.settings.php` already parses (see `$_GET['advSearch']`
+ * + `$_GET['advType']` in the `section === 'logs'` branch). No CSRF
+ * field is needed: state is not mutated by the search.
+ */
+final class AdminLogSearchView extends View
+{
+    public const TEMPLATE = 'box_admin_log_search.tpl';
+
+    /**
+     * @param list<array<string,mixed>> $admin_list Each entry is a row
+     *     from `:prefix_admins` with at minimum `aid` and `user`.
+     */
+    public function __construct(
+        public readonly array $admin_list,
+    ) {
+    }
+}

--- a/web/pages/admin.admins.search.php
+++ b/web/pages/admin.admins.search.php
@@ -19,286 +19,140 @@ Page: <http://www.sourcebans.net/> - <http://www.gameconnect.net/>
 
 global $userbank, $theme;
 
-//serverlist
-$server_list  = $GLOBALS['PDO']->query("SELECT sid, ip, port FROM `:prefix_servers` WHERE enabled = 1")->resultset();
+// Server list, plus a server-built `<script>` blob the legacy
+// default-theme template emits via {$server_script nofilter} to populate
+// each `<option id="ssSID">Loading…</option>`. The legacy blob called
+// `LoadServerHost('SID', 'id', 'ssSID', '', '', false, 200)` from
+// sourcebans.js per option; that helper is removed at #1123 D1, so we
+// emit a vanilla `sb.api.call(Actions.ServersHostPlayers, {sid})` per
+// option here — same pattern B5 established for the public servers
+// list, just in a server-built script tag because the legacy template
+// has no inline `{literal}<script>…{/literal}` of its own.
+//
+// The new sbpp2026 template owns its own inline initializer (carries an
+// `{if false}…{/if}` parity reference to `$server_script` to keep
+// SmartyTemplateRule's "unused property" check happy on the sbpp2026
+// PHPStan leg) and ignores the blob built here.
+//
+// Inputs to the blob are server-controlled integers (`:prefix_servers.sid`)
+// only — no user input flows into the emitted JS. Safe under the
+// `{$server_script nofilter}` annotation in the legacy template.
+$server_rows  = $GLOBALS['PDO']->query("SELECT sid, ip, port FROM `:prefix_servers` WHERE enabled = 1")->resultset();
 $servers      = [];
-$serverscript = "<script type=\"text/javascript\">";
-foreach ($server_list as $row) {
-    $info = [];
-    $serverscript .= "LoadServerHost('" . $row['sid'] . "', 'id', 'ss" . $row['sid'] . "', '', '', false, 200);";
-    $info['sid']  = $row['sid'];
-    $info['ip']   = $row['ip'];
-    $info['port'] = $row['port'];
-    array_push($servers, $info);
+$serverscript = '<script>(function(){'
+    . 'if (typeof sb === "undefined" || !sb || !sb.api || typeof Actions === "undefined") return;';
+foreach ($server_rows as $row) {
+    $sid          = (int) $row['sid'];
+    $servers[]    = [
+        'sid'  => $sid,
+        'ip'   => (string) $row['ip'],
+        'port' => (int) $row['port'],
+    ];
+    $serverscript .= 'sb.api.call(Actions.ServersHostPlayers,{sid:' . $sid . ',trunchostname:200}).then(function(r){'
+        . 'var el=document.getElementById("ss' . $sid . '");'
+        . 'if(!el)return;'
+        . 'if(!r||!r.ok||!r.data){el.textContent="Offline";return;}'
+        . 'var d=r.data;'
+        . 'if(d.error==="connect"){el.textContent="Offline ("+d.ip+":"+d.port+")";return;}'
+        . 'el.textContent=(d.hostname||"")+" ("+d.ip+":"+d.port+")";'
+        . '});';
 }
-$serverscript .= "</script>";
+$serverscript .= '})();</script>';
 
-//webgrouplist
 $webgroup_list = $GLOBALS['PDO']->query("SELECT gid, name FROM `:prefix_groups` WHERE type = '1'")->resultset();
 $webgroups     = [];
 foreach ($webgroup_list as $row) {
-    $data         = [];
-    $data['gid']  = $row['gid'];
-    $data['name'] = $row['name'];
-
-    array_push($webgroups, $data);
+    $webgroups[] = [
+        'gid'  => $row['gid'],
+        'name' => (string) $row['name'],
+    ];
 }
 
-//serveradmingrouplist
 $srvadmgroup_list = $GLOBALS['PDO']->query("SELECT name FROM `:prefix_srvgroups` ORDER BY name ASC")->resultset();
 $srvadmgroups     = [];
 foreach ($srvadmgroup_list as $row) {
-    $data         = [];
-    $data['name'] = $row['name'];
-
-    array_push($srvadmgroups, $data);
+    $srvadmgroups[] = ['name' => (string) $row['name']];
 }
 
-//servergroup
 $srvgroup_list = $GLOBALS['PDO']->query("SELECT gid, name FROM `:prefix_groups` WHERE type = '3'")->resultset();
 $srvgroups     = [];
 foreach ($srvgroup_list as $row) {
-    $data         = [];
-    $data['gid']  = $row['gid'];
-    $data['name'] = $row['name'];
-
-    array_push($srvgroups, $data);
+    $srvgroups[] = [
+        'gid'  => $row['gid'],
+        'name' => (string) $row['name'],
+    ];
 }
 
-//webpermissions
-$webflag[] = array(
-    "name" => "Root Admin",
-    "flag" => "ADMIN_OWNER"
-);
-$webflag[] = array(
-    "name" => "View admins",
-    "flag" => "ADMIN_LIST_ADMINS"
-);
-$webflag[] = array(
-    "name" => "Add admins",
-    "flag" => "ADMIN_ADD_ADMINS"
-);
-$webflag[] = array(
-    "name" => "Edit admins",
-    "flag" => "ADMIN_EDIT_ADMINS"
-);
-$webflag[] = array(
-    "name" => "Delete admins",
-    "flag" => "ADMIN_DELETE_ADMINS"
-);
-$webflag[] = array(
-    "name" => "View servers",
-    "flag" => "ADMIN_LIST_SERVERS"
-);
-$webflag[] = array(
-    "name" => "Add servers",
-    "flag" => "ADMIN_ADD_SERVER"
-);
-$webflag[] = array(
-    "name" => "Edit servers",
-    "flag" => "ADMIN_EDIT_SERVERS"
-);
-$webflag[] = array(
-    "name" => "Delete servers",
-    "flag" => "ADMIN_DELETE_SERVERS"
-);
-$webflag[] = array(
-    "name" => "Add bans",
-    "flag" => "ADMIN_ADD_BAN"
-);
-$webflag[] = array(
-    "name" => "Edit own bans",
-    "flag" => "ADMIN_EDIT_OWN_BANS"
-);
-$webflag[] = array(
-    "name" => "Edit groups bans",
-    "flag" => "ADMIN_EDIT_GROUP_BANS"
-);
-$webflag[] = array(
-    "name" => "Edit all bans",
-    "flag" => "ADMIN_EDIT_ALL_BANS"
-);
-$webflag[] = array(
-    "name" => "Ban protests",
-    "flag" => "ADMIN_BAN_PROTESTS"
-);
-$webflag[] = array(
-    "name" => "Ban submissions",
-    "flag" => "ADMIN_BAN_SUBMISSIONS"
-);
-$webflag[] = array(
-    "name" => "Delete bans",
-    "flag" => "ADMIN_DELETE_BAN"
-);
-$webflag[] = array(
-    "name" => "Unban own bans",
-    "flag" => "ADMIN_UNBAN_OWN_BANS"
-);
-$webflag[] = array(
-    "name" => "Unban group bans",
-    "flag" => "ADMIN_UNBAN_GROUP_BANS"
-);
-$webflag[] = array(
-    "name" => "Unban all bans",
-    "flag" => "ADMIN_UNBAN"
-);
-$webflag[] = array(
-    "name" => "Import bans",
-    "flag" => "ADMIN_BAN_IMPORT"
-);
-$webflag[] = array(
-    "name" => "Submission email notifying",
-    "flag" => "ADMIN_NOTIFY_SUB"
-);
-$webflag[] = array(
-    "name" => "Protest email notifying",
-    "flag" => "ADMIN_NOTIFY_PROTEST"
-);
-$webflag[] = array(
-    "name" => "List groups",
-    "flag" => "ADMIN_LIST_GROUPS"
-);
-$webflag[] = array(
-    "name" => "Add groups",
-    "flag" => "ADMIN_ADD_GROUP"
-);
-$webflag[] = array(
-    "name" => "Edit groups",
-    "flag" => "ADMIN_EDIT_GROUPS"
-);
-$webflag[] = array(
-    "name" => "Delete groups",
-    "flag" => "ADMIN_DELETE_GROUPS"
-);
-$webflag[] = array(
-    "name" => "Web settings",
-    "flag" => "ADMIN_WEB_SETTINGS"
-);
-$webflag[] = array(
-    "name" => "List mods",
-    "flag" => "ADMIN_LIST_MODS"
-);
-$webflag[] = array(
-    "name" => "Add mods",
-    "flag" => "ADMIN_ADD_MODS"
-);
-$webflag[] = array(
-    "name" => "Edit mods",
-    "flag" => "ADMIN_EDIT_MODS"
-);
-$webflag[] = array(
-    "name" => "Delete mods",
-    "flag" => "ADMIN_DELETE_MODS"
-);
-$webflags  = [];
-foreach ($webflag as $flag) {
-    $data['name'] = $flag["name"];
-    $data['flag'] = $flag["flag"];
+// Web-permission catalogue. Submitted as comma-joined `ADMIN_*` constant
+// names; admin.admins.php resolves each via `constant()` to build the
+// bitmask filter — same wire shape the legacy box emitted.
+$webflag = [
+    ['name' => 'Root Admin',                 'flag' => 'ADMIN_OWNER'],
+    ['name' => 'View admins',                'flag' => 'ADMIN_LIST_ADMINS'],
+    ['name' => 'Add admins',                 'flag' => 'ADMIN_ADD_ADMINS'],
+    ['name' => 'Edit admins',                'flag' => 'ADMIN_EDIT_ADMINS'],
+    ['name' => 'Delete admins',              'flag' => 'ADMIN_DELETE_ADMINS'],
+    ['name' => 'View servers',               'flag' => 'ADMIN_LIST_SERVERS'],
+    ['name' => 'Add servers',                'flag' => 'ADMIN_ADD_SERVER'],
+    ['name' => 'Edit servers',               'flag' => 'ADMIN_EDIT_SERVERS'],
+    ['name' => 'Delete servers',             'flag' => 'ADMIN_DELETE_SERVERS'],
+    ['name' => 'Add bans',                   'flag' => 'ADMIN_ADD_BAN'],
+    ['name' => 'Edit own bans',              'flag' => 'ADMIN_EDIT_OWN_BANS'],
+    ['name' => 'Edit groups bans',           'flag' => 'ADMIN_EDIT_GROUP_BANS'],
+    ['name' => 'Edit all bans',              'flag' => 'ADMIN_EDIT_ALL_BANS'],
+    ['name' => 'Ban protests',               'flag' => 'ADMIN_BAN_PROTESTS'],
+    ['name' => 'Ban submissions',            'flag' => 'ADMIN_BAN_SUBMISSIONS'],
+    ['name' => 'Delete bans',                'flag' => 'ADMIN_DELETE_BAN'],
+    ['name' => 'Unban own bans',             'flag' => 'ADMIN_UNBAN_OWN_BANS'],
+    ['name' => 'Unban group bans',           'flag' => 'ADMIN_UNBAN_GROUP_BANS'],
+    ['name' => 'Unban all bans',             'flag' => 'ADMIN_UNBAN'],
+    ['name' => 'Import bans',                'flag' => 'ADMIN_BAN_IMPORT'],
+    ['name' => 'Submission email notifying', 'flag' => 'ADMIN_NOTIFY_SUB'],
+    ['name' => 'Protest email notifying',    'flag' => 'ADMIN_NOTIFY_PROTEST'],
+    ['name' => 'List groups',                'flag' => 'ADMIN_LIST_GROUPS'],
+    ['name' => 'Add groups',                 'flag' => 'ADMIN_ADD_GROUP'],
+    ['name' => 'Edit groups',                'flag' => 'ADMIN_EDIT_GROUPS'],
+    ['name' => 'Delete groups',              'flag' => 'ADMIN_DELETE_GROUPS'],
+    ['name' => 'Web settings',               'flag' => 'ADMIN_WEB_SETTINGS'],
+    ['name' => 'List mods',                  'flag' => 'ADMIN_LIST_MODS'],
+    ['name' => 'Add mods',                   'flag' => 'ADMIN_ADD_MODS'],
+    ['name' => 'Edit mods',                  'flag' => 'ADMIN_EDIT_MODS'],
+    ['name' => 'Delete mods',                'flag' => 'ADMIN_DELETE_MODS'],
+];
 
-    array_push($webflags, $data);
-}
+// SourceMod-permission catalogue. Same wire shape (comma-joined `SM_*`
+// constant names).
+$serverflag = [
+    ['name' => 'Full Admin',     'flag' => 'SM_ROOT'],
+    ['name' => 'Reserved slot',  'flag' => 'SM_RESERVED_SLOT'],
+    ['name' => 'Generic admin',  'flag' => 'SM_GENERIC'],
+    ['name' => 'Kick',           'flag' => 'SM_KICK'],
+    ['name' => 'Ban',            'flag' => 'SM_BAN'],
+    ['name' => 'Un-ban',         'flag' => 'SM_UNBAN'],
+    ['name' => 'Slay',           'flag' => 'SM_SLAY'],
+    ['name' => 'Map change',     'flag' => 'SM_MAP'],
+    ['name' => 'Change cvars',   'flag' => 'SM_CVAR'],
+    ['name' => 'Run configs',    'flag' => 'SM_CONFIG'],
+    ['name' => 'Admin chat',     'flag' => 'SM_CHAT'],
+    ['name' => 'Start votes',    'flag' => 'SM_VOTE'],
+    ['name' => 'Password server','flag' => 'SM_PASSWORD'],
+    ['name' => 'RCON',           'flag' => 'SM_RCON'],
+    ['name' => 'Enable Cheats',  'flag' => 'SM_CHEATS'],
+    ['name' => 'Custom flag 1',  'flag' => 'SM_CUSTOM1'],
+    ['name' => 'Custom flag 2',  'flag' => 'SM_CUSTOM2'],
+    ['name' => 'Custom flag 3',  'flag' => 'SM_CUSTOM3'],
+    ['name' => 'Custom flag 4',  'flag' => 'SM_CUSTOM4'],
+    ['name' => 'Custom flag 5',  'flag' => 'SM_CUSTOM5'],
+    ['name' => 'Custom flag 6',  'flag' => 'SM_CUSTOM6'],
+];
 
-//server permissions
-$serverflag[] = array(
-    "name" => "Full Admin",
-    "flag" => "SM_ROOT"
-);
-$serverflag[] = array(
-    "name" => "Reserved slot",
-    "flag" => "SM_RESERVED_SLOT"
-);
-$serverflag[] = array(
-    "name" => "Generic admin",
-    "flag" => "SM_GENERIC"
-);
-$serverflag[] = array(
-    "name" => "Kick",
-    "flag" => "SM_KICK"
-);
-$serverflag[] = array(
-    "name" => "Ban",
-    "flag" => "SM_BAN"
-);
-$serverflag[] = array(
-    "name" => "Un-ban",
-    "flag" => "SM_UNBAN"
-);
-$serverflag[] = array(
-    "name" => "Slay",
-    "flag" => "SM_SLAY"
-);
-$serverflag[] = array(
-    "name" => "Map change",
-    "flag" => "SM_MAP"
-);
-$serverflag[] = array(
-    "name" => "Change cvars",
-    "flag" => "SM_CVAR"
-);
-$serverflag[] = array(
-    "name" => "Run configs",
-    "flag" => "SM_CONFIG"
-);
-$serverflag[] = array(
-    "name" => "Admin chat",
-    "flag" => "SM_CHAT"
-);
-$serverflag[] = array(
-    "name" => "Start votes",
-    "flag" => "SM_VOTE"
-);
-$serverflag[] = array(
-    "name" => "Password server",
-    "flag" => "SM_PASSWORD"
-);
-$serverflag[] = array(
-    "name" => "RCON",
-    "flag" => "SM_RCON"
-);
-$serverflag[] = array(
-    "name" => "Enable Cheats",
-    "flag" => "SM_CHEATS"
-);
-$serverflag[] = array(
-    "name" => "Custom flag 1",
-    "flag" => "SM_CUSTOM1"
-);
-$serverflag[] = array(
-    "name" => "Custom flag 2",
-    "flag" => "SM_CUSTOM2"
-);
-$serverflag[] = array(
-    "name" => "Custom flag 3",
-    "flag" => "SM_CUSTOM3"
-);
-$serverflag[] = array(
-    "name" => "Custom flag 4",
-    "flag" => "SM_CUSTOM4"
-);
-$serverflag[] = array(
-    "name" => "Custom flag 5",
-    "flag" => "SM_CUSTOM5"
-);
-$serverflag[] = array(
-    "name" => "Custom flag 6",
-    "flag" => "SM_CUSTOM6"
-);
-$serverflags  = [];
-foreach ($serverflag as $flag) {
-    $data['name'] = $flag["name"];
-    $data['flag'] = $flag["flag"];
-
-    array_push($serverflags, $data);
-}
-
-
-$theme->assign('server_list', $servers);
-$theme->assign('server_script', $serverscript);
-$theme->assign('webgroup_list', $webgroups);
-$theme->assign('srvadmgroup_list', $srvadmgroups);
-$theme->assign('srvgroup_list', $srvgroups);
-$theme->assign('admwebflag_list', $webflags);
-$theme->assign('admsrvflag_list', $serverflags);
-$theme->assign('can_editadmin', $userbank->HasAccess(ADMIN_EDIT_ADMINS | ADMIN_OWNER));
-
-$theme->display('box_admin_admins_search.tpl');
+\Sbpp\View\Renderer::render($theme, new \Sbpp\View\AdminAdminsSearchView(
+    can_editadmin:    $userbank->HasAccess(ADMIN_EDIT_ADMINS | ADMIN_OWNER),
+    server_list:      $servers,
+    server_script:    $serverscript,
+    webgroup_list:    $webgroups,
+    srvadmgroup_list: $srvadmgroups,
+    srvgroup_list:    $srvgroups,
+    admwebflag_list:  $webflag,
+    admsrvflag_list:  $serverflag,
+));

--- a/web/pages/admin.bans.search.php
+++ b/web/pages/admin.bans.search.php
@@ -18,39 +18,54 @@ Page: <http://www.sourcebans.net/> - <http://www.gameconnect.net/>
 *************************************************************************/
 
 global $userbank, $theme;
-$admin_list   = $GLOBALS['PDO']->query("SELECT * FROM `:prefix_admins` ORDER BY user ASC")->resultset();
-$server_list  = $GLOBALS['PDO']->query("SELECT sid, ip, port FROM `:prefix_servers` WHERE enabled = 1")->resultset();
-$servers      = [];
-$serverscript = "<script type=\"text/javascript\">";
-foreach ($server_list as $row) {
-    $info = [];
-    $serverscript .= "LoadServerHost('" . $row['sid'] . "', 'id', 'ss" . $row['sid'] . "', '', '', false, 200);";
-    $info['sid']  = $row['sid'];
-    $info['ip']   = $row['ip'];
-    $info['port'] = $row['port'];
-    $servers[] = $info;
-}
-$serverscript .= "</script>";
-$page = filter_input(INPUT_GET, 'page', FILTER_VALIDATE_INT, ['options' => ['default' => 1, 'min_range' => 1]]);
 
-$theme->assign('hideplayerips', (Config::getBool('banlist.hideplayerips') && !$userbank->is_admin()));
-$theme->assign('is_admin', $userbank->is_admin());
-$theme->assign('admin_list', $admin_list);
-$theme->assign('server_list', $servers);
-$theme->assign('server_script', $serverscript);
+$admin_list = $GLOBALS['PDO']->query("SELECT * FROM `:prefix_admins` ORDER BY user ASC")->resultset();
 
-$theme->display('box_admin_bans_search.tpl');
-?>
-<script type="text/javascript">
-function switch_length(opt)
-{
-    if (opt.options[opt.selectedIndex].value=='other') {
-        $('other_length').setStyle('display', 'block');
-        $('other_length').focus();
-        $('length').setStyle('width', '20px');
-    } else {
-        $('other_length').setStyle('display', 'none');
-        $('length').setStyle('width', '210px');
-    }
+// Server list, plus a server-built `<script>` blob the legacy
+// default-theme template emits via {$server_script nofilter} to populate
+// each `<option id="ssSID">Loading…</option>`. The legacy blob called
+// `LoadServerHost('SID', 'id', 'ssSID', '', '', false, 200)` from
+// sourcebans.js per option; that helper is removed at #1123 D1, so we
+// emit a vanilla `sb.api.call(Actions.ServersHostPlayers, {sid})` per
+// option here — same pattern B5 established for the public servers
+// list, just in a server-built script tag because the legacy template
+// has no inline `{literal}<script>…{/literal}` of its own.
+//
+// The new sbpp2026 template owns its own inline initializer (carries an
+// `{if false}…{/if}` parity reference to `$server_script` to keep
+// SmartyTemplateRule's "unused property" check happy on the sbpp2026
+// PHPStan leg) and ignores the blob built here.
+//
+// Inputs to the blob are server-controlled integers (`:prefix_servers.sid`)
+// only — no user input flows into the emitted JS. Safe under the
+// `{$server_script nofilter}` annotation in the legacy template.
+$server_rows  = $GLOBALS['PDO']->query("SELECT sid, ip, port FROM `:prefix_servers` WHERE enabled = 1")->resultset();
+$server_list  = [];
+$serverscript = '<script>(function(){'
+    . 'if (typeof sb === "undefined" || !sb || !sb.api || typeof Actions === "undefined") return;';
+foreach ($server_rows as $row) {
+    $sid           = (int) $row['sid'];
+    $server_list[] = [
+        'sid'  => $sid,
+        'ip'   => (string) $row['ip'],
+        'port' => (int) $row['port'],
+    ];
+    $serverscript .= 'sb.api.call(Actions.ServersHostPlayers,{sid:' . $sid . ',trunchostname:200}).then(function(r){'
+        . 'var el=document.getElementById("ss' . $sid . '");'
+        . 'if(!el)return;'
+        . 'if(!r||!r.ok||!r.data){el.textContent="Offline";return;}'
+        . 'var d=r.data;'
+        . 'if(d.error==="connect"){el.textContent="Offline ("+d.ip+":"+d.port+")";return;}'
+        . 'el.textContent=(d.hostname||"")+" ("+d.ip+":"+d.port+")";'
+        . '});';
 }
-</script>
+$serverscript .= '})();</script>';
+
+\Sbpp\View\Renderer::render($theme, new \Sbpp\View\AdminBansSearchView(
+    admin_list:    $admin_list,
+    server_list:   $server_list,
+    server_script: $serverscript,
+    hideplayerips: (Config::getBool('banlist.hideplayerips') && !$userbank->is_admin()),
+    hideadminname: (Config::getBool('banlist.hideadminname') && !$userbank->is_admin()),
+    is_admin:      $userbank->is_admin(),
+));

--- a/web/pages/admin.comms.search.php
+++ b/web/pages/admin.comms.search.php
@@ -23,40 +23,53 @@ Page: <https://forums.alliedmods.net/showthread.php?p=1883705> - <https://github
 *************************************************************************/
 
 global $userbank, $theme;
-$admin_list   = $GLOBALS['PDO']->query("SELECT * FROM `:prefix_admins` ORDER BY user ASC")->resultset();
-$server_list  = $GLOBALS['PDO']->query("SELECT sid, ip, port FROM `:prefix_servers` WHERE enabled = 1")->resultset();
-$servers      = [];
-$serverscript = "<script type=\"text/javascript\">";
-foreach ($server_list as $row) {
-    $info = [];
-    $serverscript .= "LoadServerHost('" . $row['sid'] . "', 'id', 'ss" . $row['sid'] . "', '', '', false, 200);";
-    $info['sid']  = $row['sid'];
-    $info['ip']   = $row['ip'];
-    $info['port'] = $row['port'];
-    array_push($servers, $info);
-}
-$serverscript .= "</script>";
-$page = isset($_GET['page']) ? $_GET['page'] : 1;
 
-$theme->assign('hideplayerips', (Config::getBool('banlist.hideplayerips') && !$userbank->is_admin()));
-$theme->assign('is_admin', $userbank->is_admin());
-$theme->assign('admin_list', $admin_list);
-$theme->assign('server_list', $servers);
-$theme->assign('server_script', $serverscript);
+$admin_list = $GLOBALS['PDO']->query("SELECT * FROM `:prefix_admins` ORDER BY user ASC")->resultset();
 
-$theme->display('box_admin_comms_search.tpl');
-?>
-<script type="text/javascript">
-function switch_length(opt)
-{
-    if(opt.options[opt.selectedIndex].value=='other')
-    {
-        $('other_length').setStyle('display', 'block');
-        $('other_length').focus();
-        $('length').setStyle('width', '20px');
-    } else {
-        $('other_length').setStyle('display', 'none');
-        $('length').setStyle('width', '210px');
-    }
+// Server list, plus a server-built `<script>` blob the legacy
+// default-theme template emits via {$server_script nofilter} to populate
+// each `<option id="ssSID">Loading…</option>`. The legacy blob called
+// `LoadServerHost('SID', 'id', 'ssSID', '', '', false, 200)` from
+// sourcebans.js per option; that helper is removed at #1123 D1, so we
+// emit a vanilla `sb.api.call(Actions.ServersHostPlayers, {sid})` per
+// option here — same pattern B5 established for the public servers
+// list, just in a server-built script tag because the legacy template
+// has no inline `{literal}<script>…{/literal}` of its own.
+//
+// The new sbpp2026 template owns its own inline initializer (carries an
+// `{if false}…{/if}` parity reference to `$server_script` to keep
+// SmartyTemplateRule's "unused property" check happy on the sbpp2026
+// PHPStan leg) and ignores the blob built here.
+//
+// Inputs to the blob are server-controlled integers (`:prefix_servers.sid`)
+// only — no user input flows into the emitted JS. Safe under the
+// `{$server_script nofilter}` annotation in the legacy template.
+$server_rows  = $GLOBALS['PDO']->query("SELECT sid, ip, port FROM `:prefix_servers` WHERE enabled = 1")->resultset();
+$server_list  = [];
+$serverscript = '<script>(function(){'
+    . 'if (typeof sb === "undefined" || !sb || !sb.api || typeof Actions === "undefined") return;';
+foreach ($server_rows as $row) {
+    $sid           = (int) $row['sid'];
+    $server_list[] = [
+        'sid'  => $sid,
+        'ip'   => (string) $row['ip'],
+        'port' => (int) $row['port'],
+    ];
+    $serverscript .= 'sb.api.call(Actions.ServersHostPlayers,{sid:' . $sid . ',trunchostname:200}).then(function(r){'
+        . 'var el=document.getElementById("ss' . $sid . '");'
+        . 'if(!el)return;'
+        . 'if(!r||!r.ok||!r.data){el.textContent="Offline";return;}'
+        . 'var d=r.data;'
+        . 'if(d.error==="connect"){el.textContent="Offline ("+d.ip+":"+d.port+")";return;}'
+        . 'el.textContent=(d.hostname||"")+" ("+d.ip+":"+d.port+")";'
+        . '});';
 }
-</script>
+$serverscript .= '})();</script>';
+
+\Sbpp\View\Renderer::render($theme, new \Sbpp\View\AdminCommsSearchView(
+    admin_list:    $admin_list,
+    server_list:   $server_list,
+    server_script: $serverscript,
+    hideadminname: (Config::getBool('banlist.hideadminname') && !$userbank->is_admin()),
+    is_admin:      $userbank->is_admin(),
+));

--- a/web/pages/admin.log.search.php
+++ b/web/pages/admin.log.search.php
@@ -20,6 +20,7 @@ Page: <http://www.sourcebans.net/> - <http://www.gameconnect.net/>
 global $theme;
 
 $admin_list = $GLOBALS['PDO']->query("SELECT * FROM `:prefix_admins` ORDER BY user ASC")->resultset();
-$theme->assign('admin_list', $admin_list);
 
-$theme->display('box_admin_log_search.tpl');
+\Sbpp\View\Renderer::render($theme, new \Sbpp\View\AdminLogSearchView(
+    admin_list: $admin_list,
+));

--- a/web/themes/sbpp2026/box_admin_admins_search.tpl
+++ b/web/themes/sbpp2026/box_admin_admins_search.tpl
@@ -1,6 +1,409 @@
-<div class="card">
-    <div class="card__body">
-        <h1>{$title}</h1>
-        <p class="text-muted">This page hasn't been redesigned yet.</p>
+{*
+    SourceBans++ 2026 — admin/admins advanced-search box.
+
+    Pair: web/pages/admin.admins.search.php +
+          web/includes/View/AdminAdminsSearchView.php (typed DTO that
+          SmartyTemplateRule keeps in lockstep with this template).
+
+    Included via {load_template file="admin.admins.search"} from
+    page_admin_admins_list.tpl. Submits as a plain `GET` to
+    ?p=admin&c=admins&advSearch=…&advType=…, mirroring the wire
+    format admin.admins.php already parses.
+
+    Wire format (kept identical to the legacy box):
+        advType=name           advSearch=<text>           (admin login)
+        advType=steam|steamid  advSearch=<text>           (partial vs exact)
+        advType=admemail       advSearch=<text>           (gated by can_edit_admins)
+        advType=webgroup       advSearch=<gid>
+        advType=srvadmgroup    advSearch=<group_name>
+        advType=srvgroup       advSearch=<gid>
+        advType=admwebflag     advSearch=<ADMIN_*>[,<ADMIN_*>…]   (multi)
+        advType=admsrvflag     advSearch=<SM_*>[,<SM_*>…]         (multi)
+        advType=server         advSearch=<sid>
+
+    Why we drop sourcebans.js' search_admins() global
+    -------------------------------------------------
+    sourcebans.js disappears at #1123 D1, so `onclick="search_admins()"`
+    would `ReferenceError`. Each row gets its own submit button with
+    inline {literal}<script>…{/literal}` dispatch — vanilla, no globals.
+    The hidden `advType` / `advSearch` inputs are populated from the
+    row's source field on click; the form submits natively.
+
+    Multi-select permission flags
+    -----------------------------
+    The legacy widget used MooTools' `getMultiple(this, 1|2)` to pull
+    the full selection from a `<select multiple>` `onblur`. The new
+    dispatcher reads `selectedOptions` directly when the user submits
+    the row, so the value collected is the full current selection at
+    submit time — tight and unsurprising. The wire shape (comma-joined
+    `ADMIN_*` constant names) is unchanged so admin.admins.php's
+    constant() resolution keeps working.
+
+    LoadServerHost replacement
+    --------------------------
+    The legacy `$server_script` payload built inline `<script>` tags
+    that called `LoadServerHost('SID', 'id', 'ssSID', '', '', false, 200)`
+    per server option. After D1 removes sourcebans.js, that helper is
+    gone; the server-side list is now plain `<option>`s with
+    `data-sid` / `data-ip` / `data-port`, and the inline initializer
+    below issues one `sb.api.call(Actions.ServersHostPlayers, {sid})`
+    per option — same pattern B5 established in page_servers.tpl.
+
+    Testability hooks (per #1123 issue body, "search-<scope>-<…>"):
+        data-testid="search-admins-form"           outer form
+        data-testid="search-admins-name"           login <input>
+        data-testid="search-admins-steamid"        SteamID <input>
+        data-testid="search-admins-steam-match"    exact / partial match
+        data-testid="search-admins-admemail"       email <input>      (gated)
+        data-testid="search-admins-webgroup"       web-group <select>
+        data-testid="search-admins-srvadmgroup"    SM admin-group <select>
+        data-testid="search-admins-srvgroup"       server-group <select>
+        data-testid="search-admins-admwebflag"     web-perms multi-select
+        data-testid="search-admins-admsrvflag"     server-perms multi-select
+        data-testid="search-admins-server"         server <select>
+        data-testid="search-admins-submit-<key>"   one per searchable field
+*}
+<form method="get"
+      action="index.php"
+      data-testid="search-admins-form"
+      class="card"
+      style="margin-top:1rem;margin-bottom:1rem">
+    <input type="hidden" name="p" value="admin">
+    <input type="hidden" name="c" value="admins">
+    <input type="hidden" name="advType" value="" data-search-type>
+    <input type="hidden" name="advSearch" value="" data-search-value>
+
+    <div class="card__header">
+        <div>
+            <h3>Advanced search</h3>
+            <p>Filter the admin list by login name, group, permission flag, or server access.</p>
+        </div>
     </div>
-</div>
+
+    <div class="card__body space-y-3">
+        <div class="grid gap-3" style="grid-template-columns:12rem 1fr auto;align-items:end">
+            <label class="label" for="search-admins-name" style="grid-column:1;align-self:end">Login name</label>
+            <input class="input"
+                   id="search-admins-name"
+                   type="text"
+                   placeholder="Substring match against the panel login&hellip;"
+                   data-testid="search-admins-name"
+                   autocomplete="off">
+            <button type="submit"
+                    class="btn btn--secondary btn--sm"
+                    data-testid="search-admins-submit-name"
+                    data-search-key="name"
+                    data-search-from="search-admins-name">
+                <i data-lucide="search" style="width:14px;height:14px"></i> Search
+            </button>
+        </div>
+
+        <div class="grid gap-3" style="grid-template-columns:12rem 1fr auto;align-items:end">
+            <label class="label" for="search-admins-steamid" style="grid-column:1;align-self:end">Steam ID</label>
+            <div class="flex gap-2" style="flex-wrap:wrap">
+                <input class="input font-mono"
+                       id="search-admins-steamid"
+                       type="text"
+                       placeholder="STEAM_0:0:1234 or [U:1:1234]&hellip;"
+                       data-testid="search-admins-steamid"
+                       style="flex:1;min-width:14rem"
+                       autocomplete="off">
+                <select class="select"
+                        id="search-admins-steam-match"
+                        data-testid="search-admins-steam-match"
+                        style="width:9rem">
+                    <option value="0" selected>Exact match</option>
+                    <option value="1">Partial match</option>
+                </select>
+            </div>
+            <button type="submit"
+                    class="btn btn--secondary btn--sm"
+                    data-testid="search-admins-submit-steamid"
+                    data-search-key=""
+                    data-search-compose="steam">
+                <i data-lucide="search" style="width:14px;height:14px"></i> Search
+            </button>
+        </div>
+
+        {if $can_editadmin}
+            <div class="grid gap-3" style="grid-template-columns:12rem 1fr auto;align-items:end">
+                <label class="label" for="search-admins-admemail" style="grid-column:1;align-self:end">E-mail</label>
+                <input class="input"
+                       id="search-admins-admemail"
+                       type="email"
+                       placeholder="Substring match against the panel e-mail&hellip;"
+                       data-testid="search-admins-admemail"
+                       autocomplete="off">
+                <button type="submit"
+                        class="btn btn--secondary btn--sm"
+                        data-testid="search-admins-submit-admemail"
+                        data-search-key="admemail"
+                        data-search-from="search-admins-admemail">
+                    <i data-lucide="search" style="width:14px;height:14px"></i> Search
+                </button>
+            </div>
+        {/if}
+
+        <div class="grid gap-3" style="grid-template-columns:12rem 1fr auto;align-items:end">
+            <div>
+                <label class="label" for="search-admins-webgroup">Web group</label>
+                <select class="select"
+                        id="search-admins-webgroup"
+                        data-testid="search-admins-webgroup">
+                    <option value="">&mdash;</option>
+                    {foreach from=$webgroup_list item="webgrp"}
+                        <option value="{$webgrp.gid}">{$webgrp.name}</option>
+                    {/foreach}
+                </select>
+            </div>
+            <div class="text-xs text-muted">Filter by panel group membership.</div>
+            <button type="submit"
+                    class="btn btn--secondary btn--sm"
+                    data-testid="search-admins-submit-webgroup"
+                    data-search-key="webgroup"
+                    data-search-from="search-admins-webgroup">
+                <i data-lucide="search" style="width:14px;height:14px"></i> Search
+            </button>
+        </div>
+
+        <div class="grid gap-3" style="grid-template-columns:12rem 1fr auto;align-items:end">
+            <div>
+                <label class="label" for="search-admins-srvadmgroup">SourceMod admin group</label>
+                <select class="select"
+                        id="search-admins-srvadmgroup"
+                        data-testid="search-admins-srvadmgroup">
+                    <option value="">&mdash;</option>
+                    {foreach from=$srvadmgroup_list item="srvadmgrp"}
+                        <option value="{$srvadmgrp.name}">{$srvadmgrp.name}</option>
+                    {/foreach}
+                </select>
+            </div>
+            <div class="text-xs text-muted">Filter by SourceMod admin-group attachment.</div>
+            <button type="submit"
+                    class="btn btn--secondary btn--sm"
+                    data-testid="search-admins-submit-srvadmgroup"
+                    data-search-key="srvadmgroup"
+                    data-search-from="search-admins-srvadmgroup">
+                <i data-lucide="search" style="width:14px;height:14px"></i> Search
+            </button>
+        </div>
+
+        <div class="grid gap-3" style="grid-template-columns:12rem 1fr auto;align-items:end">
+            <div>
+                <label class="label" for="search-admins-srvgroup">Server group</label>
+                <select class="select"
+                        id="search-admins-srvgroup"
+                        data-testid="search-admins-srvgroup">
+                    <option value="">&mdash;</option>
+                    {foreach from=$srvgroup_list item="srvgrp"}
+                        <option value="{$srvgrp.gid}">{$srvgrp.name}</option>
+                    {/foreach}
+                </select>
+            </div>
+            <div class="text-xs text-muted">Filter by server-group membership.</div>
+            <button type="submit"
+                    class="btn btn--secondary btn--sm"
+                    data-testid="search-admins-submit-srvgroup"
+                    data-search-key="srvgroup"
+                    data-search-from="search-admins-srvgroup">
+                <i data-lucide="search" style="width:14px;height:14px"></i> Search
+            </button>
+        </div>
+
+        <div class="grid gap-3" style="grid-template-columns:12rem 1fr auto;align-items:end">
+            <div>
+                <label class="label" for="search-admins-admwebflag">Web permissions</label>
+                <select class="select"
+                        id="search-admins-admwebflag"
+                        data-testid="search-admins-admwebflag"
+                        size="6"
+                        multiple
+                        data-search-multi
+                        style="height:auto">
+                    {foreach from=$admwebflag_list item="admwebflag"}
+                        <option value="{$admwebflag.flag}">{$admwebflag.name}</option>
+                    {/foreach}
+                </select>
+            </div>
+            <div class="text-xs text-muted">Hold Ctrl / &#8984; to multi-select. Submits the current selection as a comma-joined list of <code>ADMIN_*</code> constant names.</div>
+            <button type="submit"
+                    class="btn btn--secondary btn--sm"
+                    data-testid="search-admins-submit-admwebflag"
+                    data-search-key="admwebflag"
+                    data-search-multi-from="search-admins-admwebflag">
+                <i data-lucide="search" style="width:14px;height:14px"></i> Search
+            </button>
+        </div>
+
+        <div class="grid gap-3" style="grid-template-columns:12rem 1fr auto;align-items:end">
+            <div>
+                <label class="label" for="search-admins-admsrvflag">Server permissions</label>
+                <select class="select"
+                        id="search-admins-admsrvflag"
+                        data-testid="search-admins-admsrvflag"
+                        size="6"
+                        multiple
+                        data-search-multi
+                        style="height:auto">
+                    {foreach from=$admsrvflag_list item="admsrvflag"}
+                        <option value="{$admsrvflag.flag}">{$admsrvflag.name}</option>
+                    {/foreach}
+                </select>
+            </div>
+            <div class="text-xs text-muted">Hold Ctrl / &#8984; to multi-select. Submits the current selection as a comma-joined list of <code>SM_*</code> constant names.</div>
+            <button type="submit"
+                    class="btn btn--secondary btn--sm"
+                    data-testid="search-admins-submit-admsrvflag"
+                    data-search-key="admsrvflag"
+                    data-search-multi-from="search-admins-admsrvflag">
+                <i data-lucide="search" style="width:14px;height:14px"></i> Search
+            </button>
+        </div>
+
+        <div class="grid gap-3" style="grid-template-columns:12rem 1fr auto;align-items:end">
+            <div>
+                <label class="label" for="search-admins-server">Server</label>
+                <select class="select"
+                        id="search-admins-server"
+                        data-testid="search-admins-server">
+                    <option value="">&mdash;</option>
+                    {foreach from=$server_list item="server"}
+                        <option value="{$server.sid}"
+                                data-sid="{$server.sid}"
+                                data-ip="{$server.ip}"
+                                data-port="{$server.port}"
+                                data-server-host>Loading&hellip; ({$server.ip}:{$server.port})</option>
+                    {/foreach}
+                </select>
+            </div>
+            <div class="text-xs text-muted">Show admins with explicit access to the selected server. Hostnames load asynchronously.</div>
+            <button type="submit"
+                    class="btn btn--secondary btn--sm"
+                    data-testid="search-admins-submit-server"
+                    data-search-key="server"
+                    data-search-from="search-admins-server">
+                <i data-lucide="search" style="width:14px;height:14px"></i> Search
+            </button>
+        </div>
+    </div>
+</form>
+
+{*
+    Inline submit dispatcher + LoadServerHost replacement.
+
+    Submit dispatcher: each per-row button declares its search
+    criterion via `data-search-key` and either points at a single
+    source field via `data-search-from`, a multi-select source via
+    `data-search-multi-from`, or composes the SteamID exact/partial
+    pair via `data-search-compose="steam"`. On click, the hidden
+    `advType` / `advSearch` inputs are populated and the form
+    submits natively (no preventDefault on the success path), so the
+    browser navigates to the consumer URL with the correct query
+    string. Empty selections cancel the submit.
+
+    LoadServerHost replacement: the legacy box appended a
+    server-built `<script>LoadServerHost(...)</script>` blob that
+    called the (now-gone) sourcebans.js helper per option. We replace
+    it with one `sb.api.call(Actions.ServersHostPlayers, {sid})` per
+    `<option data-server-host>` option, mirroring B5's pattern in
+    page_servers.tpl. Resolved hostnames replace the loading text in
+    place; failures fall back to "Offline (ip:port)".
+*}
+<script>
+{literal}
+(function () {
+    'use strict';
+    var form = document.querySelector('[data-testid="search-admins-form"]');
+    if (!(form instanceof HTMLFormElement)) return;
+
+    var typeField = form.querySelector('[data-search-type]');
+    var valueField = form.querySelector('[data-search-value]');
+    if (!(typeField instanceof HTMLInputElement) || !(valueField instanceof HTMLInputElement)) return;
+
+    /**
+     * @param {Element} btn
+     * @returns {{ key: string, value: string }}
+     */
+    function readPair(btn) {
+        var compose = btn.getAttribute('data-search-compose');
+        if (compose === 'steam') {
+            var sid = document.getElementById('search-admins-steamid');
+            var match = document.getElementById('search-admins-steam-match');
+            var sval = (sid instanceof HTMLInputElement) ? sid.value.trim() : '';
+            var mval = (match instanceof HTMLSelectElement) ? match.value : '0';
+            return { key: (mval === '1' ? 'steam' : 'steamid'), value: sval };
+        }
+        var multiId = btn.getAttribute('data-search-multi-from');
+        if (multiId) {
+            var msel = document.getElementById(multiId);
+            if (msel instanceof HTMLSelectElement && msel.multiple) {
+                var values = [];
+                Array.prototype.forEach.call(msel.selectedOptions, function (o) {
+                    if (o instanceof HTMLOptionElement && o.value !== '') values.push(o.value);
+                });
+                return { key: btn.getAttribute('data-search-key') || '', value: values.join(',') };
+            }
+            return { key: '', value: '' };
+        }
+        var fromId = btn.getAttribute('data-search-from');
+        if (!fromId) return { key: '', value: '' };
+        var src = document.getElementById(fromId);
+        if (src instanceof HTMLInputElement || src instanceof HTMLSelectElement || src instanceof HTMLTextAreaElement) {
+            return { key: btn.getAttribute('data-search-key') || '', value: src.value.trim() };
+        }
+        return { key: '', value: '' };
+    }
+
+    Array.prototype.forEach.call(form.querySelectorAll('button[data-search-compose], button[data-search-from], button[data-search-multi-from]'), function (btn) {
+        btn.addEventListener('click', function (ev) {
+            var pair = readPair(btn);
+            if (pair.key === '' || pair.value === '' || pair.value.replace(/[,]/g, '') === '') {
+                ev.preventDefault();
+                return;
+            }
+            typeField.value = pair.key;
+            valueField.value = pair.value;
+        });
+    });
+
+    if (typeof sb === 'undefined' || !sb || !sb.api || typeof Actions === 'undefined') {
+        return;
+    }
+
+    Array.prototype.forEach.call(form.querySelectorAll('option[data-server-host]'), function (opt) {
+        var sid = Number(opt.getAttribute('data-sid'));
+        var ip = opt.getAttribute('data-ip') || '';
+        var port = opt.getAttribute('data-port') || '';
+        if (!sid) return;
+        sb.api.call(Actions.ServersHostPlayers, { sid: sid, trunchostname: 70 }).then(function (r) {
+            if (!r || !r.ok || !r.data) {
+                opt.textContent = 'Offline (' + ip + ':' + port + ')';
+                return;
+            }
+            var d = r.data;
+            if (d.error === 'connect') {
+                opt.textContent = 'Offline (' + ip + ':' + port + ')';
+                return;
+            }
+            opt.textContent = (d.hostname || (ip + ':' + port)) + ' (' + ip + ':' + port + ')';
+        }, function () {
+            opt.textContent = 'Offline (' + ip + ':' + port + ')';
+        });
+    });
+})();
+{/literal}
+</script>
+
+{*
+    Parity reference for the legacy default-theme `$server_script` blob.
+    AdminAdminsSearchView declares `$server_script` so the legacy
+    PHPStan leg (which scans `web/themes/default/box_admin_admins_search.tpl`)
+    finds it; the sbpp2026 leg would otherwise flag it
+    `unusedProperty`. The if-false branch is unreachable at render
+    time so no script blob is emitted twice — this template owns the
+    DOM and uses its own inline script above. Mirrors the parity-block
+    pattern AdminHomeView established in `page_admin.tpl` (#1123 B10).
+    D1 deletes the legacy template + the legacy-only `$server_script`
+    property; this block leaves with them.
+*}
+{if false}{$server_script nofilter}{/if}

--- a/web/themes/sbpp2026/box_admin_bans_search.tpl
+++ b/web/themes/sbpp2026/box_admin_bans_search.tpl
@@ -1,6 +1,503 @@
-<div class="card">
-    <div class="card__body">
-        <h1>{$title}</h1>
-        <p class="text-muted">This page hasn't been redesigned yet.</p>
+{*
+    SourceBans++ 2026 — public ban list advanced-search box.
+
+    Pair: web/pages/admin.bans.search.php +
+          web/includes/View/AdminBansSearchView.php (typed DTO that
+          SmartyTemplateRule keeps in lockstep with this template).
+
+    This box is included via {load_template file="admin.bans.search"}
+    from any consumer page that wants the legacy advanced-search
+    affordance. The new sbpp2026 page_bans.tpl ships its own filter
+    bar inline; this box stays as a fully-functional, paired-View
+    drop-in so future redesigns (or a "more filters" disclosure) can
+    re-mount it without re-plumbing the form.
+
+    Wire format (kept identical to the legacy box so
+    page.banlist.php?advSearch=…&advType=… continues to parse the
+    same `$_GET` shape):
+        advType=name           advSearch=<text>           (nickname)
+        advType=steam|steamid  advSearch=<text>           (partial vs exact)
+        advType=ip             advSearch=<text>           (gated by !hideplayerips)
+        advType=reason         advSearch=<text>
+        advType=date           advSearch="<dd>,<mm>,<yyyy>"
+        advType=length         advSearch="<op>,<minutes>" op ∈ e|h|l|eh|el
+        advType=btype          advSearch=<0|1>            0 = SteamID, 1 = IP
+        advType=admin          advSearch=<aid>            (gated by !hideadminname)
+        advType=where_banned   advSearch=<sid>            0 = web ban
+        advType=comment        advSearch=<text>           (admin-only)
+
+    Why we drop sourcebans.js' search_bans() global
+    -----------------------------------------------
+    sourcebans.js disappears at #1123 D1, so the legacy
+    `onclick="search_bans()"` button would `ReferenceError` post-cutover.
+    Each row gets its own submit button, with the dispatch logic inlined
+    under {literal}<script>…{/literal}` — vanilla, no globals, no
+    `sb.$idRequired` (the inline script owns its own DOM). The hidden
+    `advType` / `advSearch` inputs are populated from the row's source
+    field on click and the form submits natively; a no-JS browser still
+    gets a working (if type-less) form.
+
+    LoadServerHost replacement
+    --------------------------
+    The legacy `$server_script` payload built inline `<script>` tags
+    that called `LoadServerHost('SID', 'id', 'ssSID', '', '', false, 200)`
+    per server option to fetch the live hostname. After D1 removes
+    sourcebans.js, that helper is gone; the server-side list is now
+    plain `<option>`s carrying `data-sid` / `data-ip` / `data-port`,
+    and the inline initializer below issues one
+    `sb.api.call(Actions.ServersHostPlayers, {sid})` per option — same
+    pattern B5 established in page_servers.tpl.
+
+    Testability hooks (per #1123 issue body, "search-<scope>-<…>"):
+        data-testid="search-bans-form"           outer form
+        data-testid="search-bans-name"           nickname <input>
+        data-testid="search-bans-steamid"        SteamID <input>
+        data-testid="search-bans-steam-match"    exact / partial match
+        data-testid="search-bans-ip"             IP <input>     (gated)
+        data-testid="search-bans-reason"         reason <input>
+        data-testid="search-bans-date-day"       date triple, …-month, …-year
+        data-testid="search-bans-length-op"      length comparator
+        data-testid="search-bans-length"         length <select>
+        data-testid="search-bans-other-length"   "other length" <input>
+        data-testid="search-bans-btype"          steam / ip <select>
+        data-testid="search-bans-admin"          admin <select> (gated)
+        data-testid="search-bans-server"         server <select>
+        data-testid="search-bans-comment"        admin comment <input> (gated)
+        data-testid="search-bans-submit-<key>"   one per searchable field
+*}
+<form method="get"
+      action="index.php"
+      data-testid="search-bans-form"
+      class="card"
+      style="margin-top:1rem;margin-bottom:1rem">
+    <input type="hidden" name="p" value="banlist">
+    <input type="hidden" name="advType" value="" data-search-type>
+    <input type="hidden" name="advSearch" value="" data-search-value>
+
+    <div class="card__header">
+        <div>
+            <h3>Advanced search</h3>
+            <p>Each row is its own search criterion &mdash; the &laquo;Search&raquo; button on the right submits using just that row's value.</p>
+        </div>
     </div>
-</div>
+
+    <div class="card__body space-y-3">
+        <div class="grid gap-3" style="grid-template-columns:10rem 1fr auto;align-items:end">
+            <label class="label" for="search-bans-name" style="grid-column:1;align-self:end">Nickname</label>
+            <input class="input"
+                   id="search-bans-name"
+                   type="text"
+                   placeholder="Substring match against the player nickname&hellip;"
+                   data-testid="search-bans-name"
+                   autocomplete="off">
+            <button type="submit"
+                    class="btn btn--secondary btn--sm"
+                    data-testid="search-bans-submit-name"
+                    data-search-key="name"
+                    data-search-from="search-bans-name">
+                <i data-lucide="search" style="width:14px;height:14px"></i> Search
+            </button>
+        </div>
+
+        <div class="grid gap-3" style="grid-template-columns:10rem 1fr auto;align-items:end">
+            <label class="label" for="search-bans-steamid" style="grid-column:1;align-self:end">Steam ID</label>
+            <div class="flex gap-2" style="flex-wrap:wrap">
+                <input class="input font-mono"
+                       id="search-bans-steamid"
+                       type="text"
+                       placeholder="STEAM_0:0:1234 or [U:1:1234]&hellip;"
+                       data-testid="search-bans-steamid"
+                       style="flex:1;min-width:14rem"
+                       autocomplete="off">
+                <select class="select"
+                        id="search-bans-steam-match"
+                        data-testid="search-bans-steam-match"
+                        style="width:9rem">
+                    <option value="0" selected>Exact match</option>
+                    <option value="1">Partial match</option>
+                </select>
+            </div>
+            <button type="submit"
+                    class="btn btn--secondary btn--sm"
+                    data-testid="search-bans-submit-steamid"
+                    data-search-key=""
+                    data-search-compose="steam">
+                <i data-lucide="search" style="width:14px;height:14px"></i> Search
+            </button>
+        </div>
+
+        {if NOT $hideplayerips}
+            <div class="grid gap-3" style="grid-template-columns:10rem 1fr auto;align-items:end">
+                <label class="label" for="search-bans-ip" style="grid-column:1;align-self:end">IP</label>
+                <input class="input font-mono"
+                       id="search-bans-ip"
+                       type="text"
+                       placeholder="Exact IP address&hellip;"
+                       data-testid="search-bans-ip"
+                       autocomplete="off">
+                <button type="submit"
+                        class="btn btn--secondary btn--sm"
+                        data-testid="search-bans-submit-ip"
+                        data-search-key="ip"
+                        data-search-from="search-bans-ip">
+                    <i data-lucide="search" style="width:14px;height:14px"></i> Search
+                </button>
+            </div>
+        {/if}
+
+        <div class="grid gap-3" style="grid-template-columns:10rem 1fr auto;align-items:end">
+            <label class="label" for="search-bans-reason" style="grid-column:1;align-self:end">Reason</label>
+            <input class="input"
+                   id="search-bans-reason"
+                   type="text"
+                   placeholder="Substring match against the recorded reason&hellip;"
+                   data-testid="search-bans-reason"
+                   autocomplete="off">
+            <button type="submit"
+                    class="btn btn--secondary btn--sm"
+                    data-testid="search-bans-submit-reason"
+                    data-search-key="reason"
+                    data-search-from="search-bans-reason">
+                <i data-lucide="search" style="width:14px;height:14px"></i> Search
+            </button>
+        </div>
+
+        <div class="grid gap-3" style="grid-template-columns:10rem 1fr auto;align-items:end">
+            <span class="label" style="grid-column:1;align-self:end">Date</span>
+            <div class="flex items-center gap-2" style="flex-wrap:wrap">
+                <input class="input font-mono" style="width:3rem" type="text" maxlength="2" placeholder="DD"
+                       data-testid="search-bans-date-day"
+                       data-search-date="day"
+                       autocomplete="off"
+                       inputmode="numeric"
+                       pattern="[0-9]*">
+                <span class="text-faint">/</span>
+                <input class="input font-mono" style="width:3rem" type="text" maxlength="2" placeholder="MM"
+                       data-testid="search-bans-date-month"
+                       data-search-date="month"
+                       autocomplete="off"
+                       inputmode="numeric"
+                       pattern="[0-9]*">
+                <span class="text-faint">/</span>
+                <input class="input font-mono" style="width:4.25rem" type="text" maxlength="4" placeholder="YYYY"
+                       data-testid="search-bans-date-year"
+                       data-search-date="year"
+                       autocomplete="off"
+                       inputmode="numeric"
+                       pattern="[0-9]*">
+            </div>
+            <button type="submit"
+                    class="btn btn--secondary btn--sm"
+                    data-testid="search-bans-submit-date"
+                    data-search-key="date"
+                    data-search-compose="date">
+                <i data-lucide="search" style="width:14px;height:14px"></i> Search
+            </button>
+        </div>
+
+        <div class="grid gap-3" style="grid-template-columns:10rem 1fr auto;align-items:end">
+            <span class="label" style="grid-column:1;align-self:end">Length</span>
+            <div class="flex items-center gap-2" style="flex-wrap:wrap">
+                <select class="select"
+                        id="search-bans-length-op"
+                        data-testid="search-bans-length-op"
+                        style="width:5rem">
+                    <option value="e"  title="equal to">=</option>
+                    <option value="h"  title="greater">&gt;</option>
+                    <option value="l"  title="smaller">&lt;</option>
+                    <option value="eh" title="equal to or greater">&gt;=</option>
+                    <option value="el" title="equal to or smaller">&lt;=</option>
+                </select>
+                <select class="select"
+                        id="search-bans-length"
+                        data-testid="search-bans-length"
+                        style="flex:1;min-width:12rem"
+                        data-search-length-select>
+                    <option value="0">Permanent</option>
+                    <optgroup label="Minutes">
+                        <option value="1">1 minute</option>
+                        <option value="5">5 minutes</option>
+                        <option value="10">10 minutes</option>
+                        <option value="15">15 minutes</option>
+                        <option value="30">30 minutes</option>
+                        <option value="45">45 minutes</option>
+                    </optgroup>
+                    <optgroup label="Hours">
+                        <option value="60">1 hour</option>
+                        <option value="120">2 hours</option>
+                        <option value="180">3 hours</option>
+                        <option value="240">4 hours</option>
+                        <option value="480">8 hours</option>
+                        <option value="720">12 hours</option>
+                    </optgroup>
+                    <optgroup label="Days">
+                        <option value="1440">1 day</option>
+                        <option value="2880">2 days</option>
+                        <option value="4320">3 days</option>
+                        <option value="5760">4 days</option>
+                        <option value="7200">5 days</option>
+                        <option value="8640">6 days</option>
+                    </optgroup>
+                    <optgroup label="Weeks">
+                        <option value="10080">1 week</option>
+                        <option value="20160">2 weeks</option>
+                        <option value="30240">3 weeks</option>
+                    </optgroup>
+                    <optgroup label="Months">
+                        <option value="40320">1 month</option>
+                        <option value="80640">2 months</option>
+                        <option value="120960">3 months</option>
+                        <option value="241920">6 months</option>
+                        <option value="483840">12 months</option>
+                    </optgroup>
+                    <option value="other">Other length (minutes)&hellip;</option>
+                </select>
+                <input type="text"
+                       class="input font-mono"
+                       id="search-bans-other-length"
+                       data-testid="search-bans-other-length"
+                       data-search-length-other
+                       placeholder="Minutes"
+                       hidden
+                       inputmode="numeric"
+                       pattern="[0-9]*"
+                       style="width:7rem">
+            </div>
+            <button type="submit"
+                    class="btn btn--secondary btn--sm"
+                    data-testid="search-bans-submit-length"
+                    data-search-key="length"
+                    data-search-compose="length">
+                <i data-lucide="search" style="width:14px;height:14px"></i> Search
+            </button>
+        </div>
+
+        <div class="grid gap-3" style="grid-template-columns:10rem 1fr auto;align-items:end">
+            <div>
+                <label class="label" for="search-bans-btype">Type</label>
+                <select class="select"
+                        id="search-bans-btype"
+                        data-testid="search-bans-btype">
+                    <option value="0" selected>Steam ID</option>
+                    <option value="1">IP address</option>
+                </select>
+            </div>
+            <div class="text-xs text-muted">Filter to either SteamID-only or IP-only ban records.</div>
+            <button type="submit"
+                    class="btn btn--secondary btn--sm"
+                    data-testid="search-bans-submit-btype"
+                    data-search-key="btype"
+                    data-search-from="search-bans-btype">
+                <i data-lucide="search" style="width:14px;height:14px"></i> Search
+            </button>
+        </div>
+
+        {if NOT $hideadminname}
+            <div class="grid gap-3" style="grid-template-columns:10rem 1fr auto;align-items:end">
+                <div>
+                    <label class="label" for="search-bans-admin">Admin</label>
+                    <select class="select"
+                            id="search-bans-admin"
+                            data-testid="search-bans-admin">
+                        <option value="">&mdash;</option>
+                        {foreach from=$admin_list item="admin"}
+                            <option value="{$admin.aid}">{$admin.user}</option>
+                        {/foreach}
+                    </select>
+                </div>
+                <div class="text-xs text-muted">Show only bans issued by the selected admin.</div>
+                <button type="submit"
+                        class="btn btn--secondary btn--sm"
+                        data-testid="search-bans-submit-admin"
+                        data-search-key="admin"
+                        data-search-from="search-bans-admin">
+                    <i data-lucide="search" style="width:14px;height:14px"></i> Search
+                </button>
+            </div>
+        {/if}
+
+        <div class="grid gap-3" style="grid-template-columns:10rem 1fr auto;align-items:end">
+            <div>
+                <label class="label" for="search-bans-server">Server</label>
+                <select class="select"
+                        id="search-bans-server"
+                        data-testid="search-bans-server">
+                    <option value="0" selected>Web Ban</option>
+                    {foreach from=$server_list item="server"}
+                        <option value="{$server.sid}"
+                                data-sid="{$server.sid}"
+                                data-ip="{$server.ip}"
+                                data-port="{$server.port}"
+                                data-server-host>Loading&hellip; ({$server.ip}:{$server.port})</option>
+                    {/foreach}
+                </select>
+            </div>
+            <div class="text-xs text-muted">Hostnames load asynchronously; pre-resolution shows ip:port.</div>
+            <button type="submit"
+                    class="btn btn--secondary btn--sm"
+                    data-testid="search-bans-submit-server"
+                    data-search-key="where_banned"
+                    data-search-from="search-bans-server">
+                <i data-lucide="search" style="width:14px;height:14px"></i> Search
+            </button>
+        </div>
+
+        {if $is_admin}
+            <div class="grid gap-3" style="grid-template-columns:10rem 1fr auto;align-items:end">
+                <label class="label" for="search-bans-comment" style="grid-column:1;align-self:end">Comment</label>
+                <input class="input"
+                       id="search-bans-comment"
+                       type="text"
+                       placeholder="Substring match against admin notes&hellip;"
+                       data-testid="search-bans-comment"
+                       autocomplete="off">
+                <button type="submit"
+                        class="btn btn--secondary btn--sm"
+                        data-testid="search-bans-submit-comment"
+                        data-search-key="comment"
+                        data-search-from="search-bans-comment">
+                    <i data-lucide="search" style="width:14px;height:14px"></i> Search
+                </button>
+            </div>
+        {/if}
+    </div>
+</form>
+
+{*
+    Inline submit dispatcher + LoadServerHost replacement.
+
+    Submit dispatcher: each per-row button declares its search
+    criterion via `data-search-key` and either points at a single
+    source field via `data-search-from` or composes a multi-field tuple
+    via `data-search-compose` ("steam", "date", "length"). On click,
+    the hidden `advType` / `advSearch` inputs are populated and the
+    form submits natively (no preventDefault on the success path), so
+    the browser navigates to the consumer URL with the correct query
+    string. Empty values cancel the submit.
+
+    LoadServerHost replacement: the legacy box appended a
+    server-built `<script>LoadServerHost(...)</script>` blob that
+    called the (now-gone) sourcebans.js helper per option. We replace
+    it with one `sb.api.call(Actions.ServersHostPlayers, {sid})` per
+    `<option data-server-host>` option, mirroring B5's pattern in
+    page_servers.tpl. Resolved hostnames replace the loading text in
+    place; failures fall back to "Offline (ip:port)".
+*}
+<script>
+{literal}
+(function () {
+    'use strict';
+    var form = document.querySelector('[data-testid="search-bans-form"]');
+    if (!(form instanceof HTMLFormElement)) return;
+
+    var typeField = form.querySelector('[data-search-type]');
+    var valueField = form.querySelector('[data-search-value]');
+    if (!(typeField instanceof HTMLInputElement) || !(valueField instanceof HTMLInputElement)) return;
+
+    var lengthSelect = form.querySelector('[data-search-length-select]');
+    var lengthOther = form.querySelector('[data-search-length-other]');
+    if (lengthSelect instanceof HTMLSelectElement && lengthOther instanceof HTMLInputElement) {
+        var sync = function () {
+            if (lengthSelect.value === 'other') {
+                lengthOther.hidden = false;
+                lengthOther.focus();
+            } else {
+                lengthOther.hidden = true;
+            }
+        };
+        lengthSelect.addEventListener('change', sync);
+        sync();
+    }
+
+    /**
+     * @param {Element} btn
+     * @returns {{ key: string, value: string }}
+     */
+    function readPair(btn) {
+        var compose = btn.getAttribute('data-search-compose');
+        if (compose === 'steam') {
+            var sid = document.getElementById('search-bans-steamid');
+            var match = document.getElementById('search-bans-steam-match');
+            var sval = (sid instanceof HTMLInputElement) ? sid.value.trim() : '';
+            var mval = (match instanceof HTMLSelectElement) ? match.value : '0';
+            return { key: (mval === '1' ? 'steam' : 'steamid'), value: sval };
+        }
+        if (compose === 'date') {
+            var keys = ['day', 'month', 'year'];
+            var parts = keys.map(function (k) {
+                var el = form.querySelector('[data-search-date="' + k + '"]');
+                return (el instanceof HTMLInputElement) ? el.value : '';
+            });
+            return { key: 'date', value: parts.join(',') };
+        }
+        if (compose === 'length') {
+            var op = document.getElementById('search-bans-length-op');
+            var sel = document.getElementById('search-bans-length');
+            var oth = document.getElementById('search-bans-other-length');
+            var opv = (op instanceof HTMLSelectElement) ? op.value : 'e';
+            var selv = (sel instanceof HTMLSelectElement) ? sel.value : '';
+            var lv = (selv === 'other' && oth instanceof HTMLInputElement) ? oth.value : selv;
+            return { key: 'length', value: opv + ',' + lv };
+        }
+        var fromId = btn.getAttribute('data-search-from');
+        if (!fromId) return { key: '', value: '' };
+        var src = document.getElementById(fromId);
+        if (src instanceof HTMLInputElement || src instanceof HTMLSelectElement || src instanceof HTMLTextAreaElement) {
+            return { key: btn.getAttribute('data-search-key') || '', value: src.value.trim() };
+        }
+        return { key: '', value: '' };
+    }
+
+    Array.prototype.forEach.call(form.querySelectorAll('button[data-search-compose], button[data-search-from]'), function (btn) {
+        btn.addEventListener('click', function (ev) {
+            var pair = readPair(btn);
+            if (pair.key === '' || pair.value === '' || pair.value.replace(/[,]/g, '') === '') {
+                ev.preventDefault();
+                return;
+            }
+            typeField.value = pair.key;
+            valueField.value = pair.value;
+        });
+    });
+
+    if (typeof sb === 'undefined' || !sb || !sb.api || typeof Actions === 'undefined') {
+        return;
+    }
+
+    Array.prototype.forEach.call(form.querySelectorAll('option[data-server-host]'), function (opt) {
+        var sid = Number(opt.getAttribute('data-sid'));
+        var ip = opt.getAttribute('data-ip') || '';
+        var port = opt.getAttribute('data-port') || '';
+        if (!sid) return;
+        sb.api.call(Actions.ServersHostPlayers, { sid: sid, trunchostname: 70 }).then(function (r) {
+            if (!r || !r.ok || !r.data) {
+                opt.textContent = 'Offline (' + ip + ':' + port + ')';
+                return;
+            }
+            var d = r.data;
+            if (d.error === 'connect') {
+                opt.textContent = 'Offline (' + ip + ':' + port + ')';
+                return;
+            }
+            opt.textContent = (d.hostname || (ip + ':' + port)) + ' (' + ip + ':' + port + ')';
+        }, function () {
+            opt.textContent = 'Offline (' + ip + ':' + port + ')';
+        });
+    });
+})();
+{/literal}
+</script>
+
+{*
+    Parity reference for the legacy default-theme `$server_script` blob.
+    AdminBansSearchView declares `$server_script` so the legacy
+    PHPStan leg (which scans `web/themes/default/box_admin_bans_search.tpl`)
+    finds it; the sbpp2026 leg would otherwise flag it
+    `unusedProperty`. The if-false branch is unreachable at render
+    time so no script blob is emitted twice — this template owns the
+    DOM and uses its own inline script above. Mirrors the parity-block
+    pattern AdminHomeView established in `page_admin.tpl` (#1123 B10).
+    D1 deletes the legacy template + the legacy-only `$server_script`
+    property; this block leaves with them.
+*}
+{if false}{$server_script nofilter}{/if}

--- a/web/themes/sbpp2026/box_admin_comms_search.tpl
+++ b/web/themes/sbpp2026/box_admin_comms_search.tpl
@@ -1,6 +1,486 @@
-<div class="card">
-    <div class="card__body">
-        <h1>{$title}</h1>
-        <p class="text-muted">This page hasn't been redesigned yet.</p>
+{*
+    SourceBans++ 2026 — public comms (mute / gag) advanced-search box.
+
+    Pair: web/pages/admin.comms.search.php +
+          web/includes/View/AdminCommsSearchView.php (typed DTO that
+          SmartyTemplateRule keeps in lockstep with this template).
+
+    This box is included via {load_template file="admin.comms.search"}
+    from any consumer page that wants the legacy advanced-search
+    affordance. The new sbpp2026 page_comms.tpl ships a single search
+    bar inline, but we keep this box as a fully-functional, paired-View
+    drop-in so future redesigns can re-mount it without re-plumbing the
+    form.
+
+    Wire format (kept identical to the legacy box so
+    page.commslist.php?advSearch=…&advType=… continues to parse the
+    same `$_GET` shape):
+        advType=name           advSearch=<text>            (nickname)
+        advType=steam|steamid  advSearch=<text>            (partial vs exact)
+        advType=reason         advSearch=<text>
+        advType=date           advSearch="<dd>,<mm>,<yyyy>"
+        advType=length         advSearch="<op>,<minutes>"  op ∈ e|h|l|eh|el
+        advType=btype          advSearch=<1|2>             1 = mute, 2 = gag
+        advType=admin          advSearch=<aid>
+        advType=where_banned   advSearch=<sid>             0 = web ban
+        advType=comment        advSearch=<text>            (admin-only)
+
+    Why we drop sourcebans.js' search_blocks() global
+    -------------------------------------------------
+    sourcebans.js disappears at #1123 D1, so the legacy
+    `onclick="search_blocks()"` button would `ReferenceError`
+    post-cutover. Each row gets its own submit button, with the
+    dispatch logic inlined under {literal}<script>…{/literal}` —
+    vanilla, no globals. The hidden `advType` / `advSearch` inputs
+    are populated from the row's source field on click and the form
+    submits natively; a no-JS browser still gets a working (if
+    type-less) form.
+
+    LoadServerHost replacement
+    --------------------------
+    The legacy `$server_script` payload built inline `<script>` tags
+    that called `LoadServerHost('SID', 'id', 'ssSID', '', '', false, 200)`
+    per server option to fetch the live hostname. After D1 removes
+    sourcebans.js, that helper is gone; the server-side list is now
+    plain `<option>`s carrying `data-sid`, and the inline initializer
+    below issues one `sb.api.call(Actions.ServersHostPlayers, {sid})`
+    per option — same pattern B5 established in page_servers.tpl.
+
+    Testability hooks (per #1123 issue body, "search-<scope>-<…>"):
+        data-testid="search-comms-form"           outer form
+        data-testid="search-comms-name"           nickname <input>
+        data-testid="search-comms-steamid"        SteamID <input>
+        data-testid="search-comms-steam-match"    exact / partial match
+        data-testid="search-comms-reason"         reason <input>
+        data-testid="search-comms-date-day"       date triple, …-month, …-year
+        data-testid="search-comms-length-op"      length comparator
+        data-testid="search-comms-length"         length <select>
+        data-testid="search-comms-other-length"   "other length" <input>
+        data-testid="search-comms-btype"          mute / gag <select>
+        data-testid="search-comms-admin"          admin <select>
+        data-testid="search-comms-server"         server <select>
+        data-testid="search-comms-comment"        admin comment <input>
+        data-testid="search-comms-submit-<key>"   one per searchable field
+*}
+<form method="get"
+      action="index.php"
+      data-testid="search-comms-form"
+      class="card"
+      style="margin-top:1rem;margin-bottom:1rem">
+    <input type="hidden" name="p" value="commslist">
+    <input type="hidden" name="advType" value="" data-search-type>
+    <input type="hidden" name="advSearch" value="" data-search-value>
+
+    <div class="card__header">
+        <div>
+            <h3>Advanced search</h3>
+            <p>Each row is its own search criterion &mdash; the &laquo;Search&raquo; button on the right submits using just that row's value.</p>
+        </div>
     </div>
-</div>
+
+    <div class="card__body space-y-3">
+        <div class="grid gap-3" style="grid-template-columns:10rem 1fr auto;align-items:end">
+            <label class="label" for="search-comms-name" style="grid-column:1;align-self:end">Nickname</label>
+            <input class="input"
+                   id="search-comms-name"
+                   type="text"
+                   placeholder="Substring match against the player nickname&hellip;"
+                   data-testid="search-comms-name"
+                   autocomplete="off">
+            <button type="submit"
+                    class="btn btn--secondary btn--sm"
+                    data-testid="search-comms-submit-name"
+                    data-search-key="name"
+                    data-search-from="search-comms-name">
+                <i data-lucide="search" style="width:14px;height:14px"></i> Search
+            </button>
+        </div>
+
+        <div class="grid gap-3" style="grid-template-columns:10rem 1fr auto;align-items:end">
+            <label class="label" for="search-comms-steamid" style="grid-column:1;align-self:end">Steam ID</label>
+            <div class="flex gap-2" style="flex-wrap:wrap">
+                <input class="input font-mono"
+                       id="search-comms-steamid"
+                       type="text"
+                       placeholder="STEAM_0:0:1234 or [U:1:1234]&hellip;"
+                       data-testid="search-comms-steamid"
+                       style="flex:1;min-width:14rem"
+                       autocomplete="off">
+                <select class="select"
+                        id="search-comms-steam-match"
+                        data-testid="search-comms-steam-match"
+                        style="width:9rem">
+                    <option value="0" selected>Exact match</option>
+                    <option value="1">Partial match</option>
+                </select>
+            </div>
+            <button type="submit"
+                    class="btn btn--secondary btn--sm"
+                    data-testid="search-comms-submit-steamid"
+                    data-search-key=""
+                    data-search-compose="steam">
+                <i data-lucide="search" style="width:14px;height:14px"></i> Search
+            </button>
+        </div>
+
+        <div class="grid gap-3" style="grid-template-columns:10rem 1fr auto;align-items:end">
+            <label class="label" for="search-comms-reason" style="grid-column:1;align-self:end">Reason</label>
+            <input class="input"
+                   id="search-comms-reason"
+                   type="text"
+                   placeholder="Substring match against the recorded reason&hellip;"
+                   data-testid="search-comms-reason"
+                   autocomplete="off">
+            <button type="submit"
+                    class="btn btn--secondary btn--sm"
+                    data-testid="search-comms-submit-reason"
+                    data-search-key="reason"
+                    data-search-from="search-comms-reason">
+                <i data-lucide="search" style="width:14px;height:14px"></i> Search
+            </button>
+        </div>
+
+        <div class="grid gap-3" style="grid-template-columns:10rem 1fr auto;align-items:end">
+            <span class="label" style="grid-column:1;align-self:end">Date</span>
+            <div class="flex items-center gap-2" style="flex-wrap:wrap">
+                <input class="input font-mono" style="width:3rem" type="text" maxlength="2" placeholder="DD"
+                       data-testid="search-comms-date-day"
+                       data-search-date="day"
+                       autocomplete="off"
+                       inputmode="numeric"
+                       pattern="[0-9]*">
+                <span class="text-faint">/</span>
+                <input class="input font-mono" style="width:3rem" type="text" maxlength="2" placeholder="MM"
+                       data-testid="search-comms-date-month"
+                       data-search-date="month"
+                       autocomplete="off"
+                       inputmode="numeric"
+                       pattern="[0-9]*">
+                <span class="text-faint">/</span>
+                <input class="input font-mono" style="width:4.25rem" type="text" maxlength="4" placeholder="YYYY"
+                       data-testid="search-comms-date-year"
+                       data-search-date="year"
+                       autocomplete="off"
+                       inputmode="numeric"
+                       pattern="[0-9]*">
+            </div>
+            <button type="submit"
+                    class="btn btn--secondary btn--sm"
+                    data-testid="search-comms-submit-date"
+                    data-search-key="date"
+                    data-search-compose="date">
+                <i data-lucide="search" style="width:14px;height:14px"></i> Search
+            </button>
+        </div>
+
+        <div class="grid gap-3" style="grid-template-columns:10rem 1fr auto;align-items:end">
+            <span class="label" style="grid-column:1;align-self:end">Length</span>
+            <div class="flex items-center gap-2" style="flex-wrap:wrap">
+                <select class="select"
+                        id="search-comms-length-op"
+                        data-testid="search-comms-length-op"
+                        style="width:5rem">
+                    <option value="e"  title="equal to">=</option>
+                    <option value="h"  title="greater">&gt;</option>
+                    <option value="l"  title="smaller">&lt;</option>
+                    <option value="eh" title="equal to or greater">&gt;=</option>
+                    <option value="el" title="equal to or smaller">&lt;=</option>
+                </select>
+                <select class="select"
+                        id="search-comms-length"
+                        data-testid="search-comms-length"
+                        style="flex:1;min-width:12rem"
+                        data-search-length-select>
+                    <option value="0">Permanent</option>
+                    <optgroup label="Minutes">
+                        <option value="1">1 minute</option>
+                        <option value="5">5 minutes</option>
+                        <option value="10">10 minutes</option>
+                        <option value="15">15 minutes</option>
+                        <option value="30">30 minutes</option>
+                        <option value="45">45 minutes</option>
+                    </optgroup>
+                    <optgroup label="Hours">
+                        <option value="60">1 hour</option>
+                        <option value="120">2 hours</option>
+                        <option value="180">3 hours</option>
+                        <option value="240">4 hours</option>
+                        <option value="480">8 hours</option>
+                        <option value="720">12 hours</option>
+                    </optgroup>
+                    <optgroup label="Days">
+                        <option value="1440">1 day</option>
+                        <option value="2880">2 days</option>
+                        <option value="4320">3 days</option>
+                        <option value="5760">4 days</option>
+                        <option value="7200">5 days</option>
+                        <option value="8640">6 days</option>
+                    </optgroup>
+                    <optgroup label="Weeks">
+                        <option value="10080">1 week</option>
+                        <option value="20160">2 weeks</option>
+                        <option value="30240">3 weeks</option>
+                    </optgroup>
+                    <optgroup label="Months">
+                        <option value="40320">1 month</option>
+                        <option value="80640">2 months</option>
+                        <option value="120960">3 months</option>
+                        <option value="241920">6 months</option>
+                        <option value="483840">12 months</option>
+                    </optgroup>
+                    <option value="other">Other length (minutes)&hellip;</option>
+                </select>
+                <input type="text"
+                       class="input font-mono"
+                       id="search-comms-other-length"
+                       data-testid="search-comms-other-length"
+                       data-search-length-other
+                       placeholder="Minutes"
+                       hidden
+                       inputmode="numeric"
+                       pattern="[0-9]*"
+                       style="width:7rem">
+            </div>
+            <button type="submit"
+                    class="btn btn--secondary btn--sm"
+                    data-testid="search-comms-submit-length"
+                    data-search-key="length"
+                    data-search-compose="length">
+                <i data-lucide="search" style="width:14px;height:14px"></i> Search
+            </button>
+        </div>
+
+        <div class="grid gap-3" style="grid-template-columns:10rem 1fr auto;align-items:end">
+            <div>
+                <label class="label" for="search-comms-btype">Type</label>
+                <select class="select"
+                        id="search-comms-btype"
+                        data-testid="search-comms-btype">
+                    <option value="1" selected>Mute</option>
+                    <option value="2">Gag</option>
+                </select>
+            </div>
+            <div class="text-xs text-muted">Filter by mute (voice) or gag (text) class.</div>
+            <button type="submit"
+                    class="btn btn--secondary btn--sm"
+                    data-testid="search-comms-submit-btype"
+                    data-search-key="btype"
+                    data-search-from="search-comms-btype">
+                <i data-lucide="search" style="width:14px;height:14px"></i> Search
+            </button>
+        </div>
+
+        {if NOT $hideadminname}
+            <div class="grid gap-3" style="grid-template-columns:10rem 1fr auto;align-items:end">
+                <div>
+                    <label class="label" for="search-comms-admin">Admin</label>
+                    <select class="select"
+                            id="search-comms-admin"
+                            data-testid="search-comms-admin">
+                        <option value="">&mdash;</option>
+                        {foreach from=$admin_list item="admin"}
+                            <option value="{$admin.aid}">{$admin.user}</option>
+                        {/foreach}
+                    </select>
+                </div>
+                <div class="text-xs text-muted">Show only blocks issued by the selected admin.</div>
+                <button type="submit"
+                        class="btn btn--secondary btn--sm"
+                        data-testid="search-comms-submit-admin"
+                        data-search-key="admin"
+                        data-search-from="search-comms-admin">
+                    <i data-lucide="search" style="width:14px;height:14px"></i> Search
+                </button>
+            </div>
+        {/if}
+
+        <div class="grid gap-3" style="grid-template-columns:10rem 1fr auto;align-items:end">
+            <div>
+                <label class="label" for="search-comms-server">Server</label>
+                <select class="select"
+                        id="search-comms-server"
+                        data-testid="search-comms-server">
+                    <option value="0" selected>Web Ban</option>
+                    {foreach from=$server_list item="server"}
+                        <option value="{$server.sid}"
+                                data-sid="{$server.sid}"
+                                data-ip="{$server.ip}"
+                                data-port="{$server.port}"
+                                data-server-host>Loading&hellip; ({$server.ip}:{$server.port})</option>
+                    {/foreach}
+                </select>
+            </div>
+            <div class="text-xs text-muted">Hostnames load asynchronously; pre-resolution shows ip:port.</div>
+            <button type="submit"
+                    class="btn btn--secondary btn--sm"
+                    data-testid="search-comms-submit-server"
+                    data-search-key="where_banned"
+                    data-search-from="search-comms-server">
+                <i data-lucide="search" style="width:14px;height:14px"></i> Search
+            </button>
+        </div>
+
+        {if $is_admin}
+            <div class="grid gap-3" style="grid-template-columns:10rem 1fr auto;align-items:end">
+                <label class="label" for="search-comms-comment" style="grid-column:1;align-self:end">Comment</label>
+                <input class="input"
+                       id="search-comms-comment"
+                       type="text"
+                       placeholder="Substring match against admin notes&hellip;"
+                       data-testid="search-comms-comment"
+                       autocomplete="off">
+                <button type="submit"
+                        class="btn btn--secondary btn--sm"
+                        data-testid="search-comms-submit-comment"
+                        data-search-key="comment"
+                        data-search-from="search-comms-comment">
+                    <i data-lucide="search" style="width:14px;height:14px"></i> Search
+                </button>
+            </div>
+        {/if}
+    </div>
+</form>
+
+{*
+    Inline submit dispatcher + LoadServerHost replacement.
+
+    Submit dispatcher: each per-row button declares its search
+    criterion via `data-search-key` and either points at a single
+    source field via `data-search-from` or composes a multi-field tuple
+    via `data-search-compose` ("steam", "date", "length"). On click,
+    the hidden `advType` / `advSearch` inputs are populated and the
+    form submits natively (no preventDefault on the success path), so
+    the browser navigates to the consumer URL with the correct query
+    string. Empty values cancel the submit.
+
+    LoadServerHost replacement: the legacy box appended a
+    server-built `<script>LoadServerHost(...)</script>` blob that
+    called the (now-gone) sourcebans.js helper per option. We replace
+    it with one `sb.api.call(Actions.ServersHostPlayers, {sid})` per
+    `<option data-server-host>` option, mirroring B5's pattern in
+    page_servers.tpl. Resolved hostnames replace the loading text in
+    place; failures fall back to the original "Loading… (ip:port)"
+    placeholder, then settle on "Offline" so the operator can still
+    pick the row.
+*}
+<script>
+{literal}
+(function () {
+    'use strict';
+    var form = document.querySelector('[data-testid="search-comms-form"]');
+    if (!(form instanceof HTMLFormElement)) return;
+
+    var typeField = form.querySelector('[data-search-type]');
+    var valueField = form.querySelector('[data-search-value]');
+    if (!(typeField instanceof HTMLInputElement) || !(valueField instanceof HTMLInputElement)) return;
+
+    var lengthSelect = form.querySelector('[data-search-length-select]');
+    var lengthOther = form.querySelector('[data-search-length-other]');
+    if (lengthSelect instanceof HTMLSelectElement && lengthOther instanceof HTMLInputElement) {
+        var sync = function () {
+            if (lengthSelect.value === 'other') {
+                lengthOther.hidden = false;
+                lengthOther.focus();
+            } else {
+                lengthOther.hidden = true;
+            }
+        };
+        lengthSelect.addEventListener('change', sync);
+        sync();
+    }
+
+    /**
+     * @param {Element} btn
+     * @returns {{ key: string, value: string }}
+     */
+    function readPair(btn) {
+        var compose = btn.getAttribute('data-search-compose');
+        if (compose === 'steam') {
+            var sid = document.getElementById('search-comms-steamid');
+            var match = document.getElementById('search-comms-steam-match');
+            var sval = (sid instanceof HTMLInputElement) ? sid.value.trim() : '';
+            var mval = (match instanceof HTMLSelectElement) ? match.value : '0';
+            return { key: (mval === '1' ? 'steam' : 'steamid'), value: sval };
+        }
+        if (compose === 'date') {
+            var keys = ['day', 'month', 'year'];
+            var parts = keys.map(function (k) {
+                var el = form.querySelector('[data-search-date="' + k + '"]');
+                return (el instanceof HTMLInputElement) ? el.value : '';
+            });
+            return { key: 'date', value: parts.join(',') };
+        }
+        if (compose === 'length') {
+            var op = document.getElementById('search-comms-length-op');
+            var sel = document.getElementById('search-comms-length');
+            var oth = document.getElementById('search-comms-other-length');
+            var opv = (op instanceof HTMLSelectElement) ? op.value : 'e';
+            var selv = (sel instanceof HTMLSelectElement) ? sel.value : '';
+            var lv = (selv === 'other' && oth instanceof HTMLInputElement) ? oth.value : selv;
+            return { key: 'length', value: opv + ',' + lv };
+        }
+        var fromId = btn.getAttribute('data-search-from');
+        if (!fromId) return { key: '', value: '' };
+        var src = document.getElementById(fromId);
+        if (src instanceof HTMLInputElement || src instanceof HTMLSelectElement || src instanceof HTMLTextAreaElement) {
+            return { key: btn.getAttribute('data-search-key') || '', value: src.value.trim() };
+        }
+        return { key: '', value: '' };
+    }
+
+    Array.prototype.forEach.call(form.querySelectorAll('button[data-search-compose], button[data-search-from]'), function (btn) {
+        btn.addEventListener('click', function (ev) {
+            var pair = readPair(btn);
+            if (pair.key === '' || pair.value === '' || pair.value.replace(/[,]/g, '') === '') {
+                ev.preventDefault();
+                return;
+            }
+            typeField.value = pair.key;
+            valueField.value = pair.value;
+        });
+    });
+
+    if (typeof sb === 'undefined' || !sb || !sb.api || typeof Actions === 'undefined') {
+        return;
+    }
+
+    Array.prototype.forEach.call(form.querySelectorAll('option[data-server-host]'), function (opt) {
+        var sid = Number(opt.getAttribute('data-sid'));
+        var ip = opt.getAttribute('data-ip') || '';
+        var port = opt.getAttribute('data-port') || '';
+        if (!sid) return;
+        sb.api.call(Actions.ServersHostPlayers, { sid: sid, trunchostname: 70 }).then(function (r) {
+            if (!r || !r.ok || !r.data) {
+                opt.textContent = 'Offline (' + ip + ':' + port + ')';
+                return;
+            }
+            var d = r.data;
+            if (d.error === 'connect') {
+                opt.textContent = 'Offline (' + ip + ':' + port + ')';
+                return;
+            }
+            // d.hostname is htmlspecialchars()'d server-side; assigning to
+            // .textContent re-encodes once so what shows in the <option>
+            // matches the legacy LoadServerHost behaviour.
+            opt.textContent = (d.hostname || (ip + ':' + port)) + ' (' + ip + ':' + port + ')';
+        }, function () {
+            opt.textContent = 'Offline (' + ip + ':' + port + ')';
+        });
+    });
+})();
+{/literal}
+</script>
+
+{*
+    Parity reference for the legacy default-theme `$server_script` blob.
+    AdminCommsSearchView declares `$server_script` so the legacy
+    PHPStan leg (which scans `web/themes/default/box_admin_comms_search.tpl`)
+    finds it; the sbpp2026 leg would otherwise flag it
+    `unusedProperty`. The if-false branch is unreachable at render
+    time so no script blob is emitted twice — this template owns the
+    DOM and uses its own inline script above. Mirrors the parity-block
+    pattern AdminHomeView established in `page_admin.tpl` (#1123 B10).
+    D1 deletes the legacy template + the legacy-only `$server_script`
+    property; this block leaves with them.
+*}
+{if false}{$server_script nofilter}{/if}

--- a/web/themes/sbpp2026/box_admin_log_search.tpl
+++ b/web/themes/sbpp2026/box_admin_log_search.tpl
@@ -1,6 +1,245 @@
-<div class="card">
-    <div class="card__body">
-        <h1>{$title}</h1>
-        <p class="text-muted">This page hasn't been redesigned yet.</p>
+{*
+    SourceBans++ 2026 — admin/settings (logs) advanced-search box.
+
+    Pair: web/pages/admin.log.search.php +
+          web/includes/View/AdminLogSearchView.php (typed DTO that
+          SmartyTemplateRule keeps in lockstep with this template).
+
+    This box is included via {load_template file="admin.log.search"}
+    from page_admin_settings_logs.tpl. It is intentionally
+    self-contained so any future redesign that wants the legacy
+    "advanced search" affordance (search by admin / message / date /
+    type) can drop the load_template call back in without re-plumbing
+    the form.
+
+    Wire format (kept identical to the legacy box so the consumer
+    handler in admin.settings.php?section=logs continues to parse the
+    same `$_GET['advSearch']` / `$_GET['advType']` shape):
+        advType=admin    advSearch=<aid>
+        advType=message  advSearch=<text>
+        advType=date     advSearch="<dd>,<mm>,<yyyy>,<fhh>,<fmm>,<thh>,<tmm>"
+        advType=type     advSearch="m" | "w" | "e"
+    The hash fragment "#^2" the legacy URL appended is theme-specific
+    DOM-anchor scrolling and is dropped here; the new layout has no
+    accordion to re-target.
+
+    Why we drop sourcebans.js' search_log() global
+    ----------------------------------------------
+    sourcebans.js disappears at #1123 D1, so the legacy
+    `onclick="search_log()"` button from box_admin_log_search.tpl
+    would `ReferenceError` post-cutover. Each row gets its own submit
+    button instead, with the dispatch logic inlined under
+    {literal}<script>…{/literal}` — vanilla, no globals, no
+    `sb.$idRequired` (the inline script owns its own DOM).
+
+    Testability hooks (per #1123 issue body, "search-<scope>-<…>"):
+        data-testid="search-log-form"            outer form
+        data-testid="search-log-admin"           admin <select>
+        data-testid="search-log-message"         message <input>
+        data-testid="search-log-date-day"        … and friends
+        data-testid="search-log-type"            type <select>
+        data-testid="search-log-submit-<key>"    one per searchable field
+*}
+<form method="get"
+      action="index.php"
+      data-testid="search-log-form"
+      class="card"
+      style="margin-top:1rem;margin-bottom:1rem">
+    <input type="hidden" name="p" value="admin">
+    <input type="hidden" name="c" value="settings">
+    <input type="hidden" name="section" value="logs">
+    <input type="hidden" name="advType" value="" data-search-type>
+    <input type="hidden" name="advSearch" value="" data-search-value>
+
+    <div class="card__header">
+        <div>
+            <h3>Advanced search</h3>
+            <p>Filter the system log by admin, message text, date range, or severity.</p>
+        </div>
     </div>
-</div>
+
+    <div class="card__body space-y-3">
+        <div class="grid gap-3" style="grid-template-columns:14rem 1fr auto;align-items:end">
+            <div>
+                <label class="label" for="search-log-admin">Admin</label>
+                <select class="select"
+                        id="search-log-admin"
+                        data-testid="search-log-admin">
+                    <option value="">&mdash;</option>
+                    {foreach from=$admin_list item="admin"}
+                        <option value="{$admin.aid}">{$admin.user}</option>
+                    {/foreach}
+                </select>
+            </div>
+            <div class="text-xs text-muted">Select an admin to filter actions to that account.</div>
+            <button type="submit"
+                    class="btn btn--secondary btn--sm"
+                    data-testid="search-log-submit-admin"
+                    data-search-key="admin"
+                    data-search-from="search-log-admin">
+                <i data-lucide="search" style="width:14px;height:14px"></i> Search
+            </button>
+        </div>
+
+        <div class="grid gap-3" style="grid-template-columns:14rem 1fr auto;align-items:end">
+            <label class="label" for="search-log-message" style="grid-column:1;align-self:end">Message</label>
+            <input class="input"
+                   id="search-log-message"
+                   type="text"
+                   placeholder="Substring to match against the log message&hellip;"
+                   data-testid="search-log-message"
+                   autocomplete="off">
+            <button type="submit"
+                    class="btn btn--secondary btn--sm"
+                    data-testid="search-log-submit-message"
+                    data-search-key="message"
+                    data-search-from="search-log-message">
+                <i data-lucide="search" style="width:14px;height:14px"></i> Search
+            </button>
+        </div>
+
+        <div class="grid gap-3" style="grid-template-columns:14rem 1fr auto;align-items:end">
+            <span class="label" style="grid-column:1;align-self:end">Date range</span>
+            <div class="flex items-center gap-2" style="flex-wrap:wrap">
+                <input class="input font-mono" style="width:3rem" type="text" maxlength="2" placeholder="DD"
+                       data-testid="search-log-date-day"
+                       data-search-date="day"
+                       autocomplete="off"
+                       inputmode="numeric"
+                       pattern="[0-9]*">
+                <span class="text-faint">/</span>
+                <input class="input font-mono" style="width:3rem" type="text" maxlength="2" placeholder="MM"
+                       data-testid="search-log-date-month"
+                       data-search-date="month"
+                       autocomplete="off"
+                       inputmode="numeric"
+                       pattern="[0-9]*">
+                <span class="text-faint">/</span>
+                <input class="input font-mono" style="width:4.25rem" type="text" maxlength="4" placeholder="YYYY"
+                       data-testid="search-log-date-year"
+                       data-search-date="year"
+                       autocomplete="off"
+                       inputmode="numeric"
+                       pattern="[0-9]*">
+                <span class="text-muted text-xs" style="margin-left:0.5rem">from</span>
+                <input class="input font-mono" style="width:3rem" type="text" maxlength="2" value="00"
+                       data-testid="search-log-date-fhour"
+                       data-search-date="fhour"
+                       autocomplete="off"
+                       inputmode="numeric"
+                       pattern="[0-9]*">
+                <span class="text-faint">:</span>
+                <input class="input font-mono" style="width:3rem" type="text" maxlength="2" value="00"
+                       data-testid="search-log-date-fminute"
+                       data-search-date="fminute"
+                       autocomplete="off"
+                       inputmode="numeric"
+                       pattern="[0-9]*">
+                <span class="text-muted text-xs" style="margin-left:0.5rem">to</span>
+                <input class="input font-mono" style="width:3rem" type="text" maxlength="2" value="23"
+                       data-testid="search-log-date-thour"
+                       data-search-date="thour"
+                       autocomplete="off"
+                       inputmode="numeric"
+                       pattern="[0-9]*">
+                <span class="text-faint">:</span>
+                <input class="input font-mono" style="width:3rem" type="text" maxlength="2" value="59"
+                       data-testid="search-log-date-tminute"
+                       data-search-date="tminute"
+                       autocomplete="off"
+                       inputmode="numeric"
+                       pattern="[0-9]*">
+            </div>
+            <button type="submit"
+                    class="btn btn--secondary btn--sm"
+                    data-testid="search-log-submit-date"
+                    data-search-key="date"
+                    data-search-compose="date">
+                <i data-lucide="search" style="width:14px;height:14px"></i> Search
+            </button>
+        </div>
+
+        <div class="grid gap-3" style="grid-template-columns:14rem 1fr auto;align-items:end">
+            <div>
+                <label class="label" for="search-log-type">Type</label>
+                <select class="select"
+                        id="search-log-type"
+                        data-testid="search-log-type">
+                    <option value="m">Message</option>
+                    <option value="w">Warning</option>
+                    <option value="e">Error</option>
+                </select>
+            </div>
+            <div class="text-xs text-muted">Filter to a single severity level.</div>
+            <button type="submit"
+                    class="btn btn--secondary btn--sm"
+                    data-testid="search-log-submit-type"
+                    data-search-key="type"
+                    data-search-from="search-log-type">
+                <i data-lucide="search" style="width:14px;height:14px"></i> Search
+            </button>
+        </div>
+    </div>
+</form>
+
+{*
+    Inline submit dispatcher — vanilla, no sourcebans.js dependency.
+
+    Each per-row submit button declares the search criterion via
+    `data-search-key`. The dispatcher (1) reads either the linked
+    field via `data-search-from`, or composes the date tuple via
+    `data-search-compose="date"`, (2) populates the hidden
+    `advType` / `advSearch` form inputs, and (3) lets the form submit
+    natively. The browser navigates to the consumer URL with the
+    correct query string — same wire format as the legacy
+    `search_log()` global from sourcebans.js, minus the `#^2` hash
+    that the sbpp2026 logs page no longer needs.
+*}
+<script>
+{literal}
+(function () {
+    'use strict';
+    var form = document.querySelector('[data-testid="search-log-form"]');
+    if (!(form instanceof HTMLFormElement)) return;
+
+    var typeField = form.querySelector('[data-search-type]');
+    var valueField = form.querySelector('[data-search-value]');
+    if (!(typeField instanceof HTMLInputElement) || !(valueField instanceof HTMLInputElement)) return;
+
+    /**
+     * @param {Element} btn
+     * @returns {string}
+     */
+    function readValue(btn) {
+        var compose = btn.getAttribute('data-search-compose');
+        if (compose === 'date') {
+            var keys = ['day', 'month', 'year', 'fhour', 'fminute', 'thour', 'tminute'];
+            return keys.map(function (k) {
+                var el = form.querySelector('[data-search-date="' + k + '"]');
+                return (el instanceof HTMLInputElement) ? el.value : '';
+            }).join(',');
+        }
+        var fromId = btn.getAttribute('data-search-from');
+        if (!fromId) return '';
+        var src = document.getElementById(fromId);
+        if (src instanceof HTMLInputElement || src instanceof HTMLSelectElement || src instanceof HTMLTextAreaElement) {
+            return src.value;
+        }
+        return '';
+    }
+
+    Array.prototype.forEach.call(form.querySelectorAll('button[data-search-key]'), function (btn) {
+        btn.addEventListener('click', function (ev) {
+            var key = btn.getAttribute('data-search-key') || '';
+            var value = readValue(btn);
+            if (key === '' || value === '' || value.replace(/[,]/g, '') === '') {
+                ev.preventDefault();
+                return;
+            }
+            typeField.value = key;
+            valueField.value = value;
+        });
+    });
+})();
+{/literal}
+</script>


### PR DESCRIPTION
Part of #1123. Pre-flight follow-up to unblock D1.

D1's pre-flight scan found four `web/themes/sbpp2026/box_admin_*_search.tpl`
stubs still carrying the A1 "hasn't been redesigned yet" marker. Each
one is loaded via `{load_template file="admin.<scope>.search"}` from a
`web/pages/admin.<scope>.search.php` handler, and three of those
handlers built a `$server_script` blob full of inline
`LoadServerHost('SID', host, port)` calls — a `sourcebans.js`-only
helper that disappears when D1 deletes the legacy script bundle. After
D1 those calls would throw `ReferenceError` on every search-box render.

This change closes the gap so D1 can proceed:

## Summary

- Pair each redesigned `box_admin_*_search.tpl` with a typed
  `Sbpp\View\Admin{Admins,Bans,Comms,Log}SearchView` DTO, switch the
  four handlers to `Renderer::render`, and restore `SmartyTemplateRule`
  parity for both the `default` and `sbpp2026` PHPStan legs.
- Replace the `LoadServerHost(...)` script-builder in the three
  server-bound handlers with a vanilla `sb.api.call(Actions.ServersHostPlayers,
  {sid, trunchostname})` blob — the same pattern B5 introduced in
  `web/themes/sbpp2026/page_servers.tpl`. The blob is only consumed by
  the legacy `default` template (which still references
  `{$server_script nofilter}`); the new `sbpp2026` templates own their
  own inline `querySelector(...).forEach(... sb.api.call ...)`
  initializer and carry an `{if false}{$server_script nofilter}{/if}`
  parity reference so `SmartyTemplateRule` keeps treating
  `$server_script` as "used" while the dual-theme matrix runs.
- Rename `AdminAdminsSearchView::$can_edit_admins` → `$can_editadmin`
  to match the literal `{$can_editadmin}` the legacy template already
  reads — single source of truth instead of two-name aliasing across
  themes.
- Wire every input/select/button to `data-testid="search-<scope>-<name>"`
  for downstream e2e + the C2 command palette.

Forms are GET (no CSRF needed) and post to the same `?p=…&advSearch=…&advType=…`
URLs the legacy buttons used, so the consuming list pages remain
unchanged.

## Files touched

New View DTOs (paired with the redesigned templates):
- `web/includes/View/AdminAdminsSearchView.php`
- `web/includes/View/AdminBansSearchView.php`
- `web/includes/View/AdminCommsSearchView.php`
- `web/includes/View/AdminLogSearchView.php`

Redesigned templates (no longer stubs):
- `web/themes/sbpp2026/box_admin_admins_search.tpl`
- `web/themes/sbpp2026/box_admin_bans_search.tpl`
- `web/themes/sbpp2026/box_admin_comms_search.tpl`
- `web/themes/sbpp2026/box_admin_log_search.tpl`

Handlers (switched to `Renderer::render`; legacy `LoadServerHost`
script-builder swapped for vanilla `sb.api.call(Actions.ServersHostPlayers, …)`):
- `web/pages/admin.admins.search.php`
- `web/pages/admin.bans.search.php`
- `web/pages/admin.comms.search.php`
- `web/pages/admin.log.search.php`

## Local quality gates

- `./sbpp.sh phpstan` (default theme): **OK**
- `phpstan analyse --configuration=phpstan-sbpp2026.neon` (sbpp2026 theme): **OK**
- `./sbpp.sh test`: **280 tests, 1189 assertions, OK**
- `./sbpp.sh ts-check`: **OK**
- `./sbpp.sh composer api-contract`: **clean (no diff)**
- Stub check: `find web/themes/sbpp2026 -name 'box_admin_*_search.tpl' | xargs grep -l "hasn't been redesigned yet"` → **0 results**

## Manual verification (sbpp2026 dev stack)

`http://localhost:8460/index.php?p=admin&c=admins` after `system.apply_theme`
to `sbpp2026`:
- Page renders with the redesigned search box (no stub message).
- Theme CSS loaded: `themes/sbpp2026/css/theme.css`.
- All `data-testid="search-admins-form"`, `…-name`, `…-steamid`, `…-steam-match`,
  `…-admemail`, `…-webgroup`, `…-submit-*` hooks present in DOM.
- Inline initializer emits exactly one `sb.api.call(Actions.ServersHostPlayers,
  { sid: sid, trunchostname: 70 })` per server `<option>` with
  `data-server-host`.
- Zero `LoadServerHost` references in the rendered HTML.
- No PHP errors / warnings / notices in the web container log.

The other three search boxes (`bans`, `comms`, `log`) aren't loaded by
any sbpp2026 page yet — D1 cleanup will wire them in. Their parity is
proven by the dual-theme PHPStan matrix and the stub check.

## Test plan

- [ ] CI: PHPStan default + sbpp2026 legs both green.
- [ ] CI: PHPUnit + ts-check + api-contract gates green.
- [ ] Spot-check the rendered admin admins page under sbpp2026 — the
      "Advanced search" card renders and server `<option>`s populate
      via `sb.api.call(Actions.ServersHostPlayers)` (no console
      `ReferenceError: LoadServerHost is not defined`).