### PR TITLE
tests/e2e: foundation (Playwright + axe + screenshot gallery harness)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,94 @@
+name: E2E
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'web/**'
+      - 'docker/**'
+      - 'docker-compose.yml'
+      - 'sbpp.sh'
+      - '.github/workflows/e2e.yml'
+  pull_request:
+    paths:
+      - 'web/**'
+      - 'docker/**'
+      - 'docker-compose.yml'
+      - 'sbpp.sh'
+      - '.github/workflows/e2e.yml'
+
+jobs:
+  playwright:
+    name: Playwright + axe
+    runs-on: ubuntu-24.04
+    # Generous overall timeout: first-run includes a full chromium
+    # download + apt-install. Subsequent runs come back inside this
+    # cap easily. Persistent failures (no retries left) still fail the
+    # job — there's no `continue-on-error`.
+    timeout-minutes: 30
+
+    steps:
+      - uses: actions/checkout@v4
+
+      # Bring up the same stack a developer gets locally via
+      # `./sbpp.sh up`. CI owns the runner, so no override file is
+      # needed; the published ports default to 8080 / 8081 / 8025 /
+      # 1025 / 3307 (see docker-compose.yml).
+      - name: Bring up the dev stack
+        run: docker compose up -d --wait
+
+      - name: Wait for the panel
+        run: |
+          for i in {1..30}; do
+            code=$(curl -sS -o /dev/null -w '%{http_code}' http://localhost:8080/index.php?p=login || true)
+            if [[ "$code" == "200" ]]; then
+              echo "panel ready after attempt $i"
+              exit 0
+            fi
+            echo "attempt $i: HTTP $code, retrying"
+            sleep 3
+          done
+          echo "panel never came up" >&2
+          docker compose logs --tail=200 web db
+          exit 1
+
+      # Run the suite. `./sbpp.sh e2e` exec's into the web container
+      # and lazily installs @playwright/test + chromium + system deps
+      # on first run; CI pays this cost once per workflow because
+      # nothing is cached between runs (the install footprint is small
+      # enough that caching is more effort than it saves).
+      #
+      # Retries are wired in `playwright.config.ts` via
+      # `retries: process.env.CI ? 1 : 0` — one retry on flake, fail
+      # the job on persistent failure.
+      - name: Run E2E
+        env:
+          CI: '1'
+        run: ./sbpp.sh e2e
+
+      # Upload artifacts on failure so reviewers can debug from the
+      # PR UI without re-running locally. The HTML report and the
+      # raw test-results (traces, videos, axe report attachments)
+      # together cover almost every "what failed and why" question.
+      - name: Upload Playwright report
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: web/tests/e2e/playwright-report/
+          retention-days: 7
+          if-no-files-found: ignore
+
+      - name: Upload Playwright test-results
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-test-results
+          path: web/tests/e2e/test-results/
+          retention-days: 7
+          if-no-files-found: ignore
+
+      - name: Tear down
+        if: always()
+        run: ./sbpp.sh down

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,6 +66,7 @@ Run from the repo root. All commands are idempotent.
 ./sbpp.sh test [args]              # PHPUnit on sourcebans_test DB
 ./sbpp.sh ts-check                 # tsc --checkJs over web/scripts
 ./sbpp.sh composer api-contract    # regen scripts/api-contract.js
+./sbpp.sh e2e [args]               # Playwright E2E suite (lazy npm install + chromium browser)
 
 # DB
 ./sbpp.sh db-dump [file]           # mysqldump to host
@@ -137,14 +138,15 @@ services:
 
 ## Quality gates
 
-CI runs four gates on every PR. Match them locally before opening one.
+CI runs five gates on every PR. Match them locally before opening one.
 
-| Gate          | Local                                | CI workflow            |
-| ------------- | ------------------------------------ | ---------------------- |
-| PHPStan       | `./sbpp.sh phpstan`                  | `phpstan.yml`          |
-| PHPUnit       | `./sbpp.sh test`                     | `test.yml`             |
-| ts-check      | `./sbpp.sh ts-check`                 | `ts-check.yml`         |
-| API contract  | `./sbpp.sh composer api-contract`    | `api-contract.yml`     |
+| Gate           | Local                                | CI workflow            |
+| -------------- | ------------------------------------ | ---------------------- |
+| PHPStan        | `./sbpp.sh phpstan`                  | `phpstan.yml`          |
+| PHPUnit        | `./sbpp.sh test`                     | `test.yml`             |
+| ts-check       | `./sbpp.sh ts-check`                 | `ts-check.yml`         |
+| API contract   | `./sbpp.sh composer api-contract`    | `api-contract.yml`     |
+| Playwright E2E | `./sbpp.sh e2e`                      | `e2e.yml`              |
 
 PHPStan specifics:
 
@@ -199,6 +201,40 @@ API-contract specifics:
   need no codegen step.
 - CI fails on `git diff` after regeneration. Always commit the
   regenerated file in the same PR as the PHP change.
+
+Playwright E2E specifics:
+
+- Suite location: `web/tests/e2e/` with its own `package.json`
+  (separate from PHPUnit; PHPUnit owns `web/composer.json` /
+  `web/package.json`).
+- DB: `sourcebans_e2e` (parallel to `sourcebans_test`). Reset between
+  specs via `truncateE2eDb()` (truncate + re-seed); full
+  install only on global setup. The shim
+  `web/tests/e2e/scripts/reset-e2e-db.php` reuses
+  `Sbpp\Tests\Fixture` so the fixture stays single-source.
+- Auth: storage state minted once per run by
+  `fixtures/global-setup.ts` against the seeded `admin/admin` user.
+  The login spec is the **one** exception that drives the form
+  itself — every other spec inherits the storage state.
+- Selectors must use #1123's testability hooks (`data-testid`,
+  `[data-active]`, `[data-loading]`, `[data-skeleton]`, ARIA roles,
+  `<html class="dark">` for resolved theme). Never CSS class chains;
+  never visible text as the *primary* selector. `hasText` filters
+  are fine to disambiguate when the primary selector matches more
+  than one node (e.g. multiple toasts).
+- axe (`@axe-core/playwright`) threshold is **critical**. Use
+  `expectNoCriticalA11y(page, testInfo)` from `fixtures/axe.ts`;
+  do NOT downgrade the threshold to make tests green — file a
+  follow-up against the underlying #1123 testability patterns.
+- `prefers-reduced-motion: reduce` is set globally via
+  `playwright.config.ts`. Animations should never gate visibility;
+  if a test needs a `setTimeout`, the chrome's missing a terminal
+  attribute (see `_base.ts`).
+- `./sbpp.sh e2e --grep @screenshot SCREENSHOTS=1` produces the
+  per-PR screenshot gallery. The
+  `web/tests/e2e/scripts/upload-screenshots.sh` wrapper pushes the
+  PNGs to the `screenshots-archive` orphan branch under a per-PR
+  subdirectory and prints the markdown table to comment on the PR.
 
 ## Conventions
 
@@ -388,6 +424,13 @@ bearing assertion that the value is already safe HTML, so:
   value is safe HTML; without a `{* nofilter: <why> *}` comment above
   it, future readers can't tell whether it's a real escape hatch or a
   copy-paste accident waiting to be exploited (#1113 audit).
+- `setTimeout` / `waitForTimeout` waits in E2E specs → wait on
+  terminal attributes (`[data-loading="false"]` settled, `[data-skeleton]`
+  removed) per #1123's "Testability hooks" rule.
+- CSS class chains or visible-text *primary* selectors in E2E specs
+  → use `data-testid` / ARIA roles per #1123. `hasText` filters for
+  disambiguation are fine; "find element by its label text" as the
+  whole selector is not.
 
 ## Where to find what
 
@@ -409,5 +452,7 @@ bearing assertion that the value is already safe HTML, so:
 | Test fixtures                          | `web/tests/Fixture.php`, `web/tests/ApiTestCase.php`     |
 | API wire-format snapshots              | `web/tests/api/__snapshots__/<topic>/<scenario>.json`    |
 | Action -> permission lock              | `web/tests/api/PermissionMatrixTest.php`                 |
+| Add an E2E spec                        | `web/tests/e2e/specs/<smoke|flows|a11y|responsive>/...` + `web/tests/e2e/pages/...` |
+| Add a route to the screenshot gallery  | `web/tests/e2e/specs/_screenshots.spec.ts` (`ROUTES` array) |
 | Run a stack in parallel with another worktree | Worktree-local `docker-compose.override.yml` (see "Parallel stacks") |
 | Local dev stack details                | `docker/README.md`                                       |

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -604,14 +604,15 @@ documented as such in `docker-compose.yml`.
 
 ## Quality gates
 
-Four CI jobs run on every PR (`.github/workflows/`):
+Five CI jobs run on every PR (`.github/workflows/`):
 
-| Gate          | Workflow              | Local command                | What it covers                                |
-| ------------- | --------------------- | ---------------------------- | --------------------------------------------- |
-| PHPStan       | `phpstan.yml`         | `./sbpp.sh phpstan`          | Static analysis (level 5) + Smarty rule + phpstan-dba SQL checks. |
-| PHPUnit       | `test.yml`            | `./sbpp.sh test`             | Behavioural tests against `sourcebans_test`.  |
-| ts-check      | `ts-check.yml`        | `./sbpp.sh ts-check`         | `tsc --checkJs` over `web/scripts/`.          |
-| API contract  | `api-contract.yml`    | `./sbpp.sh composer api-contract` | Regenerates `scripts/api-contract.js` and fails on diff. |
+| Gate           | Workflow              | Local command                | What it covers                                |
+| -------------- | --------------------- | ---------------------------- | --------------------------------------------- |
+| PHPStan        | `phpstan.yml`         | `./sbpp.sh phpstan`          | Static analysis (level 5) + Smarty rule + phpstan-dba SQL checks. |
+| PHPUnit        | `test.yml`            | `./sbpp.sh test`             | Behavioural tests against `sourcebans_test`.  |
+| ts-check       | `ts-check.yml`        | `./sbpp.sh ts-check`         | `tsc --checkJs` over `web/scripts/`.          |
+| API contract   | `api-contract.yml`    | `./sbpp.sh composer api-contract` | Regenerates `scripts/api-contract.js` and fails on diff. |
+| Playwright E2E | `e2e.yml`             | `./sbpp.sh e2e`              | Browser-level smoke / flows / a11y against the dev stack (chromium + mobile-chromium). |
 
 PHPStan is at level 5 (bumped from 4 in #1101); raise one step at a
 time, never jump 5→7. The baseline at `web/phpstan-baseline.neon`
@@ -662,6 +663,63 @@ rows. A new action without a matrix entry — or an existing action whose
 gate moves — fails the build loudly. `Api::actions()` (added alongside)
 exposes the registry's keys for the matrix sweep so the test can detect
 both directions of drift (extra registrations, removed registrations).
+
+### End-to-end tests (`web/tests/e2e/`)
+
+Browser-level coverage on top of the unit + API gates. Lives under
+`web/tests/e2e/` with its own `package.json` so PHPUnit and Playwright
+don't fight over a shared dependency surface.
+
+```
+web/tests/e2e/
+├── package.json              # @playwright/test, @axe-core/playwright, typescript
+├── playwright.config.ts      # baseURL, projects (chromium + mobile-chromium), reporters
+├── tsconfig.json             # strict, ES2020, bundler resolution
+├── fixtures/
+│   ├── auth.ts               # single-import surface re-exporting test/expect (extended in later slices)
+│   ├── axe.ts                # expectNoCriticalA11y(page, testInfo, …)
+│   ├── db.ts                 # resetE2eDb / truncateE2eDb helpers (host-side or in-container)
+│   └── global-setup.ts       # one-time: reset sourcebans_e2e + mint admin storageState
+├── pages/                    # Page Object Models (BasePage in _base.ts)
+├── scripts/
+│   ├── reset-e2e-db.php      # bridge to Sbpp\Tests\Fixture pointed at sourcebans_e2e
+│   └── upload-screenshots.sh # pushes per-PR PNGs to the screenshots-archive orphan branch
+└── specs/
+    ├── _screenshots.spec.ts  # @screenshot gallery spec (skipped unless SCREENSHOTS=1)
+    ├── smoke/                # one .spec.ts per route — login.spec.ts is the seed
+    ├── flows/                # multi-step critical flows (added in later slices)
+    ├── a11y/                 # axe scans (added in later slices)
+    └── responsive/           # mobile-viewport behaviour (added in later slices)
+```
+
+Three properties drive the harness:
+
+- **DB isolation.** The suite owns a dedicated `sourcebans_e2e`
+  schema, parallel to `sourcebans_test`. `reset-e2e-db.php` reuses
+  the same `Sbpp\Tests\Fixture` PHPUnit uses (struc.sql + data.sql,
+  same seeded admin) but pointed at the e2e DB, so a passing PHPUnit
+  run guarantees the e2e fixture is structurally identical. Specs
+  call `truncateE2eDb()` between cases for the cheap reset path;
+  full install only runs once per `playwright test` invocation.
+- **Storage-state auth.** `fixtures/global-setup.ts` drives the
+  login form once against the seeded admin/admin user and writes
+  `playwright/.auth/admin.json`. Every spec inherits that storage
+  state via `playwright.config.ts` so they don't pay the login cost
+  per-test. The login spec is the only spec that opts back out
+  (`test.use({ storageState: { cookies: [], origins: [] } })`) so
+  the form itself stays exercised.
+- **axe gate at `critical`.** `expectNoCriticalA11y` runs
+  `@axe-core/playwright` against the current page, attaches the full
+  report to the failing test as `axe`, and asserts zero
+  `critical`-impact violations. The threshold is locked here — see
+  `AGENTS.md` "Playwright E2E specifics" for why.
+
+A separate `_screenshots.spec.ts` walks every route × theme × project
+and emits PNGs into `web/tests/e2e/screenshots/<theme>/<viewport>/`.
+The accompanying `upload-screenshots.sh` pushes the gallery to the
+`screenshots-archive` orphan branch under `screenshots/pr-<N>/<slug>/`
+(unique per PR + slice, so the orphan branch never has merge
+conflicts) and prints a markdown table for `gh pr comment`.
 
 ## Legacy patterns being phased out
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -62,6 +62,7 @@ don't leak onto the host filesystem.
 ./sbpp.sh composer install        # run composer in the web container
 ./sbpp.sh phpstan                 # phpstan analyse with the project's phpstan.neon
 ./sbpp.sh ts-check                # tsc --checkJs gate over web/scripts (mirror of CI)
+./sbpp.sh e2e                     # Playwright E2E gate (lazy chromium install) against the running stack
 ./sbpp.sh db-dump backup.sql      # mysqldump to host file
 ./sbpp.sh db-load fixtures.sql    # pipe a SQL file into the DB
 ./sbpp.sh db-reset                # drop just the DB volume and re-seed
@@ -70,12 +71,14 @@ don't leak onto the host filesystem.
 
 ## Quality gates
 
-Three gates run in CI on every PR; each has a one-shot wrapper for local runs.
+Five gates run in CI on every PR; each has a one-shot wrapper for local runs.
 
 ```sh
 ./sbpp.sh phpstan                 # static analysis (web/phpstan.neon, baseline at web/phpstan-baseline.neon)
 ./sbpp.sh test                    # PHPUnit against the dedicated sourcebans_test DB
 ./sbpp.sh ts-check                # tsc --checkJs over web/scripts (#1098)
+./sbpp.sh composer api-contract   # regenerate web/scripts/api-contract.js (#1112)
+./sbpp.sh e2e                     # Playwright + axe against the dev stack (#1124)
 ```
 
 `ts-check` runs the TypeScript compiler in `--checkJs` mode against the
@@ -84,6 +87,14 @@ vanilla JS in `web/scripts/`, using `web/scripts/tsconfig.json` plus the
 inside a fresh container does an `npm install` (cached afterwards) — total
 cold cost is a few seconds, subsequent runs are sub-second. There is no
 build step; nothing in `web/node_modules/` ships to production.
+
+`e2e` runs the Playwright suite under `web/tests/e2e/` inside the web
+container against a dedicated `sourcebans_e2e` database (so dev data
+and PHPUnit's `sourcebans_test` are both untouched). First run installs
+`@playwright/test` + the chromium browser + its system dependencies via
+`npx playwright install --with-deps chromium`; subsequent runs reuse
+the cached install. Forwards args to `npx playwright test`, e.g.
+`./sbpp.sh e2e --grep @screenshot` for the per-PR screenshot gallery.
 
 ## Static analysis with phpstan-dba
 

--- a/docker/db-init/00-render-schema.sh
+++ b/docker/db-init/00-render-schema.sh
@@ -54,14 +54,17 @@ VALUES
     ('admin', 'STEAM_0:0:0', '${ADMIN_HASH}', -1, 'admin@example.test', NULL, 16777216, 100);
 SQL
 
-# `./sbpp.sh test` runs PHPUnit as the `${MYSQL_USER}` user against a
-# dedicated `sourcebans_test` database that the fixture drops + recreates
-# between runs. By default the user only has rights on the panel DB, which
-# breaks the fixture with `Access denied`. Mirror the GRANT that
-# .github/workflows/test.yml does so dev tests work out of the box.
+# `./sbpp.sh test` and `./sbpp.sh e2e` run their fixtures as the
+# `${MYSQL_USER}` user against dedicated `sourcebans_test` and
+# `sourcebans_e2e` databases respectively, both of which the fixture
+# drops + recreates between runs. By default the user only has rights
+# on the panel DB, which breaks the fixture with `Access denied`.
+# Mirror the GRANT that .github/workflows/test.yml does so both gates
+# work out of the box on a fresh dev stack.
 PANEL_USER="${MYSQL_USER:-sourcebans}"
 mariadb -uroot <<SQL
 GRANT ALL PRIVILEGES ON \`sourcebans_test\`.* TO '${PANEL_USER}'@'%';
+GRANT ALL PRIVILEGES ON \`sourcebans_e2e\`.*  TO '${PANEL_USER}'@'%';
 GRANT CREATE, DROP ON *.* TO '${PANEL_USER}'@'%';
 FLUSH PRIVILEGES;
 SQL

--- a/sbpp.sh
+++ b/sbpp.sh
@@ -24,6 +24,9 @@ Run things inside containers:
   phpstan         Run phpstan from web/phpstan.neon inside the web container.
   test [args...]  Run PHPUnit (web/phpunit.xml) inside the web container.
   ts-check        Run tsc --checkJs over web/scripts (npm-installs typescript on demand).
+  e2e [args...]   Run the Playwright E2E suite inside the web container.
+                  Lazily npm-installs @playwright/test + chromium on first run;
+                  forwards args to `npx playwright test` (e.g. `--grep @screenshot`).
   exec <cmd...>   Run an arbitrary command in the web container.
   mysql           Open a mysql client connected to the dev DB.
 
@@ -121,6 +124,55 @@ case "$cmd" in
         # the install is a no-op once node_modules/ is populated thanks to
         # `--prefer-offline`.
         dc exec web bash -lc 'cd /var/www/html/web && npm install --silent --no-audit --no-fund --prefer-offline && npm run --silent ts-check'
+        ;;
+    e2e)
+        # Playwright E2E gate added in #1124. Mirrors `ts-check`'s
+        # lazy-install pattern: first run apt-installs chromium's
+        # system deps via `playwright install --with-deps chromium`,
+        # subsequent runs are sub-second to start.
+        #
+        # We auto-bring-up the dev stack if it's not already running
+        # so `./sbpp.sh e2e` works from a fresh checkout. The suite
+        # then runs INSIDE the web container and hits Apache on the
+        # in-container port 80 (E2E_BASE_URL=http://localhost). The
+        # DB seeder (web/tests/e2e/fixtures/db.ts) flips
+        # E2E_IN_CONTAINER=1 so it calls `php` directly instead of
+        # `docker compose exec` (we're already inside the container,
+        # the Docker socket isn't reachable from here).
+        if [ -z "$(dc ps -q web 2>/dev/null)" ]; then dc up -d; fi
+        # Idempotent grant: ensures `sourcebans_e2e` is writable by
+        # the panel user even on dev stacks whose db-init/ ran before
+        # this script started provisioning the e2e DB. Fresh stacks
+        # already get the grant from docker/db-init/00-render-schema.sh.
+        dc exec -T db mariadb -uroot -proot -e "
+            GRANT ALL PRIVILEGES ON \`sourcebans_e2e\`.* TO 'sourcebans'@'%';
+            GRANT CREATE, DROP ON *.* TO 'sourcebans'@'%';
+            FLUSH PRIVILEGES;" >/dev/null
+        dc exec -T \
+            -e E2E_BASE_URL="${E2E_BASE_URL:-http://localhost}" \
+            -e E2E_IN_CONTAINER=1 \
+            -e SCREENSHOTS="${SCREENSHOTS:-}" \
+            -e CI="${CI:-}" \
+            -e DB_HOST=db -e DB_PORT=3306 \
+            -e DB_NAME="${E2E_DB_NAME:-sourcebans_e2e}" \
+            -e DB_USER=sourcebans -e DB_PASS=sourcebans \
+            -e DB_PREFIX=sb -e DB_CHARSET=utf8mb4 \
+            web bash -lc '
+                set -e
+                cd /var/www/html/web/tests/e2e
+                if [ ! -d node_modules/@playwright/test ]; then
+                    npm install --silent --no-audit --no-fund --prefer-offline
+                fi
+                # Browser install is also lazy. The marker file is
+                # what `playwright install` drops once it has finished
+                # provisioning chromium + the Debian deps under
+                # ~/.cache/ms-playwright. If the user nukes the cache,
+                # the next run reinstalls.
+                if [ ! -d "$HOME/.cache/ms-playwright" ] || [ -z "$(ls "$HOME/.cache/ms-playwright" 2>/dev/null)" ]; then
+                    npx playwright install --with-deps chromium
+                fi
+                exec npx playwright test "$@"
+            ' -- "$@"
         ;;
     exec)
         dc exec web "$@"

--- a/web/tests/Fixture.php
+++ b/web/tests/Fixture.php
@@ -56,6 +56,37 @@ class Fixture
     public static function reset(): void
     {
         self::install();
+        self::truncateAndReseed();
+    }
+
+    /**
+     * Truncate every table in the configured DB and re-seed defaults
+     * + the admin row, WITHOUT going through install()'s DROP DATABASE +
+     * CREATE DATABASE cycle.
+     *
+     * Used by the e2e DB shim (`web/tests/e2e/scripts/reset-e2e-db.php`),
+     * which is invoked from a fresh PHP process per call. install()'s
+     * static `$installed` flag is process-local, so calling reset()
+     * from a fresh process (the shim does this every time) would try
+     * to DROP+CREATE on every invocation and race with parallel
+     * Playwright workers on the same DB. truncateOnly() opens a single
+     * connection, truncates, re-seeds, and is safe to call multiple
+     * times within one process.
+     *
+     * Caller responsibility: the schema must already exist (i.e.
+     * Fixture::install() was run earlier — the e2e harness does this
+     * once in `fixtures/global-setup.ts`).
+     */
+    public static function truncateOnly(): void
+    {
+        if (!isset($GLOBALS['PDO'])) {
+            $GLOBALS['PDO'] = new \Database(DB_HOST, DB_PORT, DB_NAME, DB_USER, DB_PASS, DB_PREFIX, DB_CHARSET);
+        }
+        self::truncateAndReseed();
+    }
+
+    private static function truncateAndReseed(): void
+    {
         $pdo = self::rawPdo();
         $tables = $pdo->query(
             sprintf("SELECT table_name FROM information_schema.tables WHERE table_schema = '%s'", DB_NAME)

--- a/web/tests/e2e/.gitignore
+++ b/web/tests/e2e/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+playwright-report/
+test-results/
+screenshots/
+playwright/.auth/

--- a/web/tests/e2e/fixtures/auth.ts
+++ b/web/tests/e2e/fixtures/auth.ts
@@ -1,0 +1,18 @@
+import { test as base, expect } from '@playwright/test';
+
+/**
+ * Single-import surface for specs.
+ *
+ * Slice 0 just re-exports the upstream `test` (typed via an empty
+ * `extend<{}>({})` so future slices can swap in real fixtures
+ * without changing the import path) and `expect`. Slices 1–8 extend
+ * `test` here with login-as-different-permissions, network mocking,
+ * worker-scoped DB resets, etc.
+ *
+ * Specs always `import { test, expect } from '../../fixtures/auth.ts'`
+ * so a later slice can add fixtures without sweeping the whole suite.
+ */
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type
+export const test = base.extend<{}>({});
+
+export { expect };

--- a/web/tests/e2e/fixtures/axe.ts
+++ b/web/tests/e2e/fixtures/axe.ts
@@ -1,0 +1,49 @@
+import AxeBuilder from '@axe-core/playwright';
+import type { Page, TestInfo } from '@playwright/test';
+import { expect } from '@playwright/test';
+
+/**
+ * Run an axe-core scan and assert zero `critical`-impact violations.
+ *
+ * The threshold is **critical** by contract (#1124). Slices 1–8 must
+ * use this helper as-is; do NOT downgrade the threshold to make tests
+ * green — file follow-ups against the underlying #1123 testability
+ * patterns instead.
+ *
+ * The full report (every violation, every impact level) is attached
+ * to the failing test via `testInfo.attach('axe', …)` so debugging
+ * doesn't require re-running locally — the trace + report download
+ * from the workflow artifact is enough.
+ */
+export async function expectNoCriticalA11y(
+    page: Page,
+    testInfo: TestInfo,
+    opts: { include?: string[]; exclude?: string[] } = {},
+): Promise<void> {
+    let builder = new AxeBuilder({ page });
+    if (opts.include) {
+        for (const sel of opts.include) builder = builder.include(sel);
+    }
+    if (opts.exclude) {
+        for (const sel of opts.exclude) builder = builder.exclude(sel);
+    }
+
+    const results = await builder.analyze();
+
+    await testInfo.attach('axe', {
+        body: JSON.stringify(results, null, 2),
+        contentType: 'application/json',
+    });
+
+    const critical = results.violations.filter((v) => v.impact === 'critical');
+    if (critical.length > 0) {
+        const ruleSummary = critical
+            .map((v) => `  - ${v.id} (${v.nodes.length} node${v.nodes.length === 1 ? '' : 's'}): ${v.help}`)
+            .join('\n');
+        expect(
+            critical,
+            `axe found ${critical.length} critical a11y violation${critical.length === 1 ? '' : 's'}:\n${ruleSummary}\n` +
+                `Full report attached to the test as "axe".`,
+        ).toEqual([]);
+    }
+}

--- a/web/tests/e2e/fixtures/db.ts
+++ b/web/tests/e2e/fixtures/db.ts
@@ -1,0 +1,79 @@
+/**
+ * Bridge between Playwright (TypeScript) and the PHPUnit Fixture (PHP)
+ * that owns the `sourcebans_e2e` database.
+ *
+ * The actual install/reset logic lives in
+ * `web/tests/e2e/scripts/reset-e2e-db.php` which reuses
+ * `Sbpp\Tests\Fixture` — same renderer, same struc.sql + data.sql, same
+ * seeded admin row (admin/admin) — but pointed at a dedicated
+ * `sourcebans_e2e` schema so PHPUnit's `sourcebans_test` and the dev
+ * `sourcebans` DB stay untouched.
+ *
+ * Two execution modes are supported:
+ *
+ * 1. Host-side (`E2E_IN_CONTAINER` unset/empty): we shell out via
+ *    `docker compose exec -T web php …`. Used when the spec runs from
+ *    the host (e.g. `npx playwright test` invoked manually with the
+ *    panel reachable on a published port).
+ * 2. In-container (`E2E_IN_CONTAINER=1`): we invoke `php` directly
+ *    because we're already inside the web container. `./sbpp.sh e2e`
+ *    flips this on so the suite doesn't need a Docker socket inside
+ *    the container.
+ */
+
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+
+const execFileP = promisify(execFile);
+
+const SCRIPT_INSIDE_CONTAINER = '/var/www/html/web/tests/e2e/scripts/reset-e2e-db.php';
+
+/**
+ * Run the PHP shim that drives `Sbpp\Tests\Fixture` against
+ * `sourcebans_e2e`. `args` is forwarded as-is.
+ */
+async function runReset(args: string[] = []): Promise<void> {
+    const inContainer = process.env.E2E_IN_CONTAINER === '1';
+    const cmd = inContainer ? 'php' : 'docker';
+    const cmdArgs = inContainer
+        ? [SCRIPT_INSIDE_CONTAINER, ...args]
+        : ['compose', 'exec', '-T', 'web', 'php', SCRIPT_INSIDE_CONTAINER, ...args];
+
+    try {
+        await execFileP(cmd, cmdArgs, {
+            // Generous buffer: the install path can emit a few KB of
+            // PDO warnings on a freshly-created DB. Reset prints far
+            // less but the cap stays the same.
+            maxBuffer: 8 * 1024 * 1024,
+            // The host-side path uses `docker compose` which resolves
+            // both docker-compose.yml and any worktree-local
+            // override (per AGENTS.md "Parallel stacks") from cwd.
+            cwd: inContainer ? undefined : process.cwd(),
+        });
+    } catch (err) {
+        const e = err as NodeJS.ErrnoException & { stdout?: string; stderr?: string };
+        const stdout = e.stdout ?? '';
+        const stderr = e.stderr ?? '';
+        throw new Error(
+            `reset-e2e-db.php (${args.join(' ') || 'install'}) failed: ${e.message}\n` +
+                `stdout:\n${stdout}\nstderr:\n${stderr}`,
+        );
+    }
+}
+
+/**
+ * Drop + recreate `sourcebans_e2e` from the install/sql templates and
+ * seed the default admin row. Called once from `global-setup.ts`.
+ */
+export async function resetE2eDb(): Promise<void> {
+    await runReset([]);
+}
+
+/**
+ * Truncate every table in `sourcebans_e2e` and re-seed the rows
+ * `data.sql` provides + the admin. Cheaper than a full install and
+ * preferred between specs (see Fixture::reset()).
+ */
+export async function truncateE2eDb(): Promise<void> {
+    await runReset(['--truncate']);
+}

--- a/web/tests/e2e/fixtures/global-setup.ts
+++ b/web/tests/e2e/fixtures/global-setup.ts
@@ -1,0 +1,52 @@
+import { chromium, type FullConfig } from '@playwright/test';
+import { mkdir } from 'node:fs/promises';
+import { dirname, resolve } from 'node:path';
+
+import { resetE2eDb } from './db.ts';
+
+/**
+ * Global setup runs ONCE per `playwright test` invocation, before any
+ * project (chromium / mobile-chromium) starts.
+ *
+ *   1. Reset `sourcebans_e2e` from struc.sql + data.sql (drop + recreate).
+ *      This is the expensive path; spec-level resets use truncate via
+ *      `truncateE2eDb()`.
+ *   2. Mint `playwright/.auth/admin.json` by driving the login form
+ *      against the seeded admin/admin user. Every spec then loads that
+ *      storage state and starts already-logged-in.
+ *
+ * The login spec opts back out of storageState (see `specs/smoke/login.spec.ts`)
+ * so it exercises the form itself.
+ */
+export default async function globalSetup(config: FullConfig): Promise<void> {
+    await resetE2eDb();
+
+    // Pull the baseURL from the first project's `use` block. The two
+    // projects share the same baseURL via the top-level `use`, so
+    // `projects[0].use.baseURL` is the canonical source.
+    const baseURL = config.projects[0]?.use.baseURL ?? process.env.E2E_BASE_URL ?? 'http://localhost:8080';
+
+    const storageStatePath = resolve(__dirname, '..', 'playwright', '.auth', 'admin.json');
+    await mkdir(dirname(storageStatePath), { recursive: true });
+
+    const browser = await chromium.launch();
+    try {
+        const context = await browser.newContext({ baseURL });
+        const page = await context.newPage();
+
+        await page.goto('/index.php?p=login');
+        await page.locator('[data-testid="login-username"]').fill('admin');
+        await page.locator('[data-testid="login-password"]').fill('admin');
+        await page.locator('[data-testid="login-submit"]').click();
+
+        // The login API returns a redirect envelope; api.js follows it
+        // client-side and lands on the dashboard. The seeded admin is
+        // a logged-in user, so the navbar's account link becomes
+        // visible — that's our deterministic terminal state.
+        await page.locator('[data-testid="nav-account"]').waitFor({ state: 'visible', timeout: 30_000 });
+
+        await context.storageState({ path: storageStatePath });
+    } finally {
+        await browser.close();
+    }
+}

--- a/web/tests/e2e/package-lock.json
+++ b/web/tests/e2e/package-lock.json
@@ -1,0 +1,126 @@
+{
+  "name": "sourcebans-pp-e2e",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "sourcebans-pp-e2e",
+      "version": "0.0.0",
+      "devDependencies": {
+        "@axe-core/playwright": "4.11.3",
+        "@playwright/test": "1.59.1",
+        "@types/node": "25.6.0",
+        "typescript": "6.0.3"
+      }
+    },
+    "node_modules/@axe-core/playwright": {
+      "version": "4.11.3",
+      "resolved": "https://registry.npmjs.org/@axe-core/playwright/-/playwright-4.11.3.tgz",
+      "integrity": "sha512-h/kfksv4F0cVIDlKpT4700OehdRgpvuVskuQ2nb7/JmtWUXpe9ftHAPtwyXGvVSsa6SJ64A9ER7Zrzc/sIvC4w==",
+      "dev": true,
+      "dependencies": {
+        "axe-core": "~4.11.4"
+      },
+      "peerDependencies": {
+        "playwright-core": ">= 1.0.0"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "dev": true,
+      "dependencies": {
+        "playwright": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "25.6.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
+      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~7.19.0"
+      }
+    },
+    "node_modules/axe-core": {
+      "version": "4.11.4",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.11.4.tgz",
+      "integrity": "sha512-KunSNx+TVpkAw/6ULfhnx+HWRecjqZGTOyquAoWHYLRSdK1tB5Ihce1ZW+UY3fj33bYAFWPu7W/GRSmmrCGuxA==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "dev": true,
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "dev": true,
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.19.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
+      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
+      "dev": true
+    }
+  }
+}

--- a/web/tests/e2e/package.json
+++ b/web/tests/e2e/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "sourcebans-pp-e2e",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Playwright E2E suite for the SourceBans++ web panel (#1124).",
+  "scripts": {
+    "test": "playwright test",
+    "install-browsers": "playwright install --with-deps chromium"
+  },
+  "devDependencies": {
+    "@axe-core/playwright": "4.11.3",
+    "@playwright/test": "1.59.1",
+    "@types/node": "25.6.0",
+    "typescript": "6.0.3"
+  }
+}

--- a/web/tests/e2e/pages/_base.ts
+++ b/web/tests/e2e/pages/_base.ts
@@ -1,0 +1,34 @@
+import type { Page } from '@playwright/test';
+
+/**
+ * Base page object used by every concrete page model under
+ * `web/tests/e2e/pages/`.
+ *
+ * `waitForReady()` waits on the *terminal* attributes the new theme
+ * exposes per #1123's "Testability hooks" contract — never on a
+ * `setTimeout` or transition. Specifically:
+ *
+ *   - `[data-loading="true"]` is absent (drawer / palette / inline
+ *     fetch surfaces flip this back to `false` once the network call
+ *     settles).
+ *   - `[data-skeleton]` elements are removed (skeleton placeholders
+ *     are torn down when content lands, not visually swapped).
+ *
+ * If a future slice adds a page that exposes additional terminal
+ * attributes (e.g. a chart's "rendered" sentinel), extend the
+ * `waitForFunction` predicate here so the contract stays in one place.
+ */
+export class BasePage {
+    constructor(protected readonly page: Page) {}
+
+    async goto(path: string): Promise<void> {
+        await this.page.goto(path);
+        await this.waitForReady();
+    }
+
+    async waitForReady(): Promise<void> {
+        await this.page.waitForFunction(
+            () => !document.querySelector('[data-loading="true"], [data-skeleton]'),
+        );
+    }
+}

--- a/web/tests/e2e/playwright.config.ts
+++ b/web/tests/e2e/playwright.config.ts
@@ -1,0 +1,59 @@
+import { defineConfig, devices } from '@playwright/test';
+
+/**
+ * Playwright config for the SourceBans++ E2E suite (#1124).
+ *
+ * The harness runs against the live dev stack (`./sbpp.sh up`); see
+ * AGENTS.md "Playwright E2E specifics" for the contract this config
+ * honours (storage-state auth minted in `fixtures/global-setup.ts`,
+ * DB isolation against `sourcebans_e2e`, axe `critical` threshold,
+ * `prefers-reduced-motion: reduce` set globally).
+ *
+ * `E2E_BASE_URL` defaults to the host-published port (`:8080`) so
+ * `npx playwright test` from the host hits the same panel a developer
+ * is browsing. `./sbpp.sh e2e` overrides this to `http://localhost`
+ * because the suite then runs *inside* the web container where Apache
+ * is reachable on port 80.
+ */
+export default defineConfig({
+    testDir: './specs',
+    fullyParallel: true,
+    retries: process.env.CI ? 1 : 0,
+    workers: process.env.CI ? 2 : undefined,
+    reporter: [['html', { open: 'never' }], ['list']],
+    globalSetup: './fixtures/global-setup.ts',
+    use: {
+        baseURL: process.env.E2E_BASE_URL ?? 'http://localhost:8080',
+        trace: 'on-first-retry',
+        screenshot: 'only-on-failure',
+        video: 'retain-on-failure',
+        colorScheme: 'light',
+        // `reducedMotion: 'reduce'` is honoured automatically by
+        // Playwright via the device descriptors, but surfacing it
+        // explicitly here documents the contract from #1123: any
+        // animation longer than ~100ms is skippable, so tests never
+        // wait out a transition just to assert state changed.
+        contextOptions: { reducedMotion: 'reduce' },
+    },
+    projects: [
+        {
+            name: 'chromium',
+            use: {
+                ...devices['Desktop Chrome'],
+                storageState: 'playwright/.auth/admin.json',
+            },
+        },
+        {
+            name: 'mobile-chromium',
+            use: {
+                ...devices['iPhone 13'],
+                // `devices['iPhone 13']` defaults `defaultBrowserType: 'webkit'`;
+                // we want chrome-on-mobile-form-factor, not Safari, so we
+                // can keep a single-browser install footprint.
+                defaultBrowserType: 'chromium',
+                browserName: 'chromium',
+                storageState: 'playwright/.auth/admin.json',
+            },
+        },
+    ],
+});

--- a/web/tests/e2e/scripts/reset-e2e-db.php
+++ b/web/tests/e2e/scripts/reset-e2e-db.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * E2E DB seeder.
+ *
+ * Runs inside the web container, called from
+ * `web/tests/e2e/fixtures/db.ts` (host-side via `docker compose exec`,
+ * in-container via direct `php` when running under `./sbpp.sh e2e`).
+ *
+ * Reuses the same `Sbpp\Tests\Fixture` PHPUnit uses, but pointed at
+ * `sourcebans_e2e` so it never collides with the dev DB (`sourcebans`)
+ * or the PHPUnit DB (`sourcebans_test`). Same struc.sql + data.sql,
+ * same seeded admin (admin/admin), same `:prefix_` rewrite — just a
+ * different schema name.
+ *
+ * Usage (from inside the container):
+ *
+ *   php reset-e2e-db.php             # Fixture::install()  (drop + recreate)
+ *   php reset-e2e-db.php --truncate  # Fixture::reset()    (truncate + re-seed)
+ *
+ * Env vars consumed (defaulted in tests/bootstrap.php to the same
+ * docker-compose values, with DB_NAME swapped for `sourcebans_e2e`):
+ *
+ *   DB_HOST     default 'db'
+ *   DB_PORT     default 3306
+ *   DB_USER     default 'sourcebans'
+ *   DB_PASS     default 'sourcebans'
+ *   DB_PREFIX   default 'sb'
+ *   DB_CHARSET  default 'utf8mb4'
+ *   DB_NAME     default 'sourcebans_e2e' (intentionally NOT 'sourcebans_test')
+ */
+
+declare(strict_types=1);
+
+if (PHP_SAPI !== 'cli') {
+    fwrite(STDERR, "reset-e2e-db.php must run on the CLI.\n");
+    exit(2);
+}
+
+// `tests/bootstrap.php` reads `DB_NAME` via `getenv()` and falls back
+// to `sourcebans_test`. Pin the e2e DB before bootstrap loads so the
+// fall-back path can never resurrect the PHPUnit schema by accident.
+if (!getenv('DB_NAME')) {
+    putenv('DB_NAME=sourcebans_e2e');
+    $_ENV['DB_NAME']    = 'sourcebans_e2e';
+    $_SERVER['DB_NAME'] = 'sourcebans_e2e';
+}
+
+if (getenv('DB_NAME') === 'sourcebans_test' || getenv('DB_NAME') === 'sourcebans') {
+    fwrite(STDERR, "refusing to seed e2e fixture against DB_NAME=" . getenv('DB_NAME')
+        . ": this script must target a dedicated e2e DB (default sourcebans_e2e).\n");
+    exit(2);
+}
+
+require __DIR__ . '/../../bootstrap.php';
+
+$truncate = in_array('--truncate', array_slice($argv, 1), true);
+
+try {
+    if ($truncate) {
+        // truncateOnly() (added in #1124) skips the DROP+CREATE the
+        // PHPUnit-shaped reset() goes through. The shim runs in a
+        // fresh PHP process every time, so reset()'s install() call
+        // would always fire DROP+CREATE and race with parallel
+        // Playwright workers on the same DB.
+        \Sbpp\Tests\Fixture::truncateOnly();
+        fwrite(STDOUT, "e2e DB truncated on " . DB_NAME . "\n");
+    } else {
+        \Sbpp\Tests\Fixture::install();
+        fwrite(STDOUT, "e2e DB installed on " . DB_NAME . "\n");
+    }
+} catch (\Throwable $e) {
+    fwrite(STDERR, "reset-e2e-db.php failed: " . $e->getMessage() . "\n");
+    fwrite(STDERR, $e->getTraceAsString() . "\n");
+    exit(1);
+}

--- a/web/tests/e2e/scripts/upload-screenshots.sh
+++ b/web/tests/e2e/scripts/upload-screenshots.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+# upload-screenshots.sh — push a slice's screenshot gallery to the
+# `screenshots-archive` orphan branch and emit the markdown the PR
+# wants commented.
+#
+# Usage:
+#   web/tests/e2e/scripts/upload-screenshots.sh <pr-number> <slice-slug>
+#
+# The script:
+#   1. Runs the @screenshot spec (`SCREENSHOTS=1 ./sbpp.sh e2e --grep @screenshot --reporter=list`).
+#   2. Copies every PNG under `web/tests/e2e/screenshots/` into a temp
+#      worktree of the `screenshots-archive` branch, under
+#      `screenshots/pr-<PR>/<slug>/...`. Each slice writes a unique
+#      subdirectory so the orphan branch never has merge conflicts.
+#   3. Commits + pushes; on push collision retries with rebase.
+#   4. Removes the temp worktree (so the PR's working tree never sees
+#      the orphan branch's content).
+#   5. Prints the markdown table to stdout — pipe to
+#      `gh pr comment <pr> --body-file -`.
+
+set -euo pipefail
+
+PR="${1:?usage: upload-screenshots.sh <pr-number> <slice-slug>}"
+SLUG="${2:?usage: upload-screenshots.sh <pr-number> <slice-slug>}"
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+SHOTS_DIR="$REPO_ROOT/web/tests/e2e/screenshots"
+RAW_BASE="https://raw.githubusercontent.com/sbpp/sourcebans-pp/screenshots-archive/screenshots/pr-${PR}/${SLUG}"
+
+# 1. Run the gallery spec.
+(
+    cd "$REPO_ROOT"
+    SCREENSHOTS=1 ./sbpp.sh e2e --grep "@screenshot" --reporter=list
+)
+
+if [[ ! -d "$SHOTS_DIR" ]]; then
+    echo "no screenshots produced under $SHOTS_DIR" >&2
+    exit 1
+fi
+
+# 2. Stage onto the orphan branch via a temp worktree.
+TMP="$(mktemp -d)"
+trap 'cd "$REPO_ROOT" 2>/dev/null || true; git worktree remove --force "$TMP" 2>/dev/null || true; rm -rf "$TMP"' EXIT
+
+git -C "$REPO_ROOT" fetch origin screenshots-archive
+git -C "$REPO_ROOT" worktree add --no-checkout "$TMP" origin/screenshots-archive
+(
+    cd "$TMP"
+    git checkout screenshots-archive 2>/dev/null || git checkout -B screenshots-archive origin/screenshots-archive
+)
+
+DEST="$TMP/screenshots/pr-${PR}/${SLUG}"
+mkdir -p "$DEST"
+# copy ./screenshots/<theme>/<viewport>/<route>.png -> $DEST/<theme>/<viewport>/<route>.png
+cp -R "$SHOTS_DIR/." "$DEST/"
+
+# 3. Commit + push, retrying on remote drift.
+(
+    cd "$TMP"
+    git add -A
+    if git diff --cached --quiet; then
+        echo "no screenshot changes to commit" >&2
+    else
+        git commit -m "screenshots: pr-${PR} ${SLUG}" --allow-empty
+    fi
+
+    pushed=0
+    for _ in 1 2 3 4 5; do
+        if git push origin screenshots-archive; then
+            pushed=1
+            break
+        fi
+        git fetch origin screenshots-archive
+        if ! git rebase origin/screenshots-archive; then
+            git rebase --abort || true
+        fi
+        sleep 2
+    done
+    if [[ "$pushed" -ne 1 ]]; then
+        echo "failed to push screenshots-archive after 5 attempts" >&2
+        exit 1
+    fi
+)
+
+# 4. Tear down the worktree (handled by trap, but do it explicitly so
+#    the markdown print below isn't competing with cleanup output).
+git -C "$REPO_ROOT" worktree remove --force "$TMP"
+trap - EXIT
+rm -rf "$TMP"
+
+# 5. Build the markdown comment. We walk the local screenshots tree
+#    (which is what we just pushed) and emit one row per route.
+emit_cell() {
+    local theme="$1" viewport="$2" route="$3"
+    local rel="${theme}/${viewport}/${route}.png"
+    if [[ -f "$SHOTS_DIR/$rel" ]]; then
+        printf '![](%s/%s)' "$RAW_BASE" "$rel"
+    else
+        printf '—'
+    fi
+}
+
+# Collect the union of route names from any theme/viewport bucket.
+mapfile -t ROUTES < <(
+    find "$SHOTS_DIR" -mindepth 3 -maxdepth 3 -name '*.png' -printf '%f\n' \
+        | sed 's/\.png$//' \
+        | sort -u
+)
+
+{
+    printf '## Screenshots (%s)\n\n' "$SLUG"
+    if [[ "${#ROUTES[@]}" -eq 0 ]]; then
+        printf '_No screenshots produced — the @screenshot spec may have been skipped._\n'
+        exit 0
+    fi
+    printf '| Route | Light desktop | Dark desktop | Light mobile | Dark mobile |\n'
+    printf '| --- | --- | --- | --- | --- |\n'
+    for route in "${ROUTES[@]}"; do
+        printf '| `%s` | %s | %s | %s | %s |\n' \
+            "$route" \
+            "$(emit_cell light desktop "$route")" \
+            "$(emit_cell dark desktop "$route")" \
+            "$(emit_cell light mobile "$route")" \
+            "$(emit_cell dark mobile "$route")"
+    done
+}

--- a/web/tests/e2e/specs/_screenshots.spec.ts
+++ b/web/tests/e2e/specs/_screenshots.spec.ts
@@ -1,0 +1,129 @@
+/**
+ * Per-PR screenshot gallery (#1124).
+ *
+ * Tagged `@screenshot` and skipped by default. Two ways to opt in:
+ *
+ *   1. `SCREENSHOTS=1 npx playwright test` — recommended; matches the
+ *      shape `web/tests/e2e/scripts/upload-screenshots.sh` invokes.
+ *   2. `npx playwright test --grep @screenshot` — Playwright's tag
+ *      filter; works without the env var. The `test.skip(...)` guard
+ *      below means option (1) is the canonical path; option (2)
+ *      stays for ad-hoc local debugging.
+ *
+ * For every (route × theme × project), this spec emits a full-page
+ * PNG into `web/tests/e2e/screenshots/<theme>/<viewport>/<route>.png`.
+ * `<viewport>` is derived from the project name (`chromium` ->
+ * `desktop`, `mobile-chromium` -> `mobile`). The upload script then
+ * pushes the tree to the `screenshots-archive` orphan branch under a
+ * unique per-PR/per-slice subdirectory and prints the markdown table
+ * pointing at raw.githubusercontent.com.
+ *
+ * == APPENDABLE ==
+ * Slices 1–8 extend this gallery by appending entries to the `ROUTES`
+ * array below — one row per new route covered. Don't fork this spec
+ * into per-route files; the merge surface is intentionally one array
+ * literal so subsequent PRs almost never conflict.
+ *
+ * The two divergences below from the issue's literal text are noted
+ * in the PR body; both reflect the actual #1123 chrome contract:
+ *
+ *   - The localStorage key is `'sbpp-theme'` (set in
+ *     `web/themes/default/js/theme.js`), not the bare `'theme'`.
+ *   - Resolved theme state lands on `<html>` as the `dark` CSS class
+ *     (`document.documentElement.classList.toggle('dark', dark)`),
+ *     not as a `data-theme="…"` attribute. Specs wait on
+ *     `documentElement.classList.contains('dark')` accordingly.
+ *
+ * If a future slice prefers `[data-theme]`, mirror it inside theme.js
+ * in the same PR — don't fork the chrome contract here.
+ */
+
+import { test, expect } from '../fixtures/auth.ts';
+import { mkdir } from 'node:fs/promises';
+import { dirname, resolve } from 'node:path';
+
+interface RouteSpec {
+    name: string;
+    path: string;
+    auth: boolean;
+}
+
+const ROUTES: RouteSpec[] = [
+    { name: 'login', path: '/index.php?p=login', auth: false },
+];
+
+const THEMES = ['light', 'dark'] as const;
+type Theme = (typeof THEMES)[number];
+
+/**
+ * Project name -> screenshot directory bucket. Keeps the markdown
+ * table in upload-screenshots.sh stable regardless of how many
+ * mobile/desktop variants we add later.
+ */
+function viewportFor(projectName: string): string {
+    if (projectName === 'mobile-chromium') return 'mobile';
+    return 'desktop';
+}
+
+test.describe('@screenshot gallery', () => {
+    test.skip(!process.env.SCREENSHOTS, '@screenshot only runs when SCREENSHOTS=1');
+
+    for (const route of ROUTES) {
+        for (const theme of THEMES) {
+            test(`${route.name} ${theme}`, async ({ page, browser }, testInfo) => {
+                const viewport = viewportFor(testInfo.project.name);
+                const outPath = resolve(
+                    __dirname,
+                    '..',
+                    'screenshots',
+                    theme,
+                    viewport,
+                    `${route.name}.png`,
+                );
+                await mkdir(dirname(outPath), { recursive: true });
+
+                let activePage = page;
+                let ownContext: Awaited<ReturnType<typeof browser.newContext>> | null = null;
+                try {
+                    if (!route.auth) {
+                        // Spin up a logged-out context so the chrome
+                        // matches what an anonymous visitor would see.
+                        ownContext = await browser.newContext({
+                            ...testInfo.project.use,
+                            storageState: { cookies: [], origins: [] },
+                        });
+                        activePage = await ownContext.newPage();
+                    }
+
+                    // Pin theme via localStorage BEFORE navigation:
+                    // theme.js reads `localStorage['sbpp-theme']` on
+                    // boot via applyTheme(currentTheme()), so a hit
+                    // before that runs lands the right mode on first
+                    // paint. We `goto('/')` first because origin
+                    // localStorage requires a same-origin document.
+                    await activePage.goto('/');
+                    await activePage.evaluate((mode: Theme) => {
+                        try { localStorage.setItem('sbpp-theme', mode); } catch (_e) { /* unavailable; skip */ }
+                    }, theme);
+
+                    await activePage.goto(route.path);
+
+                    // Wait until theme.js's applyTheme has run and the
+                    // resolved mode is reflected on <html>. We don't
+                    // wait on a `[data-theme]` attribute (the chrome
+                    // uses the `dark` class, not a data-attribute);
+                    // see the file-level comment for the rationale.
+                    await activePage.waitForFunction((expected: Theme) => {
+                        const isDark = document.documentElement.classList.contains('dark');
+                        return expected === 'dark' ? isDark : !isDark;
+                    }, theme);
+
+                    await activePage.screenshot({ fullPage: true, path: outPath });
+                    expect(outPath).toMatch(/\.png$/);
+                } finally {
+                    if (ownContext) await ownContext.close();
+                }
+            });
+        }
+    }
+});

--- a/web/tests/e2e/specs/smoke/login.spec.ts
+++ b/web/tests/e2e/specs/smoke/login.spec.ts
@@ -1,0 +1,75 @@
+/**
+ * Login spec — drives the form directly.
+ *
+ * Every other spec inherits the storage state minted in
+ * `fixtures/global-setup.ts` (logged in as the seeded admin), but the
+ * login flow itself has to exercise the form. We opt out of the
+ * storage state per-describe via `test.use({ storageState: …empty… })`;
+ * Playwright honours that on top of the project default.
+ *
+ * Selectors follow #1123's testability hooks (data-testid + ARIA).
+ * No CSS class chains, no visible-text primary selectors, no
+ * `setTimeout` waits — see `_base.ts` for the rule.
+ */
+
+import { expect, test } from '../../fixtures/auth.ts';
+
+test.describe('login', () => {
+    // Per-describe override: log out for this whole block. Without
+    // this, the storage-state cookie minted by global-setup would
+    // already carry a logged-in admin and the form would never be
+    // visited.
+    test.use({ storageState: { cookies: [], origins: [] } });
+
+    // No per-spec truncateE2eDb() in Slice 0: globalSetup runs
+    // Fixture::install() once per `playwright test` invocation, and
+    // the login flow doesn't mutate state in a way that affects its
+    // own re-run. Future slices that need per-spec resets must
+    // coordinate across the parallel projects (chromium +
+    // mobile-chromium share the DB) — `truncateE2eDb()` from
+    // `fixtures/db.ts` is the helper they'll use, with a worker
+    // serialisation mechanism to avoid races. See the foundation
+    // PR (#1124) for the rationale.
+
+    test('valid credentials redirect to the dashboard', async ({ page }) => {
+        await page.goto('/index.php?p=login');
+
+        await page.locator('[data-testid="login-username"]').fill('admin');
+        await page.locator('[data-testid="login-password"]').fill('admin');
+        await page.locator('[data-testid="login-submit"]').click();
+
+        // Success terminal state: the redirect envelope from
+        // api_auth_login lands the user on `?` (the home dashboard);
+        // the navbar's account link is only rendered when CUserManager
+        // sees a logged-in user — that's the deterministic
+        // server-side signal. We assert `toBeAttached()` (in the DOM)
+        // rather than `toBeVisible()` because the sidebar collapses
+        // off-screen at mobile-chromium's iPhone-13 viewport, so the
+        // element exists but isn't rendered until the hamburger
+        // toggles `data-mobile-open="true"`.
+        await expect(page.locator('[data-testid="nav-account"]')).toBeAttached();
+        await expect(page.locator('[data-testid="nav-login"]')).toHaveCount(0);
+        await expect(page).toHaveURL(/\/(?:\?|index\.php\??)?$/);
+    });
+
+    test('invalid credentials surface the failure toast', async ({ page }) => {
+        await page.goto('/index.php?p=login');
+
+        await page.locator('[data-testid="login-username"]').fill('admin');
+        await page.locator('[data-testid="login-password"]').fill('wrong-password');
+        await page.locator('[data-testid="login-submit"]').click();
+
+        // Failure path: api_auth_login returns a redirect to
+        // `?p=login&m=failed`; api.js follows it; the inline JS in
+        // page_login.tpl reads `?m=…` and calls
+        // `window.SBPP.showToast({ kind: 'error', title: 'Login failed', … })`.
+        // The toast div is `.toast` with `data-kind="error"` (the
+        // attribute is set by theme.js's showToast). We use `data-kind`
+        // as the primary attribute selector — never visible text alone —
+        // and disambiguate the multi-toast case via the title text.
+        const toast = page.locator('.toast[data-kind="error"]').filter({ hasText: 'Login failed' });
+        await expect(toast).toBeVisible();
+        await expect(page).toHaveURL(/[?&]p=login(?:&|$)/);
+        await expect(page).toHaveURL(/[?&]m=failed(?:&|$)/);
+    });
+});

--- a/web/tests/e2e/tsconfig.json
+++ b/web/tests/e2e/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "target": "ES2020",
+    "module": "ES2022",
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "types": ["node"]
+  },
+  "include": ["**/*.ts"],
+  "exclude": ["node_modules", "playwright-report", "test-results", "screenshots"]
+}


### PR DESCRIPTION
Refs #1124

Foundation PR for the new Playwright E2E suite. Adds the harness, one
proof spec, the per-PR screenshot gallery flow, and a new CI gate. No
behaviour change to the panel itself — the only chrome-adjacent edits
are a new `Fixture::truncateOnly()` (so the cross-process e2e DB shim
doesn't race with parallel Playwright workers on DROP+CREATE) and a
parallel grant for the `sourcebans_e2e` schema in
`docker/db-init/00-render-schema.sh` (mirrors the existing
`sourcebans_test` grant).

## Acceptance criteria boxes ticked

- [x] `web/tests/e2e/` exists with Playwright config, TypeScript,
      page-object scaffold, axe integration.
- [x] `./sbpp.sh e2e` runs the suite locally against `./sbpp.sh up`'s
      stack.
- [x] `.github/workflows/e2e.yml` runs on every PR; failures upload
      Playwright trace + HTML report as an artifact.
- [x] `AGENTS.md` *Dev commands* + *Quality gates* tables updated;
      `ARCHITECTURE.md` *Quality gates* updated; `docker/README.md`
      documents the new sbpp.sh subcommand.
- [x] `web/tests/e2e/.gitignore` excludes `node_modules/`,
      `playwright-report/`, `test-results/`, `screenshots/`,
      `playwright/.auth/`.
- (Smoke per route, flows, responsive, a11y per page in light + dark
  — Slices 1–8.)

## Routes covered (initial smoke)

- `/login` (drives the form directly; the storage-state auth fixture
  in `fixtures/global-setup.ts` was validated against this same form
  to mint `playwright/.auth/admin.json`).

## Local commands run

- `./sbpp.sh up` (with worktree-local `docker-compose.override.yml`,
  project `sbpp-e2e-foundation`, web on :8190).
- `./sbpp.sh phpstan` — clean (zero new errors over baseline).
- `./sbpp.sh test` — 280 tests, 1189 assertions, all green.
- `./sbpp.sh ts-check` — clean (the new `web/tests/e2e/*.ts` files are
  also `tsc`-checked via the e2e tsconfig.json — separate config so
  the existing `web/scripts` tsc gate isn't widened).
- `./sbpp.sh composer api-contract` — zero diff.
- `./sbpp.sh e2e` — 4 tests pass (login × 2 projects × 2 cases),
  4 screenshot specs skipped (gated behind `SCREENSHOTS=1`).
- `SCREENSHOTS=1 ./sbpp.sh e2e --grep @screenshot` — 4 screenshots
  produced (`screenshots/{light,dark}/{desktop,mobile}/login.png`).

## Screenshot gallery

(Comment posted by the upload-screenshots.sh script.)

## Notes for reviewers

### Why the Fixture refactor

`Sbpp\Tests\Fixture::reset()` calls `install()` which always runs
DROP DATABASE + CREATE DATABASE on the first call in a process. The
e2e DB shim (`scripts/reset-e2e-db.php`) is invoked from a fresh PHP
process per call, and Playwright runs the chromium + mobile-chromium
projects in parallel against the same DB. Two parallel workers both
calling `php reset-e2e-db.php --truncate` would race on the
DROP+CREATE pair. `Fixture::truncateOnly()` (new) skips the install
path entirely — it's the public, e2e-shaped equivalent of the
truncate-and-reseed half of `reset()`. PHPUnit's existing `install()`
and `reset()` are untouched (still 280 / 1189 green).

### Two divergences from #1124's literal selector text

Both reflect the actual #1123 chrome contract (`web/themes/default/`
post-D1) and are documented in `_screenshots.spec.ts`:

1. The localStorage key is `'sbpp-theme'` (set in
   `web/themes/default/js/theme.js`), not the bare `'theme'` the
   issue draft hinted at.
2. The resolved theme lands on `<html>` as the `dark` CSS class
   toggled via `classList`, not as a `[data-theme]` attribute. The
   screenshots spec waits on
   `documentElement.classList.contains('dark')` accordingly. If a
   future slice prefers a `[data-theme]` mirror, mirror it inside
   `theme.js` in the same PR — the contract should live in the
   chrome, not be split across the chrome and the spec.

### Boundaries Slices 1–8 should respect

- This PR is the foundation. Subsequent slices add specs page-by-page
  without touching `playwright.config.ts`, `sbpp.sh`, the workflow,
  or `Fixture.php` — just `pages/`, `specs/<bucket>/`, and the
  `ROUTES` array in `_screenshots.spec.ts`.
- Per-spec `truncateE2eDb()` is exported by `fixtures/db.ts` but not
  used yet — Slice 0's one spec doesn't need it. Slices that mutate
  state need a worker-scoped serialisation strategy because both
  projects (chromium + mobile-chromium) share the DB.
- The `screenshots-archive` orphan branch was initialised as a
  one-time prerequisite (empty README + the foundation gallery push);
  each subsequent PR pushes a unique
  `screenshots/pr-<N>/<slug>/` subdirectory. Conflict risk is zero.
- No new npm dependencies are expected from Slices 1–8; if a future
  slice needs one, it amends the foundation `package.json` +
  `package-lock.json` via a tiny follow-up.