### PR TITLE
fix(theme): platform-aware ⌘K palette hint (#1184)

### DIFF
--- a/web/themes/default/box_admin_admins_search.tpl
+++ b/web/themes/default/box_admin_admins_search.tpl
@@ -226,7 +226,7 @@
                     {/foreach}
                 </select>
             </div>
-            <div class="text-xs text-muted">Hold Ctrl / &#8984; to multi-select. Submits the current selection as a comma-joined list of <code>ADMIN_*</code> constant names.</div>
+            <div class="text-xs text-muted">Hold <kbd data-modkey>Ctrl</kbd> to multi-select. Submits the current selection as a comma-joined list of <code>ADMIN_*</code> constant names.</div>
             <button type="submit"
                     class="btn btn--secondary btn--sm"
                     data-testid="search-admins-submit-admwebflag"
@@ -251,7 +251,7 @@
                     {/foreach}
                 </select>
             </div>
-            <div class="text-xs text-muted">Hold Ctrl / &#8984; to multi-select. Submits the current selection as a comma-joined list of <code>SM_*</code> constant names.</div>
+            <div class="text-xs text-muted">Hold <kbd data-modkey>Ctrl</kbd> to multi-select. Submits the current selection as a comma-joined list of <code>SM_*</code> constant names.</div>
             <button type="submit"
                     class="btn btn--secondary btn--sm"
                     data-testid="search-admins-submit-admsrvflag"

--- a/web/themes/default/core/title.tpl
+++ b/web/themes/default/core/title.tpl
@@ -48,7 +48,12 @@
                 aria-label="Open command palette (search players, SteamIDs, pages)">
             <i data-lucide="search" style="width:14px;height:14px"></i>
             <span>Search players, SteamIDs…</span>
-            <kbd>&#8984;K</kbd>
+            {* The U+2318 ⌘ glyph is missing from the vendored JetBrains Mono
+               and the generic CSS mono fallback on every non-Mac browser, so
+               a server-rendered '⌘K' renders as tofu for the majority of users
+               (#1184). Render the Ctrl form here and let theme.js upgrade
+               Mac/iOS clients to '⌘K' at boot. *}
+            <kbd>Ctrl K</kbd>
         </button>
 
         <button type="button"

--- a/web/themes/default/js/theme.js
+++ b/web/themes/default/js/theme.js
@@ -591,4 +591,27 @@
   const initIcons = () => { if (window.lucide) window.lucide.createIcons(); };
   if (document.readyState !== 'loading') initIcons();
   else document.addEventListener('DOMContentLoaded', initIcons);
+
+  // ---- PLATFORM-AWARE SHORTCUT HINTS -----------------------
+  // The Cmd glyph (U+2318 ⌘) is missing from the vendored JetBrains Mono
+  // and the generic CSS mono fallback on every non-Mac browser, so a
+  // server-rendered '⌘' renders as tofu for the majority of users
+  // (#1184). Templates render the Ctrl form server-side; on macOS /
+  // iOS, swap the visible label to the Cmd form here at boot. The
+  // shortcut handler at line ~112 already accepts metaKey || ctrlKey,
+  // so behavior is platform-correct regardless of the visible hint.
+  /** @returns {void} */
+  function applyPlatformHints() {
+    const isMac = /Mac|iPhone|iPad/.test(navigator.userAgent)
+      || navigator.platform.toUpperCase().includes('MAC');
+    if (!isMac) return;
+    document.querySelectorAll('.topbar__search kbd').forEach((/** @type {Element} */ el) => {
+      el.textContent = '\u2318K';
+    });
+    document.querySelectorAll('[data-modkey]').forEach((/** @type {Element} */ el) => {
+      el.textContent = '\u2318';
+    });
+  }
+  if (document.readyState !== 'loading') applyPlatformHints();
+  else document.addEventListener('DOMContentLoaded', applyPlatformHints);
 })();


### PR DESCRIPTION
## Summary

- Topbar search hint hard-coded `&#8984;K` (U+2318) in `core/title.tpl`. The vendored JetBrains Mono and the generic CSS mono fallback chain don't include U+2318 on Linux/Windows Chromium, so it rendered as tofu for the majority of users.
- Render `Ctrl K` server-side; `theme.js` upgrades Mac/iOS clients to `⌘K` at boot via `navigator.platform` / `navigator.userAgent` sniffing.
- Same treatment for the two `Hold Ctrl / ⌘ to multi-select` hints in `box_admin_admins_search.tpl` (selecting multi-select option keys uses Cmd-click on macOS and Ctrl-click elsewhere). Server now renders `<kbd data-modkey>Ctrl</kbd>`; the same JS pass swaps the textContent to `⌘` on Mac. Note that the Mac form is the *correct* modifier on macOS; the previous `Ctrl / ⌘` was both informational and tofu-prone.
- The shortcut handler at `theme.js:112` already accepts `metaKey || ctrlKey`, so binding behavior was always platform-correct. Only the visible hint was wrong.

## Design choice

Server-render `Ctrl K`, JS upgrades Macs to `⌘K` at boot — strictly improves the FOUC story for the non-Mac majority (no tofu flash before JS runs); Mac users see `Ctrl K` for ~one paint, then JS swaps to `⌘K`. The alternative (server-render `⌘K`, JS downgrades non-Macs) would have the broken-glyph flash visible to most users, so we picked this direction per the issue prompt.

## Files

- `web/themes/default/core/title.tpl` — `&#8984;K` → `Ctrl K` with a Smarty comment explaining why.
- `web/themes/default/box_admin_admins_search.tpl` — `Hold Ctrl / &#8984;` → `Hold <kbd data-modkey>Ctrl</kbd>` (×2).
- `web/themes/default/js/theme.js` — new `applyPlatformHints()` runs on DOMContentLoaded, swaps `.topbar__search kbd` and `[data-modkey]` text content for Mac/iOS clients. `// @ts-check` + JSDoc.

Closes #1184.

## Test plan

- [ ] Manual: hint reads `Ctrl K` on Linux Chromium / Windows Chromium / Firefox.
- [ ] Manual: hint reads `⌘K` on macOS Safari / Chrome.
- [ ] Manual: admin search page (`?p=admin&c=admins`) shows `Hold Ctrl to multi-select` on non-Mac, `Hold ⌘ to multi-select` on Mac.
- [ ] CI: ts-check (`tsc --checkJs` over the new JSDoc-annotated function).
- [ ] CI: E2E command palette spec (Meta+K still triggers the palette, regardless of visible hint).