### PR TITLE
fix(theme): styled file-input wrapper (#1189)

### DIFF
--- a/web/themes/default/css/theme.css
+++ b/web/themes/default/css/theme.css
@@ -195,6 +195,11 @@ html.dark .btn:hover { background: white; }
 .textarea { height: auto; padding: 0.625rem 0.75rem; resize: vertical; min-height: 5rem; }
 .input--with-icon { padding-left: 2rem; }
 
+/* File-input wrapper (#1189). The native button is hidden via `hidden`
+   on the <input>; the styled <label class="btn btn--secondary"> is the
+   click target, and the sibling span mirrors the chosen filename. */
+.file-input { display: flex; align-items: center; gap: 0.5rem; flex-wrap: wrap; }
+
 .label { display: block; font-size: var(--fs-xs); font-weight: 500; color: var(--text); margin-bottom: 0.375rem; }
 
 /* ---- Card ---- */

--- a/web/themes/default/js/theme.js
+++ b/web/themes/default/js/theme.js
@@ -518,6 +518,32 @@
     showToast({ kind: 'success', title: 'Copied to clipboard' });
   });
 
+  // ---- FILE INPUTS -----------------------------------------
+  // Native <input type="file"> ships an unstyleable user-agent button
+  // that pops out of the panel's design language (#1189). Each callsite
+  // wraps the input in:
+  //   <div class="file-input">
+  //     <label class="btn btn--secondary">
+  //       <input type="file" name="…" hidden data-file-input>
+  //       Choose file…
+  //     </label>
+  //     <span class="text-muted text-sm" data-file-name>No file chosen</span>
+  //   </div>
+  // The label-wraps-input pattern preserves native click-through to the
+  // file picker; this delegated listener just mirrors the chosen
+  // filename into the sibling span so the user sees what they picked.
+  document.addEventListener('change', (/** @type {Event} */ e) => {
+    const target = e.target;
+    if (!(target instanceof HTMLInputElement)) return;
+    if (target.type !== 'file' || !target.matches('[data-file-input]')) return;
+    const lbl = target.closest('label');
+    const wrap = lbl && lbl.parentElement;
+    const span = wrap && wrap.querySelector('[data-file-name]');
+    if (!span) return;
+    const file = target.files && target.files[0];
+    span.textContent = file ? file.name : 'No file chosen';
+  });
+
   // ---- TOASTS ----------------------------------------------
   /**
    * @typedef {Object} ToastOpts

--- a/web/themes/default/page_admin_bans_import.tpl
+++ b/web/themes/default/page_admin_bans_import.tpl
@@ -40,14 +40,21 @@
 
             <div>
                 <label class="label" for="importFile">Ban file</label>
-                <input type="file"
-                       class="input"
-                       id="importFile"
-                       name="importFile"
-                       accept=".cfg,.txt"
-                       required
-                       data-testid="banimport-file"
-                       style="padding:0.375rem 0.5rem">
+                <div class="file-input">
+                    <label class="btn btn--secondary">
+                        <input type="file"
+                               id="importFile"
+                               name="importFile"
+                               accept=".cfg,.txt"
+                               required
+                               data-testid="banimport-file"
+                               data-file-input
+                               hidden>
+                        <i data-lucide="upload" style="width:14px;height:14px"></i>
+                        Choose file&hellip;
+                    </label>
+                    <span class="text-muted text-sm" data-file-name>No file chosen</span>
+                </div>
                 <div class="text-xs mt-2" id="file.msg" style="color:var(--danger);display:none"></div>
             </div>
 

--- a/web/themes/default/page_submitban.tpl
+++ b/web/themes/default/page_submitban.tpl
@@ -175,12 +175,20 @@
 
             <div>
                 <label class="label" for="submitban-demo">Upload demo or evidence</label>
-                <input type="file"
-                       class="input"
-                       id="submitban-demo"
-                       name="demo_file"
-                       accept=".dem,.zip,.rar,.7z,.bz2,.gz"
-                       data-testid="submitban-demo">
+                <div class="file-input">
+                    <label class="btn btn--secondary">
+                        <input type="file"
+                               id="submitban-demo"
+                               name="demo_file"
+                               accept=".dem,.zip,.rar,.7z,.bz2,.gz"
+                               data-testid="submitban-demo"
+                               data-file-input
+                               hidden>
+                        <i data-lucide="upload" style="width:14px;height:14px"></i>
+                        Choose file&hellip;
+                    </label>
+                    <span class="text-muted text-sm" data-file-name>No file chosen</span>
+                </div>
                 <p class="text-xs text-muted m-0 mt-2">
                     Optional. Allowed formats: <code class="font-mono">.dem</code>,
                     <code class="font-mono">.zip</code>, <code class="font-mono">.rar</code>,

--- a/web/themes/default/page_uploadfile.tpl
+++ b/web/themes/default/page_uploadfile.tpl
@@ -51,12 +51,19 @@
             <input type="hidden" name="upload" value="1">
 
             <label class="label" for="uploadfile-input">Select file</label>
-            <input type="file"
-                   id="uploadfile-input"
-                   class="input"
-                   name="{$input_name}"
-                   data-testid="uploadfile-input"
-                   required>
+            <div class="file-input">
+                <label class="btn btn--secondary">
+                    <input type="file"
+                           id="uploadfile-input"
+                           name="{$input_name}"
+                           data-testid="uploadfile-input"
+                           data-file-input
+                           required
+                           hidden>
+                    Choose file&hellip;
+                </label>
+                <span class="text-muted text-sm" data-file-name>No file chosen</span>
+            </div>
 
             <div style="margin-top:0.75rem;display:flex;justify-content:flex-end">
                 <button type="submit"
@@ -68,5 +75,21 @@
         </form>
     </div>
 </div>
+{* Popup window has no theme.js (only theme.css), so the filename mirror runs inline. *}
+<script>
+(function () {
+    document.addEventListener('change', function (e) {
+        var t = e.target;
+        if (!t || !(t instanceof HTMLInputElement)) return;
+        if (t.type !== 'file' || !t.matches('[data-file-input]')) return;
+        var lbl = t.closest('label');
+        var wrap = lbl && lbl.parentElement;
+        var span = wrap && wrap.querySelector('[data-file-name]');
+        if (!span) return;
+        var f = t.files && t.files[0];
+        span.textContent = f ? f.name : 'No file chosen';
+    });
+})();
+</script>
 </body>
 </html>


### PR DESCRIPTION
## Summary

- Wrap every `<input type=\"file\">` in a `.file-input` block with a styled `.btn--secondary` label and filename-mirror span.
- One delegated `change` listener in `theme.js` updates the filename.

Closes #1189.

## Test plan

- [ ] Manual: `?p=admin&c=bans` Import bans → button matches the panel's other CTAs; selecting a file mirrors filename next to it.
- [ ] Form still POSTs (name attribute preserved).