### PR TITLE
fix(dashboard): cards collapse on narrow viewports (#1188)

### DIFF
--- a/web/themes/default/page_dashboard.tpl
+++ b/web/themes/default/page_dashboard.tpl
@@ -82,8 +82,8 @@
 
     </div>
 
-    {* -- Recent bans + Servers (2-col) -------------------------------- *}
-    <div class="grid gap-4" style="grid-template-columns:minmax(0,2fr) minmax(0,1fr)">
+    {* -- Recent bans + Servers (2-col on desktop, collapses to 1-col below ~320px+gap per card; #1188) *}
+    <div class="grid gap-4" style="grid-template-columns:repeat(auto-fit,minmax(min(100%,320px),1fr))">
 
         <section class="card" data-testid="dashboard-recent-bans">
             <div class="card__header">


### PR DESCRIPTION
## Summary

- Dashboard cards grid locked to 2 columns below 768px, squashing card content on iPhone-13 (390px).
- Switch to `repeat(auto-fit, minmax(min(100%, 320px), 1fr))` so the grid collapses to 1 column when the viewport can't fit two 320px cards.

Closes #1188.

## Test plan

- [ ] Manual @ 390px: cards stack 1-up; "View all →" no longer wraps.
- [ ] Manual @ 1280px: cards stay 2-up.