### PR TITLE
tests/e2e: flow-comms-gag-mute (gag → list → unblock)

### DIFF
--- a/web/tests/e2e/specs/_screenshots.spec.ts
+++ b/web/tests/e2e/specs/_screenshots.spec.ts
@@ -46,6 +46,7 @@ import {
     type SubmissionFixture,
 } from '../pages/SubmitBanFlow.ts';
 import { seedBanViaApi } from '../fixtures/seeds.ts';
+import { truncateE2eDb } from '../fixtures/db.ts';
 import { mkdir } from 'node:fs/promises';
 import { dirname, resolve } from 'node:path';
 
@@ -764,3 +765,134 @@ async function captureResponsive(
         return;
     }
 }
+
+/**
+ * Flow gallery — Slice 5 (`flow-comms-gag-mute`).
+ *
+ * Drives the `comms-gag-mute.spec.ts` flow once per (theme × viewport)
+ * and captures three screenshots along the way:
+ *
+ *   1. `flow-comms-gag-mute-add-form`       — empty add-block form.
+ *   2. `flow-comms-gag-mute-list-active`    — /commslist with the new
+ *                                              gag visible (state=active).
+ *   3. `flow-comms-gag-mute-list-unblocked` — /commslist after the
+ *                                              unmute URL fired
+ *                                              (state=unmuted).
+ *
+ * The brief asks for a fourth shot of the "unblock prompt/modal";
+ * there is no such modal in the new theme — the row's `unmute_url`
+ * is a direct anchor (the legacy `UnGag()` JS confirm prompt was
+ * removed at #1123 D1) and `sb.message.show()` is a silent no-op
+ * because sbpp2026 dropped the `#dialog-placement` shell. The PR
+ * body flags both as follow-ups.
+ *
+ * The flow mirrors the assertions in `specs/flows/comms-gag-mute.spec.ts`
+ * but does NOT re-import them — keeping the gallery as its own spec
+ * means a flow regression doesn't silently kill the gallery, and a
+ * gallery breakage doesn't spam the flow's failure with screenshot
+ * noise. The DB is reset per-test so the row's `data-id` is stable
+ * across runs.
+ */
+test.describe('@screenshot flow-comms-gag-mute', () => {
+    // Same race surfaces *within* a project too: light + dark would
+    // run in parallel under `fullyParallel: true`, hit truncate at
+    // overlapping times, and collide on the seed insert. Serial mode
+    // sequences the two theme runs within this describe.
+    test.describe.configure({ mode: 'serial' });
+
+    test.skip(!process.env.SCREENSHOTS, '@screenshot only runs when SCREENSHOTS=1');
+
+    test.beforeEach(async ({}, testInfo) => {
+        // Flow gallery is desktop-only for now: state-mutating specs
+        // share the `sourcebans_e2e` schema and `truncateE2eDb()`
+        // doesn't hold a cross-process lock, so two projects
+        // (chromium + mobile-chromium) racing on `beforeEach` for the
+        // same test fail with `1062 Duplicate entry '0' for key
+        // 'PRIMARY'`. Mobile viewport coverage for the comms-add
+        // chrome will move into the gallery once Slice 0 grows a
+        // per-DB advisory lock around `Fixture::truncateOnly()`.
+        test.skip(
+            testInfo.project.name !== 'chromium',
+            'state-mutating gallery; truncateE2eDb is not parallel-project-safe (Slice 0 follow-up)',
+        );
+        await truncateE2eDb();
+    });
+
+    for (const theme of THEMES) {
+        test(`flow ${theme}`, async ({ page }, testInfo) => {
+            const viewport = viewportFor(testInfo.project.name);
+            const outDir = resolve(__dirname, '..', 'screenshots', theme, viewport);
+            await mkdir(outDir, { recursive: true });
+
+            // Pin theme via localStorage BEFORE the form-page nav:
+            // theme.js reads `sbpp-theme` on every boot via
+            // applyTheme(currentTheme()), so a hit on `/` to seed the
+            // origin then a navigation to the actual page lands the
+            // right mode on first paint. Mirrors the static-route
+            // gallery contract (see file-level docblock for the
+            // `sbpp-theme` localStorage / `<html>.dark` rationale).
+            await page.goto('/');
+            await page.evaluate((mode: Theme) => {
+                try { localStorage.setItem('sbpp-theme', mode); } catch (_e) { /* unavailable; skip */ }
+            }, theme);
+
+            // ---- 1. Add form (empty) -----------------------------
+            await page.goto('/index.php?p=admin&c=comms');
+            await page.waitForFunction((expected: Theme) => {
+                const isDark = document.documentElement.classList.contains('dark');
+                return expected === 'dark' ? isDark : !isDark;
+            }, theme);
+            await expect(page.locator('[data-testid="addcomm-form"]')).toBeVisible();
+            await page.screenshot({
+                fullPage: true,
+                path: resolve(outDir, 'flow-comms-gag-mute-add-form.png'),
+            });
+
+            // ---- 2. Submit; wait for the JSON API to settle ------
+            // (`sb.message.show` is a silent no-op in the new theme —
+            // see the file-level docblock — so we can't screenshot a
+            // success dialog here.)
+            await page.locator('[data-testid="addcomm-steam"]').fill('STEAM_0:1:7654321');
+            await page.locator('[data-testid="addcomm-nickname"]').fill('e2e-gag-target');
+            await page.locator('[data-testid="addcomm-type"]').selectOption('2');
+            await page.locator('[data-testid="addcomm-length"]').selectOption('5');
+            await page.locator('[data-testid="addcomm-reason"]').selectOption('other');
+            await page.locator('[data-testid="addcomm-reason-custom"]').fill('e2e: comms gag flow');
+            const apiSettled = page.waitForResponse(
+                (r) => r.url().includes('/api.php') && r.request().method() === 'POST',
+            );
+            await page.locator('[data-testid="addcomm-submit"]').click();
+            const apiBody = await (await apiSettled).json();
+            expect(apiBody, 'gallery comms.add succeeded').toMatchObject({ ok: true });
+
+            // ---- 3. /commslist with the gag visible --------------
+            await page.goto('/index.php?p=commslist');
+            const activeRow = page
+                .locator('[data-testid="comm-row"]')
+                .filter({ hasText: 'STEAM_0:1:7654321' });
+            await expect(activeRow).toHaveCount(1);
+            await expect(activeRow).toHaveAttribute('data-state', 'active');
+            await page.screenshot({
+                fullPage: true,
+                path: resolve(outDir, 'flow-comms-gag-mute-list-active.png'),
+            });
+
+            // ---- 4. Trigger the unblock + capture the unblocked list
+            const unmuteHref = await activeRow
+                .locator('[data-testid="row-action-unmute"]')
+                .getAttribute('href');
+            expect(unmuteHref, 'unmute href present').toBeTruthy();
+            await page.goto(`${unmuteHref}&ureason=${encodeURIComponent('e2e: lifted')}`);
+
+            await page.goto('/index.php?p=commslist');
+            const unblockedRow = page
+                .locator('[data-testid="comm-row"]')
+                .filter({ hasText: 'STEAM_0:1:7654321' });
+            await expect(unblockedRow).toHaveAttribute('data-state', 'unmuted');
+            await page.screenshot({
+                fullPage: true,
+                path: resolve(outDir, 'flow-comms-gag-mute-list-unblocked.png'),
+            });
+        });
+    }
+});

--- a/web/tests/e2e/specs/flows/comms-gag-mute.spec.ts
+++ b/web/tests/e2e/specs/flows/comms-gag-mute.spec.ts
@@ -1,0 +1,216 @@
+/**
+ * Comms (gag/mute) flow — Slice 5 of #1124.
+ *
+ * End-to-end coverage of the admin comms-add → public list → unblock
+ * loop. Single-context spec (storage-state admin); the "public" view
+ * is exercised by hitting the same /commslist URL anonymous visitors
+ * would.
+ *
+ * Selectors come from #1123's testability-hook contract:
+ *
+ *   - Add form (web/themes/default/page_admin_comms_add.tpl):
+ *       data-testid="addcomm-form"
+ *       data-testid="addcomm-{steam,nickname,type,length,reason,reason-custom,submit}"
+ *   - List rows (web/themes/default/page_comms.tpl):
+ *       data-testid="comm-row" with data-id="{cid}", data-type, data-state
+ *       data-testid="row-action-unmute"
+ *
+ * Flow:
+ *   1. truncateE2eDb() in beforeEach — fresh `sourcebans_e2e` per test.
+ *   2. Goto /index.php?p=admin&c=comms (the gag/mute add form).
+ *   3. Submit type=2 (Gag) for STEAM_0:1:7654321 with a custom reason.
+ *   4. Wait on the JSON `comms.add` response (terminal state) rather
+ *      than `sb.message.show`'s `#dialog-placement`: the new theme
+ *      doesn't ship that legacy chrome element, so the dialog is a
+ *      silent no-op. See `web/themes/default/page_youraccount.tpl`
+ *      around the `showToast()` helper for the chrome contract; a
+ *      proper toast for the comms-add success is a follow-up.
+ *   5. Goto /index.php?p=commslist, assert the row is present and
+ *      `data-state="active"` / `data-type="gag"`. Capture its `data-id`
+ *      so subsequent navigations anchor on the cid (stable integer)
+ *      regardless of list ordering.
+ *   6. Re-visit /commslist as the same admin (the brief calls this
+ *      "public list" — the route is public, the list visibility is
+ *      identical for admin and anonymous users).
+ *   7. Unblock by following the row's `row-action-unmute` href with
+ *      `&ureason=` appended; the new theme exposes a direct anchor
+ *      (the legacy JS `UnGag()` confirm prompt was removed when
+ *      sourcebans.js went away in #1123 D1).
+ *   8. Re-visit /commslist; assert the row's `data-state` flipped to
+ *      "unmuted".
+ *
+ * Divergences from the brief (called out in the PR body):
+ *   - The "row-action-unblock" data-testid the brief refers to is
+ *     `row-action-unmute` in the actual template. We assert against
+ *     what's there and don't re-tag the template (no missing-hook
+ *     escalation needed).
+ *   - The brief's step 3 says goto `/index.php?p=admin&c=comms` for
+ *     the admin list. That route renders the add form, not a list.
+ *     The list lives at `?p=commslist` for both admin and public; the
+ *     test threads through the brief's intent on that URL.
+ *   - There is no unblock confirmation modal in the new theme; the
+ *     unmute_url is a direct anchor. We pass `ureason=` through the
+ *     URL to honour the brief's "provide an unblock reason" step.
+ *   - The success toast on `comms.add` is a no-op in the new theme
+ *     (sb.message.show targets the legacy `#dialog-placement` shell
+ *     which sbpp2026 doesn't render). The spec asserts on the API
+ *     response rather than a missing UI element; PR body flags this
+ *     as a follow-up for the comms-add page-tail JS to migrate to
+ *     `window.SBPP.showToast`.
+ */
+
+import { test, expect } from '../../fixtures/auth.ts';
+import { truncateE2eDb } from '../../fixtures/db.ts';
+
+const TARGET = {
+    steam: 'STEAM_0:1:7654321',
+    name: 'e2e-gag-target',
+    reason: 'e2e: comms gag flow',
+    // Form value matches the optgroup="Minutes" → `<option value="5">`.
+    // 5 minutes keeps the row in `state="active"` for the duration of
+    // the test (the API stores `length * 60` seconds and the row's
+    // state derives from `ends > UNIX_TIMESTAMP()`).
+    lengthMinutes: '5',
+};
+
+const UNBLOCK_REASON = 'e2e: lifted';
+
+test.describe('flow: comms gag → list → unblock', () => {
+    test.beforeEach(async ({}, testInfo) => {
+        // Slice 0 harness gap: `truncateE2eDb()` truncates + reseeds
+        // the shared `sourcebans_e2e` DB without an advisory lock, so
+        // two workers (chromium + mobile-chromium) racing on
+        // `beforeEach` for the same test fail with `1062 Duplicate
+        // entry '0' for key 'PRIMARY'` when their seed inserts
+        // interleave. State-mutating flow specs only need a single
+        // browser context to assert the server-side state machine; the
+        // visual/responsive coverage lives in `_screenshots.spec.ts`
+        // (desktop only for the same reason) and the `responsive/`
+        // specs. Pin to chromium until Slice 0's harness grows a
+        // per-DB lock around `Fixture::truncateOnly()`.
+        test.skip(
+            testInfo.project.name !== 'chromium',
+            'state-mutating flow; truncateE2eDb is not parallel-project-safe (Slice 0 follow-up)',
+        );
+        await truncateE2eDb();
+    });
+
+    test('admin gags a player, sees it on /commslist, then unblocks', async ({ page }) => {
+        // ============================================================
+        // 1. Open the admin comms-add form.
+        // ============================================================
+        await page.goto('/index.php?p=admin&c=comms');
+        await expect(page.locator('[data-testid="addcomm-form"]')).toBeVisible();
+
+        // ============================================================
+        // 2. Fill + submit the gag.
+        //
+        // type=2 == "Gag (chat)" per the form's <option value="2">; the
+        // API maps 1→mute, 2→gag, 3→silence (both rows). length is in
+        // minutes — see the optgroup labels in the .tpl. The reason
+        // <select> is a curated list; we pick "other" so we can drop
+        // a freeform e2e marker into the textarea (changeReason()
+        // toggles the textarea's #dreason container).
+        // ============================================================
+        await page.locator('[data-testid="addcomm-steam"]').fill(TARGET.steam);
+        await page.locator('[data-testid="addcomm-nickname"]').fill(TARGET.name);
+        await page.locator('[data-testid="addcomm-type"]').selectOption('2');
+        await page.locator('[data-testid="addcomm-length"]').selectOption(TARGET.lengthMinutes);
+        await page.locator('[data-testid="addcomm-reason"]').selectOption('other');
+        await page.locator('[data-testid="addcomm-reason-custom"]').fill(TARGET.reason);
+
+        // Wait for the JSON API to settle — that's the deterministic
+        // terminal state in the new theme (the legacy `#dialog-placement`
+        // chrome was dropped, see file-level docblock). The
+        // setTimeout(2000) reload `ProcessBan()` schedules is the
+        // page's own clock; we navigate explicitly below to avoid
+        // waiting on it.
+        const apiResponse = page.waitForResponse(
+            (r) => r.url().includes('/api.php') && r.request().method() === 'POST',
+        );
+        await page.locator('[data-testid="addcomm-submit"]').click();
+        const response = await apiResponse;
+        expect(response.status(), 'comms.add returns 200').toBe(200);
+        const body = await response.json();
+        expect(body, 'comms.add envelope').toMatchObject({ ok: true });
+        expect(body.data?.block?.steam, 'comms.add returns the block').toBe(TARGET.steam);
+
+        // ============================================================
+        // 3. Admin /commslist — the gag is in the table.
+        //
+        // Filter by SteamID text rather than scanning every row by
+        // index; SteamIDs are unique on the table and the `comm-row`
+        // testid + `data-id` anchor lets us capture the cid for later
+        // navigations.
+        // ============================================================
+        await page.goto('/index.php?p=commslist');
+        await expect(page.locator('[data-testid="comms-table"]')).toBeAttached();
+
+        const adminRow = page
+            .locator('[data-testid="comm-row"]')
+            .filter({ hasText: TARGET.steam });
+
+        await expect(adminRow).toHaveCount(1);
+        await expect(adminRow).toHaveAttribute('data-type', 'gag');
+        await expect(adminRow).toHaveAttribute('data-state', 'active');
+        await expect(adminRow).toContainText(TARGET.name);
+
+        const cid = await adminRow.getAttribute('data-id');
+        expect(cid, 'comm row exposes a numeric data-id').toMatch(/^\d+$/);
+
+        // ============================================================
+        // 4. "Public" view — same /commslist URL.
+        //
+        // The brief asks for a public-list assertion; the route is
+        // already public and the list contents are identical regardless
+        // of who's looking (admin-only affordances are gated per-row
+        // and don't change the row's existence). We re-visit so the
+        // assertion is against a fresh page load rather than the
+        // already-painted DOM.
+        // ============================================================
+        await page.goto('/index.php?p=commslist');
+        const publicRow = page.locator(`[data-testid="comm-row"][data-id="${cid}"]`);
+        await expect(publicRow).toBeVisible();
+        await expect(publicRow).toHaveAttribute('data-type', 'gag');
+        await expect(publicRow).toContainText(TARGET.steam);
+
+        // ============================================================
+        // 5. Unblock — follow the row's unmute anchor with `&ureason=`.
+        //
+        // The legacy `UnGag('id', 'key', …)` JS confirm prompt is gone
+        // post-D1 (sourcebans.js removed); the new theme renders a
+        // direct anchor whose href already carries the cid + the
+        // session's `banlist_postkey`. The server reads `ureason`
+        // from $_GET, so appending it on the client side lets us
+        // record the brief's "e2e: lifted" reason without needing a
+        // modal in the theme.
+        // ============================================================
+        const unmuteHref = await publicRow
+            .locator('[data-testid="row-action-unmute"]')
+            .getAttribute('href');
+        expect(unmuteHref, 'unmute link exposes a key/cid query').toMatch(/[?&]a=ungag(?:&|$)/);
+        expect(unmuteHref, 'unmute link carries banlist_postkey').toMatch(/[?&]key=[^&]+/);
+
+        // URL is already query-string-encoded; appending another `&k=v`
+        // pair is safe.
+        const unmuteUrl = `${unmuteHref}&ureason=${encodeURIComponent(UNBLOCK_REASON)}`;
+        await page.goto(unmuteUrl);
+
+        // ============================================================
+        // 6. Confirm — admin re-loads /commslist, row state is now
+        //    "unmuted". The default list filter is `hide_inactive=false`
+        //    so the row is still visible (just with a different state
+        //    pill); the brief's "row gone" alternative would require
+        //    flipping the hideinactive session toggle, which is out of
+        //    scope for this slice.
+        // ============================================================
+        await page.goto('/index.php?p=commslist');
+        const unblockedRow = page.locator(`[data-testid="comm-row"][data-id="${cid}"]`);
+        await expect(unblockedRow).toBeVisible();
+        await expect(unblockedRow).toHaveAttribute('data-state', 'unmuted');
+        // The active-action affordance is gone now that the block has
+        // been lifted — `unmute_url` is null in the View when the row
+        // is no longer active, so the icon link disappears.
+        await expect(unblockedRow.locator('[data-testid="row-action-unmute"]')).toHaveCount(0);
+    });
+});


### PR DESCRIPTION
Refs #1124. Critical-flows partial (3/4 once Slices 3+4 are also in).

## Summary

Adds Slice 5 of the #1124 Playwright suite: a critical-path e2e spec
covering the admin comms (gag) → admin list → public list → unblock →
admin list flow, plus an `@screenshot` block for the per-PR gallery.

- `web/tests/e2e/specs/flows/comms-gag-mute.spec.ts` — single-context
  flow spec, truncates per-test, anchors on the row's `data-id` across
  navigations.
- `web/tests/e2e/specs/_screenshots.spec.ts` — append-only addition of
  `@screenshot flow-comms-gag-mute` (empty add form / active list /
  unblocked list, light + dark, desktop only — see "Divergences").

Local quality gates (parallel stack on ports 8240–8244):

| Gate | Result |
| --- | --- |
| `./sbpp.sh phpstan` | clean |
| `./sbpp.sh test` | OK (280 tests, 1189 assertions) |
| `./sbpp.sh ts-check` | clean |
| `./sbpp.sh composer api-contract` | zero diff |
| `./sbpp.sh e2e` | 5 passed, 9 skipped (mobile-chromium for state-mutating, see below) |
| `SCREENSHOTS=1 ./sbpp.sh e2e --grep '@screenshot flow-comms-gag-mute'` | 2 passed, 2 skipped (mobile-chromium) |

## Pre-flight bug fix (`prep` commit)

`/index.php?p=commslist` fataled on every fresh request with:

    SQLSTATE[42000]: 1064 ... near ''0','30'' ... at line 13 in Database.php:110

`page.commslist.php` passed `LIMIT ?,?` placeholders via
`resultset([..., intval($BansStart), intval($BansPerPage)])`. PDO
emulated prepares (the default) stringify positional `execute()`
arguments, so MariaDB 10.11 sees `LIMIT '0','30'` and rejects. Latent
on `main` because no spec actually loaded `/commslist` until this
slice. Fixed in all three call sites (default, searchText, advSearch)
by mirroring the inline `intval()` pattern that `admin.admins.php`
already uses for the same construct.

**Follow-up:** `page.banlist.php` carries the same anti-pattern in
three more sites (`page.banlist.php:285,312,497`). Left alone here for
Slice 1 (`smoke-public`) coordination — that slice's specs hit
`/banlist` so the bug surfaces there too. Whichever PR lands first
should pull the same `intval()` inline pattern; the other can rebase
trivially.

## Divergences from the brief

1. **Brief step 3 says goto `/index.php?p=admin&c=comms` for the admin
   list.** That route renders the add form, not a list. The list lives
   at `?p=commslist` for both admin and public; the spec threads the
   brief's intent on that URL.
2. **Brief mentions `data-testid="row-action-unblock"`.** The actual
   template emits `row-action-unmute` (#1123 B14 picked the verb that
   matches the SQL `RemoveType`, "U" / "Unmuted"). Asserting against
   what's there; no template re-tag — not a missing-hook escalation.
3. **No unblock confirmation modal.** The legacy `UnGag()` JS confirm
   was removed at #1123 D1. The row's `unmute_url` is a direct anchor;
   we append `&ureason=e2e: lifted` to the href to honour the brief's
   "provide an unblock reason" step (the server reads `ureason` from
   `$_GET`).
4. **No "unblock prompt/modal" screenshot.** There's no modal to
   capture (see #3). Gallery has three frames per (theme × desktop)
   instead of four.

## Slice 0 / harness follow-ups (flagged, not fixed here)

- **`truncateE2eDb()` is not parallel-project-safe.** Two workers
  (chromium + mobile-chromium) racing on `beforeEach` for the same
  test fail with `1062 Duplicate entry '0' for key 'PRIMARY'` when
  their seed `INSERT`s interleave. The flow spec and the screenshot
  block both pin to `chromium` until `Fixture::truncateOnly()` grows
  a per-DB advisory lock (`GET_LOCK('sbpp_e2e_truncate', N)`). Mobile
  viewport coverage for the comms-add chrome will move into the
  gallery in that follow-up.
- **`web` container's `DB_NAME` defaults to `sourcebans` (the dev
  schema), not `sourcebans_e2e`.** `truncateE2eDb()` cleans the e2e
  schema; Apache writes to dev. State-mutating specs silently collide
  with leftover dev rows. Worked around in this slice's
  `docker-compose.override.yml` via `services.web.environment.DB_NAME:
  sourcebans_e2e`. Each parallel-stack worker currently has to opt in
  the same way; long-term `./sbpp.sh e2e` should rebuild the web
  service against `sourcebans_e2e` (or the entrypoint should read an
  `E2E_*` env split) so the override isn't load-bearing.
- **`sb.message.show()` is a silent no-op in the new theme** — the
  legacy `#dialog-placement` shell isn't part of `sbpp2026`.
  `web/pages/admin.comms.php`'s `ProcessBan()` calls `sb.message.show`
  on success, so a successful gag silently submits and reloads with
  no toast feedback. The spec asserts on the JSON API response
  instead. Page-tail JS migration to `window.SBPP.showToast` is a
  separate UX cleanup.
- **`page.commslist.php` and `page.banlist.php` still call legacy
  `ShowBox()` after a state mutation.** That helper went away with
  `sourcebans.js` (#1123 D1); it now throws `ReferenceError` in the
  inline `<script>` block but the server-side update has already
  committed by then, so the test is unaffected. Visible to users as
  a missing toast on `?a=ungag` / `?a=unmute` / `?a=delete`.

## Test plan

- [x] `./sbpp.sh phpstan` clean
- [x] `./sbpp.sh test` green (280 / 1189)
- [x] `./sbpp.sh ts-check` clean
- [x] `./sbpp.sh composer api-contract` zero diff
- [x] `./sbpp.sh e2e` green (existing specs unchanged)
- [x] `SCREENSHOTS=1 ./sbpp.sh e2e --grep '@screenshot flow-comms-gag-mute'` produces six PNGs (light/dark × add-form/list-active/list-unblocked, desktop only)
- [ ] CI passes
- [ ] Screenshots archived via `web/tests/e2e/scripts/upload-screenshots.sh` (posted as PR comment after creation)