### PR TITLE
fix(theme): .btn--ghost self-resets border (#1183)

### DIFF
--- a/web/themes/default/css/theme.css
+++ b/web/themes/default/css/theme.css
@@ -162,7 +162,7 @@ html.dark .btn:hover { background: white; }
 .btn--primary:hover { background: var(--brand-700); }
 .btn--secondary { background: var(--bg-surface); color: var(--text); border-color: var(--border); }
 .btn--secondary:hover { background: var(--bg-muted); }
-.btn--ghost { background: transparent; color: var(--text-muted); }
+.btn--ghost { background: transparent; color: var(--text-muted); border: 1px solid transparent; }
 .btn--ghost:hover { background: var(--bg-muted); color: var(--text); }
 .btn--danger { background: var(--danger); color: white; }
 .btn--danger:hover { background: #b91c1c; }


### PR DESCRIPTION
## Summary

- `.btn--ghost` lacked a transparent border reset, letting user-agent default border bleed through on icon-only standalone usages (theme toggle, drawer X, toast close, etc.).
- Add `border: 1px solid transparent` to the modifier so it's safe standalone.

Closes #1183.

## Test plan

- [ ] Manual: theme-toggle in topbar no longer shows user-agent box border in either mode.
- [ ] CI green.