### PR TITLE
tests/e2e: smoke-public (smoke specs for /, /bans, /comms, /servers, /submit, /protest)

### DIFF
--- a/web/pages/page.banlist.php
+++ b/web/pages/page.banlist.php
@@ -282,10 +282,12 @@ if (isset($_GET['searchText'])) {
   LEFT JOIN `:prefix_admins` AS AD ON BA.aid = AD.aid
       WHERE " . $search_ips . $authidClause . " or BA.name LIKE ? or BA.reason LIKE ?" . $hideinactive . "
    ORDER BY BA.created DESC
-   LIMIT " . intval($BansStart) . "," . intval($BansPerPage))->resultset(array_merge($search_array, [
+   LIMIT ?,?")->resultset(array_merge($search_array, [
         $authidParam,
         $search,
         $search,
+        intval($BansStart),
+        intval($BansPerPage),
     ]));
 
 
@@ -307,7 +309,10 @@ if (isset($_GET['searchText'])) {
   LEFT JOIN `:prefix_admins` AS AD ON BA.aid = AD.aid
   " . $hideinactiven . "
    ORDER BY created DESC
-   LIMIT " . intval($BansStart) . "," . intval($BansPerPage))->resultset();
+   LIMIT ?,?")->resultset([
+        intval($BansStart),
+        intval($BansPerPage),
+    ]);
 
     $res_count  = $GLOBALS['PDO']->query("SELECT count(bid) AS cnt FROM `:prefix_bans`" . $hideinactiven)->resultset();
     $searchlink = "";
@@ -489,7 +494,10 @@ if (isset($_GET['advSearch'])) {
   " . ($type == "comment" && $userbank->is_admin() ? "LEFT JOIN `:prefix_comments` AS CO ON BA.bid = CO.bid" : "") . "
       " . $where . $hideinactive . "
    ORDER BY BA.created DESC
-   LIMIT " . intval($BansStart) . "," . intval($BansPerPage))->resultset($advcrit);
+   LIMIT ?,?")->resultset(array_merge($advcrit, [
+        intval($BansStart),
+        intval($BansPerPage),
+    ]));
 
     $res_count  = $GLOBALS['PDO']->query("SELECT count(BA.bid) AS cnt FROM `:prefix_bans` AS BA
 										  " . ($type == "comment" && $userbank->is_admin() ? "LEFT JOIN `:prefix_comments` AS CO ON BA.bid = CO.bid" : "") . " " . $where . $hideinactive)->resultset($advcrit);

--- a/web/pages/page.banlist.php
+++ b/web/pages/page.banlist.php
@@ -282,12 +282,10 @@ if (isset($_GET['searchText'])) {
   LEFT JOIN `:prefix_admins` AS AD ON BA.aid = AD.aid
       WHERE " . $search_ips . $authidClause . " or BA.name LIKE ? or BA.reason LIKE ?" . $hideinactive . "
    ORDER BY BA.created DESC
-   LIMIT ?,?")->resultset(array_merge($search_array, [
+   LIMIT " . intval($BansStart) . "," . intval($BansPerPage))->resultset(array_merge($search_array, [
         $authidParam,
         $search,
         $search,
-        intval($BansStart),
-        intval($BansPerPage),
     ]));
 
 
@@ -309,10 +307,7 @@ if (isset($_GET['searchText'])) {
   LEFT JOIN `:prefix_admins` AS AD ON BA.aid = AD.aid
   " . $hideinactiven . "
    ORDER BY created DESC
-   LIMIT ?,?")->resultset([
-        intval($BansStart),
-        intval($BansPerPage),
-    ]);
+   LIMIT " . intval($BansStart) . "," . intval($BansPerPage))->resultset();
 
     $res_count  = $GLOBALS['PDO']->query("SELECT count(bid) AS cnt FROM `:prefix_bans`" . $hideinactiven)->resultset();
     $searchlink = "";
@@ -494,10 +489,7 @@ if (isset($_GET['advSearch'])) {
   " . ($type == "comment" && $userbank->is_admin() ? "LEFT JOIN `:prefix_comments` AS CO ON BA.bid = CO.bid" : "") . "
       " . $where . $hideinactive . "
    ORDER BY BA.created DESC
-   LIMIT ?,?")->resultset(array_merge($advcrit, [
-        intval($BansStart),
-        intval($BansPerPage),
-    ]));
+   LIMIT " . intval($BansStart) . "," . intval($BansPerPage))->resultset($advcrit);
 
     $res_count  = $GLOBALS['PDO']->query("SELECT count(BA.bid) AS cnt FROM `:prefix_bans` AS BA
 										  " . ($type == "comment" && $userbank->is_admin() ? "LEFT JOIN `:prefix_comments` AS CO ON BA.bid = CO.bid" : "") . " " . $where . $hideinactive)->resultset($advcrit);

--- a/web/pages/page.commslist.php
+++ b/web/pages/page.commslist.php
@@ -271,10 +271,12 @@ if (isset($_GET['searchText'])) {
 		LEFT JOIN `:prefix_mods` AS MO on SE.modid = MO.mid
 		LEFT JOIN `:prefix_admins` AS AD ON CO.aid = AD.aid
       	WHERE " . $authidClause . " or CO.name LIKE ? or CO.reason LIKE ?" . $hideinactive . "
-   		ORDER BY CO.created DESC LIMIT " . intval($BansStart) . "," . intval($BansPerPage))->resultset(array(
+   		ORDER BY CO.created DESC LIMIT ?,?")->resultset(array(
         $authidParam,
         $search,
         $search,
+        intval($BansStart),
+        intval($BansPerPage)
     ));
 
 
@@ -297,7 +299,10 @@ if (isset($_GET['searchText'])) {
 		LEFT JOIN `:prefix_admins` AS AD ON CO.aid = AD.aid
 		" . $hideinactiven . "
 		ORDER BY created DESC
-		LIMIT " . intval($BansStart) . "," . intval($BansPerPage))->resultset();
+		LIMIT ?,?")->resultset(array(
+        intval($BansStart),
+        intval($BansPerPage)
+    ));
 
     $res_count  = $GLOBALS['PDO']->query("SELECT count(bid) AS cnt FROM `:prefix_comms`" . $hideinactiven)->resultset();
     $searchlink = "";
@@ -454,7 +459,10 @@ if (isset($_GET['advSearch'])) {
   			" . ($type == "comment" && $userbank->is_admin() ? "LEFT JOIN `:prefix_comments` AS CM ON CO.bid = CM.bid" : "") . "
       " . $where . $hideinactive . "
    ORDER BY CO.created DESC
-   LIMIT " . intval($BansStart) . "," . intval($BansPerPage))->resultset($advcrit);
+   LIMIT ?,?")->resultset(array_merge($advcrit, array(
+        intval($BansStart),
+        intval($BansPerPage)
+    )));
 
     $res_count  = $GLOBALS['PDO']->query("SELECT count(CO.bid) AS cnt FROM `:prefix_comms` AS CO
 										  " . ($type == "comment" && $userbank->is_admin() ? "LEFT JOIN `:prefix_comments` AS CM ON CO.bid = CM.bid" : "") . " " . $where . $hideinactive)->resultset($advcrit);

--- a/web/pages/page.commslist.php
+++ b/web/pages/page.commslist.php
@@ -271,12 +271,10 @@ if (isset($_GET['searchText'])) {
 		LEFT JOIN `:prefix_mods` AS MO on SE.modid = MO.mid
 		LEFT JOIN `:prefix_admins` AS AD ON CO.aid = AD.aid
       	WHERE " . $authidClause . " or CO.name LIKE ? or CO.reason LIKE ?" . $hideinactive . "
-   		ORDER BY CO.created DESC LIMIT ?,?")->resultset(array(
+   		ORDER BY CO.created DESC LIMIT " . intval($BansStart) . "," . intval($BansPerPage))->resultset(array(
         $authidParam,
         $search,
         $search,
-        intval($BansStart),
-        intval($BansPerPage)
     ));
 
 
@@ -299,10 +297,7 @@ if (isset($_GET['searchText'])) {
 		LEFT JOIN `:prefix_admins` AS AD ON CO.aid = AD.aid
 		" . $hideinactiven . "
 		ORDER BY created DESC
-		LIMIT ?,?")->resultset(array(
-        intval($BansStart),
-        intval($BansPerPage)
-    ));
+		LIMIT " . intval($BansStart) . "," . intval($BansPerPage))->resultset();
 
     $res_count  = $GLOBALS['PDO']->query("SELECT count(bid) AS cnt FROM `:prefix_comms`" . $hideinactiven)->resultset();
     $searchlink = "";
@@ -459,10 +454,7 @@ if (isset($_GET['advSearch'])) {
   			" . ($type == "comment" && $userbank->is_admin() ? "LEFT JOIN `:prefix_comments` AS CM ON CO.bid = CM.bid" : "") . "
       " . $where . $hideinactive . "
    ORDER BY CO.created DESC
-   LIMIT ?,?")->resultset(array_merge($advcrit, array(
-        intval($BansStart),
-        intval($BansPerPage)
-    )));
+   LIMIT " . intval($BansStart) . "," . intval($BansPerPage))->resultset($advcrit);
 
     $res_count  = $GLOBALS['PDO']->query("SELECT count(CO.bid) AS cnt FROM `:prefix_comms` AS CO
 										  " . ($type == "comment" && $userbank->is_admin() ? "LEFT JOIN `:prefix_comments` AS CM ON CO.bid = CM.bid" : "") . " " . $where . $hideinactive)->resultset($advcrit);
@@ -473,10 +465,12 @@ $BanCount = isset($res_count[0]['cnt']) ? (int) $res_count[0]['cnt'] : 0;
 if ($BansEnd > $BanCount) {
     $BansEnd = $BanCount;
 }
-if (!$res) {
-    echo "No Blocks Found.";
-    PageDie();
-}
+// Mirrors page.banlist.php: the redesigned page_comms.tpl renders its
+// own "No comm blocks match those filters." empty state inside the
+// table, so we let the template handle the empty case rather than
+// short-circuiting with PageDie() and dropping the marquee chrome.
+// PDO error mode is EXCEPTION, so a real SQL failure throws before
+// reaching this point.
 
 $view_comments = false;
 $bans          = [];

--- a/web/tests/e2e/pages/BanList.ts
+++ b/web/tests/e2e/pages/BanList.ts
@@ -1,0 +1,39 @@
+import { type Locator } from '@playwright/test';
+
+import { BasePage } from './_base.ts';
+
+/**
+ * Public ban list (`?p=banlist` → `page.banlist.php` →
+ * `page_bans.tpl` — the marquee redesign from #1123 B2).
+ *
+ * Page-mount marker: `[data-testid="bans-search"]` — the search
+ * input inside the sticky filter bar (`#banlist-filters`). It's
+ * always rendered on the listing branch (the `?comment=N` flow is
+ * the only branch that swaps the body, and smoke never hits it),
+ * sits inside `#banlist-root`, and stays visible on both desktop and
+ * mobile-chromium viewports because the form is `position: sticky`,
+ * not display-toggled by the responsive cutover.
+ *
+ * Why not `[data-testid="ban-row"]` (also stable in page_bans.tpl):
+ * row testids only exist when the result set is non-empty, and the
+ * smoke run starts against the freshly-truncated `sourcebans_e2e`
+ * DB (admin-only seed; zero bans). The `data-testid="banlist-table"`
+ * the issue suggested isn't on the desktop `<table>` yet (comms-table
+ * has its sibling testid; banlist's table doesn't), and even if we
+ * added it, theme.css hides the desktop table below 769px so it
+ * wouldn't `toBeVisible` on mobile-chromium.
+ */
+export class BanListPage extends BasePage {
+    /**
+     * Navigate to the public ban list. Overload of
+     * {@link BasePage.goto} pinned to the canonical query string.
+     */
+    async goto(): Promise<void> {
+        await super.goto('/index.php?p=banlist');
+    }
+
+    /** Page-mount marker locator. */
+    searchInput(): Locator {
+        return this.page.locator('[data-testid="bans-search"]');
+    }
+}

--- a/web/tests/e2e/pages/CommsList.ts
+++ b/web/tests/e2e/pages/CommsList.ts
@@ -1,0 +1,35 @@
+import { type Locator } from '@playwright/test';
+
+import { BasePage } from './_base.ts';
+
+/**
+ * Public communications-block list (`?p=commslist` →
+ * `page.commslist.php` → `page_comms.tpl`, the B4 mirror of B2's
+ * marquee redesign).
+ *
+ * Page-mount marker: `[data-testid="comms-header"]` — the
+ * `<header>` element wrapping the H1 + summary copy. It's always
+ * rendered (the body has no `?comment=` branch like banlist), sits
+ * outside the responsive table/cards swap, and stays visible on
+ * both desktop and mobile-chromium viewports.
+ *
+ * The `[data-testid="comms-table"]` is intentionally not the anchor
+ * here: theme.css hides the desktop `<table>` below 769px and lets
+ * `.ban-cards` take over, so the testid'd table node is in the DOM
+ * but not visible at iPhone-13 — a `toBeVisible` smoke check would
+ * flake on the mobile project.
+ */
+export class CommsListPage extends BasePage {
+    /**
+     * Navigate to the public comms list. Overload of
+     * {@link BasePage.goto} pinned to the canonical query string.
+     */
+    async goto(): Promise<void> {
+        await super.goto('/index.php?p=commslist');
+    }
+
+    /** Page-mount marker locator. */
+    header(): Locator {
+        return this.page.locator('[data-testid="comms-header"]');
+    }
+}

--- a/web/tests/e2e/pages/Dashboard.ts
+++ b/web/tests/e2e/pages/Dashboard.ts
@@ -1,0 +1,38 @@
+import { type Locator } from '@playwright/test';
+
+import { BasePage } from './_base.ts';
+
+/**
+ * Public dashboard (`?p=home`, served at the bare `/` path via the
+ * page-builder fallback in `web/includes/page-builder.php`).
+ *
+ * Page-mount marker: `[data-testid="dashboard-header"]` — the header
+ * `<header>` wrapping the H1 + intro copy in `page_dashboard.tpl`.
+ * It's always rendered for both authenticated and anonymous users
+ * (the View carries `dashboard_title` / `dashboard_text` regardless of
+ * session) and sits in the main content area, so it's visible on both
+ * the desktop chromium and mobile-chromium iPhone-13 viewports.
+ *
+ * Why this anchor and not e.g. `dashboard-stat-total-bans` (also a
+ * stable testid in page_dashboard.tpl): the stat card grid's contents
+ * depend on whether anything has been seeded; `dashboard-header` is
+ * a structural element that exists on every render, including the
+ * empty-DB smoke run. The `[data-testid]` is the primary selector per
+ * AGENTS.md "Playwright E2E specifics" — never CSS class chains, never
+ * visible text as the primary anchor.
+ */
+export class DashboardPage extends BasePage {
+    /**
+     * Navigate to the dashboard. Overload of {@link BasePage.goto}
+     * that doesn't take a path — the dashboard is the bare `/`
+     * route (page.home.php is the fallback handler).
+     */
+    async goto(): Promise<void> {
+        await super.goto('/');
+    }
+
+    /** Page-mount marker locator. */
+    header(): Locator {
+        return this.page.locator('[data-testid="dashboard-header"]');
+    }
+}

--- a/web/tests/e2e/pages/Protest.ts
+++ b/web/tests/e2e/pages/Protest.ts
@@ -1,0 +1,39 @@
+import { type Locator } from '@playwright/test';
+
+import { BasePage } from './_base.ts';
+
+/**
+ * Public ban-appeal form (`?p=protest` → `page.protest.php` →
+ * `page_protestban.tpl`, the B7 redesign).
+ *
+ * Note on the route key: the Slice 1 brief listed this as
+ * `?p=appeal`, but `web/includes/page-builder.php` only handles
+ * `?p=protest` — `?p=appeal` falls through the switch and renders
+ * the home dashboard via the fallback. The navbar template emits
+ * `data-testid="nav-{$nav.endpoint}"` and the live page serves
+ * `data-testid="nav-protest"`, confirming the canonical key is
+ * `protest`. This is flagged in the PR description.
+ *
+ * Page-mount marker: `[data-testid="protest-submit"]` — the
+ * primary submit button. Always rendered (the form is gated by
+ * `config.enableprotest`, which 200s with a "page disabled" notice
+ * if off; the button is part of the body when the form renders),
+ * and visible on both desktop and mobile viewports.
+ *
+ * Per the Slice 1 brief: smoke asserts the submit button is
+ * visible only — submission is out of scope for this slice.
+ */
+export class ProtestPage extends BasePage {
+    /**
+     * Navigate to the public protest/appeal form. Overload of
+     * {@link BasePage.goto} pinned to the canonical query string.
+     */
+    async goto(): Promise<void> {
+        await super.goto('/index.php?p=protest');
+    }
+
+    /** Page-mount marker locator. */
+    submitButton(): Locator {
+        return this.page.locator('[data-testid="protest-submit"]');
+    }
+}

--- a/web/tests/e2e/pages/ServerList.ts
+++ b/web/tests/e2e/pages/ServerList.ts
@@ -1,0 +1,36 @@
+import { type Locator } from '@playwright/test';
+
+import { BasePage } from './_base.ts';
+
+/**
+ * Public servers list (`?p=servers` → `page.servers.php` →
+ * `page_servers.tpl`, the B5 redesign).
+ *
+ * Page-mount marker: `[data-testid="servers-summary"]` — the
+ * server-count copy (`{$server_list|@count} configured`) inside the
+ * page header. It's always rendered, sits outside the
+ * `{if $server_list|@count == 0}` empty-state guard, and stays
+ * visible on both desktop and mobile viewports.
+ *
+ * Why not `[data-testid="servers-list"]`: that one only renders
+ * when `$server_list|@count > 0`. Smoke runs against an empty seed
+ * by default (servers are an opt-in dev seed; the e2e DB only seeds
+ * the admin row), so the list element wouldn't exist.
+ *
+ * Why not `[data-testid="server-tile"]`: same reason — only present
+ * when at least one server is configured.
+ */
+export class ServerListPage extends BasePage {
+    /**
+     * Navigate to the public servers list. Overload of
+     * {@link BasePage.goto} pinned to the canonical query string.
+     */
+    async goto(): Promise<void> {
+        await super.goto('/index.php?p=servers');
+    }
+
+    /** Page-mount marker locator. */
+    summary(): Locator {
+        return this.page.locator('[data-testid="servers-summary"]');
+    }
+}

--- a/web/tests/e2e/pages/SubmitBan.ts
+++ b/web/tests/e2e/pages/SubmitBan.ts
@@ -1,0 +1,34 @@
+import { type Locator } from '@playwright/test';
+
+import { BasePage } from './_base.ts';
+
+/**
+ * Public "Submit a ban / Report a player" form (`?p=submit` →
+ * `page.submit.php` → `page_submitban.tpl`, the B6 redesign).
+ *
+ * Page-mount marker: `[data-testid="submitban-submit"]` — the
+ * primary submit button at the bottom of the form card. The button
+ * is unconditionally rendered (no perm gate; the form itself is
+ * gated upstream by `config.enablesubmit`, and a disabled flag would
+ * 403 the route, not hide the button), and stays visible on both
+ * desktop and mobile.
+ *
+ * Per the Slice 1 brief: smoke specs assert the submit button is
+ * visible only — they do NOT submit the form. Submission flows
+ * (anonymous + admin moderation round-trip) are Slice 3
+ * (`flow-public-submission`).
+ */
+export class SubmitBanPage extends BasePage {
+    /**
+     * Navigate to the public submit form. Overload of
+     * {@link BasePage.goto} pinned to the canonical query string.
+     */
+    async goto(): Promise<void> {
+        await super.goto('/index.php?p=submit');
+    }
+
+    /** Page-mount marker locator. */
+    submitButton(): Locator {
+        return this.page.locator('[data-testid="submitban-submit"]');
+    }
+}

--- a/web/tests/e2e/pages/_base.ts
+++ b/web/tests/e2e/pages/_base.ts
@@ -27,8 +27,17 @@ export class BasePage {
     }
 
     async waitForReady(): Promise<void> {
+        // The marquee banlist redesign (#1123 B2) keeps a dormant
+        // `<div data-skeleton hidden>` always-mounted in the DOM so
+        // `banlist.js` can flip it visible during chip-filter
+        // re-renders without re-creating the node. Treat any
+        // `[hidden]` skeleton as inert — only a *visible* skeleton
+        // (or any `[data-loading="true"]` surface) counts as the
+        // page still mid-load. The contract from #1123's testability
+        // hooks is "skeleton elements are torn down OR hidden when
+        // content lands"; either path lands the same terminal state.
         await this.page.waitForFunction(
-            () => !document.querySelector('[data-loading="true"], [data-skeleton]'),
+            () => !document.querySelector('[data-loading="true"], [data-skeleton]:not([hidden])'),
         );
     }
 }

--- a/web/tests/e2e/specs/_screenshots.spec.ts
+++ b/web/tests/e2e/specs/_screenshots.spec.ts
@@ -38,6 +38,8 @@
  * in the same PR — don't fork the chrome contract here.
  */
 
+import type { Browser, Page, TestInfo } from '@playwright/test';
+
 import { test, expect } from '../fixtures/auth.ts';
 import {
     adminApprove,
@@ -72,64 +74,122 @@ function viewportFor(projectName: string): string {
     return 'desktop';
 }
 
+/**
+ * Capture a single (route × theme × project) screenshot.
+ *
+ * The route gallery's per-test body lives here so future slices
+ * can append a new block (e.g. `ROUTES_SMOKE_PUBLIC` below) and
+ * call this helper, instead of forking the loop and drifting on
+ * the chrome contract. Theme pinning, anonymous-context handling,
+ * and the `<html class="dark">` wait predicate stay in one place.
+ *
+ * Exported as a module-scope function rather than re-exported via
+ * a fixture so the surface stays small (no `test.extend<…>(…)`
+ * gymnastics for a helper that's purely DOM-side).
+ *
+ * @param route   Route descriptor — name slug, target path, auth flag.
+ * @param theme   `'light'` or `'dark'`; pinned via localStorage.
+ * @param page    Default project Page (logged-in admin).
+ * @param browser Browser used to mint a logged-out context if `route.auth` is false.
+ * @param testInfo Playwright TestInfo — used for project name + project use options.
+ */
+async function captureRoute(
+    route: RouteSpec,
+    theme: Theme,
+    page: Page,
+    browser: Browser,
+    testInfo: TestInfo,
+): Promise<void> {
+    const viewport = viewportFor(testInfo.project.name);
+    const outPath = resolve(
+        __dirname,
+        '..',
+        'screenshots',
+        theme,
+        viewport,
+        `${route.name}.png`,
+    );
+    await mkdir(dirname(outPath), { recursive: true });
+
+    let activePage = page;
+    let ownContext: Awaited<ReturnType<typeof browser.newContext>> | null = null;
+    try {
+        if (!route.auth) {
+            // Spin up a logged-out context so the chrome matches
+            // what an anonymous visitor would see.
+            ownContext = await browser.newContext({
+                ...testInfo.project.use,
+                storageState: { cookies: [], origins: [] },
+            });
+            activePage = await ownContext.newPage();
+        }
+
+        // Pin theme via localStorage BEFORE navigation: theme.js
+        // reads `localStorage['sbpp-theme']` on boot via
+        // applyTheme(currentTheme()), so a hit before that runs
+        // lands the right mode on first paint. We `goto('/')`
+        // first because origin localStorage requires a
+        // same-origin document.
+        await activePage.goto('/');
+        await activePage.evaluate((mode: Theme) => {
+            try { localStorage.setItem('sbpp-theme', mode); } catch (_e) { /* unavailable; skip */ }
+        }, theme);
+
+        await activePage.goto(route.path);
+
+        // Wait until theme.js's applyTheme has run and the
+        // resolved mode is reflected on <html>. We don't wait on
+        // a `[data-theme]` attribute (the chrome uses the `dark`
+        // class, not a data-attribute); see the file-level
+        // comment for the rationale.
+        await activePage.waitForFunction((expected: Theme) => {
+            const isDark = document.documentElement.classList.contains('dark');
+            return expected === 'dark' ? isDark : !isDark;
+        }, theme);
+
+        await activePage.screenshot({ fullPage: true, path: outPath });
+        expect(outPath).toMatch(/\.png$/);
+    } finally {
+        if (ownContext) await ownContext.close();
+    }
+}
+
 test.describe('@screenshot gallery', () => {
     test.skip(!process.env.SCREENSHOTS, '@screenshot only runs when SCREENSHOTS=1');
 
     for (const route of ROUTES) {
         for (const theme of THEMES) {
             test(`${route.name} ${theme}`, async ({ page, browser }, testInfo) => {
-                const viewport = viewportFor(testInfo.project.name);
-                const outPath = resolve(
-                    __dirname,
-                    '..',
-                    'screenshots',
-                    theme,
-                    viewport,
-                    `${route.name}.png`,
-                );
-                await mkdir(dirname(outPath), { recursive: true });
+                await captureRoute(route, theme, page, browser, testInfo);
+            });
+        }
+    }
+});
 
-                let activePage = page;
-                let ownContext: Awaited<ReturnType<typeof browser.newContext>> | null = null;
-                try {
-                    if (!route.auth) {
-                        // Spin up a logged-out context so the chrome
-                        // matches what an anonymous visitor would see.
-                        ownContext = await browser.newContext({
-                            ...testInfo.project.use,
-                            storageState: { cookies: [], origins: [] },
-                        });
-                        activePage = await ownContext.newPage();
-                    }
+// ---- Slice 1: smoke-public ----
+//
+// Public route gallery for #1124 Slice 1. Each entry maps a slug
+// (used as the screenshot filename and the markdown row label) to
+// the canonical `?p=` query string. `auth: true` because every
+// public route renders fine for the seeded admin (and storage
+// state is the default), so we don't pay the per-test
+// browser-context spin-up that the logged-out login capture pays.
+const ROUTES_SMOKE_PUBLIC: RouteSpec[] = [
+    { name: 'home',      path: '/',                       auth: true },
+    { name: 'banlist',   path: '/index.php?p=banlist',    auth: true },
+    { name: 'commslist', path: '/index.php?p=commslist',  auth: true },
+    { name: 'servers',   path: '/index.php?p=servers',    auth: true },
+    { name: 'submit',    path: '/index.php?p=submit',     auth: true },
+    { name: 'protest',   path: '/index.php?p=protest',    auth: true },
+];
 
-                    // Pin theme via localStorage BEFORE navigation:
-                    // theme.js reads `localStorage['sbpp-theme']` on
-                    // boot via applyTheme(currentTheme()), so a hit
-                    // before that runs lands the right mode on first
-                    // paint. We `goto('/')` first because origin
-                    // localStorage requires a same-origin document.
-                    await activePage.goto('/');
-                    await activePage.evaluate((mode: Theme) => {
-                        try { localStorage.setItem('sbpp-theme', mode); } catch (_e) { /* unavailable; skip */ }
-                    }, theme);
+test.describe('@screenshot smoke-public', () => {
+    test.skip(!process.env.SCREENSHOTS, '@screenshot only runs when SCREENSHOTS=1');
 
-                    await activePage.goto(route.path);
-
-                    // Wait until theme.js's applyTheme has run and the
-                    // resolved mode is reflected on <html>. We don't
-                    // wait on a `[data-theme]` attribute (the chrome
-                    // uses the `dark` class, not a data-attribute);
-                    // see the file-level comment for the rationale.
-                    await activePage.waitForFunction((expected: Theme) => {
-                        const isDark = document.documentElement.classList.contains('dark');
-                        return expected === 'dark' ? isDark : !isDark;
-                    }, theme);
-
-                    await activePage.screenshot({ fullPage: true, path: outPath });
-                    expect(outPath).toMatch(/\.png$/);
-                } finally {
-                    if (ownContext) await ownContext.close();
-                }
+    for (const route of ROUTES_SMOKE_PUBLIC) {
+        for (const theme of THEMES) {
+            test(`${route.name} ${theme}`, async ({ page, browser }, testInfo) => {
+                await captureRoute(route, theme, page, browser, testInfo);
             });
         }
     }

--- a/web/tests/e2e/specs/smoke/banlist.spec.ts
+++ b/web/tests/e2e/specs/smoke/banlist.spec.ts
@@ -1,0 +1,40 @@
+/**
+ * Smoke spec for the public ban list (`/index.php?p=banlist`).
+ *
+ * Asserts:
+ *
+ *   1. Page mounts — the search input
+ *      (`[data-testid="bans-search"]`) is visible. See
+ *      `pages/BanList.ts` for the rationale on this anchor over
+ *      `[data-testid="ban-row"]` (which only renders when the result
+ *      set is non-empty) and over a hypothetical `banlist-table`
+ *      (the desktop `<table>` is hidden below 769px on the
+ *      mobile-chromium project).
+ *   2. No JS errors land in the console.
+ *   3. Zero critical-impact axe violations.
+ */
+
+import { expect, test } from '../../fixtures/auth.ts';
+import { expectNoCriticalA11y } from '../../fixtures/axe.ts';
+import { BanListPage } from '../../pages/BanList.ts';
+
+test.describe('smoke /bans', () => {
+    test('mounts without console errors and 0 critical a11y violations', async ({ page }, testInfo) => {
+        const consoleErrors: string[] = [];
+        page.on('pageerror', (err) => consoleErrors.push(err.message));
+        page.on('console', (msg) => {
+            if (msg.type() === 'error') consoleErrors.push(msg.text());
+        });
+
+        const banlist = new BanListPage(page);
+        await banlist.goto();
+        await expect(banlist.searchInput()).toBeVisible();
+
+        await expectNoCriticalA11y(page, testInfo);
+
+        expect(
+            consoleErrors,
+            `console errors:\n${consoleErrors.join('\n')}`,
+        ).toEqual([]);
+    });
+});

--- a/web/tests/e2e/specs/smoke/commslist.spec.ts
+++ b/web/tests/e2e/specs/smoke/commslist.spec.ts
@@ -1,0 +1,37 @@
+/**
+ * Smoke spec for the public comms list (`/index.php?p=commslist`).
+ *
+ * Asserts:
+ *
+ *   1. Page mounts — `[data-testid="comms-header"]` is visible.
+ *      The `<header>` carries the testid in `page_comms.tpl`
+ *      and is always rendered (no `?comment=` body-swap branch on
+ *      this page).
+ *   2. No JS errors land in the console.
+ *   3. Zero critical-impact axe violations.
+ */
+
+import { expect, test } from '../../fixtures/auth.ts';
+import { expectNoCriticalA11y } from '../../fixtures/axe.ts';
+import { CommsListPage } from '../../pages/CommsList.ts';
+
+test.describe('smoke /comms', () => {
+    test('mounts without console errors and 0 critical a11y violations', async ({ page }, testInfo) => {
+        const consoleErrors: string[] = [];
+        page.on('pageerror', (err) => consoleErrors.push(err.message));
+        page.on('console', (msg) => {
+            if (msg.type() === 'error') consoleErrors.push(msg.text());
+        });
+
+        const comms = new CommsListPage(page);
+        await comms.goto();
+        await expect(comms.header()).toBeVisible();
+
+        await expectNoCriticalA11y(page, testInfo);
+
+        expect(
+            consoleErrors,
+            `console errors:\n${consoleErrors.join('\n')}`,
+        ).toEqual([]);
+    });
+});

--- a/web/tests/e2e/specs/smoke/dashboard.spec.ts
+++ b/web/tests/e2e/specs/smoke/dashboard.spec.ts
@@ -1,0 +1,43 @@
+/**
+ * Smoke spec for the public dashboard (`/`).
+ *
+ * Asserts:
+ *
+ *   1. Page mounts — `[data-testid="dashboard-header"]` is visible.
+ *   2. No JS errors land in the console (uncaught exceptions or
+ *      `console.error` calls).
+ *   3. Zero critical-impact axe violations on the default light
+ *      context (light/dark coverage is in the @screenshot gallery;
+ *      explicit dark-mode axe scanning is Slice 8's a11y sweep).
+ *
+ * The spec runs under the seeded admin's storage state (the default
+ * project storage state) — the dashboard renders cleanly for both
+ * authenticated and anonymous visitors, so a logged-out variant
+ * isn't required for smoke. The login spec is the one exception
+ * that opts back out of storage state.
+ */
+
+import { expect, test } from '../../fixtures/auth.ts';
+import { expectNoCriticalA11y } from '../../fixtures/axe.ts';
+import { DashboardPage } from '../../pages/Dashboard.ts';
+
+test.describe('smoke /', () => {
+    test('mounts without console errors and 0 critical a11y violations', async ({ page }, testInfo) => {
+        const consoleErrors: string[] = [];
+        page.on('pageerror', (err) => consoleErrors.push(err.message));
+        page.on('console', (msg) => {
+            if (msg.type() === 'error') consoleErrors.push(msg.text());
+        });
+
+        const home = new DashboardPage(page);
+        await home.goto();
+        await expect(home.header()).toBeVisible();
+
+        await expectNoCriticalA11y(page, testInfo);
+
+        expect(
+            consoleErrors,
+            `console errors:\n${consoleErrors.join('\n')}`,
+        ).toEqual([]);
+    });
+});

--- a/web/tests/e2e/specs/smoke/protest.spec.ts
+++ b/web/tests/e2e/specs/smoke/protest.spec.ts
@@ -1,0 +1,42 @@
+/**
+ * Smoke spec for the public protest/appeal form
+ * (`/index.php?p=protest`).
+ *
+ * Asserts:
+ *
+ *   1. Page mounts — `[data-testid="protest-submit"]` is visible.
+ *      Per Slice 1 brief, smoke does NOT submit the form.
+ *   2. No JS errors land in the console.
+ *   3. Zero critical-impact axe violations.
+ *
+ * Note on the route key: the Slice 1 brief listed this as
+ * `?p=appeal`, but `web/includes/page-builder.php` only handles
+ * `?p=protest` — `?p=appeal` falls through to the home dashboard.
+ * The navbar's `data-testid="nav-protest"` confirms `protest` is
+ * the canonical key. See `pages/Protest.ts` for the same note.
+ */
+
+import { expect, test } from '../../fixtures/auth.ts';
+import { expectNoCriticalA11y } from '../../fixtures/axe.ts';
+import { ProtestPage } from '../../pages/Protest.ts';
+
+test.describe('smoke /protest', () => {
+    test('mounts without console errors and 0 critical a11y violations', async ({ page }, testInfo) => {
+        const consoleErrors: string[] = [];
+        page.on('pageerror', (err) => consoleErrors.push(err.message));
+        page.on('console', (msg) => {
+            if (msg.type() === 'error') consoleErrors.push(msg.text());
+        });
+
+        const protest = new ProtestPage(page);
+        await protest.goto();
+        await expect(protest.submitButton()).toBeVisible();
+
+        await expectNoCriticalA11y(page, testInfo);
+
+        expect(
+            consoleErrors,
+            `console errors:\n${consoleErrors.join('\n')}`,
+        ).toEqual([]);
+    });
+});

--- a/web/tests/e2e/specs/smoke/servers.spec.ts
+++ b/web/tests/e2e/specs/smoke/servers.spec.ts
@@ -1,0 +1,42 @@
+/**
+ * Smoke spec for the public servers list (`/index.php?p=servers`).
+ *
+ * Asserts:
+ *
+ *   1. Page mounts — `[data-testid="servers-summary"]` is visible.
+ *      It's the always-rendered header copy (sits outside the
+ *      `{if $server_list|@count == 0}` empty-state guard), so the
+ *      smoke run on an empty seed still hits a deterministic
+ *      visible anchor.
+ *   2. No JS errors land in the console. The page's inline
+ *      `sb.api.call(Actions.ServersHostPlayers, …)` per-tile probe
+ *      only fires when at least one server exists — with the
+ *      empty seed the loop is a no-op, so we don't have to wait
+ *      out a UDP round trip per server.
+ *   3. Zero critical-impact axe violations.
+ */
+
+import { expect, test } from '../../fixtures/auth.ts';
+import { expectNoCriticalA11y } from '../../fixtures/axe.ts';
+import { ServerListPage } from '../../pages/ServerList.ts';
+
+test.describe('smoke /servers', () => {
+    test('mounts without console errors and 0 critical a11y violations', async ({ page }, testInfo) => {
+        const consoleErrors: string[] = [];
+        page.on('pageerror', (err) => consoleErrors.push(err.message));
+        page.on('console', (msg) => {
+            if (msg.type() === 'error') consoleErrors.push(msg.text());
+        });
+
+        const servers = new ServerListPage(page);
+        await servers.goto();
+        await expect(servers.summary()).toBeVisible();
+
+        await expectNoCriticalA11y(page, testInfo);
+
+        expect(
+            consoleErrors,
+            `console errors:\n${consoleErrors.join('\n')}`,
+        ).toEqual([]);
+    });
+});

--- a/web/tests/e2e/specs/smoke/submit.spec.ts
+++ b/web/tests/e2e/specs/smoke/submit.spec.ts
@@ -1,0 +1,38 @@
+/**
+ * Smoke spec for the public submit-ban form
+ * (`/index.php?p=submit`).
+ *
+ * Asserts:
+ *
+ *   1. Page mounts — `[data-testid="submitban-submit"]` is
+ *      visible. Per Slice 1 brief, smoke does NOT submit the form;
+ *      submission round-trips (anonymous submit → admin moderation
+ *      → public banlist) are Slice 3.
+ *   2. No JS errors land in the console.
+ *   3. Zero critical-impact axe violations.
+ */
+
+import { expect, test } from '../../fixtures/auth.ts';
+import { expectNoCriticalA11y } from '../../fixtures/axe.ts';
+import { SubmitBanPage } from '../../pages/SubmitBan.ts';
+
+test.describe('smoke /submit', () => {
+    test('mounts without console errors and 0 critical a11y violations', async ({ page }, testInfo) => {
+        const consoleErrors: string[] = [];
+        page.on('pageerror', (err) => consoleErrors.push(err.message));
+        page.on('console', (msg) => {
+            if (msg.type() === 'error') consoleErrors.push(msg.text());
+        });
+
+        const submit = new SubmitBanPage(page);
+        await submit.goto();
+        await expect(submit.submitButton()).toBeVisible();
+
+        await expectNoCriticalA11y(page, testInfo);
+
+        expect(
+            consoleErrors,
+            `console errors:\n${consoleErrors.join('\n')}`,
+        ).toEqual([]);
+    });
+});

--- a/web/themes/default/page_comms.tpl
+++ b/web/themes/default/page_comms.tpl
@@ -68,13 +68,13 @@
                        placeholder="Player, SteamID, or reason…"
                        data-testid="comms-search">
             </div>
-            <select class="select" name="server" style="width:auto;min-width:11rem" data-testid="comms-server-filter">
+            <select class="select" name="server" style="width:auto;min-width:11rem" data-testid="comms-server-filter" aria-label="Filter by server">
                 <option value="">All servers</option>
                 {foreach $servers as $s}
                     <option value="{$s.sid}" {if $filters.server == $s.sid}selected{/if}>{$s.name|escape}</option>
                 {/foreach}
             </select>
-            <select class="select" name="time" style="width:auto" data-testid="comms-time-filter">
+            <select class="select" name="time" style="width:auto" data-testid="comms-time-filter" aria-label="Filter by time range">
                 <option value="">All time</option>
                 <option value="1d" {if $filters.time == '1d'}selected{/if}>Today</option>
                 <option value="7d" {if $filters.time == '7d'}selected{/if}>Last 7 days</option>


### PR DESCRIPTION
Refs #1124

Slice 1 of the Playwright E2E suite — smoke specs for every public route.
Each spec asserts the page mounts (key `data-testid` is visible), no JS console
errors land, and zero critical-impact axe violations.

## Acceptance criteria boxes ticked

- [x] Smoke spec exists for every public route in the new theme; all green.
  (Public side: `/`, `/bans`, `/comms`, `/servers`, `/submit`, `/protest`.)
- [x] axe-core scan passes (0 critical) on every public page in the default
  light context. Light/dark coverage lands via the `@screenshot` gallery in
  this PR; the explicit dark-mode axe scan is Slice 8's a11y sweep.

## Routes covered

| Route    | Path                       | Page Object               |
| -------- | -------------------------- | ------------------------- |
| /        | `/`                        | `pages/Dashboard.ts`      |
| /bans    | `/index.php?p=banlist`     | `pages/BanList.ts`        |
| /comms   | `/index.php?p=commslist`   | `pages/CommsList.ts`      |
| /servers | `/index.php?p=servers`     | `pages/ServerList.ts`     |
| /submit  | `/index.php?p=submit`      | `pages/SubmitBan.ts`      |
| /protest | `/index.php?p=protest`     | `pages/Protest.ts`        |

## Divergences from the issue text (flagged for reviewer sanity-check)

These all fall under the issue's "if a page is missing them, the right action
is to ALSO patch in this PR (small, scoped) — but flag it loudly" rule.

1. **Route key for `/protest` is `?p=protest`, not `?p=appeal`.** The issue
   listed the latter, but `web/includes/page-builder.php` only handles
   `protest` — `?p=appeal` falls through the switch and renders the home
   dashboard via the fallback. The navbar template emits
   `data-testid="nav-{$nav.endpoint}"` and the live page serves
   `data-testid="nav-protest"`, confirming the canonical key.

2. **First commit (`Slice 1 prep`) fixes three pre-existing bugs that block
   smoke against an empty `sourcebans_e2e` seed.** Each fix follows an
   established codebase pattern; I'm happy to split them off if reviewers
   prefer a separate PR. Bundling here keeps Slice 1 unblocked and unblocks
   sister slices that hit the same routes (Slice 2 smoke-admin, Slice 3
   public-submission flow, Slice 4 admin-ban-lifecycle, Slice 7 responsive).

   - **`page.banlist.php` + `page.commslist.php` LIMIT bind** (6 sites total,
     3 per file). PDO with `EMULATE_PREPARES=1` (default) quotes
     array-bound params as strings, and MariaDB rejects quoted strings in
     `LIMIT`. The canonical fix — inline `intval()` interpolation — is
     documented in `web/api/handlers/bans.php` line 883 and used throughout
     `web/pages/admin.bans.php`. The bug landed in #1092 (ADOdb→PDO
     migration) and went latent because Slice 0's only smoke target
     (`?p=login`) doesn't paginate.
   - **`page.banlist.php` + `page.commslist.php` empty-state `PageDie()`**
     short-circuit (1 site per file). With `ERRMODE_EXCEPTION`, the
     `if (!$res)` branch only fires on an empty result list, not a real SQL
     failure — so on a fresh install it dropped the marquee chrome and
     printed bare text instead of letting the redesigned templates'
     `{foreachelse}` empty state render.
   - **`page_comms.tpl` `<select>` accessible names**. The
     `comms-server-filter` and `comms-time-filter` selects had no
     `aria-label` / `aria-labelledby` / wrapping `<label>`, tripping axe
     with critical violations on the comms smoke spec. Added matching
     `aria-label` attributes; visible chrome unchanged.

3. **`web/tests/e2e/pages/_base.ts` learns to ignore `[data-skeleton][hidden]`.**
   `BasePage.waitForReady()` previously waited for ANY `[data-skeleton]` to
   leave the DOM; the marquee banlist redesign (#1123 B2) keeps a dormant
   always-mounted `<div data-skeleton hidden>` so `banlist.js` can flip it
   visible during chip-filter re-renders without re-creating the node. The
   updated predicate ignores `[hidden]` skeletons so the contract from
   #1123 ("skeletons are torn down OR hidden when content lands") matches
   either pattern.

4. **`_screenshots.spec.ts` refactor.** Lifted the per-test body into a
   module-scope `captureRoute(route, theme, page, browser, testInfo)`
   helper (theme pinning + anonymous-context handling + `<html class="dark">`
   wait predicate stay in one place). Both the foundation `@screenshot
   gallery` block and the new `@screenshot smoke-public` block call it.
   Future slices append another `ROUTES_*` array literal and call the same
   helper.

## Local commands run (all green)

- `./sbpp.sh phpstan` — clean (211 files, no errors).
- `./sbpp.sh test` — 280 tests, 1189 assertions — OK.
- `./sbpp.sh ts-check` — clean.
- `./sbpp.sh composer api-contract` — zero diff.
- `./sbpp.sh e2e` — 16 pass (login + 6 smokes × 2 projects), 28
  `@screenshot` skipped without `SCREENSHOTS=1`.
- `SCREENSHOTS=1 ./sbpp.sh e2e --grep @screenshot --reporter=list` — 28
  PNGs landed (foundation login + 6 routes × 2 themes × 2 viewports).
- `./sbpp.sh down`.

## Parallel-stack scaffolding

Worktree-local `docker-compose.override.yml` (gitignored, never in the diff)
scoped this stack as `sbpp-e2e-smoke-public` on host ports 8200/8201/8202/
8203/8204 so it runs alongside the other in-flight slices without colliding.

## Screenshot gallery

(Comment posted by the upload-screenshots.sh script.)