### PR TITLE
fix(page.submit): replace dead ShowBox() with toast (#1176)

### DIFF
--- a/web/pages/page.submit.php
+++ b/web/pages/page.submit.php
@@ -28,8 +28,70 @@ if (!defined("IN_SB")) {
     echo "You should not be here. Only follow links!";
     die();
 }
+
+/**
+ * Emits an inline `<script>` that surfaces a toast via
+ * `window.SBPP.showToast` (theme.js) on the current response, with
+ * `sb.message.*` (sb.js) as a fallback. Replaces the v1.x-era
+ * `<script>ShowBox(…)</script>` calls — `ShowBox` shipped in
+ * `web/scripts/sourcebans.js`, which was deleted in #1123 D1 / #1160,
+ * so the legacy callsite throws ReferenceError and silently swallows
+ * the message in the sbpp2026 chrome (#1176).
+ *
+ * No redirect: the submit page re-renders its own form on the same URL
+ * (validation-error replay or post-success reset to empty values), so
+ * the toast fires inline on whichever response the browser is already
+ * loading. The helper waits for `DOMContentLoaded` before calling
+ * `window.SBPP.showToast` because page handlers emit this `<script>`
+ * mid-body, before `core/footer.tpl` includes `theme.js` — the IIFE
+ * runs synchronously during parse, when `window.SBPP` is still
+ * undefined.
+ *
+ * `$kind` is one of `'info' | 'success' | 'warn' | 'error'`, matching
+ * the `ToastOpts.kind` typedef in `web/themes/default/js/theme.js`.
+ *
+ * Strings are JSON-encoded with the same flag set as the canonical
+ * helper in `web/pages/admin.edit.ban.php` so embedded quotes /
+ * newlines / non-ASCII bytes survive the round-trip into the script
+ * body without further escaping.
+ */
+function emitSubmitToast(string $kind, string $title, string $body): void
+{
+    $flags = JSON_THROW_ON_ERROR | JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT;
+    $kindJs = json_encode($kind, $flags);
+    $titleJs = json_encode($title, $flags);
+    $bodyJs = json_encode($body, $flags);
+    echo <<<HTML
+<script>
+(function () {
+    var kind = {$kindJs};
+    var title = {$titleJs};
+    var body = {$bodyJs};
+    function show() {
+        var SBPP = window.SBPP;
+        if (SBPP && typeof SBPP.showToast === 'function') {
+            SBPP.showToast({ kind: kind, title: title, body: body });
+            return;
+        }
+        if (window.sb && window.sb.message) {
+            var fn = (kind === 'error') ? window.sb.message.error
+                : (kind === 'success') ? window.sb.message.success
+                : window.sb.message.info;
+            if (typeof fn === 'function') fn(title, body || '');
+        }
+    }
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', show);
+    } else {
+        show();
+    }
+})();
+</script>
+HTML;
+}
+
 if (!Config::getBool('config.enablesubmit')) {
-    print "<script>ShowBox('Error', 'This page is disabled. You should not be here.', 'red');</script>";
+    emitSubmitToast('error', 'Submissions disabled', 'This page is disabled. You should not be here.');
     PageDie();
 }
 if (!isset($_POST['subban']) || $_POST['subban'] != 1) {
@@ -90,7 +152,15 @@ if (!isset($_POST['subban']) || $_POST['subban'] != 1) {
 
 
     if (!$validsubmit) {
-        print "<script>ShowBox('Error', '$errors', 'red');</script>";
+        // Validation errors are accumulated as `* msg<br>` HTML
+        // fragments (legacy ShowBox markup). Convert <br> separators
+        // to plain spaces so the toast `body` (rendered as text via
+        // theme.js's escapeHtml) reads as a single line per error.
+        emitSubmitToast(
+            'error',
+            'Please fix the following',
+            (string) preg_replace('#<br\s*/?>#i', ' ', $errors)
+        );
     }
 
     if ($validsubmit) {
@@ -186,9 +256,17 @@ if (!isset($_POST['subban']) || $_POST['subban'] != 1) {
                 ]);
             }
 
-            print "<script>ShowBox('Successful', 'Your submission has been added into the database, and will be reviewed by one of our admins.', 'green');</script>";
+            emitSubmitToast(
+                'success',
+                'Submitted',
+                'Your submission has been added into the database, and will be reviewed by one of our admins.'
+            );
         } else {
-            print "<script>ShowBox('Error', 'There was an error uploading your demo to the server. Please try again later.', 'red');</script>";
+            emitSubmitToast(
+                'error',
+                'Upload failed',
+                'There was an error uploading your demo to the server. Please try again later.'
+            );
             Log::add("e", "Demo Upload Failed", "A demo failed to upload for a submission from ($Email)");
         }
     }

--- a/web/tests/e2e/specs/flows/public-ban-submission.spec.ts
+++ b/web/tests/e2e/specs/flows/public-ban-submission.spec.ts
@@ -42,17 +42,16 @@
  *     drives that real flow end-to-end via the UI; it does not
  *     introduce a new `row-action-approve` testid.
  *
- *   - The page handler `web/pages/page.submit.php` still emits
- *     `print "<script>ShowBox('Successful', …)</script>"` on success,
- *     but `ShowBox` was deleted in #1123 D1 (it lived in
- *     `web/scripts/sourcebans.js`). The script tag therefore fires a
- *     ReferenceError and no visible "thank you" toast lands in the
- *     sbpp2026 chrome. The deterministic terminal state we anchor on
- *     instead is the form-reset behaviour of page.submit.php (every
- *     captured POST value is set to `""` before re-rendering on
- *     success), so the BanReason textarea round-trips to empty. We
- *     flag this in the PR body so the missing visible feedback gets
- *     a follow-up; it doesn't block this slice's contract.
+ *   - The deterministic terminal state we anchor on for a successful
+ *     submission is the form-reset behaviour of page.submit.php
+ *     (every captured POST value is set to `""` before re-rendering
+ *     on success), so the BanReason textarea round-trips to empty.
+ *     The handler also emits a success toast via
+ *     `window.SBPP.showToast` (#1176 replaced the dead `ShowBox(...)`
+ *     callsite that ate it before this slice landed), but the toast
+ *     is animated chrome that races with the navigation, not server
+ *     state — the form-reset anchor stays the deterministic hook
+ *     even now that the toast lands.
  *
  *   - The inline ban-from-submission handler in
  *     `page_admin_bans_submissions.tpl` originally referenced the


### PR DESCRIPTION
## Summary

- `web/pages/page.submit.php` was still emitting four legacy `<script>ShowBox(...)</script>` lines (success + three error branches). `ShowBox` was deleted in #1123 D1 / #1160 along with the rest of `web/scripts/sourcebans.js`, so each callsite fired a `ReferenceError` in the sbpp2026 chrome and silently swallowed its message — anonymous submitters never saw a "thank you" toast on success.
- Add a small `emitSubmitToast()` helper in `page.submit.php` modelled on `admin.edit.ban.php`'s canonical `emitEditBanToastAndRedirect` (no redirect since the submit page re-renders its own form on the next response). The helper guards on `DOMContentLoaded` so `window.SBPP` is wired up by `core/footer.tpl`'s `theme.js` before `show()` runs.
- Replace all four `ShowBox(...)` callsites with the new helper. The validation-error path runs the legacy `<br>`-separated message string through `preg_replace` so the toast `body` (rendered as text via `theme.js`'s `escapeHtml`) reads as a single line per error.
- Tighten the `public-ban-submission` spec comment: the form-reset anchor remains the deterministic hook, but the "follow-up needed" footnote is obsolete now that the toast lands.

Closes #1176.
Refs #1124 Slice 3 (#1175).

## Out of scope

Per the issue's scoping note, **only** `page.submit.php` is touched here. Other live `ShowBox(` callsites surfaced by the audit grep that need their own focused PRs:

- `web/pages/page.login.php`, `page.lostpassword.php`, `page.home.php`, `page.banlist.php`, `page.commslist.php`, `page.protest.php`
- `web/pages/admin.edit.admingroup.php`, `admin.edit.admindetails.php`, `admin.edit.server.php`, `admin.edit.mod.php`, `admin.edit.comms.php`, `admin.settings.php`
- `web/themes/default/page_login.tpl`, `page_admin_overrides.tpl`
- `web/includes/View/LostPasswordView.php`

Excluded from the audit (intentionally untouched):

- `web/install/template/page.{1..6}.php` + `web/install/scripts/sourcebans.js` — legacy installer wizard, `AGENTS.md` says don't extend it.
- `web/pages/admin.edit.ban.php` — only mentions `ShowBox` in commentary documenting the v1.x → v2.0.0 transition.

## Test plan

- [ ] Manual repro: submit a ban request anonymously, observe the success toast lands instead of a `ReferenceError` in the console.
- [ ] Manual repro of each error branch: disabled submissions, missing required fields, demo upload failure — each surfaces a toast with the correct title/body.
- [ ] Playwright Slice 3 spec (`flows/public-ban-submission.spec.ts`) still passes — its form-reset anchor is unchanged.
- [ ] `phpstan` / `ts-check` / API contract green via CI.