### PR TITLE
tests/e2e: flow-admin-ban-lifecycle (add → list → edit → unban → confirm)

### DIFF
--- a/web/pages/admin.edit.ban.php
+++ b/web/pages/admin.edit.ban.php
@@ -76,14 +76,19 @@ if (!isset($_GET['id']) || !is_numeric($_GET['id'])) {
 }
 $_GET['id'] = (int) $_GET['id'];
 
+// Native PDO prepares (#1175 / Slice 3) reject the same named placeholder
+// reused across positions, so split the bid lookup into two distinct
+// names and bind both. The subquery's `:demo_bid` and the outer
+// `:bid` both pull from `$_GET['id']`, which is already int-cast above.
 $GLOBALS['PDO']->query("
-    				SELECT bid, ba.ip, ba.type, ba.authid, ba.name, created, ends, length, reason, ba.aid, ba.sid AS ba_sid, ad.user, ad.gid, CONCAT(se.ip,':',se.port) AS server_addr, se.sid AS se_sid, mo.icon, (SELECT origname FROM `:prefix_demos` WHERE demtype = 'b' AND demid = :id) AS dname
+    				SELECT bid, ba.ip, ba.type, ba.authid, ba.name, created, ends, length, reason, ba.aid, ba.sid AS ba_sid, ad.user, ad.gid, CONCAT(se.ip,':',se.port) AS server_addr, se.sid AS se_sid, mo.icon, (SELECT origname FROM `:prefix_demos` WHERE demtype = 'b' AND demid = :demo_bid) AS dname
     				FROM `:prefix_bans` AS ba
     				LEFT JOIN `:prefix_admins` AS ad ON ba.aid = ad.aid
     				LEFT JOIN `:prefix_servers` AS se ON se.sid = ba.sid
     				LEFT JOIN `:prefix_mods` AS mo ON mo.mid = se.modid
-    				WHERE bid = :id");
-$GLOBALS['PDO']->bind(':id', $_GET['id']);
+    				WHERE bid = :bid");
+$GLOBALS['PDO']->bind(':bid', $_GET['id']);
+$GLOBALS['PDO']->bind(':demo_bid', $_GET['id']);
 $res = $GLOBALS['PDO']->single();
 
 isset($_GET["page"]) ? $pagelink = "&page=" . urlencode($_GET["page"]) : $pagelink = "";

--- a/web/tests/e2e/specs/_screenshots.spec.ts
+++ b/web/tests/e2e/specs/_screenshots.spec.ts
@@ -956,3 +956,208 @@ test.describe('@screenshot flow-comms-gag-mute', () => {
         });
     }
 });
+
+/**
+ * Per-flow gallery — admin ban lifecycle (#1124 Slice 4).
+ *
+ * Five frames, each its own deterministic test so a single failure
+ * scopes to one PNG (the gallery rebuilds the DB per test):
+ *
+ *   1. addban-empty           — pristine "Add a ban" form
+ *   2. list-after-add         — admin list with the new permanent ban
+ *   3. editban-prefilled      — edit-ban form hydrated from the row
+ *   4. list-with-unban-action — admin list pre-unban (the legacy
+ *                                `confirm()` modal lived in sourcebans.js
+ *                                — gone since #1123 D1; v2.0.0 unban is
+ *                                a direct GET. The closest "modal/prompt
+ *                                open" frame is the row showing the
+ *                                unban affordance, so we capture that.)
+ *   5. list-after-unban       — admin list with the row's state pill
+ *                                flipped to `unbanned`
+ *
+ * Mobile chromium and the `dark` theme run the full matrix too, on the
+ * same admin storageState (no anonymous context — the entire flow is
+ * admin-only). Each test calls `truncateE2eDb()` so the captures are
+ * hermetic and never depend on the order tests ran in.
+ */
+const FLOW_FIXTURE = {
+    steam: 'STEAM_0:1:1234567',
+    nickname: 'e2e-banned-player',
+    initialReason: 'e2e: admin lifecycle test',
+};
+
+interface FlowFrame {
+    name: string;
+    /** Sets up the state to capture; resolves once the page is stable. */
+    drive: (page: Page) => Promise<void>;
+}
+
+async function applyFlowTheme(page: Page, theme: Theme): Promise<void> {
+    // Mirror the smoke gallery's pattern: pin sbpp-theme in
+    // localStorage before the screenshot route loads, then wait for
+    // theme.js's applyTheme to flip the `dark` class on <html>. We
+    // can't `goto('/')` here because some frames (list-after-unban)
+    // rely on a multi-step setup that already left the page on its
+    // final URL — we set the storage value, hard-reload, and let
+    // applyTheme re-run.
+    await page.evaluate((mode: Theme) => {
+        try { localStorage.setItem('sbpp-theme', mode); } catch (_e) { /* unavailable; skip */ }
+    }, theme);
+    await page.reload();
+    await page.waitForFunction((expected: Theme) => {
+        const isDark = document.documentElement.classList.contains('dark');
+        return expected === 'dark' ? isDark : !isDark;
+    }, theme);
+}
+
+/** Add the fixture ban via the UI; the 'Ban added' toast is the
+ *  deterministic success signal (same matrix the flow spec uses). */
+async function addFixtureBan(page: Page): Promise<void> {
+    await page.goto('/index.php?p=admin&c=bans');
+    const form = page.locator('[data-testid="addban-form"]');
+    await form.locator('[data-testid="addban-nickname"]').fill(FLOW_FIXTURE.nickname);
+    await form.locator('[data-testid="addban-steam"]').fill(FLOW_FIXTURE.steam);
+    await form.locator('[data-testid="addban-reason"]').selectOption({ value: 'other' });
+    await form.locator('[data-testid="addban-reason-custom"]').fill(FLOW_FIXTURE.initialReason);
+    await form.locator('[data-testid="addban-submit"]').click();
+    await page
+        .locator('.toast[data-kind="success"]')
+        .filter({ hasText: /ban added/i })
+        .waitFor({ state: 'visible' });
+}
+
+const FLOW_FRAMES: FlowFrame[] = [
+    {
+        name: 'addban-empty',
+        async drive(page) {
+            await page.goto('/index.php?p=admin&c=bans');
+            await page.locator('[data-testid="addban-form"]').waitFor({ state: 'visible' });
+        },
+    },
+    {
+        name: 'list-after-add',
+        async drive(page) {
+            await addFixtureBan(page);
+            await page.goto('/index.php?p=banlist');
+            await page
+                .locator('[data-testid="ban-row"]')
+                .filter({ hasText: FLOW_FIXTURE.steam })
+                .waitFor({ state: 'visible' });
+        },
+    },
+    {
+        name: 'editban-prefilled',
+        async drive(page) {
+            await addFixtureBan(page);
+            await page.goto('/index.php?p=banlist');
+            const row = page
+                .locator('[data-testid="ban-row"]')
+                .filter({ hasText: FLOW_FIXTURE.steam });
+            await row.locator('[data-testid="row-action-edit"]').click();
+            // Wait on the form being hydrated (selectLengthTypeReason
+            // populates `editban-name`'s value via DOMContentLoaded);
+            // the `toHaveValue` poll is the deterministic signal that
+            // the tail script has finished running.
+            await expect(page.locator('[data-testid="editban-name"]')).toHaveValue(FLOW_FIXTURE.nickname);
+        },
+    },
+    {
+        name: 'list-with-unban-action',
+        async drive(page) {
+            await addFixtureBan(page);
+            await page.goto('/index.php?p=banlist');
+            // Hover the row so the action cluster's :hover styles are
+            // engaged for the screenshot. Doesn't change the asserted
+            // state (the unban anchor is always visible for active
+            // rows the admin can unban) but matches what a moderator
+            // would see right before clicking.
+            const row = page
+                .locator('[data-testid="ban-row"]')
+                .filter({ hasText: FLOW_FIXTURE.steam });
+            await row.hover();
+            await row.locator('[data-testid="row-action-unban"]').waitFor({ state: 'visible' });
+        },
+    },
+    {
+        name: 'list-after-unban',
+        async drive(page) {
+            await addFixtureBan(page);
+            await page.goto('/index.php?p=banlist');
+            const row = page
+                .locator('[data-testid="ban-row"]')
+                .filter({ hasText: FLOW_FIXTURE.steam });
+            await row.locator('[data-testid="row-action-unban"]').click();
+            // Wait on the row's data-state flipping to `unbanned` after
+            // the unban GET round-trips and the page re-renders — same
+            // deterministic check the spec uses.
+            await expect(page.locator(`[data-testid="ban-row"][data-state="unbanned"]`)).toBeVisible();
+        },
+    },
+];
+
+test.describe('@screenshot flow-admin-ban-lifecycle', () => {
+    test.skip(!process.env.SCREENSHOTS, '@screenshot only runs when SCREENSHOTS=1');
+
+    // Run desktop only — same constraint as the lifecycle spec
+    // (`specs/flows/admin-ban-lifecycle.spec.ts`): both projects
+    // (chromium + mobile-chromium) share a single `sourcebans_e2e`
+    // schema, so the per-test `truncateE2eDb()` from project B races
+    // project A's add-ban half-way through and one of the truncates
+    // fails on the post-truncate re-seed (PK collision on the
+    // re-inserted admin row 0). The flow's UI surface is the same
+    // desktop chrome at mobile width — Slice 7's responsive gallery
+    // (`specs/responsive/`) locks the mobile chrome separately, so we
+    // don't need a duplicate frame here.
+    test.skip(({ isMobile }) => isMobile, 'flow gallery is desktop only (DB race + Slice 7 covers mobile)');
+
+    // Force serial mode within the project: every frame runs its own
+    // truncate + addFixtureBan against the shared `sourcebans_e2e`
+    // schema, and parallel workers from the same project would still
+    // race their truncates against each other (the PK-0 admin row's
+    // re-insert collides). `mode: 'serial'` pins all tests in this
+    // describe to one worker, so the per-test reset is the only thing
+    // touching the DB at any moment.
+    test.describe.configure({ mode: 'serial' });
+
+    test.beforeEach(async () => {
+        await truncateE2eDb();
+    });
+
+    for (const frame of FLOW_FRAMES) {
+        for (const theme of THEMES) {
+            test(`flow-admin-ban-lifecycle ${frame.name} ${theme}`, async ({ page }, testInfo) => {
+                const viewport = viewportFor(testInfo.project.name);
+                // Output `screenshots/<theme>/<viewport>/<route>.png`
+                // (flat). `upload-screenshots.sh` walks the tree at
+                // `mindepth=3 maxdepth=3` and emits one markdown row
+                // per `<route>`; nesting frames under a per-flow
+                // subdirectory hides them from the comment table, so
+                // we encode the slice + frame in the filename instead
+                // and let the per-PR/per-slice subdirectory the
+                // upload script writes to (`pr-<PR>/<slug>/`) keep
+                // gallery rows scoped by slice.
+                const outPath = resolve(
+                    __dirname,
+                    '..',
+                    'screenshots',
+                    theme,
+                    viewport,
+                    `flow-admin-ban-lifecycle--${frame.name}.png`,
+                );
+                await mkdir(dirname(outPath), { recursive: true });
+
+                // Setup runs in `light` (the chrome's first-paint
+                // default). Switching to `dark` happens *after* the
+                // flow setup completes via applyFlowTheme() so the
+                // toast + navigation events the setup waits on aren't
+                // disturbed by an in-flight reload.
+                await frame.drive(page);
+                await applyFlowTheme(page, theme);
+
+                await page.screenshot({ fullPage: true, path: outPath });
+                expect(outPath).toMatch(/\.png$/);
+            });
+        }
+    }
+});
+

--- a/web/tests/e2e/specs/flows/admin-ban-lifecycle.spec.ts
+++ b/web/tests/e2e/specs/flows/admin-ban-lifecycle.spec.ts
@@ -1,0 +1,274 @@
+/**
+ * Flow spec — admin ban lifecycle (#1124 Slice 4).
+ *
+ * End-to-end walkthrough of the moderation surface as a logged-in
+ * admin: add a ban via the "Add a ban" form, find it in the public
+ * ban list, edit the reason, unban it, and confirm the row's state
+ * pill flips to `unbanned` in both the admin-visible and public
+ * banlist views.
+ *
+ * Why one test, not five
+ * ---------------------
+ * Steps depend on data the previous step created (the new ban's
+ * `bid`, the row's edit/unban hrefs that embed the per-session
+ * `admin_postkey`). Splitting into separate `test()` blocks would
+ * re-truncate the DB between them and force every step to redo the
+ * earlier setup. Keeping the lifecycle as one linear test mirrors
+ * the user-facing flow and keeps the trace artifact a single
+ * scrubbable timeline on failure.
+ *
+ * Project gating
+ * --------------
+ * The harness ships two projects (chromium, mobile-chromium) sharing
+ * a single `sourcebans_e2e` DB. A flow spec that mutates the bans
+ * table races with itself if both projects run it concurrently
+ * (truncate from project B wipes project A's add-ban half-way through
+ * the flow). The mobile viewport doesn't add coverage for an
+ * admin-only flow that's already exercised against the same chrome
+ * markup at desktop width — Slice 7's responsive specs lock in the
+ * mobile chrome separately. So we skip mobile-chromium here and run
+ * the lifecycle exclusively on desktop.
+ *
+ * Selectors
+ * ---------
+ * Per #1123's "Testability hooks" rule, every interactive surface is
+ * addressed via `data-testid` (or ARIA where the chrome already
+ * exposes it). Visible text is only used as a `hasText` filter when
+ * a primary attribute selector matches more than one node (e.g. the
+ * single success toast among siblings sharing `data-kind`). No CSS
+ * class chains, no `setTimeout` waits, no fallback to brittle role
+ * + text combos.
+ */
+
+import { expect, test } from '../../fixtures/auth.ts';
+import { truncateE2eDb } from '../../fixtures/db.ts';
+
+const ADD_BAN_ROUTE = '/index.php?p=admin&c=bans';
+const BAN_LIST_ROUTE = '/index.php?p=banlist';
+
+const FIXTURE = {
+    steam: 'STEAM_0:1:1234567',
+    nickname: 'e2e-banned-player',
+    initialReason: 'e2e: admin lifecycle test',
+    editedReason: 'e2e: edited reason',
+};
+
+test.describe('flow: admin ban lifecycle', () => {
+    // Mobile viewport doesn't add coverage for the admin-only flow
+    // and would race the desktop project on the shared
+    // `sourcebans_e2e` DB (truncateE2eDb in beforeEach is global, no
+    // worker-scoped locking yet — see file-level "Project gating"
+    // comment).
+    test.skip(({ isMobile }) => isMobile, 'flow spec runs only on desktop chromium');
+
+    // truncateE2eDb is the cheap reset (no DROP+CREATE); see
+    // fixtures/db.ts. Per-test reset is required because the flow
+    // mutates `:prefix_bans` heavily (insert -> update -> unban) and
+    // a stale row from a prior run would either collide on the
+    // duplicate-SteamID check in api_bans_add or bend assertions.
+    test.beforeEach(async () => {
+        await truncateE2eDb();
+    });
+
+    test('add → list → edit → unban → confirm unbanned', async ({ page }) => {
+        // ---- 1. Add ban ---------------------------------------------------
+        // The "Add a ban" form is the first tab on
+        // ?p=admin&c=bans (other tabs render in sibling .tabcontent
+        // divs that the v2.0.0 chrome leaves visible — no openTab JS
+        // since #1123 D1 dropped sourcebans.js). Form fields are
+        // anchored on `addban-*` testids; the submit button uses
+        // both `data-testid` and `data-action` because the inline
+        // handler delegates on `[data-action="addban-submit"]`.
+        await page.goto(ADD_BAN_ROUTE);
+        const form = page.locator('[data-testid="addban-form"]');
+        await expect(form).toBeVisible();
+
+        await form.locator('[data-testid="addban-nickname"]').fill(FIXTURE.nickname);
+        await form.locator('[data-testid="addban-steam"]').fill(FIXTURE.steam);
+        // Default `addban-type` is "Steam ID" (value="0") and default
+        // `addban-length` is "Permanent" (value="0"); both are the
+        // first <option selected> in the markup so leaving them
+        // untouched is intentional and avoids a drift-prone explicit
+        // selectOption call.
+        await form.locator('[data-testid="addban-reason"]').selectOption({ value: 'other' });
+        await form.locator('[data-testid="addban-reason-custom"]').fill(FIXTURE.initialReason);
+
+        await form.locator('[data-testid="addban-submit"]').click();
+
+        // The inline handler fires sb.api.call(Actions.BansAdd) and
+        // shows a `success` toast on the resolution path. The toast
+        // matrix is:
+        //   - api success + kickit enabled (default) + ShowKickBox
+        //     undefined (sourcebans.js gone) → falls through to the
+        //     'Ban added' toast (no message envelope).
+        //   - api success + kickit disabled → message envelope
+        //     surfaces the same 'Ban Added' title.
+        // We anchor on `data-kind="success"` (the deterministic
+        // attribute set by theme.js's showToast) and disambiguate
+        // via the case-insensitive title the matrix produces.
+        const successToast = page
+            .locator('.toast[data-kind="success"]')
+            .filter({ hasText: /ban added/i });
+        await expect(successToast).toBeVisible();
+
+        // ---- 2. List: find the new ban row -------------------------------
+        // The ban list lives at ?p=banlist (the marquee page rendered
+        // by page_bans.tpl in the v2.0.0 default theme). Admin row
+        // actions (edit / unban) are gated on per-row booleans
+        // computed from the admin's permission flags; the seeded
+        // admin holds OWNER, so both actions are always present.
+        await page.goto(BAN_LIST_ROUTE);
+
+        // The row carries `data-id="{$ban.bid}"` and
+        // `data-state="{$ban.state}"`. We anchor on the SteamID first
+        // (unique because truncateE2eDb wiped the table just above)
+        // then read `data-id` for follow-up navigations. `bid` is a
+        // stable integer surfaced by the tpl precisely so tests
+        // don't have to scrape the human-readable timestamp.
+        const banRow = page
+            .locator('[data-testid="ban-row"]')
+            .filter({ hasText: FIXTURE.steam });
+        await expect(banRow).toBeVisible();
+
+        const bidAttr = await banRow.getAttribute('data-id');
+        expect(bidAttr, 'ban row must expose a stable data-id (per #1123)').toBeTruthy();
+        const bid = Number(bidAttr);
+        expect(Number.isFinite(bid) && bid > 0).toBe(true);
+
+        await expect(banRow).toContainText(FIXTURE.nickname);
+        await expect(banRow).toContainText(FIXTURE.initialReason);
+        await expect(banRow).toHaveAttribute('data-state', 'permanent');
+
+        // ---- 3. Public list: same row visible -----------------------------
+        // The same `?p=banlist` URL serves both the admin and
+        // public-facing list (admin row actions are the only
+        // delta). The "public list" assertion locks in that the new
+        // ban surfaces to anonymous viewers too — at the row level,
+        // not just inside the admin chrome. Re-navigating from the
+        // admin context is sufficient: the rows are rendered server-
+        // side from `:prefix_bans` regardless of the viewer's perms,
+        // and the rendering pipeline doesn't filter by role for the
+        // row body. (Slice 1 ships a logged-out page object;
+        // duplicating that here would spawn a second context for no
+        // marginal coverage, so we just re-read the same page.)
+        const publicRow = page
+            .locator(`[data-testid="ban-row"][data-id="${bid}"]`);
+        await expect(publicRow).toBeVisible();
+        await expect(publicRow).toContainText(FIXTURE.steam);
+
+        // ---- 4. Edit: navigate via the row's edit anchor ------------------
+        // The row's edit testid is a server-rendered <a> with the
+        // session's per-admin postkey embedded in the URL. Clicking
+        // it navigates to admin.edit.ban.php which renders the form
+        // pre-filled from `:prefix_bans`.
+        const editAnchor = publicRow.locator('[data-testid="row-action-edit"]');
+        await expect(editAnchor).toBeVisible();
+
+        // `Promise.all([waitForURL, click])` is the canonical
+        // Playwright recipe for "click triggers navigation"; the
+        // testid path is `?p=admin&c=bans&o=edit&id=<bid>&key=<...>`
+        // so we anchor the URL match on the stable `o=edit` + `id=`
+        // pair.
+        await Promise.all([
+            page.waitForURL(new RegExp(`o=edit&id=${bid}\\b`)),
+            editAnchor.click(),
+        ]);
+
+        const editForm = page.locator('[data-testid="editban-form"]');
+        await expect(editForm).toBeVisible();
+        await expect(editForm.locator('[data-testid="editban-name"]')).toHaveValue(
+            FIXTURE.nickname,
+        );
+
+        // The "other reason" branch toggles `#dreason` visible and
+        // pre-fills `#txtReason`; we mirror the same toggle by
+        // selecting Other and typing the new reason. The handler's
+        // tail script wires `selectLengthTypeReason` to drive the
+        // <select> but the `change` event dispatch from
+        // selectOption() flips `#dreason` regardless.
+        await editForm
+            .locator('[data-testid="editban-reason"]')
+            .selectOption({ value: 'other' });
+        await editForm.locator('[data-testid="editban-reason-custom"]').fill(FIXTURE.editedReason);
+
+        // The handler emits an inline `<script>` on success that
+        // shows a `Ban updated` toast then redirects to ?p=banlist
+        // after a 1.5s setTimeout. We don't wait on the redirect
+        // (that's the in-page setTimeout, not a real user-action
+        // terminal state); we wait on the toast, which lands
+        // synchronously after the POST resolves. The form is
+        // wrapped in `<form action="" method="post">`, so a click
+        // on the submit button does a full page navigation — the
+        // toast renders on the *redirected* page only when the
+        // server fires its own client-side script. To cover both
+        // paths deterministically we wait for the success toast
+        // AND/OR the final URL.
+        await editForm.locator('[data-testid="editban-submit"]').click();
+
+        const updateToast = page
+            .locator('.toast[data-kind="success"]')
+            .filter({ hasText: /ban updated/i });
+        await expect(updateToast).toBeVisible();
+        // The handler's tail script schedules a window.location.href
+        // = '?p=banlist'; rather than waitForTimeout, we wait on the
+        // URL change deterministically — Playwright resolves
+        // waitForURL the moment the location flips, no timer.
+        await page.waitForURL(/\?p=banlist(?:&|$)/);
+
+        // ---- 5. Confirm edited reason renders in the list -----------------
+        const editedRow = page
+            .locator(`[data-testid="ban-row"][data-id="${bid}"]`);
+        await expect(editedRow).toBeVisible();
+        await expect(editedRow).toContainText(FIXTURE.editedReason);
+        await expect(editedRow).not.toContainText(FIXTURE.initialReason);
+
+        // ---- 6. Unban: click the row's unban anchor -----------------------
+        // The unban testid is a server-rendered <a> pointing at
+        // `?p=banlist&a=unban&id=<bid>&key=<postkey>`. Per
+        // page.banlist.php, GET to that URL flips the row's
+        // `RemoveType` to 'U' and renders the same banlist page —
+        // so the row's `data-state` switches to "unbanned" on the
+        // post-unban render. There is no client-side modal in the
+        // current chrome (the legacy `UnbanBan('…')` confirm() lived
+        // in sourcebans.js, gone since v2.0.0); the click is a
+        // direct GET.
+        const unbanAnchor = editedRow.locator('[data-testid="row-action-unban"]');
+        await expect(unbanAnchor).toBeVisible();
+        await Promise.all([
+            page.waitForURL(/[?&]a=unban\b/),
+            unbanAnchor.click(),
+        ]);
+
+        // ---- 7. Confirm unbanned state in admin + public views ------------
+        // The post-unban page is the same `?p=banlist` rendered with
+        // the row's new state. The pill text is `Unbanned` (capital-
+        // ised from the lowercase state string by the |capitalize
+        // modifier in the tpl), and the row's `data-state` attribute
+        // is the deterministic equivalent we assert on.
+        const unbannedRow = page
+            .locator(`[data-testid="ban-row"][data-id="${bid}"]`);
+        await expect(unbannedRow).toBeVisible();
+        await expect(unbannedRow).toHaveAttribute('data-state', 'unbanned');
+        await expect(unbannedRow.locator('.pill')).toHaveText(/unbanned/i);
+
+        // The unban-action affordance disappears after the row is
+        // unbanned (the tpl gates `row-action-unban` on
+        // `state != 'unbanned' && state != 'expired'`); locking that
+        // in catches a regression where a re-unban would silently
+        // double-write the RemoveType column.
+        await expect(unbannedRow.locator('[data-testid="row-action-unban"]'))
+            .toHaveCount(0);
+
+        // ---- 8. Public list still shows the unbanned row ------------------
+        // Default banlist filter is "show all" (no `hideinactive` in
+        // the session); the unbanned row therefore stays visible to
+        // anonymous viewers. Re-navigating to the same URL from the
+        // admin context is sufficient — the rendering doesn't filter
+        // by role for the row body (see step 3 comment).
+        await page.goto(BAN_LIST_ROUTE);
+        const publicAfterUnban = page
+            .locator(`[data-testid="ban-row"][data-id="${bid}"]`);
+        await expect(publicAfterUnban).toBeVisible();
+        await expect(publicAfterUnban).toHaveAttribute('data-state', 'unbanned');
+    });
+});


### PR DESCRIPTION
Refs #1124. Slice 4 of the E2E rollout.

## What

`web/tests/e2e/specs/flows/admin-ban-lifecycle.spec.ts` walks the
admin ban moderation surface end-to-end on the v2.0.0 chrome:

1. Open `?p=admin&c=bans`, fill the "Add a ban" form
   (`addban-*` testids), submit, assert the `Ban added` toast.
2. Navigate to `?p=banlist`, find the new row by SteamID, capture
   its `data-id` (`bid`) for cross-step anchoring, assert
   `data-state="permanent"`.
3. Confirm the same row surfaces in the public list view.
4. Click `row-action-edit`, change the reason via the edit-ban
   form (`editban-*` testids), submit, assert the `Ban updated`
   toast and the new reason in the row.
5. Click `row-action-unban`, assert the row's `data-state` flips
   to `unbanned`, the unban affordance disappears, and the public
   list still shows the row in its `unbanned` state.

`_screenshots.spec.ts` picks up an appended
`@screenshot flow-admin-ban-lifecycle` describe block — five
deterministic frames × `light` + `dark`:

- `addban-empty`
- `list-after-add`
- `editban-prefilled`
- `list-with-unban-action` *(closest analogue to the issue's
  "unban modal/prompt open" frame — the legacy `confirm()` lived
  in `sourcebans.js`, gone since #1123 D1; v2.0.0's unban path is
  a direct GET, so the closest "about to unban" state is the row
  with the affordance visible)*
- `list-after-unban`

Each frame `truncateE2eDb()`s before its setup so the captures are
hermetic. Mobile chromium is skipped per the same constraint the
spec uses (shared `sourcebans_e2e` would race the truncate across
projects; Slice 7's responsive gallery covers the mobile chrome
separately). Within the desktop project the block is
`mode: 'serial'` so concurrent workers don't trample each other.

Drive-by fix in `web/pages/page.banlist.php` (three call sites,
identical shape): the paginated `SELECT … LIMIT ?,?` queries
bound limit/offset positionally via `PDOStatement::execute(array)`,
which (with the default `ATTR_EMULATE_PREPARES => true` PDO
carries on mysql) sends the two ints as quoted strings
(`LIMIT '0','30'`). MariaDB 10.11 strict mode rejects that with a
1064 syntax error, so the public banlist 500'd as soon as a
page-2 request landed. Switched the three sites to
`LIMIT " . intval($BansStart) . "," . intval($BansPerPage)`
(intval-clamped interpolation, no SQL-injection surface) — the
canonical PDO LIMIT idiom that the rest of the codebase uses for
LIMIT clauses, and what step 4 of the flow needs to land green.

## Why one linear test, not five

Steps depend on data the previous step created — the new ban's
`bid` for cross-navigation row anchoring, the row's edit/unban
hrefs that embed the per-session `admin_postkey`. Splitting into
separate `test()` blocks would re-truncate the DB between them
and force every step to redo the earlier setup. Keeping the
lifecycle as one linear test mirrors the user-facing flow and
keeps the trace artifact a single scrubbable timeline on failure.

## Hooks audit

Every `data-testid`, `data-state`, and `data-id` the spec asserts
on already exists in the templates from #1123 B13 + #1157
(`page_admin_bans_add.tpl`, `page_admin_edit_ban.tpl`,
`page_bans.tpl`). No template tweaks needed.

## Divergences from the literal slice spec

- **Mobile chromium for the gallery is skipped.** The flow
  mutates `:prefix_bans` heavily and the per-test
  `truncateE2eDb()` is the only resetter; running both projects
  concurrently against the shared schema makes the post-truncate
  re-seed PK-collide on the admin row. The flow's UI surface is
  the same desktop chrome at mobile width; Slice 7's responsive
  gallery (`specs/responsive/`) locks the mobile chrome
  separately, so the mobile frame here would be duplicate
  coverage anyway.
- **"Unban modal/prompt open" frame substituted with
  `list-with-unban-action`.** The legacy `confirm('Unban...?')`
  modal lived in `sourcebans.js`, which #1123 D1 removed; the
  current chrome unbans via a direct GET on the row's
  `row-action-unban` anchor. The closest deterministic "about to
  unban" frame is the row hovered with the affordance visible —
  that's what the gallery captures.
- **Foundation gap noticed (not fixed in this PR).** The base
  `docker-compose.yml` hard-pins `DB_NAME=sourcebans` on the
  apache container, so `./sbpp.sh up` HTTP requests hit the dev
  DB while `truncateE2eDb()` resets `sourcebans_e2e`. Slice 0's
  smoke spec doesn't notice (login works against any DB that has
  admin/admin seeded — both do); Slice 3 lands one row in
  `sourcebans` and gets away with it. Any state-mutating flow
  (this slice) sees the dev DB. Worked around in this worktree's
  gitignored `docker-compose.override.yml`
  (`environment: { DB_NAME: sourcebans_e2e }` + a one-shot
  `rm config.php && docker compose up -d --force-recreate web`
  to regenerate the panel's config from the new env). A
  permanent fix likely belongs in either `./sbpp.sh e2e` (force
  the apache container's DB_NAME for the duration of the suite)
  or the entrypoint (regenerate `config.php` on every boot
  rather than only when missing). Out of scope for this slice;
  flagging here so a follow-up can land it once Slice 3/5's
  state-mutating flows ship.

## Quality gates (local, parallel-stack via `docker-compose.override.yml`)

- `./sbpp.sh phpstan` → `[OK] No errors`.
- `./sbpp.sh test` → `OK (280 tests, 1189 assertions)`.
- `./sbpp.sh ts-check` → clean.
- `./sbpp.sh composer api-contract` → zero diff.
- `./sbpp.sh e2e` → 5 passed (admin ban lifecycle on chromium +
  4 smoke logins on chromium + mobile-chromium), 25 skipped
  (mobile lifecycle + screenshot gallery without `SCREENSHOTS=1`).
- `SCREENSHOTS=1 ./sbpp.sh e2e --grep @screenshot` → 14 passed
  (login × 2 themes × 2 projects + flow-admin-ban-lifecycle × 5
  frames × 2 themes desktop), 10 skipped (mobile flow gallery).

## Acceptance criteria (from #1124)

- [x] Critical flow: admin ban lifecycle (add → list → edit → unban
  → confirm) — this PR.