### PR TITLE
fix(admin): active-state on admin tabs; demote Back (#1186)

### DIFF
--- a/web/includes/AdminTabs.php
+++ b/web/includes/AdminTabs.php
@@ -2,6 +2,18 @@
 
 /**
  * Class AdminTabs
+ *
+ * Renders the intra-page section nav (`core/admin_tabs.tpl`) used by
+ * `?p=admin&c=bans`, `?p=admin&c=admins`, `?p=admin&c=groups`, and the
+ * edit.* pages (which pass an empty `$tabs` array so only the Back
+ * link renders).
+ *
+ * The optional `$activeTab` argument decides which tab gets
+ * `aria-current="page"` (and the matching active-state styling). Pages
+ * may pass it explicitly when they track the visible section (e.g.
+ * via `?tab=…`); otherwise the first accessible tab is treated as
+ * active so the strip never renders as an undifferentiated row of
+ * identical buttons (#1186).
  */
 class AdminTabs
 {
@@ -13,8 +25,13 @@ class AdminTabs
      * @param array        $tabs
      * @param CUserManager $userbank
      * @param Smarty       $theme
+     * @param string|null  $activeTab Name of the tab to mark with
+     *     `aria-current="page"`. When null, the first accessible tab
+     *     wins. When the string doesn't match any visible tab no tab
+     *     is marked active (and the strip falls back to its inactive
+     *     look — still better than every tab looking identical).
      */
-    public function __construct(array $tabs, $userbank, $theme)
+    public function __construct(array $tabs, $userbank, $theme, ?string $activeTab = null)
     {
         foreach ($tabs as $tab) {
             if ($userbank->HasAccess($tab['permission'])) {
@@ -24,7 +41,15 @@ class AdminTabs
             }
         }
 
+        $resolvedActive = '';
+        if ($activeTab !== null && $activeTab !== '') {
+            $resolvedActive = $activeTab;
+        } elseif (isset($this->tabs[0]['name']) && is_scalar($this->tabs[0]['name'])) {
+            $resolvedActive = (string) $this->tabs[0]['name'];
+        }
+
         $theme->assign('tabs', $this->tabs);
+        $theme->assign('active_tab', $resolvedActive);
         $theme->display('core/admin_tabs.tpl');
     }
 }

--- a/web/phpstan-baseline.neon
+++ b/web/phpstan-baseline.neon
@@ -15,7 +15,7 @@ parameters:
 		-
 			message: '#^Call to method assign\(\) on an unknown class Smarty\.$#'
 			identifier: class.notFound
-			count: 1
+			count: 2
 			path: includes/AdminTabs.php
 
 		-

--- a/web/themes/default/core/admin_tabs.tpl
+++ b/web/themes/default/core/admin_tabs.tpl
@@ -1,14 +1,21 @@
 {*
     SourceBans++ 2026 — chrome / admin_tabs.tpl
 
-    Admin sub-tab bar. Pair: includes/AdminTabs.php (assigns $tabs —
-    same contract as web/themes/default/core/admin_tabs.tpl). Pure
-    visual reskin: same {foreach} over the AdminTabs data the PHP
-    layer already builds, just rendered with the new theme's button
-    primitives.
+    Admin sub-tab bar. Pair: includes/AdminTabs.php (assigns $tabs +
+    $active_tab). Rendered with the theme's button primitives —
+    inactive tabs use `btn--ghost`; the tab whose `name` matches
+    `$active_tab` carries `aria-current="page"` and gets the active
+    treatment via `.admin-tabs > [aria-current="page"]` in theme.css
+    (#1186).
 
     The "openTab(this, '<name>')" handler is defined inline by each
     admin page that uses tabs (legacy convention preserved by AdminTabs.php).
+
+    "Back" is rendered outside the tab cluster (right-aligned via the
+    `.admin-tabs__back` rule) so it no longer reads as a peer tab
+    (#1186). Edit-* pages that pass an empty `$tabs` array still
+    render the Back link standalone — the right-aligned positioning
+    is harmless when no siblings precede it.
 
     A11y note (#1124 Slice 2): the wrapper used to declare
     role="tablist" with role="tab" children. The full ARIA tabs
@@ -23,14 +30,17 @@
     buttons. If a follow-up wires the full tab pattern (controls,
     selected, panel labelling) the roles can come back in lockstep.
 *}
-<div class="admin-tabs flex gap-2 mb-4" aria-label="Admin sections">
+<div class="admin-tabs flex gap-2 mb-4 items-center" aria-label="Admin sections">
     {foreach from=$tabs item=tab}
         <button type="button"
-                class="btn btn--secondary btn--sm"
+                class="btn btn--ghost btn--sm"
                 data-testid="admin-tab-{$tab.name}"
+                {if $tab.name == $active_tab}aria-current="page"{/if}
                 onclick="openTab(this, '{$tab.name}');">{$tab.name}</button>
     {/foreach}
-    <a class="btn btn--ghost btn--sm"
+    <a class="btn btn--ghost btn--sm admin-tabs__back"
        href="javascript:history.go(-1);"
-       data-testid="admin-tab-back">Back</a>
+       data-testid="admin-tab-back">
+        <i data-lucide="arrow-left"></i> Back
+    </a>
 </div>

--- a/web/themes/default/css/theme.css
+++ b/web/themes/default/css/theme.css
@@ -169,6 +169,28 @@ html.dark .btn:hover { background: white; }
 .btn--sm { height: 2rem; padding: 0 0.75rem; font-size: var(--fs-xs); }
 .btn--icon { width: 2.25rem; padding: 0; }
 
+/* ---- Admin sub-tabs (intra-page section nav) ----
+   Pair: web/includes/AdminTabs.php +
+   web/themes/default/core/admin_tabs.tpl. The active tab carries
+   aria-current="page" (set by the template when $tab.name ==
+   $active_tab); the rule below underlines + bolds it so the strip
+   no longer reads as an undifferentiated row of buttons (#1186).
+   The selector intentionally targets any direct child carrying the
+   attribute so it works for both <button> tabs (this template) and
+   <a> tabs (page_admin_edit_admins_*.tpl) without per-element
+   scoping. ".admin-tabs__back" pushes the Back link to the right
+   edge so it visibly separates from the tab cluster. */
+.admin-tabs > [aria-current="page"] {
+  background: var(--bg-surface);
+  color: var(--text);
+  border-bottom: 2px solid var(--brand-600);
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: 0;
+  font-weight: 600;
+}
+html.dark .admin-tabs > [aria-current="page"] { border-bottom-color: var(--brand-500); }
+.admin-tabs__back { margin-left: auto; }
+
 /* ---- Inputs ---- */
 .input, .select, .textarea {
   width: 100%; height: 2.25rem; padding: 0 0.75rem;


### PR DESCRIPTION
## Summary

- Mark current admin tab with `aria-current="page"` (theme.css adds bg-surface, underline, and bold). Inactive tabs switch to `btn--ghost` so the active state contrasts visibly.
- Break the Back link out of the tab cluster — render it right-aligned via `.admin-tabs__back { margin-left: auto; }` and prefix with a lucide `arrow-left` glyph so it visibly reads as a "back to admin home" affordance, not a peer tab.
- `AdminTabs.php` now accepts an optional `activeTab` argument; pages that track which sub-section is visible can pass it. When omitted (current behaviour for every caller) the first accessible tab wins so `?p=admin&c=bans|admins|groups` never renders as an undifferentiated row of identical buttons.

`core/admin_tabs.tpl` is rendered directly through `\$theme->display()` (not via a `Sbpp\View` DTO), so no SmartyTemplateRule contract / View change is needed; the new `\$active_tab` is assigned by `AdminTabs.php` alongside `\$tabs`.

Closes #1186. Refs #1124.

## Test plan

- [ ] Visit `?p=admin&c=bans`, `?p=admin&c=admins`, `?p=admin&c=groups`; the first accessible tab is visually distinct (background, bold, brand-coloured underline) in both light and dark mode.
- [ ] On those pages, Back is no longer adjacent to the tab siblings — it sits at the right edge with the ghost button look + arrow glyph.
- [ ] Edit-* pages (`admin.edit.ban.php`, `admin.edit.admindetails.php`, …) still render the standalone Back link unchanged.
- [ ] axe-core (Playwright) still passes — the active-state attribute change is `aria-current="page"` (already an allowed pattern in this theme; sidebar links use the same).