### PR TITLE
[#1124 Slice 2] tests/e2e: smoke-admin (smoke specs for /admin/*, /admin/myaccount)

### DIFF
--- a/web/tests/e2e/pages/admin/AdminAdmins.ts
+++ b/web/tests/e2e/pages/admin/AdminAdmins.ts
@@ -1,0 +1,28 @@
+import type { Locator, Page } from '@playwright/test';
+
+import { BasePage } from '../_base.ts';
+
+/**
+ * Admin > Admins (`?p=admin&c=admins`).
+ *
+ * Pair: `web/pages/admin.admins.php` -> Sbpp\View\AdminAdminsListView
+ * + `page_admin_admins_list.tpl`. The list view is gated on
+ * `$can_list_admins`; the seeded admin holds OWNER so the `<span
+ * data-testid="admin-count">` lands unconditionally — that's the
+ * stable terminal mark we wait on.
+ */
+export class AdminAdminsPage extends BasePage {
+    constructor(page: Page) {
+        super(page);
+    }
+
+    readonly path = '/index.php?p=admin&c=admins';
+
+    get pageMounted(): Locator {
+        return this.page.locator('[data-testid="admin-count"]');
+    }
+
+    async goto(): Promise<void> {
+        await super.goto(this.path);
+    }
+}

--- a/web/tests/e2e/pages/admin/AdminAudit.ts
+++ b/web/tests/e2e/pages/admin/AdminAudit.ts
@@ -1,0 +1,29 @@
+import type { Locator, Page } from '@playwright/test';
+
+import { BasePage } from '../_base.ts';
+
+/**
+ * Admin > Audit log (`?p=admin&c=audit`).
+ *
+ * Pair: `web/pages/admin.audit.php` -> Sbpp\View\AuditLogView +
+ * `page_admin_audit.tpl`. The page is gated on `ADMIN_OWNER` (the
+ * router enforces `CheckAdminAccess(ADMIN_OWNER)` for `c=audit`); the
+ * seeded admin holds OWNER, so the search + filter chips render
+ * unconditionally. We pin on `audit-search` (the search input) which
+ * exists regardless of how many log rows the queue currently holds.
+ */
+export class AdminAuditPage extends BasePage {
+    constructor(page: Page) {
+        super(page);
+    }
+
+    readonly path = '/index.php?p=admin&c=audit';
+
+    get pageMounted(): Locator {
+        return this.page.locator('[data-testid="audit-search"]');
+    }
+
+    async goto(): Promise<void> {
+        await super.goto(this.path);
+    }
+}

--- a/web/tests/e2e/pages/admin/AdminBans.ts
+++ b/web/tests/e2e/pages/admin/AdminBans.ts
@@ -1,0 +1,32 @@
+import type { Locator, Page } from '@playwright/test';
+
+import { BasePage } from '../_base.ts';
+
+/**
+ * Admin > Bans (`?p=admin&c=bans`).
+ *
+ * Pair: `web/pages/admin.bans.php` renders `core/admin_tabs.tpl`
+ * followed by every accessible tab content (Add a ban, Ban protests,
+ * Ban submissions, …). Each tab block is a separate Renderer::render
+ * call against its own View; see admin.bans.php for the full list.
+ *
+ * The "Add a ban" tab is the first one in the AdminTabs constructor
+ * and is gated on `ADMIN_OWNER | ADMIN_ADD_BAN`. The seeded admin
+ * holds OWNER so the form's `addban-section` testid is always
+ * present — that's the page-mounted signal.
+ */
+export class AdminBansPage extends BasePage {
+    constructor(page: Page) {
+        super(page);
+    }
+
+    readonly path = '/index.php?p=admin&c=bans';
+
+    get pageMounted(): Locator {
+        return this.page.locator('[data-testid="addban-section"]');
+    }
+
+    async goto(): Promise<void> {
+        await super.goto(this.path);
+    }
+}

--- a/web/tests/e2e/pages/admin/AdminGroups.ts
+++ b/web/tests/e2e/pages/admin/AdminGroups.ts
@@ -1,0 +1,29 @@
+import type { Locator, Page } from '@playwright/test';
+
+import { BasePage } from '../_base.ts';
+
+/**
+ * Admin > Groups (`?p=admin&c=groups`).
+ *
+ * Pair: `web/pages/admin.groups.php` -> Sbpp\View\AdminGroupsListView
+ * + `page_admin_groups_list.tpl`. The list template lays out three
+ * sections: web admin groups (master-detail), server admin groups,
+ * and server groups. The first section's wrapper exposes
+ * `data-testid="web-groups-section"` whenever `$permission_listgroups`
+ * is true — that's the mount signal.
+ */
+export class AdminGroupsPage extends BasePage {
+    constructor(page: Page) {
+        super(page);
+    }
+
+    readonly path = '/index.php?p=admin&c=groups';
+
+    get pageMounted(): Locator {
+        return this.page.locator('[data-testid="web-groups-section"]');
+    }
+
+    async goto(): Promise<void> {
+        await super.goto(this.path);
+    }
+}

--- a/web/tests/e2e/pages/admin/AdminHome.ts
+++ b/web/tests/e2e/pages/admin/AdminHome.ts
@@ -1,0 +1,31 @@
+import type { Locator, Page } from '@playwright/test';
+
+import { BasePage } from '../_base.ts';
+
+/**
+ * Admin landing page (`?p=admin`, no `c=`).
+ *
+ * Pair: `web/pages/page.admin.php` -> `web/themes/default/page_admin.tpl`.
+ *
+ * The seeded admin holds `ADMIN_OWNER`, so every `$can_<area>` boolean
+ * the View precomputes resolves to true and every `admin-card-*` tile
+ * renders. We pin on `admin-card-bans` because the Bans tile is the
+ * area an admin most consistently has access to (anyone with even a
+ * single ADMIN_*BAN flag sees it), so the same selector keeps working
+ * if a future slice runs this spec under a non-OWNER fixture.
+ */
+export class AdminHomePage extends BasePage {
+    constructor(page: Page) {
+        super(page);
+    }
+
+    readonly path = '/index.php?p=admin';
+
+    get pageMounted(): Locator {
+        return this.page.locator('[data-testid="admin-card-bans"]');
+    }
+
+    async goto(): Promise<void> {
+        await super.goto(this.path);
+    }
+}

--- a/web/tests/e2e/pages/admin/AdminSettings.ts
+++ b/web/tests/e2e/pages/admin/AdminSettings.ts
@@ -1,0 +1,29 @@
+import type { Locator, Page } from '@playwright/test';
+
+import { BasePage } from '../_base.ts';
+
+/**
+ * Admin > Settings (`?p=admin&c=settings`).
+ *
+ * Pair: `web/pages/admin.settings.php` -> Sbpp\View\AdminSettingsView
+ * + `page_admin_settings_settings.tpl` (default `?section=settings`).
+ * The sub-nav at the top of every settings page renders the
+ * `[data-testid="settings-tab-settings"]` link unconditionally; the
+ * sub-nav itself sits outside the `$can_web_settings` gate, so this
+ * selector remains valid even on the access-denied fallback.
+ */
+export class AdminSettingsPage extends BasePage {
+    constructor(page: Page) {
+        super(page);
+    }
+
+    readonly path = '/index.php?p=admin&c=settings';
+
+    get pageMounted(): Locator {
+        return this.page.locator('[data-testid="settings-tab-settings"]');
+    }
+
+    async goto(): Promise<void> {
+        await super.goto(this.path);
+    }
+}

--- a/web/tests/e2e/pages/admin/MyAccount.ts
+++ b/web/tests/e2e/pages/admin/MyAccount.ts
@@ -1,0 +1,28 @@
+import type { Locator, Page } from '@playwright/test';
+
+import { BasePage } from '../_base.ts';
+
+/**
+ * Your account (`?p=account`).
+ *
+ * Pair: `web/pages/page.youraccount.php` -> Sbpp\View\YourAccountView
+ * + `page_youraccount.tpl`. The route lives at top-level `?p=account`
+ * (not under `?p=admin`); navbar.tpl wires the "Logged in as <user>"
+ * link to it. The page header carries `data-testid="account-header"`
+ * unconditionally for any logged-in user — that's the mount signal.
+ */
+export class MyAccountPage extends BasePage {
+    constructor(page: Page) {
+        super(page);
+    }
+
+    readonly path = '/index.php?p=account';
+
+    get pageMounted(): Locator {
+        return this.page.locator('[data-testid="account-header"]');
+    }
+
+    async goto(): Promise<void> {
+        await super.goto(this.path);
+    }
+}

--- a/web/tests/e2e/specs/_screenshots.spec.ts
+++ b/web/tests/e2e/specs/_screenshots.spec.ts
@@ -127,3 +127,74 @@ test.describe('@screenshot gallery', () => {
         }
     }
 });
+
+// ---- Slice 2: smoke-admin (#1124) ----
+//
+// One row per admin route covered by `specs/smoke/admin/*.spec.ts`.
+// The `auth: true` flag means we reuse the project-default storage
+// state (admin/admin minted in fixtures/global-setup.ts) instead of
+// spinning up a logged-out context. The describe block below mirrors
+// the `@screenshot gallery` shape exactly, just looped over this
+// slice's route list — kept inline rather than lifted into a shared
+// helper because Slice 0 left the gallery as a flat literal and the
+// extraction is a separate concern best done once a third slice has
+// to repeat the same body.
+const ROUTES_SMOKE_ADMIN: RouteSpec[] = [
+    { name: 'admin-home',     path: '/index.php?p=admin',             auth: true },
+    { name: 'admin-bans',     path: '/index.php?p=admin&c=bans',      auth: true },
+    { name: 'admin-admins',   path: '/index.php?p=admin&c=admins',    auth: true },
+    { name: 'admin-groups',   path: '/index.php?p=admin&c=groups',    auth: true },
+    { name: 'admin-settings', path: '/index.php?p=admin&c=settings',  auth: true },
+    { name: 'admin-audit',    path: '/index.php?p=admin&c=audit',     auth: true },
+    { name: 'myaccount',      path: '/index.php?p=account',           auth: true },
+];
+
+test.describe('@screenshot smoke-admin', () => {
+    test.skip(!process.env.SCREENSHOTS, '@screenshot only runs when SCREENSHOTS=1');
+
+    for (const route of ROUTES_SMOKE_ADMIN) {
+        for (const theme of THEMES) {
+            test(`${route.name} ${theme}`, async ({ page, browser }, testInfo) => {
+                const viewport = viewportFor(testInfo.project.name);
+                const outPath = resolve(
+                    __dirname,
+                    '..',
+                    'screenshots',
+                    theme,
+                    viewport,
+                    `${route.name}.png`,
+                );
+                await mkdir(dirname(outPath), { recursive: true });
+
+                let activePage = page;
+                let ownContext: Awaited<ReturnType<typeof browser.newContext>> | null = null;
+                try {
+                    if (!route.auth) {
+                        ownContext = await browser.newContext({
+                            ...testInfo.project.use,
+                            storageState: { cookies: [], origins: [] },
+                        });
+                        activePage = await ownContext.newPage();
+                    }
+
+                    await activePage.goto('/');
+                    await activePage.evaluate((mode: Theme) => {
+                        try { localStorage.setItem('sbpp-theme', mode); } catch (_e) { /* unavailable; skip */ }
+                    }, theme);
+
+                    await activePage.goto(route.path);
+
+                    await activePage.waitForFunction((expected: Theme) => {
+                        const isDark = document.documentElement.classList.contains('dark');
+                        return expected === 'dark' ? isDark : !isDark;
+                    }, theme);
+
+                    await activePage.screenshot({ fullPage: true, path: outPath });
+                    expect(outPath).toMatch(/\.png$/);
+                } finally {
+                    if (ownContext) await ownContext.close();
+                }
+            });
+        }
+    }
+});

--- a/web/tests/e2e/specs/smoke/admin/admins.spec.ts
+++ b/web/tests/e2e/specs/smoke/admin/admins.spec.ts
@@ -1,0 +1,29 @@
+/**
+ * Smoke: `/admin/admins` (`?p=admin&c=admins`).
+ *
+ * Asserts the admins list renders without console errors and 0
+ * critical axe violations. Storage state is admin/admin (logged in
+ * by default), so the route is accessible without a per-spec login.
+ *
+ * Selector contract: see `pages/admin/AdminAdmins.ts` (pinned on
+ * `admin-count`, the headcount span next to the Admins H1).
+ */
+import { test, expect } from '../../../fixtures/auth.ts';
+import { expectNoCriticalA11y } from '../../../fixtures/axe.ts';
+import { AdminAdminsPage } from '../../../pages/admin/AdminAdmins.ts';
+
+test.describe('smoke /admin/admins', () => {
+    test('mounts without console errors and 0 critical a11y violations', async ({ page }, testInfo) => {
+        const consoleErrors: string[] = [];
+        page.on('pageerror', (err) => consoleErrors.push(err.message));
+        page.on('console', (msg) => {
+            if (msg.type() === 'error') consoleErrors.push(msg.text());
+        });
+
+        const p = new AdminAdminsPage(page);
+        await p.goto();
+        await expect(p.pageMounted).toBeVisible();
+        await expectNoCriticalA11y(page, testInfo);
+        expect(consoleErrors, `console errors:\n${consoleErrors.join('\n')}`).toEqual([]);
+    });
+});

--- a/web/tests/e2e/specs/smoke/admin/audit.spec.ts
+++ b/web/tests/e2e/specs/smoke/admin/audit.spec.ts
@@ -1,0 +1,29 @@
+/**
+ * Smoke: `/admin/audit` (`?p=admin&c=audit`).
+ *
+ * Asserts the audit log page renders without console errors and 0
+ * critical axe violations. Storage state is admin/admin (logged in
+ * by default), so the route is accessible without a per-spec login.
+ *
+ * Selector contract: see `pages/admin/AdminAudit.ts` (pinned on
+ * the always-rendered `audit-search` input).
+ */
+import { test, expect } from '../../../fixtures/auth.ts';
+import { expectNoCriticalA11y } from '../../../fixtures/axe.ts';
+import { AdminAuditPage } from '../../../pages/admin/AdminAudit.ts';
+
+test.describe('smoke /admin/audit', () => {
+    test('mounts without console errors and 0 critical a11y violations', async ({ page }, testInfo) => {
+        const consoleErrors: string[] = [];
+        page.on('pageerror', (err) => consoleErrors.push(err.message));
+        page.on('console', (msg) => {
+            if (msg.type() === 'error') consoleErrors.push(msg.text());
+        });
+
+        const p = new AdminAuditPage(page);
+        await p.goto();
+        await expect(p.pageMounted).toBeVisible();
+        await expectNoCriticalA11y(page, testInfo);
+        expect(consoleErrors, `console errors:\n${consoleErrors.join('\n')}`).toEqual([]);
+    });
+});

--- a/web/tests/e2e/specs/smoke/admin/bans.spec.ts
+++ b/web/tests/e2e/specs/smoke/admin/bans.spec.ts
@@ -1,0 +1,29 @@
+/**
+ * Smoke: `/admin/bans` (`?p=admin&c=bans`).
+ *
+ * Asserts the admin bans page renders without console errors and 0
+ * critical axe violations. Storage state is admin/admin (logged in
+ * by default), so the route is accessible without a per-spec login.
+ *
+ * Selector contract: see `pages/admin/AdminBans.ts` (pinned on the
+ * "Add a ban" tab content's `addban-section`).
+ */
+import { test, expect } from '../../../fixtures/auth.ts';
+import { expectNoCriticalA11y } from '../../../fixtures/axe.ts';
+import { AdminBansPage } from '../../../pages/admin/AdminBans.ts';
+
+test.describe('smoke /admin/bans', () => {
+    test('mounts without console errors and 0 critical a11y violations', async ({ page }, testInfo) => {
+        const consoleErrors: string[] = [];
+        page.on('pageerror', (err) => consoleErrors.push(err.message));
+        page.on('console', (msg) => {
+            if (msg.type() === 'error') consoleErrors.push(msg.text());
+        });
+
+        const p = new AdminBansPage(page);
+        await p.goto();
+        await expect(p.pageMounted).toBeVisible();
+        await expectNoCriticalA11y(page, testInfo);
+        expect(consoleErrors, `console errors:\n${consoleErrors.join('\n')}`).toEqual([]);
+    });
+});

--- a/web/tests/e2e/specs/smoke/admin/groups.spec.ts
+++ b/web/tests/e2e/specs/smoke/admin/groups.spec.ts
@@ -1,0 +1,29 @@
+/**
+ * Smoke: `/admin/groups` (`?p=admin&c=groups`).
+ *
+ * Asserts the groups page renders without console errors and 0
+ * critical axe violations. Storage state is admin/admin (logged in
+ * by default), so the route is accessible without a per-spec login.
+ *
+ * Selector contract: see `pages/admin/AdminGroups.ts` (pinned on
+ * the master-detail wrapper `web-groups-section`).
+ */
+import { test, expect } from '../../../fixtures/auth.ts';
+import { expectNoCriticalA11y } from '../../../fixtures/axe.ts';
+import { AdminGroupsPage } from '../../../pages/admin/AdminGroups.ts';
+
+test.describe('smoke /admin/groups', () => {
+    test('mounts without console errors and 0 critical a11y violations', async ({ page }, testInfo) => {
+        const consoleErrors: string[] = [];
+        page.on('pageerror', (err) => consoleErrors.push(err.message));
+        page.on('console', (msg) => {
+            if (msg.type() === 'error') consoleErrors.push(msg.text());
+        });
+
+        const p = new AdminGroupsPage(page);
+        await p.goto();
+        await expect(p.pageMounted).toBeVisible();
+        await expectNoCriticalA11y(page, testInfo);
+        expect(consoleErrors, `console errors:\n${consoleErrors.join('\n')}`).toEqual([]);
+    });
+});

--- a/web/tests/e2e/specs/smoke/admin/home.spec.ts
+++ b/web/tests/e2e/specs/smoke/admin/home.spec.ts
@@ -1,0 +1,30 @@
+/**
+ * Smoke: `/admin` (admin home, `?p=admin`).
+ *
+ * Asserts the admin landing renders without console errors and 0
+ * critical axe violations. Storage state is admin/admin (logged in
+ * by default), so the route is accessible without a per-spec login.
+ *
+ * Selector contract: see `pages/admin/AdminHome.ts` (pinned on
+ * `admin-card-bans` because that tile is gated on the smallest
+ * permissions union the route renders for).
+ */
+import { test, expect } from '../../../fixtures/auth.ts';
+import { expectNoCriticalA11y } from '../../../fixtures/axe.ts';
+import { AdminHomePage } from '../../../pages/admin/AdminHome.ts';
+
+test.describe('smoke /admin', () => {
+    test('mounts without console errors and 0 critical a11y violations', async ({ page }, testInfo) => {
+        const consoleErrors: string[] = [];
+        page.on('pageerror', (err) => consoleErrors.push(err.message));
+        page.on('console', (msg) => {
+            if (msg.type() === 'error') consoleErrors.push(msg.text());
+        });
+
+        const p = new AdminHomePage(page);
+        await p.goto();
+        await expect(p.pageMounted).toBeVisible();
+        await expectNoCriticalA11y(page, testInfo);
+        expect(consoleErrors, `console errors:\n${consoleErrors.join('\n')}`).toEqual([]);
+    });
+});

--- a/web/tests/e2e/specs/smoke/admin/myaccount.spec.ts
+++ b/web/tests/e2e/specs/smoke/admin/myaccount.spec.ts
@@ -1,0 +1,32 @@
+/**
+ * Smoke: `/admin/myaccount` (`?p=account`).
+ *
+ * Note: the user-account page is NOT under `?p=admin`. The "Logged
+ * in as <user>" link in the sidebar (navbar.tpl) routes here, and
+ * the legacy admin index treated this as the canonical "my account"
+ * surface. Asserts the page renders without console errors and 0
+ * critical axe violations. Storage state is admin/admin (logged in
+ * by default).
+ *
+ * Selector contract: see `pages/admin/MyAccount.ts` (pinned on the
+ * `account-header` block which renders for any logged-in user).
+ */
+import { test, expect } from '../../../fixtures/auth.ts';
+import { expectNoCriticalA11y } from '../../../fixtures/axe.ts';
+import { MyAccountPage } from '../../../pages/admin/MyAccount.ts';
+
+test.describe('smoke /admin/myaccount', () => {
+    test('mounts without console errors and 0 critical a11y violations', async ({ page }, testInfo) => {
+        const consoleErrors: string[] = [];
+        page.on('pageerror', (err) => consoleErrors.push(err.message));
+        page.on('console', (msg) => {
+            if (msg.type() === 'error') consoleErrors.push(msg.text());
+        });
+
+        const p = new MyAccountPage(page);
+        await p.goto();
+        await expect(p.pageMounted).toBeVisible();
+        await expectNoCriticalA11y(page, testInfo);
+        expect(consoleErrors, `console errors:\n${consoleErrors.join('\n')}`).toEqual([]);
+    });
+});

--- a/web/tests/e2e/specs/smoke/admin/settings.spec.ts
+++ b/web/tests/e2e/specs/smoke/admin/settings.spec.ts
@@ -1,0 +1,30 @@
+/**
+ * Smoke: `/admin/settings` (`?p=admin&c=settings`).
+ *
+ * Asserts the settings page renders without console errors and 0
+ * critical axe violations. Storage state is admin/admin (logged in
+ * by default), so the route is accessible without a per-spec login.
+ *
+ * Selector contract: see `pages/admin/AdminSettings.ts` (pinned on
+ * the settings sub-nav, which sits outside the `$can_web_settings`
+ * gate so the selector remains stable on the access-denied fallback).
+ */
+import { test, expect } from '../../../fixtures/auth.ts';
+import { expectNoCriticalA11y } from '../../../fixtures/axe.ts';
+import { AdminSettingsPage } from '../../../pages/admin/AdminSettings.ts';
+
+test.describe('smoke /admin/settings', () => {
+    test('mounts without console errors and 0 critical a11y violations', async ({ page }, testInfo) => {
+        const consoleErrors: string[] = [];
+        page.on('pageerror', (err) => consoleErrors.push(err.message));
+        page.on('console', (msg) => {
+            if (msg.type() === 'error') consoleErrors.push(msg.text());
+        });
+
+        const p = new AdminSettingsPage(page);
+        await p.goto();
+        await expect(p.pageMounted).toBeVisible();
+        await expectNoCriticalA11y(page, testInfo);
+        expect(consoleErrors, `console errors:\n${consoleErrors.join('\n')}`).toEqual([]);
+    });
+});

--- a/web/themes/default/box_admin_admins_search.tpl
+++ b/web/themes/default/box_admin_admins_search.tpl
@@ -111,6 +111,7 @@
                 <select class="select"
                         id="search-admins-steam-match"
                         data-testid="search-admins-steam-match"
+                        aria-label="Steam ID match mode"
                         style="width:9rem">
                     <option value="0" selected>Exact match</option>
                     <option value="1">Partial match</option>

--- a/web/themes/default/core/admin_tabs.tpl
+++ b/web/themes/default/core/admin_tabs.tpl
@@ -9,12 +9,24 @@
 
     The "openTab(this, '<name>')" handler is defined inline by each
     admin page that uses tabs (legacy convention preserved by AdminTabs.php).
+
+    A11y note (#1124 Slice 2): the wrapper used to declare
+    role="tablist" with role="tab" children. The full ARIA tabs
+    pattern is NOT implemented (no aria-controls, no aria-selected on
+    the buttons; the .tabcontent panes have no role="tabpanel" /
+    aria-labelledby), so the roles described an interaction model the
+    DOM didn't honour. axe-core's `aria-required-children` rule
+    additionally flags the trailing "Back" anchor as an unallowed
+    [tabindex] child of role="tablist". Both reasons argue for the
+    same fix: drop the partial ARIA roles, label the wrapper as a
+    plain "Admin sections" toolbar so SR users hear the buttons as
+    buttons. If a follow-up wires the full tab pattern (controls,
+    selected, panel labelling) the roles can come back in lockstep.
 *}
-<div class="admin-tabs flex gap-2 mb-4" role="tablist" aria-label="Admin tabs">
+<div class="admin-tabs flex gap-2 mb-4" aria-label="Admin sections">
     {foreach from=$tabs item=tab}
         <button type="button"
                 class="btn btn--secondary btn--sm"
-                role="tab"
                 data-testid="admin-tab-{$tab.name}"
                 onclick="openTab(this, '{$tab.name}');">{$tab.name}</button>
     {/foreach}

--- a/web/themes/default/page_admin_admins_add.tpl
+++ b/web/themes/default/page_admin_admins_add.tpl
@@ -106,7 +106,8 @@
                         <label for="a_useserverpass" class="text-sm font-medium" style="margin:0">Set in-game admin password</label>
                         <input class="input" id="a_serverpass" name="a_serverpass" type="password"
                                style="max-width:14rem;margin-left:auto" disabled tabindex="7"
-                               data-testid="admin-add-serverpass" autocomplete="new-password">
+                               data-testid="admin-add-serverpass" autocomplete="new-password"
+                               aria-label="In-game admin password">
                     </div>
                     <div id="a_serverpass.msg" class="text-xs" style="color:var(--danger)"></div>
                 </div>


### PR DESCRIPTION
## Summary

Slice 2 of #1124's Tier 4 plan: Playwright smoke specs for every
admin route, plus the matching `@screenshot` gallery rows. Builds on
Slice 0's harness (#1162); no new npm deps, no new sbpp.sh
subcommands.

Routes covered (one spec + one page object each):

| Conceptual path | Actual path | Page object |
| --- | --- | --- |
| `/admin` | `?p=admin` | `pages/admin/AdminHome.ts` |
| `/admin/bans` | `?p=admin&c=bans` | `pages/admin/AdminBans.ts` |
| `/admin/admins` | `?p=admin&c=admins` | `pages/admin/AdminAdmins.ts` |
| `/admin/groups` | `?p=admin&c=groups` | `pages/admin/AdminGroups.ts` |
| `/admin/settings` | `?p=admin&c=settings` | `pages/admin/AdminSettings.ts` |
| `/admin/audit` | `?p=admin&c=audit` | `pages/admin/AdminAudit.ts` |
| `/admin/myaccount` | `?p=account` | `pages/admin/MyAccount.ts` |

`/admin/myaccount` lives at top-level `?p=account`, **not** under
`?p=admin`. `web/themes/default/core/navbar.tpl` wires the "Logged
in as &lt;user&gt;" link to `?p=account`, and `page-builder.php`'s
outer switch confirms the route shape.

Each spec asserts:
- the page mounts (a stable `data-testid` per route is visible),
- no `pageerror` or `console.error` events fired during the load,
- `expectNoCriticalA11y(page, testInfo)` finds zero critical violations.

The screenshot block (`specs/_screenshots.spec.ts`) appends a sibling
`@screenshot smoke-admin` describe loop over a new
`ROUTES_SMOKE_ADMIN` array. The body is inlined with the same shape
as the existing `@screenshot gallery` loop — a future slice can
extract a shared helper once a third caller appears.

## A11y fixes carried in this slice

The first run of the smoke specs surfaced three real a11y bugs in
the chrome / admin forms. Each is a 1–3 line tweak to a single
template, matching the issue's "if it's a 3-line tpl tweak, do it in
this PR and flag in the body" rule. None changes behaviour.

- `web/themes/default/core/admin_tabs.tpl` — drop `role="tablist"` +
  `role="tab"` from the AdminTabs bar. The full ARIA tabs pattern
  isn't implemented (no `aria-controls`, no `aria-selected`, the
  `.tabcontent` panes carry no `role="tabpanel"` / `aria-labelledby`),
  and axe additionally flagged the trailing "Back" anchor as an
  unallowed `[tabindex]` child of `role="tablist"`. Wrapper now
  carries `aria-label="Admin sections"` so SR users hear the buttons
  as buttons. If a follow-up wires the full tab pattern the roles
  can come back in lockstep.
- `web/themes/default/page_admin_admins_add.tpl` — add
  `aria-label="In-game admin password"` to `#a_serverpass`. The
  input had no associated `<label>` (the visible "Set in-game admin
  password" label is bound to the sibling checkbox).
- `web/themes/default/box_admin_admins_search.tpl` — add
  `aria-label="Steam ID match mode"` to `#search-admins-steam-match`.
  The Steam ID row has one shared `<label>` and it's bound to the
  text input; the match-mode dropdown previously had no accessible
  name.

## Local quality gates (all green)

- `./sbpp.sh phpstan` — No errors
- `./sbpp.sh test` — 280 tests, 1189 assertions
- `./sbpp.sh ts-check` — clean
- `./sbpp.sh composer api-contract` — zero diff
- `./sbpp.sh e2e` — 18 passed, 32 skipped (`@screenshot` opts in via `SCREENSHOTS=1`)
- `SCREENSHOTS=1 ./sbpp.sh e2e --grep "@screenshot smoke-admin"` — 28 passed (7 routes × 2 themes × 2 viewports)

## Test plan

- [ ] CI: PHPStan, PHPUnit, ts-check, api-contract, e2e all green.
- [ ] Sanity-check the `## Screenshots (smoke-admin)` comment posted
      on this PR by `upload-screenshots.sh`: every cell renders in
      light + dark, on desktop + mobile.
- [ ] Verify the chrome a11y tweak doesn't regress the look of the
      AdminTabs bar (Bans / Admins / Groups / Mods / Comms).

Refs #1124