### PR TITLE
[#1123 followup] Vanilla replacements for unguarded sourcebans.js callers (D1 prep)

### DIFF
--- a/web/pages/admin.bans.php
+++ b/web/pages/admin.bans.php
@@ -32,9 +32,10 @@ new AdminTabs([
 ], $userbank, $theme);
 
 if (isset($_GET['mode']) && $_GET['mode'] == "delete") {
-    echo "<script>ShowBox('Ban Deleted', 'The ban has been deleted from SourceBans', 'green', '', true);</script>";
+    // Inlined sourcebans.js helper (#1123 D1 prep): ShowBox is removed at D1; sb.message is in sb.js.
+    echo "<script>sb.message.show('Ban Deleted', 'The ban has been deleted from SourceBans', 'green', '', true);</script>";
 } elseif (isset($_GET['mode']) && $_GET['mode']=="unban") {
-    echo "<script>ShowBox('Player Unbanned', 'The Player has been unbanned from SourceBans', 'green', '', true);</script>";
+    echo "<script>sb.message.show('Player Unbanned', 'The Player has been unbanned from SourceBans', 'green', '', true);</script>";
 }
 
 if (isset($GLOBALS['IN_ADMIN'])) {
@@ -99,15 +100,20 @@ if (isset($_POST['action']) && $_POST['action'] == "importBans") {
         Log::add("m", "Bans imported", "$bancnt Ban(s) imported");
     }
 
-    echo "<script>ShowBox('Bans Import', '$bancnt ban" . ($bancnt != 1 ? "s have" : " has") . " been imported and posted.', 'green', '');</script>";
+    // Inlined sourcebans.js helper (#1123 D1 prep): ShowBox is removed at D1; sb.message is in sb.js.
+    echo "<script>sb.message.show('Bans Import', '$bancnt ban" . ($bancnt != 1 ? "s have" : " has") . " been imported and posted.', 'green', '');</script>";
 }
 
+// Inlined sourcebans.js helpers (#1123 D1 prep): LoadPrepareReban / LoadPasteBan / ShowBox / applyBanFields
+// disappear at D1; rebuild on top of sb.api.call + a small DOM-prefill helper that lives in this file's
+// tail script (window.__sbppApplyBanFields). Both inline scripts below dispatch through Actions.*
+// (api-contract.js) and use sb.ready so the helper is defined by the time the API response lands.
 if (isset($_GET["rebanid"])) {
-    echo '<script type="text/javascript">LoadPrepareReban("' . (int) $_GET["rebanid"] . '");</script>';
+    echo '<script type="text/javascript">sb.ready(function(){sb.api.call(Actions.BansPrepareReban,{bid:' . (int) $_GET["rebanid"] . '}).then(function(r){if(r&&r.ok&&r.data&&typeof window.__sbppApplyBanFields==="function")window.__sbppApplyBanFields(r.data);});});</script>';
 }
 if ((isset($_GET['action']) && $_GET['action'] == "pasteBan") && isset($_GET['pName']) && isset($_GET['sid'])) {
     $pNameJs = json_encode((string) $_GET['pName'], JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP);
-    echo "<script type=\"text/javascript\">ShowBox('Loading..','<b>Loading...</b><br><i>Please Wait!</i>', 'blue', '', true);sb.hide('dialog-control');LoadPasteBan(" . (int) $_GET['sid'] . ", " . $pNameJs . ");</script>";
+    echo "<script type=\"text/javascript\">sb.ready(function(){sb.message.show('Loading..','<b>Loading...</b><br><i>Please Wait!</i>','blue','',true);sb.hide('dialog-control');sb.api.call(Actions.BansPaste,{sid:" . (int) $_GET['sid'] . ",name:" . $pNameJs . ",type:0}).then(function(r){if(r&&r.ok&&r.data){if(typeof window.__sbppApplyBanFields==='function')window.__sbppApplyBanFields(r.data);sb.show('dialog-control');sb.hide('dialog-placement');}else if(r&&r.ok===false&&r.error){sb.message.error('Error',r.error.message);sb.show('dialog-control');}});});</script>";
 }
 
 echo '<div id="admin-page-content">';
@@ -174,7 +180,7 @@ if (strlen($next) > 0) {
 
 $pages = ceil($page_count / $ItemsPerPage);
 if ($pages > 1) {
-    $page_nav .= '&nbsp;<select onchange="changePage(this,\'P\',\'\',\'\');">';
+    $page_nav .= '&nbsp;<select onchange="if(this.value!==\'0\')window.location.href=\'index.php?p=admin&c=bans&ppage=\'+this.value+\'#^1\';">';
     for ($i = 1; $i <= $pages; $i++) {
         if ($i == $page) {
             $page_nav .= '<option value="' . $i . '" selected="selected">' . $i . '</option>';
@@ -328,7 +334,7 @@ if (strlen($next) > 0) {
 
 $pages = ceil($page_count / $ItemsPerPage);
 if ($pages > 1) {
-    $page_nav .= '&nbsp;<select onchange="changePage(this,\'PA\',\'\',\'\');">';
+    $page_nav .= '&nbsp;<select onchange="if(this.value!==\'0\')window.location.href=\'index.php?p=admin&c=bans&papage=\'+this.value+\'#^1~p1\';">';
     for ($i = 1; $i <= $pages; $i++) {
         if ($i == $page) {
             $page_nav .= '<option value="' . $i . '" selected="selected">' . $i . '</option>';
@@ -506,7 +512,7 @@ if (strlen($next) > 0) {
 
 $pages = ceil($page_count / $ItemsPerPage);
 if ($pages > 1) {
-    $page_nav .= '&nbsp;<select onchange="changePage(this,\'S\',\'\',\'\');">';
+    $page_nav .= '&nbsp;<select onchange="if(this.value!==\'0\')window.location.href=\'index.php?p=admin&c=bans&spage=\'+this.value+\'#^2\';">';
     for ($i = 1; $i <= $pages; $i++) {
         if ($i == $page) {
             $page_nav .= '<option value="' . $i . '" selected="selected">' . $i . '</option>';
@@ -646,7 +652,7 @@ if (strlen($next) > 0) {
 
 $pages = ceil($page_count / $ItemsPerPage);
 if ($pages > 1) {
-    $page_nav .= '&nbsp;<select onchange="changePage(this,\'SA\',\'\',\'\');">';
+    $page_nav .= '&nbsp;<select onchange="if(this.value!==\'0\')window.location.href=\'index.php?p=admin&c=bans&sapage=\'+this.value+\'#^2~s1\';">';
     for ($i = 1; $i <= $pages; $i++) {
         if ($i == $page) {
             $page_nav .= '<option value="' . $i . '" selected="selected">' . $i . '</option>';
@@ -863,12 +869,33 @@ function ProcessBan()
         reason:   reason,
         fromsub:  Number($('fromsub').value || 0),
     }).then(function (r) {
+        // Inlined sourcebans.js helpers (#1123 D1 prep): ShowKickBox / TabToReload /
+        // applyApiResponse are deleted at D1; rebuild on top of sb.message (sb.js, survives D1).
         if (r && r.ok && r.data && r.data.kickit) {
-            ShowKickBox(r.data.kickit.check, r.data.kickit.type);
-            if (r.data.reload) TabToReload();
+            sb.message.show(
+                'Ban Added',
+                'The ban has been successfully added<br><iframe id="srvkicker" frameborder="0" width="100%" src="pages/admin.kickit.php?check='
+                    + encodeURIComponent(r.data.kickit.check) + '&type=' + encodeURIComponent(r.data.kickit.type) + '"></iframe>',
+                'green',
+                'index.php?p=admin&c=bans',
+                true
+            );
+            if (r.data.reload) setTimeout(function () { window.location.href = window.location.href.replace(/#\^.*$/, ''); }, 2000);
             return;
         }
-        applyApiResponse(r);
+        if (!r) return;
+        if (r.redirect) return;
+        if (r.ok === false) {
+            if (r.error) sb.message.error('Error', r.error.message || 'Unknown error');
+            return;
+        }
+        var data = r.data || {};
+        if (data.message) {
+            sb.message.show(data.message.title, data.message.body, data.message.kind, data.message.redir, data.message.noclose);
+        }
+        if (data.reload) {
+            setTimeout(function () { window.location.href = window.location.href.replace(/#\^.*$/, ''); }, 2000);
+        }
     });
 }
 function ProcessGroupBan()
@@ -896,5 +923,25 @@ function CheckGroupBan()
         }
     }
 }
+
+// Inlined sourcebans.js helper (#1123 D1 prep): applyBanFields disappears at D1; rebuild on top of sb.js
+// primitives so both LoadPrepareReban and LoadPasteBan keep prefilling the form post-cutover.
+window.__sbppApplyBanFields = function (d) {
+    var byId = function (id) { return document.getElementById(id); };
+    if (byId('nickname'))   byId('nickname').value   = d.nickname || '';
+    if (byId('fromsub'))    byId('fromsub').value    = d.subid    || '';
+    if (byId('steam'))      byId('steam').value      = d.steam    || '';
+    if (byId('ip'))         byId('ip').value         = d.ip       || '';
+    if (byId('txtReason'))  byId('txtReason').value  = '';
+    if (byId('demo.msg'))   byId('demo.msg').innerHTML = '';
+    if (typeof window.selectLengthTypeReason === 'function') {
+        window.selectLengthTypeReason(d.length || 0, d.type || 0, d.reason || '');
+    }
+    if (d.demo) {
+        if (byId('demo.msg')) byId('demo.msg').innerHTML = d.demo.origname || '';
+        if (typeof window.demo === 'function') window.demo(d.demo.filename, d.demo.origname);
+    }
+    if (typeof window.swapTab === 'function') window.swapTab(0);
+};
 </script>
 </div>

--- a/web/pages/admin.comms.php
+++ b/web/pages/admin.comms.php
@@ -93,13 +93,18 @@ function ProcessBan()
     }).then(function (r) {
         // Inlined sourcebans.js helpers (#1123 D1 prep): ShowBlockBox / TabToReload /
         // applyApiResponse are deleted at D1; rebuild on top of sb.message (sb.js, survives D1).
+        // The iframe is load-bearing — pages/admin.blockit.php loops the enabled servers and
+        // fires `sc_fw_block` via rcon for each one. Without it the DB row exists but no live
+        // server learns about the gag/mute, matching the bans/kickit shape one branch above.
         if (r && r.ok && r.data && r.data.block) {
+            var b = r.data.block;
             sb.message.show(
                 'Block Added',
-                'The block has been successfully added.',
+                'The block has been successfully added<br><iframe id="srvkicker" frameborder="0" width="100%" src="pages/admin.blockit.php?check='
+                    + encodeURIComponent(b.steam) + '&type=' + encodeURIComponent(b.type) + '&length=' + encodeURIComponent(b.length) + '"></iframe>',
                 'green',
                 'index.php?p=admin&c=comms',
-                false
+                true
             );
             if (r.data.reload) setTimeout(function () { window.location.href = window.location.href.replace(/#\^.*$/, ''); }, 2000);
             return;

--- a/web/pages/admin.comms.php
+++ b/web/pages/admin.comms.php
@@ -33,9 +33,11 @@ new AdminTabs([
 ], $userbank, $theme);
 
 if (isset($_GET['mode']) && $_GET['mode'] == "delete") {
-    echo "<script>ShowBox('Ban Deleted', 'The ban has been deleted from SourceBans', 'green', '', true);</script>";
+    // Inlined sourcebans.js helper (#1123 D1 prep): ShowBox is removed at D1; sb.message is in sb.js.
+    echo "<script>sb.message.show('Ban Deleted', 'The ban has been deleted from SourceBans', 'green', '', true);</script>";
 } elseif (isset($_GET['mode']) && $_GET['mode']=="unban") {
-    echo "<script>ShowBox('Player Unbanned', 'The Player has been unbanned from SourceBans', 'green', '', true);</script>";
+    // Inlined sourcebans.js helper (#1123 D1 prep): ShowBox is removed at D1; sb.message is in sb.js.
+    echo "<script>sb.message.show('Player Unbanned', 'The Player has been unbanned from SourceBans', 'green', '', true);</script>";
 }
 
 if (isset($GLOBALS['IN_ADMIN'])) {
@@ -43,13 +45,16 @@ if (isset($GLOBALS['IN_ADMIN'])) {
 }
 
 
+// Inlined sourcebans.js helpers (#1123 D1 prep): LoadPrepareReblock / LoadPrepareBlockFromBan /
+// LoadPasteBlock / ShowBox / applyBlockFields disappear at D1; rebuild on top of sb.api.call +
+// a small DOM-prefill helper (window.__sbppApplyBlockFields) defined in this file's tail script.
 if (isset($_GET["rebanid"])) {
-    echo '<script type="text/javascript">LoadPrepareReblock("' . (int) $_GET["rebanid"] . '");</script>';
+    echo '<script type="text/javascript">sb.ready(function(){sb.api.call(Actions.CommsPrepareReblock,{bid:' . (int) $_GET["rebanid"] . '}).then(function(r){if(r&&r.ok&&r.data&&typeof window.__sbppApplyBlockFields==="function")window.__sbppApplyBlockFields(r.data);});});</script>';
 } elseif (isset($_GET["blockfromban"])) {
-    echo '<script type="text/javascript">LoadPrepareBlockFromBan("' . (int) $_GET["blockfromban"] . '");</script>';
+    echo '<script type="text/javascript">sb.ready(function(){sb.api.call(Actions.CommsPrepareBlockFromBan,{bid:' . (int) $_GET["blockfromban"] . '}).then(function(r){if(r&&r.ok&&r.data&&typeof window.__sbppApplyBlockFields==="function")window.__sbppApplyBlockFields(r.data);});});</script>';
 } elseif ((isset($_GET['action']) && $_GET['action'] == "pasteBan") && isset($_GET['pName']) && isset($_GET['sid'])) {
     $pNameJs = json_encode((string) $_GET['pName'], JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP);
-    echo "<script type=\"text/javascript\">ShowBox('Loading..','<b>Loading...</b><br><i>Please Wait!</i>', 'blue', '', true);sb.hide('dialog-control');LoadPasteBlock(" . (int) $_GET['sid'] . ", " . $pNameJs . ");</script>";
+    echo "<script type=\"text/javascript\">sb.ready(function(){sb.message.show('Loading..','<b>Loading...</b><br><i>Please Wait!</i>','blue','',true);sb.hide('dialog-control');sb.api.call(Actions.CommsPaste,{sid:" . (int) $_GET['sid'] . ",name:" . $pNameJs . ",type:0}).then(function(r){if(r&&r.ok&&r.data){if(typeof window.__sbppApplyBlockFields==='function')window.__sbppApplyBlockFields(r.data);sb.show('dialog-control');sb.hide('dialog-placement');}else if(r&&r.ok===false&&r.error){sb.message.error('Error',r.error.message);sb.show('dialog-control');}});});</script>";
 }
 
 echo '<div id="admin-page-content">';
@@ -86,13 +91,47 @@ function ProcessBan()
         length:   Number($('banlength').value),
         reason:   reason,
     }).then(function (r) {
+        // Inlined sourcebans.js helpers (#1123 D1 prep): ShowBlockBox / TabToReload /
+        // applyApiResponse are deleted at D1; rebuild on top of sb.message (sb.js, survives D1).
         if (r && r.ok && r.data && r.data.block) {
-            ShowBlockBox(r.data.block.steam, r.data.block.type, r.data.block.length);
-            if (r.data.reload) TabToReload();
+            sb.message.show(
+                'Block Added',
+                'The block has been successfully added.',
+                'green',
+                'index.php?p=admin&c=comms',
+                false
+            );
+            if (r.data.reload) setTimeout(function () { window.location.href = window.location.href.replace(/#\^.*$/, ''); }, 2000);
             return;
         }
-        applyApiResponse(r);
+        if (!r) return;
+        if (r.redirect) return;
+        if (r.ok === false) {
+            if (r.error) sb.message.error('Error', r.error.message || 'Unknown error');
+            return;
+        }
+        var data = r.data || {};
+        if (data.message) {
+            sb.message.show(data.message.title, data.message.body, data.message.kind, data.message.redir, data.message.noclose);
+        }
+        if (data.reload) {
+            setTimeout(function () { window.location.href = window.location.href.replace(/#\^.*$/, ''); }, 2000);
+        }
     });
 }
+
+// Inlined sourcebans.js helper (#1123 D1 prep): applyBlockFields disappears at D1; rebuild on top
+// of sb.js primitives so reblock / blockfromban / pasteBlock all keep prefilling the form.
+window.__sbppApplyBlockFields = function (d) {
+    var byId = function (id) { return document.getElementById(id); };
+    if (byId('nickname'))   byId('nickname').value   = d.nickname || '';
+    if (byId('fromsub'))    byId('fromsub').value    = d.subid    || '';
+    if (byId('steam'))      byId('steam').value      = d.steam    || '';
+    if (byId('txtReason'))  byId('txtReason').value  = '';
+    if (typeof window.selectLengthTypeReason === 'function') {
+        window.selectLengthTypeReason(d.length || 0, d.type || 0, d.reason || '');
+    }
+    if (typeof window.swapTab === 'function') window.swapTab(0);
+};
 </script>
 </div>

--- a/web/pages/admin.edit.adminservers.php
+++ b/web/pages/admin.edit.adminservers.php
@@ -133,9 +133,14 @@ if (isset($_POST['editadminserver'])) {
             }
         }
 
-        echo '<script>ShowRehashBox("' . implode(",", $allservers) . '", "Admin server access updated", "The admin server access has been updated successfully", "green", "index.php?p=admin&c=admins");TabToReload();</script>';
+        // Inlined sourcebans.js helpers (#1123 D1 prep): ShowRehashBox / ShowBox / TabToReload disappear
+        // at D1; replicate the rehash dialog on top of sb.message + sb.api.call (sb.js, survives D1).
+        $serversJs = json_encode(implode(",", $allservers), JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP);
+        echo '<script>(function(){var servers=' . $serversJs . ';var msg="The admin server access has been updated successfully<br /><hr /><i>Rehashing Admin and Group data on all related servers...</i><div id=\"rehashDiv\" name=\"rehashDiv\" width=\"100%\"></div>";sb.message.show("Admin server access updated",msg,"green","index.php?p=admin&c=admins",true);sb.hide("dialog-control");sb.api.call(Actions.SystemRehashAdmins,{servers:servers}).then(function(r){if(!r||!r.ok||!r.data)return;var div=sb.$id("rehashDiv");if(!div)return;var total=r.data.results.length;r.data.results.forEach(function(row,i){div.innerHTML+="Server #"+row.sid+" ("+(i+1)+"/"+total+"): "+(row.success?"<font color=\"green\">successful</font>.":"<font color=\"red\">failed</font>.")+"<br />";});sb.show("dialog-control");setTimeout(function(){window.location.href=window.location.href.replace(/#\^.*$/,"");},2000);});})();</script>';
     } else {
-        echo '<script>ShowBox("Admin server access updated", "The admin server access has been updated successfully", "green", "index.php?p=admin&c=admins");TabToReload();</script>';
+        // Inlined sourcebans.js helpers (#1123 D1 prep): ShowBox / TabToReload disappear at D1;
+        // sb.message (sb.js) survives D1, and we just reload after the success toast.
+        echo '<script>sb.message.show("Admin server access updated","The admin server access has been updated successfully","green","index.php?p=admin&c=admins",false);setTimeout(function(){window.location.href=window.location.href.replace(/#\^.*$/,"");},2000);</script>';
     }
 
     $GLOBALS['PDO']->query("SELECT user FROM `:prefix_admins` WHERE aid = :aid");

--- a/web/pages/admin.groups.php
+++ b/web/pages/admin.groups.php
@@ -216,5 +216,10 @@ echo '<div class="tabcontent" id="Add a group">';
 ));
 echo '</div>';
 ?>
-<script>InitAccordion('tr.opener', 'div.opener', 'mainwrapper');</script>
+<script>
+// Inlined sourcebans.js helper (#1123 D1 prep): InitAccordion is removed at D1; sb.accordion (sb.js)
+// is the actual implementation, so call it directly. The legacy helper also stashed the controller in
+// a global `accordion` variable, but no template reads it back, so we drop that side effect.
+sb.ready(function () { sb.accordion('tr.opener', 'div.opener', 'mainwrapper', -1); });
+</script>
 </div>

--- a/web/pages/page.home.php
+++ b/web/pages/page.home.php
@@ -24,6 +24,22 @@ if (!defined("IN_SB")) {
 }
 define('IN_HOME', true);
 
+/**
+ * Inlined sourcebans.js helpers (#1123 D1 prep): see page.servers.php for the canonical
+ * definition. Duplicated under function_exists() because page.home.php builds its
+ * LoadServerHostProperty()-equivalent calls before it requires page.servers.php, and we
+ * need the helper definitions to land at the head of $server_qry.
+ */
+if (!function_exists('SbppServerQryHelpers')) {
+    function SbppServerQryHelpers(): string
+    {
+        return <<<'JS'
+if(typeof window.__sbppLoadServerHost!=="function"){window.__sbppLoadServerHost=function(sid){sb.api.call(Actions.ServersHostPlayers,{sid:sid,trunchostname:70}).then(function(r){if(!r||!r.ok||!r.data)return;var d=r.data,hostEl=sb.$id("host_"+sid),playersEl=sb.$id("players_"+sid),osEl=sb.$id("os_"+sid),vacEl=sb.$id("vac_"+sid),mapEl=sb.$id("map_"+sid);if(d.error==="connect"){var ipPort=(d.ip||"")+":"+(d.port||"");if(hostEl)hostEl.innerHTML="<b>Error connecting</b> (<i>"+ipPort+"</i>)";if(!d.is_owner){if(playersEl)playersEl.textContent="N/A";if(osEl)osEl.textContent="N/A";if(vacEl)vacEl.textContent="N/A";if(mapEl)mapEl.textContent="N/A";}return;}if(hostEl)hostEl.innerHTML=d.hostname;if(playersEl)playersEl.textContent=(d.players||0)+"/"+(d.maxplayers||0);if(osEl)osEl.innerHTML="<i class='"+(d.os_class||"")+" fa-2x'></i>";if(vacEl&&d.secure)vacEl.innerHTML="<i class='fas fa-shield-alt fa-2x'></i>";if(mapEl)mapEl.textContent=d.map||"";});};}
+if(typeof window.__sbppLoadServerHostProperty!=="function"){window.__sbppLoadServerHostProperty=function(sid,obId,obProp){sb.api.call(Actions.ServersHostProperty,{sid:sid,trunchostname:100}).then(function(r){if(!r||!r.ok||!r.data)return;var text=r.data.error==="connect"?("Error connecting ("+(r.data.ip||"")+":"+(r.data.port||"")+")"):r.data.hostname;var el=sb.$id(obId);if(!el)return;if(obProp==="innerHTML")el.innerHTML=text;else el.setAttribute(obProp,text);});};}
+JS;
+    }
+}
+
 $totalstopped = (int) $GLOBALS['PDO']->query("SELECT count(name) AS cnt FROM `:prefix_banlog`")->single()['cnt'];
 
 $rows = $GLOBALS['PDO']->query("SELECT bl.name, time, bl.sid, bl.bid, b.type, b.authid, b.ip,
@@ -33,7 +49,7 @@ $rows = $GLOBALS['PDO']->query("SELECT bl.name, time, bl.sid, bl.bid, b.type, b.
 								LEFT JOIN `:prefix_servers` AS se ON se.sid = bl.sid
 								ORDER BY time DESC LIMIT 10")->resultset();
 
-$GLOBALS['server_qry'] = "";
+$GLOBALS['server_qry'] = SbppServerQryHelpers();
 $stopped               = [];
 $blcount               = 0;
 foreach ($rows as $row) {
@@ -68,7 +84,7 @@ foreach ($rows as $row) {
     }
     $info['popup']    = "ShowBox('Blocked player: " . $cleaned_name . "', '" . $cleaned_name . " tried to enter<br />' + document.getElementById('" . $info['server'] . "').title + '<br />at " . $info['date'] . "<br /><div align=middle><a href=" . $info['search_link'] . ">Click here for ban details.</a></div>', 'red', '', true);";
 
-    $GLOBALS['server_qry'] .= "LoadServerHostProperty(" . $row['sid'] . ", 'block_" . $row['sid'] . "_$blcount', 'title', 100);";
+    $GLOBALS['server_qry'] .= "__sbppLoadServerHostProperty(" . (int) $row['sid'] . ", 'block_" . (int) $row['sid'] . "_$blcount', 'title');";
 
     // sbpp2026 fields. Stored alongside the legacy keys above so the
     // new dashboard template reads `$player.bid` / `$player.sname`

--- a/web/pages/page.servers.php
+++ b/web/pages/page.servers.php
@@ -23,9 +23,35 @@ if (!defined("IN_SB")) {
     die();
 }
 
+/**
+ * Inlined sourcebans.js helpers (#1123 D1 prep): vanilla replacements for
+ * LoadServerHost / LoadServerHostProperty. Both are emitted into
+ * $GLOBALS['server_qry'] from page.{servers,home}.php and rendered through
+ * legacy themes' core/footer.tpl. Post-D1 sourcebans.js is gone, so we
+ * define the helper as window.__sbppLoadServerHost{,Property} and call those
+ * instead. The new sbpp2026 theme's footer doesn't emit {$query nofilter} so
+ * neither the helper definition nor the calls run there; legacy + third-party
+ * themes that copy the legacy footer pattern still get the populate behavior.
+ *
+ * Wrapped in function_exists so the same helper definition can ship from
+ * page.home.php too without redefining the function.
+ */
+if (!function_exists('SbppServerQryHelpers')) {
+    function SbppServerQryHelpers(): string
+    {
+        return <<<'JS'
+if(typeof window.__sbppLoadServerHost!=="function"){window.__sbppLoadServerHost=function(sid){sb.api.call(Actions.ServersHostPlayers,{sid:sid,trunchostname:70}).then(function(r){if(!r||!r.ok||!r.data)return;var d=r.data,hostEl=sb.$id("host_"+sid),playersEl=sb.$id("players_"+sid),osEl=sb.$id("os_"+sid),vacEl=sb.$id("vac_"+sid),mapEl=sb.$id("map_"+sid);if(d.error==="connect"){var ipPort=(d.ip||"")+":"+(d.port||"");if(hostEl)hostEl.innerHTML="<b>Error connecting</b> (<i>"+ipPort+"</i>)";if(!d.is_owner){if(playersEl)playersEl.textContent="N/A";if(osEl)osEl.textContent="N/A";if(vacEl)vacEl.textContent="N/A";if(mapEl)mapEl.textContent="N/A";}return;}if(hostEl)hostEl.innerHTML=d.hostname;if(playersEl)playersEl.textContent=(d.players||0)+"/"+(d.maxplayers||0);if(osEl)osEl.innerHTML="<i class='"+(d.os_class||"")+" fa-2x'></i>";if(vacEl&&d.secure)vacEl.innerHTML="<i class='fas fa-shield-alt fa-2x'></i>";if(mapEl)mapEl.textContent=d.map||"";});};}
+if(typeof window.__sbppLoadServerHostProperty!=="function"){window.__sbppLoadServerHostProperty=function(sid,obId,obProp){sb.api.call(Actions.ServersHostProperty,{sid:sid,trunchostname:100}).then(function(r){if(!r||!r.ok||!r.data)return;var text=r.data.error==="connect"?("Error connecting ("+(r.data.ip||"")+":"+(r.data.port||"")+")"):r.data.hostname;var el=sb.$id(obId);if(!el)return;if(obProp==="innerHTML")el.innerHTML=text;else el.setAttribute(obProp,text);});};}
+JS;
+    }
+}
+
 $number = -1;
 if (!defined('IN_HOME')) {
-    $GLOBALS['server_qry'] = "";
+    // The legacy default theme wraps {$query nofilter} in <script>...</script> via core/footer.tpl,
+    // so we emit RAW JS here. The new sbpp2026 footer drops {$query nofilter} entirely, so this
+    // payload only runs under themes that preserved the legacy footer pattern.
+    $GLOBALS['server_qry'] = SbppServerQryHelpers();
     if (isset($_GET['s'])) {
         $number = (int) $_GET['s'];
     }
@@ -51,7 +77,7 @@ foreach ($rows as $row) {
         $info['evOnClick'] = "window.location = 'index.php?p=servers&s=" . $info['index'] . "';";
     }
 
-    $GLOBALS['server_qry'] .= "LoadServerHost({$info['sid']}, 'servers', '', '" . $i . "', '" . $number . "', " . (defined('IN_HOME') ? 'true' : 'false') . ", 70);";
+    $GLOBALS['server_qry'] .= '__sbppLoadServerHost(' . (int) $info['sid'] . ');';
     array_push($servers, $info);
     $i++;
 }

--- a/web/themes/sbpp2026/page_admin_bans_groups.tpl
+++ b/web/themes/sbpp2026/page_admin_bans_groups.tpl
@@ -173,7 +173,58 @@
                    string contents and never terminates early. Matches the legacy default theme's behaviour.
                    DO NOT add `nofilter` here without an alternative escape (e.g. json_encode in the View);
                    doing so re-opens a reflected XSS via `?p=admin&c=bans&fid=…');alert(1);//`. *}
-                <script>LoadGetGroups('{$list_steam_groups}');</script>
+                <script>
+                {literal}
+                // Inlined sourcebans.js helper (#1123 D1 prep): the legacy LoadGetGroups lives in
+                // sourcebans.js, which sbpp2026 doesn't load. Vanilla replacement against
+                // Actions.BansGetGroups; mirrors the legacy DOM-ops shape so #steamGroupsTable
+                // rows stay structurally identical (TickSelectAll / CheckGroupBan keep working).
+                (function (friendid) {
+                    sb.ready(function () {
+                        sb.api.call(Actions.BansGetGroups, { friendid: friendid }).then(function (r) {
+                            if (!r || !r.ok || !r.data) return;
+                            var groups = r.data.groups || [];
+                            var tbl = sb.$id('steamGroupsTable');
+                            if (!tbl) return;
+                            if (groups.length === 0) {
+                                sb.message.error('Error', "There was an error retrieving the group data. Maybe the player isn't member of any group or his profile is private?", 'index.php?p=banlist');
+                                var txt = sb.$id('steamGroupsText');
+                                if (txt) txt.innerHTML = '<i>No groups...</i>';
+                                return;
+                            }
+                            groups.forEach(function (g, i) {
+                                var safeUrl = encodeURIComponent(String(g.url || ''));
+                                var tr = tbl.insertRow();
+                                var td1 = tr.insertCell();
+                                td1.style.padding = '0px';
+                                td1.style.width = '3px';
+                                var cb = document.createElement('input');
+                                cb.type = 'checkbox';
+                                cb.id = 'chkb_' + i;
+                                cb.value = String(g.url || '');
+                                td1.appendChild(cb);
+                                var td2 = tr.insertCell();
+                                var a = document.createElement('a');
+                                a.href = 'http://steamcommunity.com/groups/' + safeUrl;
+                                a.target = '_blank';
+                                a.rel = 'noopener noreferrer';
+                                a.textContent = String(g.name || '');
+                                td2.appendChild(a);
+                                td2.appendChild(document.createTextNode(' ('));
+                                var span = document.createElement('span');
+                                span.id = 'membcnt_' + i;
+                                span.setAttribute('value', String(g.member_count || 0));
+                                span.textContent = String(g.member_count || 0);
+                                td2.appendChild(span);
+                                td2.appendChild(document.createTextNode(' Members)'));
+                            });
+                            sb.hide('steamGroupsText');
+                            sb.show('steamGroups');
+                        });
+                    });
+                })({/literal}'{$list_steam_groups}'{literal});
+                {/literal}
+                </script>
             {/if}
         </section>
     {/if}

--- a/web/themes/sbpp2026/page_admin_groups_add.tpl
+++ b/web/themes/sbpp2026/page_admin_groups_add.tpl
@@ -97,28 +97,31 @@ function SbppGroupsAdd(event) {
     }).then(function (r) {
         // Inlined sourcebans.js helper (#1123 D1 prep): applyApiResponse is removed at D1.
         // sb.api.call already follows r.redirect natively, so we only need to surface
-        // the success/error toast. Prefer the new theme's toast; fall back to sb.message.
+        // the success/error toast. SBPP.showToast (theme.js) takes {kind,title,body};
+        // sb.message is the legacy fallback (no-ops under sbpp2026 since #dialog-* is
+        // legacy-default-only, but kept so a third-party theme that never wired SBPP
+        // still gets some signal).
         if (!r) return;
         if (r.redirect) return;
         if (r.ok === false) {
             var em = (r.error && r.error.message) || 'Unknown error';
             if (window.SBPP && typeof window.SBPP.showToast === 'function') {
-                window.SBPP.showToast({ type: 'error', message: em });
+                window.SBPP.showToast({ kind: 'error', title: 'Error', body: em });
             } else {
                 sb.message.error('Error', em);
             }
             return;
         }
         var data = r.data || {};
-        var msg = (data.message && data.message.body) || 'Group added.';
+        var body = (data.message && data.message.body) || 'Group added.';
         var title = (data.message && data.message.title) || 'Group added';
         if (window.SBPP && typeof window.SBPP.showToast === 'function') {
-            window.SBPP.showToast({ type: 'success', message: msg });
+            window.SBPP.showToast({ kind: 'success', title: title, body: body });
         } else {
-            sb.message.success(title, msg, data.message ? data.message.redir : '');
+            sb.message.success(title, body, data.message ? data.message.redir : '');
         }
         if (data.reload) {
-            setTimeout(function () { window.location.reload(); }, 1500);
+            setTimeout(function () { window.location.reload(); }, 2000);
         }
     });
     return false;

--- a/web/themes/sbpp2026/page_admin_groups_add.tpl
+++ b/web/themes/sbpp2026/page_admin_groups_add.tpl
@@ -94,7 +94,33 @@ function SbppGroupsAdd(event) {
         type: type,
         bitmask: 0,
         srvflags: srvflags
-    }).then(function (r) { applyApiResponse(r); });
+    }).then(function (r) {
+        // Inlined sourcebans.js helper (#1123 D1 prep): applyApiResponse is removed at D1.
+        // sb.api.call already follows r.redirect natively, so we only need to surface
+        // the success/error toast. Prefer the new theme's toast; fall back to sb.message.
+        if (!r) return;
+        if (r.redirect) return;
+        if (r.ok === false) {
+            var em = (r.error && r.error.message) || 'Unknown error';
+            if (window.SBPP && typeof window.SBPP.showToast === 'function') {
+                window.SBPP.showToast({ type: 'error', message: em });
+            } else {
+                sb.message.error('Error', em);
+            }
+            return;
+        }
+        var data = r.data || {};
+        var msg = (data.message && data.message.body) || 'Group added.';
+        var title = (data.message && data.message.title) || 'Group added';
+        if (window.SBPP && typeof window.SBPP.showToast === 'function') {
+            window.SBPP.showToast({ type: 'success', message: msg });
+        } else {
+            sb.message.success(title, msg, data.message ? data.message.redir : '');
+        }
+        if (data.reload) {
+            setTimeout(function () { window.location.reload(); }, 1500);
+        }
+    });
     return false;
 }
 {/literal}


### PR DESCRIPTION
Part of #1123. Pre-flight follow-up to unblock D1. Replaces 8 unguarded `sourcebans.js` function call sites (and the adjacent `ShowBox` / `LoadPaste*` siblings in the same files that would also `ReferenceError` post-D1) with vanilla equivalents or guarded shims so D1's `git rm web/scripts/sourcebans.js` doesn't break the panel.

## Summary

| File | Sites addressed | Replacement strategy |
|------|-----------------|----------------------|
| `web/pages/admin.bans.php` | `ProcessBan` (`ShowKickBox` / `TabToReload` / `applyApiResponse`), 4× `<select onchange="changePage(...)">`, `LoadPrepareReban` / `LoadPasteBan`, 2× `ShowBox` banners | Inline `sb.message.show` + `setTimeout(location.reload)`; direct `window.location.href` updates; `sb.api.call(Actions.BansPrepareReban / Actions.BansPaste)` + new `window.__sbppApplyBanFields` tail helper (replaces `applyBanFields`). |
| `web/pages/admin.comms.php` | `ProcessBan` (`ShowBlockBox` / `TabToReload` / `applyApiResponse`), `LoadPrepareReblock` / `LoadPrepareBlockFromBan` / `LoadPasteBlock`, 2× `ShowBox` banners | Same shape as `admin.bans.php`, plus `window.__sbppApplyBlockFields` helper (replaces `applyBlockFields`). |
| `web/pages/admin.groups.php` | `InitAccordion` | `sb.accordion(...)` (lives in `sb.js`, survives D1). |
| `web/pages/admin.edit.adminservers.php` | `ShowRehashBox` + `TabToReload` + `ShowBox` | Inline `sb.api.call(Actions.SystemRehashAdmins)` + `sb.message.show`. |
| `web/pages/page.servers.php` | `LoadServerHost` script-builder | New `SbppServerQryHelpers()` PHP function (function_exists-guarded) emits `window.__sbppLoadServerHost{,Property}` definitions; the loop emits `__sbppLoadServerHost(SID);` calls. |
| `web/pages/page.home.php` | `LoadServerHostProperty` script-builder | Mirror of above; both files ship the same helper definition so either can lead. |
| `web/themes/sbpp2026/page_admin_groups_add.tpl` | `applyApiResponse(r)` | Inline envelope handler that prefers `window.SBPP.showToast` and falls back to `sb.message`. |
| `web/themes/sbpp2026/page_admin_bans_groups.tpl` | `LoadGetGroups` | Inline `sb.api.call(Actions.BansGetGroups)` with the same DOM-ops shape, so `TickSelectAll` / `CheckGroupBan` keep operating on the same `#steamGroupsTable` rows. |

Replacements: 13 call sites across 8 files (8 from the original D1 pre-flight scan + 5 adjacent `sourcebans.js`-only sites in the same files that would also `ReferenceError` post-D1). All inline replacements; no guarded shims needed.

The new `sbpp2026/core/footer.tpl` deliberately drops `{$query nofilter}`, so `__sbppLoadServerHost{,Property}` only runs under the legacy default theme + any third-party theme that keeps the legacy footer shape.

## Test plan

Local gates (all green):
- `./sbpp.sh phpstan` — 0 errors (208 files).
- `./sbpp.sh ts-check` — clean.
- `./sbpp.sh composer api-contract` — no diff (no handler changes).
- `./sbpp.sh test` — 280 tests / 1189 assertions, all passing.
- `php -l` clean on every modified PHP file.

Manual smoke-test:
- [ ] `/?p=home` renders under sbpp2026 theme; no `ReferenceError` in console.
- [ ] `/?p=servers` renders under sbpp2026 theme; per-card `Actions.ServersHostPlayers` call still fires (uses the template's own JS, unrelated to the helper).
- [ ] `/?p=admin&c=bans` admin tab list pagination + Add a ban form (incl. paste-from-server flow) under both default and sbpp2026 themes.
- [ ] `/?p=admin&c=comms` Add a block form (incl. reblock + block-from-ban + paste flows) under both themes.
- [ ] `/?p=admin&c=groups` accordion open/close under both themes.
- [ ] `/?p=admin&c=admins&o=editservers` rehash dialog after submitting under both themes.

Out of scope (separate followups, per the task brief):
- 4 search-box stub redesigns.
- `page_admin_edit_ban.tpl` redesign.
- Script-builders in `admin.{bans,admins,comms}.search.php` that emit `LoadServerHost` (handled by the search-stubs follow-up).