### PR TITLE
fix(admin/bans): chip-row filter on protests/submissions (#1187)

### DIFF
--- a/web/pages/admin.bans.php
+++ b/web/pages/admin.bans.php
@@ -133,17 +133,17 @@ echo '</div>';
 
 // Protests
 echo '<div class="tabcontent" id="Ban protests">';
-echo '<div id="tabsWrapper" style="margin:0px;">
-    <div id="tabs">
-	<ul>
-		<li id="utab-p0" class="active">
-			<a href="index.php?p=admin&c=bans#^1~p0" id="admin_utab_p0" onclick="Swap2ndPane(0,\'p\');" class="tip" title="Show Protests :: Show current protests." target="_self">Current</a>
-		</li>
-		<li id="utab-p1" class="nonactive">
-			<a href="index.php?p=admin&c=bans#^1~p1" id="admin_utab_p1" onclick="Swap2ndPane(1,\'p\');" class="tip" title="Show Archive :: Show the protest archive." target="_self">Archive</a>
-		</li>
-	</ul>
-	</div>
+// Current/Archive segmented control. v1.x emitted a <ul><li> styled by
+// the (now-removed) #tabsWrapper / .nonactive CSS pair (#1124, #1187);
+// the v2.0.0 sweep deleted those rules but kept the bullet markup, so
+// it was rendering as a browser-default disc list. Re-skinned as a
+// .chip-row matching banlist/comms/audit; `data-active="true"` is the
+// #1123 testability hook. The legacy id="admin_utab_p*" + onclick=
+// Swap2ndPane attribute is kept verbatim so any caller that re-supplies
+// that helper (or sb.tabs.init() reading the URL anchor) keeps working.
+echo '<div class="chip-row" role="tablist" aria-label="Protest archive filter" data-testid="protests-archive-tabs" style="margin-bottom:0.75rem">
+		<a class="chip" id="admin_utab_p0" data-active="true" data-testid="filter-chip-protests-current" role="tab" aria-selected="true" aria-controls="p0" href="index.php?p=admin&c=bans#^1~p0" onclick="Swap2ndPane(0,\'p\');" title="Show current protests">Current</a>
+		<a class="chip" id="admin_utab_p1" data-active="false" data-testid="filter-chip-protests-archive" role="tab" aria-selected="false" aria-controls="p1" href="index.php?p=admin&c=bans#^1~p1" onclick="Swap2ndPane(1,\'p\');" title="Show the protest archive">Archive</a>
 	</div>';
 // current protests
 echo '<div id="p0">';
@@ -466,17 +466,13 @@ echo '</div>';
 
 //Submissions page
 echo '<div class="tabcontent" id="Ban submissions">';
-echo '<div id="tabsWrapper" style="margin:0px;">
-    <div id="tabs">
-	<ul>
-		<li id="utab-s0" class="active">
-			<a href="index.php?p=admin&c=bans#^2~s0" id="admin_utab_s0" onclick="Swap2ndPane(0,\'s\');" class="tip" title="Show Submissions :: Show current submissions." target="_self">Current</a>
-		</li>
-		<li id="utab-s1" class="nonactive">
-			<a href="index.php?p=admin&c=bans#^2~s1" id="admin_utab_s1" onclick="Swap2ndPane(1,\'s\');" class="tip" title="Show Archive :: Show the submission archive." target="_self">Archive</a>
-		</li>
-	</ul>
-	</div>
+// Same Current/Archive segmented control as the protests block above —
+// see the comment on the protests echo for the bullet-list backstory
+// (#1124, #1187). Aria/testid hooks are scoped with `submissions-` so
+// e2e specs can target each filter row independently.
+echo '<div class="chip-row" role="tablist" aria-label="Submission archive filter" data-testid="submissions-archive-tabs" style="margin-bottom:0.75rem">
+		<a class="chip" id="admin_utab_s0" data-active="true" data-testid="filter-chip-submissions-current" role="tab" aria-selected="true" aria-controls="s0" href="index.php?p=admin&c=bans#^2~s0" onclick="Swap2ndPane(0,\'s\');" title="Show current submissions">Current</a>
+		<a class="chip" id="admin_utab_s1" data-active="false" data-testid="filter-chip-submissions-archive" role="tab" aria-selected="false" aria-controls="s1" href="index.php?p=admin&c=bans#^2~s1" onclick="Swap2ndPane(1,\'s\');" title="Show the submission archive">Archive</a>
 	</div>';
 echo '<div id="s0">'; // current submissions
 $ItemsPerPage = SB_BANS_PER_PAGE;

--- a/web/themes/default/css/theme.css
+++ b/web/themes/default/css/theme.css
@@ -230,11 +230,18 @@ html.dark .pill--online    { color: #6ee7b7; }
   height: 1.75rem; border-radius: var(--radius-full); border: 1px solid var(--border);
   background: var(--bg-surface); color: var(--text-muted);
   font-size: var(--fs-xs); font-weight: 500; transition: background-color .15s, color .15s;
+  text-decoration: none;
 }
 .chip:hover { background: var(--bg-muted); color: var(--text); }
-.chip[aria-pressed="true"] { background: var(--zinc-900); color: white; border-color: var(--zinc-900); }
-html.dark .chip[aria-pressed="true"] { background: var(--zinc-100); color: var(--zinc-900); border-color: var(--zinc-100); }
+.chip[aria-pressed="true"],
+.chip[data-active="true"] { background: var(--zinc-900); color: white; border-color: var(--zinc-900); }
+html.dark .chip[aria-pressed="true"],
+html.dark .chip[data-active="true"] { background: var(--zinc-100); color: var(--zinc-900); border-color: var(--zinc-100); }
 .chip__dot { width: 0.375rem; height: 0.375rem; border-radius: 50%; }
+/* Segmented chip group (e.g. admin/bans Current/Archive). The chips
+   inside inherit `.chip` styling; this just lays them out and gives
+   the row a consistent gap so it doesn't collapse onto the heading. */
+.chip-row { display: inline-flex; align-items: center; gap: 0.5rem; flex-wrap: wrap; }
 
 /* ---- Table ---- */
 .table { width: 100%; font-size: var(--fs-base); border-collapse: collapse; }


### PR DESCRIPTION
## Summary

- Protests + Submissions filter widget rendered as `<ul><li>` with browser-default disc bullets — v1.x relied on `#tabsWrapper` / `.nonactive` CSS that the v2.0.0 theme sweep deleted (#1124) but the markup itself kept shipping.
- Replace each block with the `.chip-row` + `.chip` pattern used by banlist/comms/audit; mark the active filter with `[data-active=\"true\"]` so the #1123 testability hooks latch on.
- CSS: tiny `.chip-row` rule + `.chip[data-active=\"true\"]` selector layered onto the existing `.chip[aria-pressed=\"true\"]` style; `text-decoration:none` so anchor-form chips render without underline.
- Legacy `id=\"admin_utab_p*\"` ids and `onclick=\"Swap2ndPane(...)\"` attributes are preserved so `sb.tabs.init()`'s URL-anchor reader stays wired up if/when that helper returns.

Closes #1187. Refs #1124.

## Test plan

- [ ] Manual: \`?p=admin&c=bans\` — protests + submissions tabs each render a single chip row with the active chip highlighted (no disc bullets).
- [ ] Manual: dark mode flips the active chip's contrast colours correctly.
- [ ] CI: PHPStan, Playwright a11y (no new critical violations expected — \`addban-section\` smoke selector is unchanged), api-contract noop.