### PR TITLE
fix(theme): drop topbar search min-width on mobile (#1180)

### DIFF
--- a/web/tests/e2e/specs/responsive/banlist.spec.ts
+++ b/web/tests/e2e/specs/responsive/banlist.spec.ts
@@ -19,19 +19,16 @@
  *   L291) — `overflow-x: auto; scrollbar-width: none`. At iPhone-13
  *   width the chip row's `scrollWidth` legitimately EXCEEDS its
  *   `clientWidth` because that's the design: chips horizontal-scroll
- *   inside a viewport-constrained container, they don't wrap. The
- *   page-level `documentElement.scrollWidth > clientWidth` check is
- *   ALSO not a clean signal here: the topbar in core/title.tpl
- *   (`.topbar__search { min-width: 16rem }` next to the theme
- *   toggle) currently overflows the iPhone-13 viewport by ~28px,
- *   which is a separate chrome-layout regression (tracked as #1180),
- *   not a chip-bar one. The user-visible contract for THIS spec
- *   ("filter bar remains usable, every chip reachable, container
- *   is bounded by the viewport so no chip silently lives at
- *   x=2000px") still holds; we assert that and let the topbar
- *   overflow be tracked as its own follow-up. If a future redesign
- *   switches the chip row to `flex-wrap: wrap`, tighten the chip-
- *   container assertion below to `scrollWidth <= clientWidth + 1`.
+ *   inside a viewport-constrained container, they don't wrap. We
+ *   therefore assert the OUTER chip-row container is bounded by the
+ *   viewport (the user contract: "no chip silently lives at
+ *   x=2000px") rather than chip-row `scrollWidth <= clientWidth`.
+ *   Page-level `documentElement.scrollWidth <= clientWidth` IS now
+ *   asserted: #1180 dropped the topbar's `min-width: 16rem` at
+ *   <=1024px so the chrome no longer overflows iPhone-13. If a
+ *   future redesign switches the chip row to `flex-wrap: wrap`,
+ *   tighten the chip-container assertion below to
+ *   `scrollWidth <= clientWidth + 1`.
  */
 
 import type { Page } from '@playwright/test';
@@ -133,6 +130,14 @@ test.describe('responsive: ban list', () => {
         expect(barBox!.width).toBeLessThanOrEqual(vw + 1);
         expect(barBox!.x).toBeGreaterThanOrEqual(-1);
         expect(barBox!.x + barBox!.width).toBeLessThanOrEqual(vw + 1);
+
+        // Page-level: nothing in the chrome (topbar, sidebar drawer,
+        // …) leaks past the viewport either. #1180 fixed the topbar
+        // search min-width regression that previously left ~28px of
+        // horizontal scroll on iPhone-13.
+        await expect.poll(() => page.evaluate(() =>
+            document.documentElement.scrollWidth - document.documentElement.clientWidth
+        )).toBeLessThanOrEqual(1);
 
         // Every chip is reachable on mobile: Playwright's auto-scroll
         // brings horizontally-scrolled-out elements into view, so a

--- a/web/themes/default/css/theme.css
+++ b/web/themes/default/css/theme.css
@@ -146,6 +146,9 @@ html.dark .topbar { background: rgb(9 9 11 / 0.8); }
   border: 1px solid var(--border); background: var(--bg-page);
   color: var(--text-muted); font-size: var(--fs-base);
 }
+@media (max-width: 1024px) {
+  .topbar__search { min-width: 0; flex: 1 1 auto; }
+}
 .topbar__search kbd { margin-left: auto; padding: 0.125rem 0.375rem; border-radius: var(--radius-sm); background: var(--bg-surface); border: 1px solid var(--border); font-family: var(--font-mono); font-size: 0.625rem; color: var(--text-muted); }
 
 /* ---- Buttons ---- */


### PR DESCRIPTION
## Summary

- `.topbar__search` carries a `min-width: 16rem` that overflows iPhone-13's 390px viewport by ~28px.
- Add a `<=1024px` media-query that resets `min-width` and lets the field flex-shrink.
- Banlist responsive spec tightened to assert page-level scrollWidth <= clientWidth + 1.

Closes #1180.

## Test plan

- [ ] Playwright responsive banlist spec passes the new no-page-overflow assertion.