### PR TITLE
tests/e2e: a11y (axe scan every route × light/dark, 0 critical)

### DIFF
--- a/web/tests/e2e/specs/a11y/routes.spec.ts
+++ b/web/tests/e2e/specs/a11y/routes.spec.ts
@@ -141,9 +141,17 @@ test.describe('a11y axe scan (0 critical)', () => {
 
                     // Wait for any [data-loading] / [data-skeleton] terminal
                     // attributes to clear — see `pages/_base.ts` for the
-                    // shared definition of "page is ready".
+                    // canonical predicate. The marquee banlist (#1123 B2)
+                    // keeps a dormant `<div data-skeleton hidden>`
+                    // always-mounted so banlist.js can flip it visible
+                    // during chip-filter re-renders without re-creating
+                    // the node, so we treat any `[hidden]` skeleton as
+                    // inert (only a *visible* skeleton means the page is
+                    // still loading).
                     await activePage.waitForFunction(
-                        () => !document.querySelector('[data-loading="true"], [data-skeleton]'),
+                        () => !document.querySelector(
+                            '[data-loading="true"], [data-skeleton]:not([hidden])',
+                        ),
                     );
 
                     await expectNoCriticalA11y(activePage, testInfo);

--- a/web/tests/e2e/specs/a11y/routes.spec.ts
+++ b/web/tests/e2e/specs/a11y/routes.spec.ts
@@ -1,0 +1,156 @@
+/**
+ * a11y axe scan — every route × light + dark theme (#1124 Slice 8).
+ *
+ * Contract from #1124 / #1123:
+ *   - axe-core scan passes with **0 critical violations** on every page,
+ *     in both light and dark mode.
+ *   - The threshold is **critical**, sourced from the shared helper in
+ *     `fixtures/axe.ts`. Do NOT lower it locally to make tests green —
+ *     file follow-ups against the underlying #1123 testability patterns
+ *     and `test.fixme()` the failing cell with the issue number.
+ *
+ * Project filter:
+ *   This spec runs on the `chromium` project only. The `mobile-chromium`
+ *   project shares the same markup (only the viewport differs) and axe's
+ *   WCAG checks don't change with viewport — running on both would
+ *   double the time without revealing different findings. We skip
+ *   non-chromium projects via `test.skip()` inside each test.
+ *
+ * Theme handling:
+ *   We pin the resolved theme via `localStorage['sbpp-theme']` BEFORE
+ *   navigating to the route, so theme.js's boot-time `applyTheme()` lands
+ *   the correct mode on first paint. We then wait for the resolved
+ *   class on `<html>` (`<html class="dark">` for dark, no `dark` class
+ *   for light) — see `_screenshots.spec.ts` for the rationale on why
+ *   the chrome uses a class instead of `[data-theme]`.
+ *
+ * Logged-out routes:
+ *   `/index.php?p=login` is the one route an anonymous visitor sees;
+ *   we spin up a fresh context with empty storageState for it so the
+ *   chrome matches what a logged-out visitor would render. Every other
+ *   route relies on the storage state minted by `fixtures/global-setup.ts`.
+ *
+ * Note on the `protest` route:
+ *   The route handler key is `?p=protest` (see
+ *   `web/includes/page-builder.php`). The route name is `protest`.
+ *
+ * Known-bad cells:
+ *   None — Slice 3 (#1175) landed `Database.php` PDO native-prepares
+ *   on `main`, which resolved #1167 (PDO `LIMIT ?,?` rejected by MariaDB
+ *   10.11 strict mode). Both `banlist dark` and `commslist dark` now
+ *   render normally and are real assertions. The `FIXME_CELLS` table
+ *   below is the documented escape hatch for any future cell that
+ *   regresses against an unfixed issue — keep the shape, never lower
+ *   the axe `critical` threshold to make a cell green.
+ */
+
+import { test } from '../../fixtures/auth.ts';
+import { expectNoCriticalA11y } from '../../fixtures/axe.ts';
+
+interface A11yRoute {
+    name: string;
+    path: string;
+    /** false → use a logged-out context (empty storageState). */
+    auth: boolean;
+}
+
+const ROUTES: A11yRoute[] = [
+    // Public surface
+    { name: 'login', path: '/index.php?p=login', auth: false },
+    { name: 'home', path: '/', auth: true },
+    { name: 'banlist', path: '/index.php?p=banlist', auth: true },
+    { name: 'commslist', path: '/index.php?p=commslist', auth: true },
+    { name: 'servers', path: '/index.php?p=servers', auth: true },
+    { name: 'submit', path: '/index.php?p=submit', auth: true },
+    { name: 'protest', path: '/index.php?p=protest', auth: true },
+    // Admin surface
+    { name: 'admin-home', path: '/index.php?p=admin', auth: true },
+    { name: 'admin-bans', path: '/index.php?p=admin&c=bans', auth: true },
+    { name: 'admin-admins', path: '/index.php?p=admin&c=admins', auth: true },
+    { name: 'admin-groups', path: '/index.php?p=admin&c=groups', auth: true },
+    { name: 'admin-settings', path: '/index.php?p=admin&c=settings', auth: true },
+    { name: 'admin-audit', path: '/index.php?p=admin&c=audit', auth: true },
+    { name: 'myaccount', path: '/index.php?p=account', auth: true },
+];
+
+const THEMES = ['light', 'dark'] as const;
+type Theme = (typeof THEMES)[number];
+
+/**
+ * `test.fixme()` table — `${routeName} ${theme}` -> follow-up reference.
+ * Per #1124's MUST-NOT-lower-threshold rule, every entry here is paired
+ * with a filed issue. Update the message string when the upstream fix
+ * lands and re-enable by removing the entry.
+ *
+ * Currently empty — every cell is a real assertion (#1167 was resolved
+ * by Slice 3). Add an entry here (and file the follow-up issue first)
+ * if a future regression makes a specific (route × theme) cell fail
+ * for reasons unrelated to a11y proper.
+ */
+const FIXME_CELLS: Readonly<Record<string, string>> = {};
+
+test.describe('a11y axe scan (0 critical)', () => {
+    for (const route of ROUTES) {
+        for (const theme of THEMES) {
+            const cellKey = `${route.name} ${theme}`;
+            test(cellKey, async ({ page, browser }, testInfo) => {
+                test.skip(
+                    testInfo.project.name !== 'chromium',
+                    'a11y outcomes are markup-driven; viewport does not change WCAG findings',
+                );
+
+                const fixmeReason = FIXME_CELLS[cellKey];
+                if (fixmeReason) {
+                    test.fixme(true, fixmeReason);
+                }
+
+                let activePage = page;
+                let ownContext: Awaited<ReturnType<typeof browser.newContext>> | null = null;
+                try {
+                    if (!route.auth) {
+                        ownContext = await browser.newContext({
+                            ...testInfo.project.use,
+                            storageState: { cookies: [], origins: [] },
+                        });
+                        activePage = await ownContext.newPage();
+                    }
+
+                    // Pin theme via localStorage BEFORE navigating to the
+                    // target route. theme.js reads `localStorage['sbpp-theme']`
+                    // on boot; setting it after a same-origin `goto('/')`
+                    // ensures the next navigation paints in the right mode.
+                    await activePage.goto('/');
+                    await activePage.evaluate((mode: Theme) => {
+                        try {
+                            localStorage.setItem('sbpp-theme', mode);
+                        } catch (_e) {
+                            /* localStorage unavailable in this context; skip */
+                        }
+                    }, theme);
+
+                    await activePage.goto(route.path);
+
+                    // Wait for theme.js's class flip on <html>. The new
+                    // theme uses `<html class="dark">` (set by
+                    // `document.documentElement.classList.toggle('dark', dark)`),
+                    // not `[data-theme="…"]`.
+                    await activePage.waitForFunction((expected: Theme) => {
+                        const isDark = document.documentElement.classList.contains('dark');
+                        return expected === 'dark' ? isDark : !isDark;
+                    }, theme);
+
+                    // Wait for any [data-loading] / [data-skeleton] terminal
+                    // attributes to clear — see `pages/_base.ts` for the
+                    // shared definition of "page is ready".
+                    await activePage.waitForFunction(
+                        () => !document.querySelector('[data-loading="true"], [data-skeleton]'),
+                    );
+
+                    await expectNoCriticalA11y(activePage, testInfo);
+                } finally {
+                    if (ownContext) await ownContext.close();
+                }
+            });
+        }
+    }
+});


### PR DESCRIPTION
Closes #1124

Final slice of the Playwright E2E suite. Adds axe-core scans for every
route in light + dark mode, asserting 0 critical violations everywhere
via the shared `expectNoCriticalA11y` helper from `fixtures/axe.ts`.

14 routes × 2 themes = 28 chromium-only assertions, scoped to the
`chromium` project (markup-driven; `mobile-chromium` would just double
the time without revealing different WCAG findings — same DOM, only
viewport differs). The `chromium` filter is enforced inside each test
via `test.skip()` so the parameterised spec stays a single literal.

## All slices in the issue (now merged)

- #1162 Slice 0: Foundation — Playwright + axe + screenshot gallery harness.
- #1169 Slice 2: smoke-admin — admin route smoke + 3 a11y tpl fixes.
- #1175 Slice 3: flow-public-submission — anonymous submit → admin
  approve → public list. Foundation fixes: `Database.php` PDO native
  prepares (resolves #1167), `sbpp.sh` DB isolation,
  `__sbppApplyBanFields` rename.
- #1171 Slice 1: smoke-public — public route smoke.
- #1173 Slice 4: flow-admin-ban-lifecycle — add → list → edit → unban.
- #1174 Slice 5: flow-comms-gag-mute — gag → list → unblock.
- #1172 Slice 6: flow-ui — theme toggle, command palette, player drawer.
- #1170 Slice 7: responsive — iPhone-13 viewport contract.
- #1168 (this PR) Slice 8: a11y — axe scan every route × light/dark, 0 critical.

## Acceptance criteria from #1124

- [x] `web/tests/e2e/` exists with Playwright config, TypeScript,
  page-object scaffold, axe integration. (Slice 0)
- [x] `./sbpp.sh e2e` runs locally. (Slice 0)
- [x] Smoke spec exists for every route. (Slices 1+2)
- [x] At least the four critical flows covered. (Slices 3+4+5+6)
- [x] Responsive specs pass at iPhone-13 viewport. (Slice 7)
- [x] axe-core scan passes (0 critical) on every page in light + dark
  mode. (Slice 8 — this PR)
- [x] `.github/workflows/e2e.yml` runs on PRs; failures upload artifacts.
  (Slice 0)
- [x] AGENTS.md / ARCHITECTURE.md / docker/README.md updated. (Slice 0)
- [x] `.gitignore` excludes `node_modules` / `playwright-report` /
  `test-results`. (Slice 0)

## Routes covered (this PR's spec)

14 routes × 2 themes = 28 chromium-only assertions:

| Route | path | light | dark |
| --- | --- | --- | --- |
| login | `?p=login` | ✓ | ✓ |
| home | `/` | ✓ | ✓ |
| banlist | `?p=banlist` | ✓ | ✓ |
| commslist | `?p=commslist` | ✓ | ✓ |
| servers | `?p=servers` | ✓ | ✓ |
| submit | `?p=submit` | ✓ | ✓ |
| protest | `?p=protest` | ✓ | ✓ |
| admin-home | `?p=admin` | ✓ | ✓ |
| admin-bans | `?p=admin&c=bans` | ✓ | ✓ |
| admin-admins | `?p=admin&c=admins` | ✓ | ✓ |
| admin-groups | `?p=admin&c=groups` | ✓ | ✓ |
| admin-settings | `?p=admin&c=settings` | ✓ | ✓ |
| admin-audit | `?p=admin&c=audit` | ✓ | ✓ |
| myaccount | `?p=account` | ✓ | ✓ |

## Known-bad cells

None — all 28 pass.

The Worker initially `test.fixme()`'d `banlist dark` and `commslist dark`
against #1167 (PDO `LIMIT ?,?` rejected by MariaDB 10.11 strict mode).
Slice 3 (#1175) landed `Database.php`'s `PDO::ATTR_EMULATE_PREPARES = false`
on `main`, which fixed that root cause; both cells are now real assertions
and the `FIXME_CELLS` table in `routes.spec.ts` is empty (kept as the
documented escape hatch for any future regression).

## a11y violations fixed up the stack

The 3 Smarty template fixes that earlier drafts of this PR carried (the
admin tablist `aria-required-children` violation, the in-game admin
password input's missing label, the SteamID match-mode `select` missing
label) all landed via Slice 2 (#1169) before this PR rebased. They're
on `main` already and the `chromium` axe runs prove the underlying
violations are gone. No template changes ship in this PR.

## Foundation hygiene

After Slice 3 unmasked the banlist render path, `routes.spec.ts`'s
page-ready predicate timed out against the marquee banlist's dormant
`<div data-skeleton hidden aria-hidden="true">` placeholder (always-mounted
per #1123 B2 so `banlist.js` can flip it visible during chip-filter
re-renders without re-creating the node). `pages/_base.ts` already
encoded the canonical fix as `[data-skeleton]:not([hidden])`; aligned
`routes.spec.ts` to the same predicate so the page-ready contract stays
in lockstep across the whole suite. Carried as a follow-on commit on
this branch; collapses on squash-merge.

## Follow-ups filed during the rollout

- #1165 — Player drawer: implement Overview/History/Comms/Notes tabs
  (current drawer is single-body; #1123 followup).
- #1167 — Public ban list & comms list fatal under MariaDB 10.11 strict
  mode (PDO `LIMIT ?,?` binds as strings). **Resolved by Slice 3's
  Database.php native-prepares fix; issue auto-close not wired (Slice 3
  used `Refs #1124`, not `Closes #1167`). Safe to close.**
- #1176 — `page.submit.php` emits dead `ShowBox()` reference (#1123
  followup).
- #1177 — Mobile hamburger button is `display:none` with no media-query
  override.
- #1178 — Mobile sidebar drawer has no close affordance.
- #1179 — `data-mobile-open` attribute on `#sidebar` never updates in JS.
- #1180 — Topbar overflows iPhone-13 viewport (~28px horizontal scroll).
- #1181 — Filter chip bar uses `.scroll-x` horizontal scroll instead of
  `flex-wrap` on mobile.

## Local commands run

- `./sbpp.sh phpstan` — clean (`[OK] No errors`).
- `./sbpp.sh test` — green (280 tests, 1189 assertions).
- `./sbpp.sh ts-check` — clean.
- `./sbpp.sh composer api-contract` — zero diff.
- `./sbpp.sh e2e specs/a11y/` — 28 passed, 28 skipped (mobile-chromium
  filtered per `test.skip()` inside the spec).

## Hard-rule compliance

- axe `critical` threshold not lowered. The single shared helper
  `expectNoCriticalA11y` in `fixtures/axe.ts` is the only call site;
  `routes.spec.ts` consumes it without a per-test impact override.
- No screenshot block added (Slice 8 wasn't required to extend
  `_screenshots.spec.ts`; the chromium spec is functional-only).
- No anti-patterns reintroduced (vanilla TS, no MooTools/React/bundler;
  `:prefix_` discipline preserved in tpl edits that are now on main via
  Slice 2).
