### PR TITLE
tests/e2e: flow-public-submission (anonymous submit → admin approve → public list)

### DIFF
--- a/sbpp.sh
+++ b/sbpp.sh
@@ -148,13 +148,44 @@ case "$cmd" in
             GRANT ALL PRIVILEGES ON \`sourcebans_e2e\`.* TO 'sourcebans'@'%';
             GRANT CREATE, DROP ON *.* TO 'sourcebans'@'%';
             FLUSH PRIVILEGES;" >/dev/null
+        # Pin the panel at the e2e DB for the duration of the run, then
+        # restore on exit. docker/php/web-entrypoint.sh renders config.php
+        # once at container start with `define('DB_NAME', 'sourcebans')`
+        # — the dev DB. Apache+mod_php holds that constant for the life
+        # of the container, so the `-e DB_NAME=sourcebans_e2e` below only
+        # affects the bash shell that drives `npx playwright test` (and
+        # the truncate shim it shells into). Without this swap the panel
+        # the test browser hits writes to `sourcebans` while the fixture
+        # truncates `sourcebans_e2e`, and any spec that mutates DB state
+        # is non-hermetic across runs (#1124 Slice 3 was the first slice
+        # to exercise the write path; Slice 0's smoke specs only login,
+        # which masked the gap). Apache re-reads config.php on every
+        # request so an in-place sed takes effect immediately with no
+        # restart; the trap restores the dev-DB value so the developer's
+        # browser session is unaffected once the suite finishes.
+        e2e_db="${E2E_DB_NAME:-sourcebans_e2e}"
+        dc exec -T web bash -c "
+            set -e
+            cfg=/var/www/html/web/config.php
+            stash=/var/www/html/web/config.php.e2e-stash
+            [ ! -f \$stash ] && cp \$cfg \$stash
+            sed -i \"s/define('DB_NAME', '[^']*');/define('DB_NAME', '${e2e_db}');/\" \$cfg
+        "
+        restore_panel_db() {
+            dc exec -T web bash -c '
+                cfg=/var/www/html/web/config.php
+                stash=/var/www/html/web/config.php.e2e-stash
+                if [ -f $stash ]; then mv $stash $cfg; fi
+            ' 2>/dev/null || true
+        }
+        trap restore_panel_db EXIT INT TERM
         dc exec -T \
             -e E2E_BASE_URL="${E2E_BASE_URL:-http://localhost}" \
             -e E2E_IN_CONTAINER=1 \
             -e SCREENSHOTS="${SCREENSHOTS:-}" \
             -e CI="${CI:-}" \
             -e DB_HOST=db -e DB_PORT=3306 \
-            -e DB_NAME="${E2E_DB_NAME:-sourcebans_e2e}" \
+            -e DB_NAME="${e2e_db}" \
             -e DB_USER=sourcebans -e DB_PASS=sourcebans \
             -e DB_PREFIX=sb -e DB_CHARSET=utf8mb4 \
             web bash -lc '

--- a/web/includes/Database.php
+++ b/web/includes/Database.php
@@ -26,7 +26,20 @@ class Database
         $this->prefix = $prefix;
         $dsn = 'mysql:host=' . $host . ';port=' . $port . ';dbname=' . $dbname . ';charset=' . $charset;
         $options = array(
-            PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION
+            PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
+            // Native (non-emulated) prepares: PDOStatement::execute([...])
+            // forwards values via MySQL's binary protocol with proper
+            // type metadata, instead of literal-substituting them as
+            // strings client-side. The latter breaks `LIMIT ?,?` (MariaDB
+            // rejects `LIMIT '0','30'` as a syntax error) — a regression
+            // that surfaced once page.banlist.php / page.commslist.php
+            // started running on PDO post-#1092 (the ADOdb→PDO refactor)
+            // and went unnoticed until the e2e suite first exercised the
+            // public ban list with rows present (#1124 Slice 3). Existing
+            // call sites that go through Database::bind() already auto-
+            // detect PARAM_INT for ints, so this is purely additive on
+            // the array-shortcut path.
+            PDO::ATTR_EMULATE_PREPARES => false,
         );
 
         try {

--- a/web/tests/e2e/pages/SubmitBanFlow.ts
+++ b/web/tests/e2e/pages/SubmitBanFlow.ts
@@ -1,0 +1,214 @@
+/**
+ * Shared helpers for the public ban-submission flow (#1124 Slice 3).
+ *
+ * The spec at `specs/flows/public-ban-submission.spec.ts` and the
+ * `flow-public-submission` screenshot block in
+ * `specs/_screenshots.spec.ts` both walk the same three pages —
+ * public `/submit`, admin moderation queue, public `/banlist` — and
+ * assert the same testability hooks. Lifting the page interactions
+ * here keeps the contract in one place and lets the screenshot block
+ * prep DB state through the real UI rather than a server-side shim.
+ *
+ * Selectors are pinned to #1123's testability hooks:
+ *
+ *   - `data-testid="submitban-*"` on the public form (page_submitban.tpl).
+ *   - `data-testid="submission-row"` / `submission-row-steam` /
+ *     `submission-row-name` / `row-action-ban` in the admin queue
+ *     (page_admin_bans_submissions.tpl).
+ *   - `data-testid="addban-*"` on the Add Ban form
+ *     (page_admin_bans_add.tpl) — the moderation flow opens this form
+ *     pre-populated via `Actions.BansSetupBan`.
+ *   - `data-testid="ban-row"` on the public banlist (page_bans.tpl).
+ *
+ * All waits land on terminal attributes (form-state changes, toast
+ * appearance, locator visibility) — never on `setTimeout` / network
+ * idle. See AGENTS.md "Playwright E2E specifics" for the rule.
+ */
+
+import { expect, type Browser, type BrowserContext, type Page } from '@playwright/test';
+
+/**
+ * Deterministic fixture for one trip through the flow. Every spec
+ * that reuses these helpers passes a fresh fixture so re-runs against
+ * a non-truncated DB still don't trip the page handler's
+ * "already_banned" guard on the second pass.
+ */
+export interface SubmissionFixture {
+    /** Steam2 ID — must satisfy SteamID::isValidID (STEAM_X:Y:Z). */
+    readonly steam: string;
+    /** Player nickname; required by page.submit.php. */
+    readonly playerName: string;
+    /** Free-text comments / reason; required by page.submit.php. */
+    readonly reason: string;
+    /** Submitter (reporter) display name. */
+    readonly reporterName: string;
+    /** Submitter email; required by FILTER_VALIDATE_EMAIL. */
+    readonly email: string;
+}
+
+/**
+ * Drive the public "Submit a ban request" form against a logged-out
+ * page. Fills every required field, picks the "Other server" option
+ * (value="0") so the server-side validator passes without a seeded
+ * `:prefix_servers` row, submits, and asserts the success-side-effect:
+ * the form re-renders with a cleared `BanReason` textarea.
+ *
+ * Why the textarea is the success anchor: page.submit.php resets
+ * every captured POST value to `""` before re-rendering SubmitBanView
+ * on success — so the Reason field round-trips to empty. A validation
+ * bounce keeps the original text in place; that's the distinguishing
+ * signal we anchor on. We deliberately avoid the SteamID input
+ * because page.submit.php substitutes the literal `"STEAM_0:"` for an
+ * empty SteamID, which collides with the initial-load default and
+ * wouldn't flip on a round-trip.
+ *
+ * The form is `<form method="post" action="index.php?p=submit">` so
+ * Submit triggers a full-page POST + reload. We wait on
+ * `domcontentloaded` (the rerender is a server round-trip, not an
+ * XHR) before asserting.
+ */
+export async function anonymousSubmit(page: Page, fx: SubmissionFixture): Promise<void> {
+    await page.goto('/index.php?p=submit');
+
+    await page.locator('[data-testid="submitban-steam"]').fill(fx.steam);
+    await page.locator('[data-testid="submitban-name"]').fill(fx.playerName);
+    await page.locator('[data-testid="submitban-reason"]').fill(fx.reason);
+    await page.locator('[data-testid="submitban-reporter-name"]').fill(fx.reporterName);
+    await page.locator('[data-testid="submitban-reporter-email"]').fill(fx.email);
+    // value="0" is the static "Other server / Not listed here" option
+    // page_submitban.tpl emits below the (possibly empty) tracked-server
+    // list; page.submit.php gates on `SID == -1` so picking 0 keeps
+    // us inside the success branch without depending on a seeded
+    // :prefix_servers row.
+    await page.locator('[data-testid="submitban-server"]').selectOption('0');
+
+    await Promise.all([
+        page.waitForLoadState('domcontentloaded'),
+        page.locator('[data-testid="submitban-submit"]').click(),
+    ]);
+
+    await expect(page.locator('[data-testid="submitban-reason"]')).toHaveValue('');
+    await expect(page).toHaveURL(/[?&]p=submit(?:&|$)/);
+}
+
+/**
+ * Locate a pending submission row in the admin queue by SteamID.
+ *
+ * The admin bans page renders all sub-tabs as stacked `.tabcontent`
+ * sections (no `swapTab` helper in sbpp2026 — sourcebans.js was
+ * dropped at #1123 D1), so the queue is scrollable on the same
+ * `?p=admin&c=bans` URL — no `&action=…` sub-query is needed.
+ *
+ * We anchor the filter on `submission-row-steam` (a unique-per-row
+ * cell that carries the visible SteamID) rather than on the row's
+ * outer `hasText` because the expanded `<details>` body would also
+ * match the SteamID and double-count.
+ */
+export function adminSubmissionRow(page: Page, steam: string): ReturnType<Page['locator']> {
+    return page
+        .locator('[data-testid="submission-row"]')
+        .filter({ has: page.locator('[data-testid="submission-row-steam"]', { hasText: steam }) });
+}
+
+/**
+ * Approve a submission via the live UI flow:
+ *
+ *   1. Click `[data-testid="row-action-ban"]` on the row → fires
+ *      `Actions.BansSetupBan` and pre-populates the Add Ban form via
+ *      `__sbppApplyBanFields` (admin.bans.php tail script).
+ *   2. Wait until the Add Ban nickname input reflects the
+ *      submission's player name — that's the deterministic terminal
+ *      state for "Setup-ban succeeded; form is ready".
+ *   3. Pick a reason from the static dropdown. Length defaults to
+ *      Permanent (0), already selected.
+ *   4. Click `[data-testid="addban-submit"]` → fires `Actions.BansAdd`
+ *      with `fromsub=<subid>`, which inserts the ban + flips the
+ *      submission to `archiv=3` (the api_bans_add handler updates
+ *      every submission with the matching SteamId, so the row leaves
+ *      the queue).
+ *   5. Wait for the success toast: theme.js's showToast emits a
+ *      `.toast[data-kind="success"]` element synchronously inside
+ *      the BansAdd `.then()` handler. The visible title is "Ban added"
+ *      (the kickit-disabled fallback string from
+ *      page_admin_bans_add.tpl — server-side `'message' => null` when
+ *      `config.enablekickit=1` and ShowKickBox is undefined in
+ *      sbpp2026, so the inline script falls through to the literal
+ *      'Ban added' default). We disambiguate via `hasText` while
+ *      keeping `[data-kind="success"]` as the primary attribute
+ *      selector.
+ *
+ * `reasonOption` defaults to "Inappropriate Language" because it's a
+ * legacy-locked option in the static `<optgroup label="Behavior">`
+ * inside page_admin_bans_add.tpl — no DB seed required.
+ */
+export async function adminApprove(
+    page: Page,
+    fx: Pick<SubmissionFixture, 'steam' | 'playerName'>,
+    opts: { reasonOption?: string } = {},
+): Promise<void> {
+    const reasonOption = opts.reasonOption ?? 'Inappropriate Language';
+
+    await page.goto('/index.php?p=admin&c=bans');
+
+    const row = adminSubmissionRow(page, fx.steam);
+    await expect(row).toBeVisible();
+
+    await row.locator('[data-testid="row-action-ban"]').click();
+
+    // Terminal state for setup-ban: __sbppApplyBanFields writes the
+    // submission's name into #nickname after the BansSetupBan promise
+    // resolves; that's the deterministic post-setup signal. The Add
+    // Ban form lives ABOVE the submissions queue on the same admin
+    // page (each tab is rendered as a stacked `.tabcontent` div in
+    // sbpp2026 — see "no swapTab" comment above), so the input is
+    // already in the DOM when the click fires.
+    const nicknameInput = page.locator('[data-testid="addban-nickname"]');
+    await expect(nicknameInput).toHaveValue(fx.playerName);
+
+    // listReason starts at "" (the placeholder option) and must be
+    // set explicitly; the inline submit handler validates that
+    // `reason` is non-empty before dispatching BansAdd.
+    await page.locator('[data-testid="addban-reason"]').selectOption(reasonOption);
+
+    await page.locator('[data-testid="addban-submit"]').click();
+
+    const toast = page.locator('.toast[data-kind="success"]').filter({ hasText: 'Ban added' });
+    await expect(toast).toBeVisible();
+}
+
+/**
+ * Locate a public ban-list row by SteamID.
+ *
+ * page_bans.tpl emits both a desktop `<tr data-testid="ban-row">` and
+ * a mobile `<a class="ban-row">` card — only the desktop one carries
+ * the `data-testid`, and theme.css hides the table below 769px. At
+ * iPhone-13 (390px) the testid'd nodes are present in the DOM but
+ * `display:none`; specs that need to assert on the *visible* card
+ * view should locate `.ban-cards .ban-row[data-id]` instead. The
+ * desktop spec calls `expect(...).toBeVisible()` and is therefore
+ * pinned to chromium (see `test.skip(({isMobile})=>...)` at the spec
+ * level).
+ */
+export function banlistRow(page: Page, steam: string): ReturnType<Page['locator']> {
+    return page.locator('[data-testid="ban-row"]').filter({ hasText: steam });
+}
+
+/**
+ * Spin up a logged-out browser context that inherits the project's
+ * device descriptor (viewport, user agent, reducedMotion, …) but
+ * drops the storage state Slice 0's global-setup minted for
+ * `admin/admin`.
+ *
+ * Test code must always call `await ctx.close()` — Playwright's
+ * fixture cleanup only tears down contexts it minted, not contexts
+ * the test created via `browser.newContext`.
+ */
+export async function newAnonymousContext(
+    browser: Browser,
+    projectUse: Record<string, unknown>,
+): Promise<BrowserContext> {
+    return browser.newContext({
+        ...projectUse,
+        storageState: { cookies: [], origins: [] },
+    });
+}

--- a/web/tests/e2e/specs/_screenshots.spec.ts
+++ b/web/tests/e2e/specs/_screenshots.spec.ts
@@ -39,6 +39,12 @@
  */
 
 import { test, expect } from '../fixtures/auth.ts';
+import {
+    adminApprove,
+    anonymousSubmit,
+    newAnonymousContext,
+    type SubmissionFixture,
+} from '../pages/SubmitBanFlow.ts';
 import { mkdir } from 'node:fs/promises';
 import { dirname, resolve } from 'node:path';
 
@@ -196,5 +202,243 @@ test.describe('@screenshot smoke-admin', () => {
                 }
             });
         }
+    }
+});
+
+/**
+ * Stateful captures specific to Slice 3 (flow-public-submission).
+ *
+ * The route-driven gallery above can't capture the moderation queue
+ * with a row visible (it'd render the empty state) or the public
+ * banlist with the freshly-approved ban (it'd render "no bans match
+ * those filters"). This block walks the actual flow up to each
+ * capture point, reusing the helpers in `pages/SubmitBanFlow.ts` so
+ * the screenshot path and the gate spec drive exactly the same UI.
+ *
+ * Captures (one PNG per theme × viewport for each):
+ *
+ *   - `flow-public-submit-form`         — public `/submit` form, logged
+ *                                          out. No DB state required.
+ *   - `flow-public-submit-admin-queue`  — admin moderation queue with
+ *                                          the just-submitted row.
+ *   - `flow-public-submit-banlist`      — public ban list with the
+ *                                          freshly-approved ban.
+ *
+ * Why the inline-flow shape (vs the issue's "small PHP shim that
+ * inserts the same submission" alternative): we already have
+ * page-object helpers from Slice 3's gate spec, and reusing them
+ * keeps the shotline data identical to what a real admin would see
+ * after going through the form. A shim would need its own truncate,
+ * its own DB-side fixture insert, and its own approve path — three
+ * surfaces that drift over time. The flow approach has zero
+ * additional surfaces; the runtime cost (a few extra page hits per
+ * variant) is acceptable when SCREENSHOTS=1 is the only invocation
+ * that exercises this block.
+ *
+ * Cross-project parallelism: chromium + mobile-chromium share a single
+ * `sourcebans_e2e` DB, so naively running the same fixture in both
+ * would race on `(SteamId)` uniqueness inside `:prefix_submissions`
+ * and trip BansAdd's `already_banned` guard on the second admin
+ * approve. We give every (state × theme × viewport) variant a unique
+ * SteamID seed, so concurrent runs never collide. We also do NOT
+ * `truncateE2eDb()` between captures — that would race the gate spec
+ * if both ran in the same invocation (which is the supported case
+ * when CI runs `npx playwright test` once with SCREENSHOTS=1 set in
+ * a different job, or when a developer runs the full suite locally).
+ */
+test.describe('@screenshot flow-public-submission', () => {
+    test.skip(!process.env.SCREENSHOTS, '@screenshot only runs when SCREENSHOTS=1');
+
+    /**
+     * Pin the theme key in localStorage on the panel origin so the
+     * NEXT navigation boots theme.js with the right value (theme.js
+     * reads `localStorage['sbpp-theme']` once at IIFE-time via
+     * `applyTheme(currentTheme())`; setting localStorage on the page
+     * we're already on is too late, the class is locked at the
+     * pre-set value until a fresh document loads). Pair with
+     * `expectTheme()` after the screenshot navigation if you need a
+     * deterministic post-navigation wait — the form/queue/banlist
+     * screenshot anchors below already gate on a visible primary
+     * element, which is enough to guarantee theme.js has resolved.
+     */
+    async function pinTheme(page: import('@playwright/test').Page, theme: Theme): Promise<void> {
+        await page.goto('/');
+        await page.evaluate((mode: Theme) => {
+            try {
+                localStorage.setItem('sbpp-theme', mode);
+            } catch {
+                /* localStorage unavailable; skip */
+            }
+        }, theme);
+    }
+
+    /**
+     * Wait until <html> reflects the resolved theme. Call AFTER the
+     * page navigates to the screenshot target, never on the
+     * `pinTheme` page (where the class is already locked at the
+     * pre-pin value).
+     */
+    async function expectTheme(page: import('@playwright/test').Page, theme: Theme): Promise<void> {
+        await page.waitForFunction((expected: Theme) => {
+            const isDark = document.documentElement.classList.contains('dark');
+            return expected === 'dark' ? isDark : !isDark;
+        }, theme);
+    }
+
+    function snapshotPath(theme: Theme, viewport: string, name: string): string {
+        return resolve(__dirname, '..', 'screenshots', theme, viewport, `${name}.png`);
+    }
+
+    /**
+     * Build a fixture whose SteamID, name, and email are unique per
+     * (state × theme × viewport). The third octet of the steamid
+     * encodes the state (queue vs banlist), the fourth is the
+     * theme/viewport tuple. Without this, two parallel projects'
+     * `BansAdd` calls would race on `(authid)` and the second one
+     * would 4xx as `already_banned`.
+     */
+    function fixture(
+        state: 'queue' | 'banlist',
+        theme: Theme,
+        viewport: string,
+    ): SubmissionFixture {
+        // Two distinct seeds keep `queue` and `banlist` from sharing a
+        // SteamID — the banlist capture inserts a ban with the
+        // submission's SteamID, and the next queue capture would
+        // otherwise trip `already_banned` on its own approve step.
+        const stateSeed = state === 'queue' ? '88' : '99';
+        // Theme + viewport seed: `light/desktop = 0`, `light/mobile = 1`,
+        // `dark/desktop = 2`, `dark/mobile = 3`. Numeric to keep the
+        // SteamID's third group a plain integer (SteamID::isValidID
+        // only accepts /STEAM_[01]:[01]:\d+/).
+        const tvSeed =
+            (theme === 'dark' ? 2 : 0) + (viewport === 'mobile' ? 1 : 0);
+        const tag = `${state}-${theme}-${viewport}`;
+        return {
+            steam: `STEAM_0:1:${stateSeed}1124${tvSeed}`,
+            playerName: `e2e-flow-${tag}`,
+            reason: `e2e screenshot: ${tag}`,
+            reporterName: `e2e-screenshot-${tag}`,
+            email: `e2e-${tag}@example.test`,
+        };
+    }
+
+    for (const theme of THEMES) {
+        test(`flow-public-submit-form ${theme}`, async ({ browser }, testInfo) => {
+            const viewport = viewportFor(testInfo.project.name);
+            const path = snapshotPath(theme, viewport, 'flow-public-submit-form');
+            await mkdir(dirname(path), { recursive: true });
+
+            // Public form is rendered for logged-out visitors; spin up
+            // an anonymous context so the chrome matches what a real
+            // submitter would see (no admin chrome, no nav-account).
+            const ctx = await newAnonymousContext(browser, testInfo.project.use);
+            try {
+                const anon = await ctx.newPage();
+                await pinTheme(anon, theme);
+                await anon.goto('/index.php?p=submit');
+                // The form has no async loads (the server list is
+                // pre-rendered into the <select>), so a successful
+                // navigation is itself the terminal state. We assert
+                // on the submit button to make sure the form mounted
+                // before snapshotting, then on the resolved theme so
+                // the screenshot shows the right palette.
+                await expect(anon.locator('[data-testid="submitban-submit"]')).toBeVisible();
+                await expectTheme(anon, theme);
+                await anon.screenshot({ fullPage: true, path });
+                expect(path).toMatch(/\.png$/);
+            } finally {
+                await ctx.close();
+            }
+        });
+
+        test(`flow-public-submit-admin-queue ${theme}`, async ({ page, browser }, testInfo) => {
+            const viewport = viewportFor(testInfo.project.name);
+            const path = snapshotPath(theme, viewport, 'flow-public-submit-admin-queue');
+            await mkdir(dirname(path), { recursive: true });
+
+            const fx = fixture('queue', theme, viewport);
+
+            // Submit anonymously first (separate context) so the
+            // queue has a row to render.
+            const anonCtx = await newAnonymousContext(browser, testInfo.project.use);
+            try {
+                const anon = await anonCtx.newPage();
+                await anonymousSubmit(anon, fx);
+            } finally {
+                await anonCtx.close();
+            }
+
+            // Pin theme on the admin context, then navigate to the
+            // queue. The page is server-rendered (no skeletons on
+            // this surface) so the row is in the DOM by the time
+            // theme application is observable on <html>.
+            await pinTheme(page, theme);
+            await page.goto('/index.php?p=admin&c=bans');
+            await expect(
+                page
+                    .locator('[data-testid="submission-row"]')
+                    .filter({ has: page.locator('[data-testid="submission-row-steam"]', { hasText: fx.steam }) }),
+            ).toBeVisible();
+            await expectTheme(page, theme);
+
+            await page.screenshot({ fullPage: true, path });
+            expect(path).toMatch(/\.png$/);
+        });
+
+        test(`flow-public-submit-banlist ${theme}`, async ({ page, browser }, testInfo) => {
+            const viewport = viewportFor(testInfo.project.name);
+            const path = snapshotPath(theme, viewport, 'flow-public-submit-banlist');
+            await mkdir(dirname(path), { recursive: true });
+
+            const fx = fixture('banlist', theme, viewport);
+
+            // Walk submit → approve via the same helpers the gate
+            // spec uses. The DB stays mutated after this test
+            // finishes; that's intentional — every fixture is unique
+            // per (theme × viewport), so the next gallery run won't
+            // collide. `globalSetup` runs `Fixture::install()` (drop +
+            // recreate sourcebans_e2e) at the start of every
+            // `playwright test` invocation, so the leftover rows
+            // never accumulate across runs.
+            const anonCtx = await newAnonymousContext(browser, testInfo.project.use);
+            try {
+                const anon = await anonCtx.newPage();
+                await anonymousSubmit(anon, fx);
+            } finally {
+                await anonCtx.close();
+            }
+
+            // Pin theme on the admin context BEFORE the approve flow
+            // navigates the page — adminApprove does its own
+            // page.goto under the hood and we want the resolved theme
+            // to land on first paint there too. (pinTheme does the
+            // localStorage write on `/`, which is a same-origin
+            // document, so the value carries over.)
+            await pinTheme(page, theme);
+            await adminApprove(page, fx);
+
+            // Public ban list should now show the row. We pick the
+            // desktop testid; on mobile-chromium the `<tr>` is in the
+            // DOM but `display:none`, and the visible card view's
+            // `<a class="ban-row">` is selected by `.ban-cards
+            // .ban-row[data-state]` rather than testid (the testid
+            // only lives on the desktop `<tr>` in #1123 B2). For the
+            // screenshot we just need the page to settle in a
+            // post-load state; either projection is acceptable.
+            await page.goto('/index.php?p=banlist');
+            const row = page.locator('[data-testid="ban-row"]').filter({ hasText: fx.steam });
+            const card = page.locator(`.ban-cards .ban-row[data-state]`).filter({ hasText: fx.steam });
+            // `attached` rather than `visible` so the assertion holds
+            // for both desktop (testid'd `<tr>` is visible) and mobile
+            // (testid'd `<tr>` exists in the DOM but is `display:none`,
+            // and the card sibling carries the visible markup).
+            const present = row.or(card);
+            await expect(present.first()).toBeAttached();
+            await expectTheme(page, theme);
+
+            await page.screenshot({ fullPage: true, path });
+            expect(path).toMatch(/\.png$/);
+        });
     }
 });

--- a/web/tests/e2e/specs/flows/public-ban-submission.spec.ts
+++ b/web/tests/e2e/specs/flows/public-ban-submission.spec.ts
@@ -1,0 +1,186 @@
+/**
+ * Public ban-submission lifecycle (#1124 Slice 3, "flow-public-submission").
+ *
+ *   1. Anonymous visitor submits a report via /index.php?p=submit.
+ *   2. Admin sees the submission in the moderation queue at
+ *      /index.php?p=admin&c=bans.
+ *   3. Admin clicks the row's "Ban" action → BansSetupBan prefills
+ *      the Add Ban form above the queue. Admin picks a reason and
+ *      clicks the submit button → BansAdd inserts the ban and the
+ *      handler flips every submission for that SteamID to
+ *      `archiv = '3'` (so the row leaves the queue).
+ *   4. The ban shows up on the public /index.php?p=banlist as a row
+ *      identified by the SteamID.
+ *
+ * The shared interactions (filling the public form, finding the
+ * queue row, approving via the Add Ban form, locating the new ban
+ * in the public list) live in `pages/SubmitBanFlow.ts` so the
+ * `flow-public-submission` screenshot block can replay the same
+ * three pages deterministically without forking the contract.
+ *
+ * Selector discipline (#1123 testability hooks)
+ * ---------------------------------------------
+ *   - Every primary selector is a `data-testid` from the locked hooks
+ *     in page_submitban.tpl, page_admin_bans_submissions.tpl,
+ *     page_admin_bans_add.tpl, page_bans.tpl. `hasText` filters
+ *     disambiguate when more than one node matches (e.g. the success
+ *     toast shares its container with future warning toasts; the
+ *     queue row's outer `<details>` body would re-match the SteamID).
+ *   - Waits anchor on terminal attributes / locator state, not
+ *     `setTimeout` / `waitForTimeout` / `networkidle`. See helper
+ *     docs in SubmitBanFlow.ts for the rationale on each anchor.
+ *
+ * Documented divergence from the issue's literal text
+ * ---------------------------------------------------
+ *   - The issue describes the approve action as `row-action-approve`,
+ *     but the actual hook in page_admin_bans_submissions.tpl is
+ *     `row-action-ban` — clicking it loads the submission's data
+ *     into the Add Ban form (via `Actions.BansSetupBan`), and the
+ *     admin then submits that form (via `Actions.BansAdd` with
+ *     `fromsub=<subid>`) to actually insert the ban + flip the
+ *     submission to `archiv=3` ("player has been banned"). This spec
+ *     drives that real flow end-to-end via the UI; it does not
+ *     introduce a new `row-action-approve` testid.
+ *
+ *   - The page handler `web/pages/page.submit.php` still emits
+ *     `print "<script>ShowBox('Successful', …)</script>"` on success,
+ *     but `ShowBox` was deleted in #1123 D1 (it lived in
+ *     `web/scripts/sourcebans.js`). The script tag therefore fires a
+ *     ReferenceError and no visible "thank you" toast lands in the
+ *     sbpp2026 chrome. The deterministic terminal state we anchor on
+ *     instead is the form-reset behaviour of page.submit.php (every
+ *     captured POST value is set to `""` before re-rendering on
+ *     success), so the BanReason textarea round-trips to empty. We
+ *     flag this in the PR body so the missing visible feedback gets
+ *     a follow-up; it doesn't block this slice's contract.
+ *
+ *   - The inline ban-from-submission handler in
+ *     `page_admin_bans_submissions.tpl` originally referenced the
+ *     legacy `window.applyBanFields` helper (deleted with
+ *     sourcebans.js); the actual sbpp2026 helper is
+ *     `window.__sbppApplyBanFields` (defined in admin.bans.php's
+ *     tail script). The Ban-from-submission button was therefore a
+ *     no-op in this theme. This slice fixes the reference (one tpl
+ *     edit) so the UI flow the spec drives is the same flow a real
+ *     admin lives in. Without that fix the BansSetupBan response
+ *     would round-trip but the Add Ban form above the queue would
+ *     stay empty, and the spec would have to reach past the buggy
+ *     UI by typing the steam/nickname/reason itself — which is
+ *     exactly the kind of "drive the API, not the UI" anti-pattern
+ *     this slice exists to avoid.
+ *
+ * Cross-project parallelism
+ * -------------------------
+ * The flow mutates `:prefix_submissions` and `:prefix_bans`, so two
+ * Playwright projects (chromium + mobile-chromium) running this spec
+ * in parallel would race on `(SteamId)` uniqueness and trip BansAdd's
+ * `already_banned` guard. We pin the spec to the desktop chrome via
+ * `test.skip(({ isMobile }) => isMobile, …)` — the desktop path
+ * covers the ban-state contract; the mobile chrome is exercised by
+ * the screenshot block, which uses unique fixture data per
+ * (theme × project) for the same reason.
+ *
+ * Why no `truncateE2eDb()` here
+ * -----------------------------
+ * The fixture's `:prefix_admins` row is the seeded `admin/admin`
+ * account; `Sbpp\Tests\Fixture::truncateOnly()` walks every table
+ * and re-seeds the admin at the end. There's a small window between
+ * `TRUNCATE :prefix_admins` and the re-INSERT where the admin doesn't
+ * exist, and any spec running in parallel that authenticates against
+ * the panel (currently `smoke/login.spec.ts`) sees the seam and
+ * fails its login. The Slice 0 PR (#1162) flagged this as the
+ * "worker-scoped serialisation strategy" follow-up. Until that
+ * helper lands, we get hermeticity from a per-test-run unique
+ * SteamID — the panel only rejects re-submitting the *same* SteamID
+ * with `already_banned`, so a unique seed sidesteps the guard
+ * without touching the admin row at all. The cost is leftover rows
+ * in `:prefix_bans` / `:prefix_submissions` between specs — fine
+ * for the e2e DB (`globalSetup` does a full install at the start of
+ * each `playwright test` invocation).
+ */
+
+import { expect, test } from '../../fixtures/auth.ts';
+import {
+    adminApprove,
+    adminSubmissionRow,
+    anonymousSubmit,
+    banlistRow,
+    newAnonymousContext,
+    type SubmissionFixture,
+} from '../../pages/SubmitBanFlow.ts';
+
+test.describe('flow: public ban submission -> admin approve -> public list', () => {
+    test.skip(
+        ({ isMobile }) => Boolean(isMobile),
+        'flow runs against the desktop chrome; mobile chrome is exercised by the @screenshot block',
+    );
+
+    test('anonymous submit -> admin approve -> ban shown publicly', async ({ page, browser }, testInfo) => {
+        // Per-run unique SteamID. Date.now() gives ms-precision (the
+        // gate spec runs in a single worker per project; collisions
+        // would require <1ms apart which the truncate-free design
+        // makes impossible) and stays inside Steam2's
+        // `STEAM_0:Y:Z` shape (Y ∈ {0,1}; Z is any non-negative int).
+        // testInfo.workerIndex disambiguates if Playwright ever
+        // schedules two instances of this spec on different workers
+        // (currently impossible — chromium pins to one worker by
+        // default — but cheap insurance).
+        const seed = `${Date.now()}${testInfo.workerIndex}`;
+        const FIXTURE: SubmissionFixture = {
+            steam: `STEAM_0:1:${seed}`,
+            playerName: `e2e-submitter-${seed}`,
+            reason: `e2e: public submission flow ${seed}`,
+            reporterName: 'e2e-reporter',
+            email: 'e2e-reporter@example.test',
+        };
+
+        // Stage 1 — anonymous visitor submits the form. We mint a
+        // dedicated logged-out context so the public page never sees
+        // the admin storage state Slice 0's global-setup baked into
+        // the project default. `testInfo.project.use` carries the
+        // device descriptor (viewport, user-agent, reduced-motion);
+        // dropping `storageState` is the only delta from the project
+        // default.
+        const anonContext = await newAnonymousContext(browser, testInfo.project.use);
+        try {
+            const anonPage = await anonContext.newPage();
+            await anonymousSubmit(anonPage, FIXTURE);
+        } finally {
+            await anonContext.close();
+        }
+
+        // Stage 2 — switch to the admin context (the default `page`
+        // fixture inherits playwright/.auth/admin.json minted by
+        // global-setup). Verify the submission is queued, identified
+        // by the SteamID we submitted. The row-level
+        // `data-testid="submission-row"` is unique-per-DB-id, so we
+        // anchor through the inner `submission-row-steam` cell to
+        // disambiguate the unique seeded SteamID from any leftover
+        // rows previous specs in this `playwright test` invocation
+        // wrote (we don't truncate between tests — see file-level
+        // "Why no truncateE2eDb()" comment).
+        await page.goto('/index.php?p=admin&c=bans');
+        const queueRow = adminSubmissionRow(page, FIXTURE.steam);
+        await expect(queueRow).toBeVisible();
+        await expect(queueRow.locator('[data-testid="submission-row-name"]')).toContainText(
+            FIXTURE.playerName,
+        );
+
+        // Stage 3 — approve via the real "Ban" → fill Add Ban → submit
+        // path. Helper waits on the success toast (the BansAdd
+        // .then() emits `.toast[data-kind="success"]` synchronously)
+        // before returning.
+        await adminApprove(page, FIXTURE);
+
+        // Stage 4 — the ban appears on the public ban list. We use
+        // the same admin-authenticated `page` here because the public
+        // banlist renders the same `data-testid="ban-row"` regardless
+        // of viewer privilege; admin-only row-actions are gated
+        // separately in the row body and don't affect identity /
+        // SteamID rendering.
+        await page.goto('/index.php?p=banlist');
+        const newBan = banlistRow(page, FIXTURE.steam);
+        await expect(newBan).toBeVisible();
+        await expect(newBan).toContainText(FIXTURE.playerName);
+    });
+});

--- a/web/themes/default/page_admin_bans_submissions.tpl
+++ b/web/themes/default/page_admin_bans_submissions.tpl
@@ -225,9 +225,19 @@
             var a = api(), A = actions();
             if (!a || !A || !Number.isFinite(subid)) return;
             a.call(A.BansSetupBan, { subid: subid }).then(function (r) {
-                if (r && r.ok && r.data && typeof window.applyBanFields === 'function') {
-                    window.applyBanFields(r.data);
-                }
+                if (!r || !r.ok || !r.data) return;
+                // sbpp2026 ships __sbppApplyBanFields (defined in
+                // admin.bans.php's tail script) as the replacement for
+                // sourcebans.js's legacy applyBanFields. Without this
+                // call the BansSetupBan response would arrive but the
+                // Add Ban form above the queue would stay empty —
+                // silently breaking the entire "Ban a submission" UX.
+                // We keep the legacy name as a fallback so a third-party
+                // theme that still loads sourcebans.js keeps working.
+                var fill = (typeof window.__sbppApplyBanFields === 'function')
+                    ? window.__sbppApplyBanFields
+                    : (typeof window.applyBanFields === 'function' ? window.applyBanFields : null);
+                if (fill) fill(r.data);
                 if (typeof window.swapTab === 'function') window.swapTab(0);
             });
             return;


### PR DESCRIPTION
Refs #1124

Slice 3 of #1124 — first stateful Playwright spec covering one of the
"four critical flows" the parent issue asks for:

> At least the four critical flows above are covered end-to-end —
> partial (1/4: public ban submission).

The spec drives the full lifecycle via the live UI:

1. **Anonymous submit** — logged-out browser context (`browser.newContext({ storageState: empty, ...projectUse })`) hits `/index.php?p=submit`, fills every required field with deterministic-but-unique fixture data, picks the static "Other server" option (value=0 — passes server-side validation without depending on a `:prefix_servers` seed), and submits. We anchor the success-side-effect on `data-testid="submitban-reason"` round-tripping to empty (`page.submit.php` resets every captured POST value on success; a validation bounce keeps the original text intact).

2. **Admin queue** — switch back to the admin context (`page` fixture inherits Slice 0's `playwright/.auth/admin.json`). Goto `/index.php?p=admin&c=bans`, find the queued row by SteamID via `data-testid="submission-row"` filtered through `submission-row-steam`.

3. **Approve** — click `data-testid="row-action-ban"` on the row → `Actions.BansSetupBan` pre-fills the Add Ban form via `__sbppApplyBanFields`. Wait for `data-testid="addban-nickname"` to reflect the submission's player name (terminal state: setup-ban succeeded). Pick a static reason (`Inappropriate Language` from the legacy-locked optgroup), submit. `Actions.BansAdd` inserts the ban + flips every submission for that SteamID to `archiv=3`. Helper waits on `.toast[data-kind="success"]` filtered by "Ban added".

4. **Public banlist** — goto `/index.php?p=banlist`, assert `data-testid="ban-row"` filtered by SteamID is visible.

The shared interactions live in `web/tests/e2e/pages/SubmitBanFlow.ts` so the gate spec and the `@screenshot flow-public-submission` block in `_screenshots.spec.ts` drive identical UI.

## Acceptance criteria

- [x] `web/tests/e2e/specs/flows/public-ban-submission.spec.ts` — full lifecycle covered.
- [x] `web/tests/e2e/pages/SubmitBanFlow.ts` — page-object helpers for the three pages.
- [x] `_screenshots.spec.ts` — `@screenshot flow-public-submission` block appended (3 routes × 2 themes × 2 viewports = 12 PNGs, plus Slice 0's 4 = 16 total).
- [x] Selectors use #1123 testability hooks; no CSS class chains, no visible-text primaries, no `setTimeout` / `waitForTimeout`.
- [x] `docker-compose.override.yml` gitignored (`sbpp-slice3-pubsub`, ports 8225–8229).
- [x] Existing specs unchanged; Slice 0 contract preserved.
- [x] axe `critical` threshold not downgraded.
- [x] No new npm deps.

## Foundation gaps surfaced (and fixed inline; all small, all flagged)

Slice 0 (#1162) explicitly noted "Slices that mutate state need a worker-scoped serialisation strategy because both projects (chromium + mobile-chromium) share the DB". This is the first stateful spec; three additional foundation gaps surfaced once the spec actually drove the flow end-to-end. All three fixes are tiny, targeted, and documented inline at the call sites.

### 1. `web/includes/Database.php` — enable native prepares

PDO's emulated-prepares default literal-substitutes array-shortcut `execute([...])` params as strings, so `LIMIT ?,?` becomes `LIMIT '0','30'` — invalid syntax in MariaDB. This **500'd both `/index.php?p=banlist` and `/index.php?p=commslist`** whenever the relevant tables had any rows, a regression latent since #1092's ADOdb→PDO refactor (ADOdb did its own type detection on array binds; PDO does not). The fix is one line — `PDO::ATTR_EMULATE_PREPARES => false` in the constructor — with a comment explaining the regression and why native prepares are safe (existing call sites that go through `Database::bind()` already auto-detect `PARAM_INT` for ints, so native prepares are purely additive on the array-shortcut path). PHPUnit stays green at 280 / 1189.

### 2. `sbpp.sh` `e2e` command — swap `config.php`'s `DB_NAME`

`docker/php/web-entrypoint.sh` renders `config.php` once at container start with `define('DB_NAME', 'sourcebans')` (the dev DB). Apache+mod_php holds that constant for the life of the container, so the existing `dc exec -e DB_NAME=sourcebans_e2e` only affects the bash shell that drives `npx playwright test` (and the truncate shim it shells into). Without this swap the panel the test browser hits writes to `sourcebans` while the fixture truncates `sourcebans_e2e` — the two halves of "DB isolation" point at different schemas. Apache re-reads `config.php` on every request so the in-place `sed` takes effect immediately with no restart; the `trap` restores the dev-DB value so the developer's browser session is unaffected once the suite finishes.

CI inherits the swap because CI's `e2e` job goes through the same `./sbpp.sh e2e` entrypoint.

### 3. `web/themes/default/page_admin_bans_submissions.tpl` — `__sbppApplyBanFields`

The inline ban-from-submission handler called the legacy `window.applyBanFields` (deleted with `web/scripts/sourcebans.js` in #1123 D1); the actual sbpp2026 helper is `window.__sbppApplyBanFields` (defined in `admin.bans.php`'s tail script). Without the fix the BansSetupBan response round-trips but the Add Ban form stays empty — silently breaking the entire "Ban a submission" UX. The spec would have to reach past the broken UI by typing the steam/nickname/reason itself — the "drive the API, not the UI" anti-pattern this slice exists to avoid. Fallback to the legacy name kept so a third-party theme that still loads `sourcebans.js` keeps working.

### Why no `truncateE2eDb()` here (a fourth gap, sidestepped not fixed)

`Sbpp\Tests\Fixture::truncateAndReseed()` walks every table (`TRUNCATE :prefix_admins` included) and re-seeds the admin at the end. There's a small window between the truncate and the re-INSERT where the admin doesn't exist, and any spec running in parallel that authenticates against the panel (currently `smoke/login.spec.ts`) sees the seam and fails its login. We get hermeticity from a per-run unique SteamID seed (`STEAM_0:1:${Date.now()}${workerIndex}`) instead — the panel only rejects re-submitting the *same* SteamID with `already_banned`, so a unique seed sidesteps the guard without touching the admin row at all. The cost is leftover rows in `:prefix_bans` / `:prefix_submissions` between specs, fine for the e2e DB (`globalSetup` does a full install at the start of each `playwright test` invocation).

The "worker-scoped serialisation strategy" Slice 0 promised stays a follow-up. When that helper lands, the gate spec can flip back to `truncateE2eDb()` in a `beforeEach` and the comment in this PR's spec explains the migration path.

## Documented divergences from the issue text

- The issue describes the approve action as `data-testid="row-action-approve"`. The actual hook in `page_admin_bans_submissions.tpl` is `data-testid="row-action-ban"` — clicking it loads the submission's data into the Add Ban form via `Actions.BansSetupBan`, and the admin then submits *that* form via `Actions.BansAdd` with `fromsub=<subid>` to insert the ban + flip the submission to `archiv=3`. The spec drives that real flow end-to-end via the UI; it does not introduce a new `row-action-approve` testid.

- `web/pages/page.submit.php` still emits `print "<script>ShowBox('Successful', …)</script>"` on success, but `ShowBox` was deleted with `sourcebans.js` in #1123 D1, so no visible "thank you" toast lands in the sbpp2026 chrome on success. Filed as #1176 for a separate fix; the spec anchors on the deterministic form-reset behaviour (`BanReason` textarea round-trips to empty on success) instead, so this slice is not blocked.

## Local commands run

| Gate | Result |
| --- | --- |
| `./sbpp.sh phpstan` | clean (211 files, no errors over baseline) |
| `./sbpp.sh test` | 280 tests, 1189 assertions, all green |
| `./sbpp.sh ts-check` | clean |
| `./sbpp.sh composer api-contract` | zero diff |
| `./sbpp.sh e2e` | 5 passed, 17 skipped (16 `@screenshot` variants + 1 mobile flow) |
| `SCREENSHOTS=1 ./sbpp.sh e2e --grep @screenshot` | 16 PNGs produced (4 login + 3×2×2 flow) |

Worktree-local `docker-compose.override.yml`: project `sbpp-slice3-pubsub`, ports 8225–8229.

## Screenshots

(Comment posted by the upload-screenshots.sh script.)
