### PR TITLE
fix(theme): chip filter row wraps on mobile (#1181)

### DIFF
--- a/web/tests/e2e/specs/responsive/banlist.spec.ts
+++ b/web/tests/e2e/specs/responsive/banlist.spec.ts
@@ -6,29 +6,17 @@
  *     `.ban-cards` block (page_bans.tpl L204) becomes the canonical
  *     listing. Each card preserves the `[data-testid="drawer-trigger"]`
  *     hook so the drawer flow still works on mobile.
- *   - The sticky filter chip bar above the list keeps every chip
- *     reachable on mobile widths.
+ *   - The sticky filter chip bar above the list wraps onto multiple
+ *     rows (#1181, theme.css `<=768px`) so every chip is statically
+ *     visible without a horizontal swipe. The chip container itself
+ *     must therefore have NO internal horizontal overflow:
+ *     `scrollWidth <= clientWidth + 1`.
+ *   - Page-level `documentElement.scrollWidth <= clientWidth` is now
+ *     asserted too — #1180 dropped the topbar's `min-width: 16rem`
+ *     at <=1024px, so the chrome no longer overflows iPhone-13.
  *
  * Project gating: mobile-chromium only (see sidebar.spec.ts header
  * for the rationale on `beforeEach` skip vs. `describe.configure`).
- *
- * == Divergence from the issue's literal text ==
- *
- *   The brief's "filter chips wrap" subtest assumes flex-wrap, but
- *   page_bans.tpl wraps the chip group in `.scroll-x` (theme.css
- *   L291) — `overflow-x: auto; scrollbar-width: none`. At iPhone-13
- *   width the chip row's `scrollWidth` legitimately EXCEEDS its
- *   `clientWidth` because that's the design: chips horizontal-scroll
- *   inside a viewport-constrained container, they don't wrap. We
- *   therefore assert the OUTER chip-row container is bounded by the
- *   viewport (the user contract: "no chip silently lives at
- *   x=2000px") rather than chip-row `scrollWidth <= clientWidth`.
- *   Page-level `documentElement.scrollWidth <= clientWidth` IS now
- *   asserted: #1180 dropped the topbar's `min-width: 16rem` at
- *   <=1024px so the chrome no longer overflows iPhone-13. If a
- *   future redesign switches the chip row to `flex-wrap: wrap`,
- *   tighten the chip-container assertion below to
- *   `scrollWidth <= clientWidth + 1`.
  */
 
 import type { Page } from '@playwright/test';
@@ -118,12 +106,17 @@ test.describe('responsive: ban list', () => {
             await expect(chip).toHaveCount(1);
         }
 
-        // Spirit of "no horizontal overflow": the chip row container
-        // is bounded by the viewport. Chips inside may horizontally
-        // scroll inside the `.scroll-x` wrapper (by design, see the
-        // file-level divergence note); what the user contract gates
-        // is that the OUTER row doesn't extend past the viewport,
-        // which is what `.scroll-x` clamps it to.
+        // #1181: at <=768px the chip row wraps via `flex-wrap: wrap`,
+        // so the container must have NO internal horizontal scroll.
+        // Allow a 1px tolerance for sub-pixel rounding.
+        const overflow = await chipBar.evaluate((el) => ({
+            scrollWidth: el.scrollWidth,
+            clientWidth: el.clientWidth,
+        }));
+        expect(overflow.scrollWidth).toBeLessThanOrEqual(overflow.clientWidth + 1);
+
+        // And the row itself is bounded by the viewport horizontally —
+        // no chip silently lives at x=2000px off-screen.
         const vw = page.viewportSize()?.width ?? 0;
         const barBox = await chipBar.boundingBox();
         expect(barBox, 'chip bar must render a bounding box').not.toBeNull();
@@ -139,9 +132,10 @@ test.describe('responsive: ban list', () => {
             document.documentElement.scrollWidth - document.documentElement.clientWidth
         )).toBeLessThanOrEqual(1);
 
-        // Every chip is reachable on mobile: Playwright's auto-scroll
-        // brings horizontally-scrolled-out elements into view, so a
-        // `.click()` succeeds on the rightmost chip and toggles state.
+        // Every chip is reachable on mobile: with wrap in place the
+        // rightmost chip renders within the viewport (possibly on a
+        // second row), so `.click()` succeeds without horizontal
+        // auto-scroll and toggles state.
         const last = page.locator('[data-testid="filter-chip-unbanned"]');
         await last.click();
         await expect(last).toHaveAttribute('aria-pressed', 'true');

--- a/web/tests/e2e/specs/responsive/filters.spec.ts
+++ b/web/tests/e2e/specs/responsive/filters.spec.ts
@@ -3,11 +3,11 @@
  *
  * iPhone-13 viewport contract:
  *   - Every filter chip on the public ban list (`page_bans.tpl`) is
- *     clickable and updates the URL state — even when chips
- *     horizontally scroll inside their `.scroll-x` container at
- *     mobile widths (see banlist.spec.ts for the wrap/scroll
- *     divergence note; banlist.spec.ts already covers the geometry,
- *     so this file focuses on interaction).
+ *     clickable and updates the URL state. At mobile widths the chip
+ *     row wraps via `flex-wrap` (#1181, theme.css `<=768px`), so
+ *     every chip renders inside the viewport without horizontal
+ *     scroll; banlist.spec.ts covers the wrap geometry, this file
+ *     focuses on interaction.
  *   - Each click pins `aria-pressed="true"` on the chosen chip and
  *     stamps `?state=<name>` onto the URL (banlist.js
  *     `applyStateFilter`).
@@ -41,10 +41,10 @@ test.describe('responsive: filter bar', () => {
             const chip = page.locator(`[data-testid="filter-chip-${id}"]`);
             await expect(chip).toHaveAttribute('aria-pressed', 'false');
 
-            // Playwright auto-scrolls a horizontally scrolled-out
-            // chip into view before clicking; that's the contract
-            // banlist.spec.ts (geometry) and this file (interaction)
-            // jointly rely on. No `force: true` needed.
+            // After #1181 the row wraps onto multiple lines at
+            // <=768px, so every chip renders within the viewport.
+            // `.click()` works directly — no horizontal auto-scroll
+            // and no `force: true` needed.
             await chip.click();
 
             await expect(chip).toHaveAttribute('aria-pressed', 'true');

--- a/web/themes/default/css/theme.css
+++ b/web/themes/default/css/theme.css
@@ -285,6 +285,12 @@ html.dark .skel { background: linear-gradient(90deg, var(--zinc-800) 0, var(--zi
 @media (max-width: 768px) {
   .table { display: none; }
   .ban-cards { display: block; }
+  /* #1181: filter chip rows wrap onto multiple lines on mobile
+     instead of horizontal-scrolling, so every chip is reachable
+     without a swipe. The .scroll-x desktop affordance is the
+     overflow fallback when the chip row would otherwise extend
+     past a wide viewport. */
+  .scroll-x { overflow-x: visible; flex-wrap: wrap; row-gap: 0.5rem; }
 }
 @media (min-width: 769px) {
   .ban-cards { display: none; }


### PR DESCRIPTION
## Summary

- Filter chip row used `.scroll-x` (horizontal scroll) on mobile; the #1124 Slice 7 brief specified flex-wrap.
- Override `.scroll-x` inside the existing `<=768px` media query: `overflow-x: visible; flex-wrap: wrap; row-gap: 0.5rem`. Desktop (>=769px) keeps the original horizontal-scroll affordance unchanged.
- Tighten `web/tests/e2e/specs/responsive/banlist.spec.ts` to assert the chip container has no internal horizontal scroll (`scrollWidth <= clientWidth + 1`), and rewrite the file-level "Divergence from the issue's literal text" note now that wrap matches the brief.
- Refresh stale `.scroll-x` references in `web/tests/e2e/specs/responsive/filters.spec.ts` so the doc-comments match the code.

The change is CSS-only on the implementation side — `page_bans.tpl` keeps the `flex items-center gap-2 mt-2 scroll-x` class chain (also reused on `page_comms.tpl`), and the same wrap behavior now applies to the comms page's quick-filters chip row consistently.

The `#1180` topbar overflow note is preserved in the spec header — that's a separate chrome-layout regression and out of scope.

Closes #1181.

## Test plan

- [ ] Playwright responsive banlist spec passes the tightened `scrollWidth <= clientWidth + 1` assertion.
- [ ] Playwright responsive filter spec still clicks every chip on mobile.