### PR TITLE
fix: routing + truthiness fixes (slice 3 of #1207)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -466,7 +466,8 @@ bearing assertion that the value is already safe HTML, so:
 | Add admin-only per-player notes | `web/api/handlers/notes.php` (CRUD) — Notes tab is gated by `bans.detail`'s `notes_visible` flag |
 | Render admin-authored Markdown to safe HTML | `web/includes/Markup/IntroRenderer.php` (`Sbpp\Markup`) |
 | Bootstrap (paths, autoload, theme)     | `web/init.php`                                           |
-| Routing (`?p=…&c=…&o=…`)               | `web/includes/page-builder.php`                          |
+| Routing (`?p=…&c=…&o=…`)               | `web/includes/page-builder.php` — unrecognised admin `c=…` returns the 404 page slot via `web/pages/page.404.php` + `Sbpp\View\NotFoundView` (#1207 ADM-1) |
+| Resolve the panel version (`SB_VERSION`, `data-version="…"` footer hook) | `web/includes/Version.php` (`Sbpp\Version::resolve()`) — three-tier fallback: `configs/version.json` → `git describe` → the `'dev'` sentinel (#1207 CC-5) |
 | Auth / JWT cookie                      | `web/includes/auth/`                                     |
 | CSRF                                   | `web/includes/security/CSRF.php`                         |
 | Schema                                 | `web/install/includes/sql/struc.sql`                     |

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -139,9 +139,17 @@ Both scripts include `init.php` first, which performs identical bootstrap.
 3. Loads Composer autoload (`includes/vendor/autoload.php`).
 4. Manually requires the auth + security + Database modules (they aren't
    PSR-4 namespaced) and initialises them.
-5. Reads `configs/permissions/web.json` + `sourcemod.json` and `define()`s
+5. Resolves the panel version via `Sbpp\Version::resolve()` — three-tier
+   fallback (release tarball's `configs/version.json` → `git describe`
+   → the `'dev'` sentinel) and `define()`s `SB_VERSION` / `SB_GITREV` /
+   `SB_DEV` from the result. The chrome's `<footer data-version="…">`
+   hook (`web/themes/default/core/footer.tpl`) mirrors `SB_VERSION`
+   verbatim so telemetry and E2E specs can distinguish dev installs
+   (`data-version="dev"`) from release tarball installs without
+   parsing the user-visible string (#1207 CC-5).
+6. Reads `configs/permissions/web.json` + `sourcemod.json` and `define()`s
    each flag as a global PHP constant (`ADMIN_OWNER`, `ADMIN_ADD_BAN`, …).
-6. Constructs the global `$theme` (Smarty) with the configured theme dir,
+7. Constructs the global `$theme` (Smarty) with the configured theme dir,
    registers custom functions (`{csrf_field}`, `{help_icon}`, …), and
    assigns `csrf_token` / `csrf_field_name` so every rendered page has
    them available.
@@ -166,6 +174,12 @@ After `init.php` returns, callers may rely on these globals:
 2. `route(default_page)` reads `?p=` (page), `?c=` (category), `?o=`
    (option) from the query string and returns `[title, page_php_file]`.
    Admin pages also call `CheckAdminAccess(flags)` before returning.
+   An unrecognised admin sub-route (e.g. `?p=admin&c=overrides`,
+   `?p=admin&c=bnas`) returns `['Page not found', '/page.404.php']` and
+   sets `http_response_code(404)` so the chrome still renders around
+   the error message but the HTTP status reflects reality (#1207 ADM-1).
+   The bare admin landing (`?p=admin` with no `c=`) still resolves to
+   the admin home — only *populated*, unrecognised `c=` values 404.
 3. `build(title, page)` includes `pages/core/header.php`,
    `pages/core/navbar.php`, `pages/core/title.php`, then the page file,
    then `pages/core/footer.php`.

--- a/web/includes/Version.php
+++ b/web/includes/Version.php
@@ -1,0 +1,120 @@
+<?php
+declare(strict_types=1);
+
+namespace Sbpp;
+
+/**
+ * Three-tier version resolution for the panel chrome (#1207 CC-5).
+ *
+ * Sources, in order:
+ *
+ *   1. `configs/version.json` — emitted into release tarballs by the
+ *      release pipeline. Self-hosters who installed by unzipping a tarball
+ *      always hit this branch.
+ *   2. `git describe --tags --always` (with `git rev-parse --short HEAD`
+ *      as a sibling) — covers operators running directly off a git
+ *      checkout outside Docker. Returns a tag (e.g. `2.1.0`) when
+ *      HEAD is exactly on one and a `<tag>-<n>-g<sha>` describe string
+ *      otherwise.
+ *   3. The literal sentinel `'dev'` — the third-tier fallback. Surfaces
+ *      when both higher tiers resolved empty: typically the dev docker
+ *      container (no `.git` bind-mount, no `git` binary in the image)
+ *      or any operator running from a non-tarball source where git
+ *      isn't available.
+ *
+ * Pre-#1207 the third tier was the literal `'N/A'`, which read like a
+ * runtime error in the footer and confused operators. `'dev'` is a
+ * self-describing sentinel; the chrome's `<footer data-version="…">`
+ * hook (see `web/themes/default/core/footer.tpl`) lets telemetry and
+ * E2E specs distinguish dev installs from release tarball installs
+ * without parsing the user-visible string.
+ *
+ * Pure helper: no DB, no Smarty. Side-effect-free except for `shell_exec`
+ * to git. The class exists so PHPUnit can lock the fallback contract
+ * without `defined('SB_VERSION')` blowing up against bootstrap-time
+ * constants.
+ */
+final class Version
+{
+    public const DEV_SENTINEL = 'dev';
+
+    /**
+     * Resolve the version triple `[version, git, dev]` exactly the
+     * way `init.php` consumes it for the SB_* constants.
+     *
+     * @param  callable|null $jsonReader  fn(string $path): ?array — defaults to
+     *                                    file_get_contents + json_decode.
+     * @param  callable|null $gitDescribe fn(): string — defaults to shell_exec.
+     * @param  callable|null $gitShortRev fn(): string — defaults to shell_exec.
+     * @return array{version: string, git: int|string, dev: bool}
+     */
+    public static function resolve(
+        string $versionJsonPath,
+        ?callable $jsonReader = null,
+        ?callable $gitDescribe = null,
+        ?callable $gitShortRev = null,
+    ): array {
+        $jsonReader  ??= self::defaultJsonReader();
+        $gitDescribe ??= self::defaultGitDescribe();
+        $gitShortRev ??= self::defaultGitShortRev();
+
+        $tarball = $jsonReader($versionJsonPath);
+        if (is_array($tarball) && isset($tarball['version'])) {
+            return [
+                'version' => (string) $tarball['version'],
+                'git'     => $tarball['git'] ?? 0,
+                'dev'     => (bool) ($tarball['dev'] ?? false),
+            ];
+        }
+
+        $tag = trim($gitDescribe());
+        $sha = trim($gitShortRev());
+        if ($tag !== '' || $sha !== '') {
+            return [
+                'version' => $tag !== '' ? $tag : self::DEV_SENTINEL,
+                'git'     => $sha,
+                'dev'     => true,
+            ];
+        }
+
+        return [
+            'version' => self::DEV_SENTINEL,
+            'git'     => 0,
+            'dev'     => true,
+        ];
+    }
+
+    /**
+     * @return callable(string): ?array<string, mixed>
+     */
+    private static function defaultJsonReader(): callable
+    {
+        return static function (string $path): ?array {
+            if (!is_readable($path)) {
+                return null;
+            }
+            $raw = @file_get_contents($path);
+            if ($raw === false || $raw === '') {
+                return null;
+            }
+            $decoded = @json_decode($raw, true);
+            return is_array($decoded) ? $decoded : null;
+        };
+    }
+
+    /**
+     * @return callable(): string
+     */
+    private static function defaultGitDescribe(): callable
+    {
+        return static fn (): string => (string) @shell_exec('git describe --tags --always 2>/dev/null');
+    }
+
+    /**
+     * @return callable(): string
+     */
+    private static function defaultGitShortRev(): callable
+    {
+        return static fn (): string => (string) @shell_exec('git rev-parse --short HEAD 2>/dev/null');
+    }
+}

--- a/web/includes/View/NotFoundView.php
+++ b/web/includes/View/NotFoundView.php
@@ -1,0 +1,37 @@
+<?php
+declare(strict_types=1);
+
+namespace Sbpp\View;
+
+/**
+ * 404 "page not found" view — binds to `page_404.tpl`.
+ *
+ * Used by `route()` (web/includes/page-builder.php) when the URL
+ * resolves to a sub-route that doesn't exist. Currently the only
+ * caller is the `?p=admin&c=<unknown>` default branch (#1207 ADM-1):
+ * unrecognised `c=…` values used to fall through to the admin home,
+ * which made typos and stale bookmarks invisible. The route now
+ * returns an HTTP 404 status alongside this template so the chrome
+ * still renders (sidebar + topbar + footer) but the page slot is
+ * the error message.
+ *
+ * The chrome itself is intentionally NOT suppressed here — keeping
+ * the sidebar visible lets the user navigate away without a back
+ * button, and the page-builder pipeline (header → navbar → title →
+ * page → footer) is the same shape every other page uses, so
+ * SmartyTemplateRule and the rest of the View DTO contract stay
+ * uniform. The 404 status code goes out via `http_response_code(404)`
+ * in `route()`, so search crawlers and monitoring tools see the
+ * correct signal.
+ *
+ * The View declares no properties: the message is static, so the
+ * template renders without per-request data. The class exists so
+ * the page handler can use `Renderer::render()` instead of an
+ * untyped `$theme->display(...)` call, and so SmartyTemplateRule
+ * guards the template against accidentally growing untyped variable
+ * references in a follow-up.
+ */
+final class NotFoundView extends View
+{
+    public const TEMPLATE = 'page_404.tpl';
+}

--- a/web/includes/page-builder.php
+++ b/web/includes/page-builder.php
@@ -119,6 +119,16 @@ function route($fallback)
                     CheckAdminAccess(ADMIN_OWNER);
                     return ['Audit Log', '/admin.audit.php'];
                 default:
+                    // Unrecognised `c=…` used to silently fall through to
+                    // the admin home (#1207 ADM-1), which made typos and
+                    // stale bookmarks invisible (?p=admin&c=overrides
+                    // looked indistinguishable from ?p=admin). Surface
+                    // them as a 404 instead. The naked admin landing
+                    // (`?p=admin` with no c=) still renders the home.
+                    if ($categorie !== null && $categorie !== '') {
+                        http_response_code(404);
+                        return ['Page not found', '/page.404.php'];
+                    }
                     CheckAdminAccess(ALL_WEB);
                     return ['Administration', '/page.admin.php'];
         }

--- a/web/init.php
+++ b/web/init.php
@@ -79,25 +79,16 @@ require_once(INCLUDES_PATH.'/auth/Host.php');
 require_once(INCLUDES_PATH.'/CUserManager.php');
 require_once(INCLUDES_PATH.'/AdminTabs.php');
 
-$version = is_readable('configs/version.json')
-    ? @json_decode(file_get_contents('configs/version.json'), true)
-    : null;
+// Three-tier version resolution (#1207 CC-5): tarball JSON, git describe,
+// then the literal 'dev' sentinel. See \Sbpp\Version::resolve() for the
+// full rationale; this block just unpacks the result into the constants
+// the chrome and views consume. \Sbpp\Version is PSR-4 autoloaded via
+// composer (Sbpp\\ -> includes/), so no explicit require is needed.
+$version = \Sbpp\Version::resolve(ROOT . 'configs/version.json');
 
-if (!$version) {
-    $tag = trim((string) @shell_exec('git describe --tags --always 2>/dev/null'));
-    $sha = trim((string) @shell_exec('git rev-parse --short HEAD 2>/dev/null'));
-    if ($tag !== '' || $sha !== '') {
-        $version = [
-            'version' => $tag !== '' ? $tag : 'N/A',
-            'git' => $sha,
-            'dev' => true,
-        ];
-    }
-}
-
-define('SB_VERSION', $version['version'] ?? 'N/A');
-define('SB_GITREV', $version['git'] ??  0);
-define('SB_DEV', $version['dev'] ?? false);
+define('SB_VERSION', $version['version']);
+define('SB_GITREV', $version['git']);
+define('SB_DEV', $version['dev']);
 
 // ---------------------------------------------------
 //  Setup our DB

--- a/web/pages/page.404.php
+++ b/web/pages/page.404.php
@@ -1,0 +1,40 @@
+<?php
+/*************************************************************************
+This file is part of SourceBans++
+
+SourceBans++ (c) 2014-2026 by SourceBans++ Dev Team
+
+The SourceBans++ Web panel is licensed under a
+Creative Commons Attribution-NonCommercial-ShareAlike 3.0 Unported License.
+
+You should have received a copy of the license along with this
+work.  If not, see <http://creativecommons.org/licenses/by-nc-sa/3.0/>.
+
+This program is based off work covered by the following copyright(s):
+SourceBans 1.4.11
+Copyright © 2007-2014 SourceBans Team - Part of GameConnect
+Licensed under CC-BY-NC-SA 3.0
+Page: <http://www.sourcebans.net/> - <http://www.gameconnect.net/>
+*************************************************************************/
+
+if (!defined("IN_SB")) {
+    echo "You should not be here. Only follow links!";
+    die();
+}
+
+global $theme;
+
+/*
+ * 404 page (#1207 ADM-1).
+ *
+ * Currently reached only via `route()`'s `?p=admin&c=<unknown>`
+ * branch (web/includes/page-builder.php), but the surface is
+ * deliberately not admin-coupled — any future caller can return
+ * `['Page not found', '/page.404.php']` after `http_response_code(404)`
+ * and the chrome will render around this page slot.
+ *
+ * The HTTP status is set in `route()` (not here) so it lands before
+ * the chrome's header.php emits any output that would otherwise
+ * lock the response code in.
+ */
+\Sbpp\View\Renderer::render($theme, new \Sbpp\View\NotFoundView());

--- a/web/pages/page.lostpassword.php
+++ b/web/pages/page.lostpassword.php
@@ -1,10 +1,21 @@
 <?php
 
-global $theme;
+global $theme, $userbank;
 
 use Sbpp\Mail\EmailType;
 use Sbpp\Mail\Mail;
 use Sbpp\Mail\Mailer;
+
+// Issue #1207 AUTH-1: a user trying to recover their password is by
+// definition logged out, so a logged-in admin (or any authenticated
+// visitor) reaching this URL should be sent home rather than rendering
+// the form with the admin sidebar leaking around it. Mirrors the
+// equivalent guard in page.login.php (which redirects logged-in users
+// to `index.php` so the form is never shown to them either).
+if ($userbank->is_logged_in()) {
+    header('Location: index.php');
+    die();
+}
 
 // Issue #1102: when normal login is disabled the entire password-recovery
 // flow is meaningless (a reset password can't be used to log in), and the

--- a/web/pages/page.lostpassword.php
+++ b/web/pages/page.lostpassword.php
@@ -12,9 +12,22 @@ use Sbpp\Mail\Mailer;
 // the form with the admin sidebar leaking around it. Mirrors the
 // equivalent guard in page.login.php (which redirects logged-in users
 // to `index.php` so the form is never shown to them either).
+//
+// JS redirect rather than `header('Location:')` because this handler
+// runs INSIDE `build()` — `pages/core/header.php`,
+// `pages/core/navbar.php`, and `pages/core/title.php` have already
+// flushed ~9 KB of HTML (including the admin sidebar this guard exists
+// to suppress) by the time we get here. PHP's `header()` is a no-op
+// after output starts, so the redirect would silently fail and the
+// admin chrome leak the audit screenshot caught would still ship —
+// just with the form body missing on top, because `die()` halts
+// rendering mid-page. `page.login.php`'s 200-line-old equivalent
+// guard (`page.login.php:27-30`) uses the same JS redirect for the
+// same reason; mirror it here so the user-observable behaviour is
+// identical to the login surface.
 if ($userbank->is_logged_in()) {
-    header('Location: index.php');
-    die();
+    echo "<script>window.location.href = 'index.php';</script>";
+    exit;
 }
 
 // Issue #1102: when normal login is disabled the entire password-recovery

--- a/web/tests/e2e/specs/smoke/routing-truthiness.spec.ts
+++ b/web/tests/e2e/specs/smoke/routing-truthiness.spec.ts
@@ -157,6 +157,36 @@ test.describe('#1207 routing + truthiness fixes', () => {
         });
     });
 
+    test.describe('AUTH-1: logged-in visitors get bounced off lostpassword', () => {
+        // No storageState override here: this block inherits the
+        // project-default authenticated session minted by
+        // `fixtures/global-setup.ts` for the seeded admin. That's the
+        // exact case the audit screenshot caught — a logged-in admin
+        // landing on `?p=lostpassword` saw the admin sidebar leak
+        // around the form. The page handler's guard mirrors
+        // page.login.php: emit `<script>window.location.href = 'index.php'</script>`
+        // and `exit;`, so the user-observable result is the browser
+        // ends up on the dashboard, not on the form.
+        test('logged-in admin visiting lostpassword does NOT see the form', async ({ page }) => {
+            // The JS redirect fires on `DOMContentLoaded`-ish timing,
+            // but Playwright's default `goto` waits for `load`, by
+            // which point `window.location.href = …` has already run
+            // and the navigation chain has settled on the dashboard.
+            await page.goto('/index.php?p=lostpassword');
+
+            // Terminal assertion: the URL must NOT be lostpassword
+            // anymore. Same shape as `specs/smoke/login.spec.ts`'s
+            // logged-in redirect assertion.
+            await expect(page).not.toHaveURL(/[?&]p=lostpassword(?:&|#|$)/);
+
+            // And the form body must NOT be in the DOM — even if a
+            // future refactor changes the redirect destination, the
+            // user must never reach a state where they can fill in
+            // the lost-password email field while authenticated.
+            await expect(page.locator('[data-testid="lostpw-email"]')).toHaveCount(0);
+        });
+    });
+
     test.describe('CC-5 + CC-6: footer credibility', () => {
         test('footer carries data-version="dev" in the dev stack', async ({ page }) => {
             await page.goto('/');

--- a/web/tests/e2e/specs/smoke/routing-truthiness.spec.ts
+++ b/web/tests/e2e/specs/smoke/routing-truthiness.spec.ts
@@ -1,0 +1,211 @@
+/**
+ * Issue #1207 Slice 3 (routing + truthiness fixes).
+ *
+ * Covers the user-observable invariants for ADM-1, ADM-2, AUTH-1, CC-5,
+ * and CC-6 — i.e. the things the audit screenshots showed and that the
+ * fix was supposed to land:
+ *
+ *   - **ADM-1** — `?p=admin&c=overrides` (the pre-fix "Overrides" card
+ *     href) and any other unrecognised `c=…` returns the 404 page slot
+ *     with HTTP 404, instead of silently rendering the admin landing.
+ *   - **ADM-1** (cont.) — clicking the admin-home Overrides card lands
+ *     on `?p=admin&c=admins#overrides` and the overrides editor anchor
+ *     is in the DOM.
+ *   - **ADM-2** — the audit-log card description no longer contains
+ *     the misleading "(coming soon)" copy.
+ *   - **AUTH-1** — the lostpassword page rendered to a logged-out
+ *     visitor shows the public chrome (Login link visible, no admin
+ *     section).
+ *   - **CC-5** — the footer carries `data-version="dev"` in dev (no
+ *     tarball, no git binary), so telemetry / E2E specs can pin the
+ *     dev sentinel without parsing the user-visible string.
+ *   - **CC-6** — the footer attribution link points at the GitHub
+ *     repo, not the marketing site.
+ *
+ * Selectors follow #1123's testability hooks (`data-testid`,
+ * `data-version`, ARIA roles) — never CSS class chains, never visible
+ * text as the *primary* selector. The `hasText` filters here are
+ * disambiguators, not primary selectors.
+ */
+
+import { test, expect } from '../../fixtures/auth.ts';
+
+test.describe('#1207 routing + truthiness fixes', () => {
+    test.describe('ADM-1: unknown c=… returns 404', () => {
+        test('?p=admin&c=overrides renders the 404 page with HTTP 404', async ({ page }) => {
+            const response = await page.goto('/index.php?p=admin&c=overrides');
+
+            // The route() function calls http_response_code(404) BEFORE
+            // emitting any body, so the response status is the
+            // deterministic signal monitoring tools see — pin it.
+            expect(response?.status(), 'unknown ?c= must surface as HTTP 404').toBe(404);
+
+            // The 404 page slot renders inside the chrome (sidebar +
+            // topbar + footer all stay), so the user can navigate
+            // away. The `data-testid="page-404"` outer wrapper is the
+            // stable terminal mark; the home CTA below is part of the
+            // same component.
+            await expect(page.locator('[data-testid="page-404"]')).toBeVisible();
+            await expect(page.locator('[data-testid="page-404-home"]')).toBeVisible();
+        });
+
+        test('typo categories (e.g. ?c=bnas) also 404, not silently fall through', async ({ page }) => {
+            const response = await page.goto('/index.php?p=admin&c=bnas');
+            expect(response?.status()).toBe(404);
+            await expect(page.locator('[data-testid="page-404"]')).toBeVisible();
+        });
+
+        test('the bare admin landing (?p=admin) still renders', async ({ page }) => {
+            // Regression guard: the 404 branch must not swallow the
+            // intentional "no c=" route. The Bans card is the most
+            // permissively-gated tile (any ADMIN_*BAN flag lights it
+            // up) so it lands for the seeded ADMIN_OWNER user too.
+            const response = await page.goto('/index.php?p=admin');
+            expect(response?.status()).toBe(200);
+            await expect(page.locator('[data-testid="admin-card-bans"]')).toBeVisible();
+        });
+    });
+
+    test.describe('ADM-1: Overrides card links to the editor', () => {
+        test('admin home Overrides card href anchors to ?c=admins#overrides', async ({ page }) => {
+            await page.goto('/index.php?p=admin');
+
+            const card = page.locator('[data-testid="admin-card-overrides"]');
+            await expect(card).toBeVisible();
+            await expect(card).toHaveAttribute('href', /index\.php\?p=admin&(?:amp;)?c=admins#overrides$/);
+        });
+
+        test('clicking the Overrides card lands on the admins page with the overrides editor in the DOM', async ({ page }) => {
+            await page.goto('/index.php?p=admin');
+            await page.locator('[data-testid="admin-card-overrides"]').click();
+
+            // The editor lives at the bottom of admin.admins.php's
+            // c=admins route (admin.overrides.php is `require`d there).
+            // The hash anchors to `#overrides` — the wrapper div in
+            // page_admin_overrides.tpl. We assert the URL contains
+            // both the c=admins query and the #overrides fragment,
+            // and that the editor anchor is in the DOM.
+            await expect(page).toHaveURL(/\?p=admin&(?:amp;)?c=admins#overrides$/);
+            // The "Overrides" wrapper div is the editor anchor; the
+            // `overrides-form` testid is the form inside it (added
+            // for the CSRF discipline note in page_admin_overrides.tpl).
+            await expect(page.locator('#overrides')).toBeAttached();
+            await expect(page.locator('[data-testid="overrides-form"]')).toBeVisible();
+        });
+    });
+
+    test.describe('ADM-2: audit-log card copy', () => {
+        test('Audit log card description no longer contains "(coming soon)"', async ({ page }) => {
+            await page.goto('/index.php?p=admin');
+
+            // Pin the description text negatively (and a positive
+            // anchor on the card itself) so a future copy edit
+            // doesn't accidentally reintroduce the legacy parenthetical.
+            const card = page.locator('[data-testid="admin-card-audit"]');
+            await expect(card).toBeVisible();
+            await expect(card).not.toContainText('coming soon');
+            await expect(card).toContainText(/admin actions/i);
+        });
+    });
+
+    test.describe('AUTH-1: lostpassword renders public chrome to logged-out visitors', () => {
+        // Per-describe override: log out for this whole block. The
+        // fixture's project-default storageState carries the seeded
+        // admin's session cookie, which would (post-fix) bounce the
+        // browser to /home before the form ever rendered. This block
+        // exists specifically to exercise the logged-out path.
+        test.use({ storageState: { cookies: [], origins: [] } });
+
+        test('logged-out visitor sees public chrome (no admin section, login link visible)', async ({ page }) => {
+            await page.goto('/index.php?p=lostpassword');
+
+            // The form itself is the deterministic terminal mark for
+            // the logged-out path — the page handler's redirect guard
+            // would have sent us elsewhere if we were authenticated.
+            await expect(page.locator('[data-testid="lostpw-email"]')).toBeVisible();
+
+            // Public chrome contract: the bottom-left cluster shows a
+            // Login link (data-testid="nav-login"), NOT the
+            // account/Logout pair (`nav-account` + `nav-logout`).
+            //
+            // We assert `toBeAttached()` rather than `toBeVisible()`
+            // because the sidebar collapses off-screen at the
+            // mobile-chromium project's iPhone-13 viewport — the
+            // element exists in the DOM but isn't rendered until the
+            // hamburger toggles `data-mobile-open="true"`. Same
+            // pattern as `specs/smoke/login.spec.ts`'s `nav-account`
+            // assertion.
+            await expect(page.locator('[data-testid="nav-login"]')).toBeAttached();
+            await expect(page.locator('[data-testid="nav-account"]')).toHaveCount(0);
+            await expect(page.locator('[data-testid="nav-logout"]')).toHaveCount(0);
+
+            // No admin sub-section: the entire `{if $isAdmin}…{/if}`
+            // block in core/navbar.tpl is gated off, so no
+            // `nav-admin-*` link should exist anywhere in the DOM.
+            await expect(page.locator('[data-testid^="nav-admin-"]')).toHaveCount(0);
+            // And `nav-admin` (the top-level "Admin Panel" link) is
+            // built from the `permission` flag in navbar.php — gated
+            // on `$userbank->is_admin()`, so it's excluded.
+            await expect(page.locator('[data-testid="nav-admin"]')).toHaveCount(0);
+        });
+
+        test('logged-out visitor lands on the form, not a redirect', async ({ page }) => {
+            // Belt-and-braces: the URL must remain on lostpassword.
+            // The post-fix guard only redirects logged-in visitors.
+            await page.goto('/index.php?p=lostpassword');
+            await expect(page).toHaveURL(/[?&]p=lostpassword(?:&|#|$)/);
+        });
+    });
+
+    test.describe('CC-5 + CC-6: footer credibility', () => {
+        test('footer carries data-version="dev" in the dev stack', async ({ page }) => {
+            await page.goto('/');
+
+            const footer = page.locator('footer.sbpp-footer');
+            await expect(footer).toBeAttached();
+
+            // The dev docker image doesn't ship `git`, doesn't bind-mount
+            // `.git`, and doesn't carry a release tarball's
+            // `configs/version.json`. So `Sbpp\Version::resolve()` falls
+            // through to the third-tier sentinel `'dev'`. The
+            // `data-version` attribute mirrors SB_VERSION verbatim,
+            // so the dev stack always lands `dev` here.
+            //
+            // Release-tarball installs would render
+            // `data-version="2.1.0"` (or whatever version.json
+            // declares), which the regex in this assertion still
+            // accepts via the alternation — so a future "test against
+            // a release-tarball image" wouldn't have to fork the spec.
+            await expect(footer).toHaveAttribute('data-version', /^(?:dev|\d+\.\d+\.\d+\S*)$/);
+
+            // Also pin the user-visible string for the dev sentinel
+            // case: pre-#1207 the footer rendered the literal "N/A",
+            // which read like a runtime error. The new sentinel is
+            // self-describing.
+            const versionAttr = await footer.getAttribute('data-version');
+            if (versionAttr === 'dev') {
+                await expect(footer).toContainText('dev');
+                await expect(footer).not.toContainText('N/A');
+            }
+        });
+
+        test('footer attribution link points at the GitHub repo', async ({ page }) => {
+            await page.goto('/');
+
+            // Locate the link by its containing footer + the
+            // attribute we ship as the canonical contract — never by
+            // visible text alone.
+            const link = page.locator('footer.sbpp-footer a[href*="github.com/sbpp/sourcebans-pp"]');
+            await expect(link).toBeVisible();
+            await expect(link).toHaveAttribute('href', 'https://github.com/sbpp/sourcebans-pp');
+            await expect(link).toHaveAttribute('target', '_blank');
+            await expect(link).toHaveAttribute('rel', /noopener/);
+
+            // Anti-regression: the legacy marketing-site URL must
+            // not appear anywhere in the footer. If a future PR
+            // adds a second attribution row, this catches the wrong
+            // one slipping back in.
+            await expect(page.locator('footer.sbpp-footer a[href*="sbpp.github.io"]')).toHaveCount(0);
+        });
+    });
+});

--- a/web/tests/integration/LostPasswordChromeTest.php
+++ b/web/tests/integration/LostPasswordChromeTest.php
@@ -17,12 +17,15 @@ use Smarty\Smarty;
  * The fix is two-pronged:
  *
  *   1. `web/pages/page.lostpassword.php` redirects logged-in visitors
- *      to `index.php` BEFORE rendering, mirroring the equivalent guard
- *      in `page.login.php`. Logged-in admins simply never see the form.
- *      That guard's redirect+die() shape isn't directly testable in
- *      PHPUnit without process isolation; the E2E spec
- *      (`smoke/lostpassword-public-chrome.spec.ts`) covers the runtime
- *      observable.
+ *      to `index.php` BEFORE rendering the form body, mirroring the
+ *      equivalent guard in `page.login.php` (a `<script>window.location
+ *      …</script>` + `exit;` shape — `header('Location:')` would no-op
+ *      because the chrome above already flushed output). Logged-in
+ *      admins simply never see the form. That redirect's runtime shape
+ *      isn't directly testable in PHPUnit without process isolation;
+ *      the E2E spec (`smoke/routing-truthiness.spec.ts`, the
+ *      `AUTH-1: logged-in visitors get bounced off lostpassword`
+ *      describe block) covers the runtime observable.
  *   2. The navbar (the chrome's sidebar) gates the admin section on
  *      `$userbank->is_admin()`, so an unauthenticated visitor — which
  *      is the only state where the form actually renders — can never

--- a/web/tests/integration/LostPasswordChromeTest.php
+++ b/web/tests/integration/LostPasswordChromeTest.php
@@ -1,0 +1,164 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sbpp\Tests\Integration;
+
+use Sbpp\Tests\ApiTestCase;
+use Smarty\Smarty;
+
+/**
+ * Issue #1207 AUTH-1: the password-recovery page rendered the admin
+ * sidebar (Admin Panel, Admins, Servers, Bans, …) when a logged-in
+ * admin happened to visit `?p=lostpassword`. A user trying to recover
+ * their password is by definition logged out, so this surface should
+ * render the public chrome (the same shape the login page uses).
+ *
+ * The fix is two-pronged:
+ *
+ *   1. `web/pages/page.lostpassword.php` redirects logged-in visitors
+ *      to `index.php` BEFORE rendering, mirroring the equivalent guard
+ *      in `page.login.php`. Logged-in admins simply never see the form.
+ *      That guard's redirect+die() shape isn't directly testable in
+ *      PHPUnit without process isolation; the E2E spec
+ *      (`smoke/lostpassword-public-chrome.spec.ts`) covers the runtime
+ *      observable.
+ *   2. The navbar (the chrome's sidebar) gates the admin section on
+ *      `$userbank->is_admin()`, so an unauthenticated visitor — which
+ *      is the only state where the form actually renders — can never
+ *      see the admin links. This test pins THAT invariant: the
+ *      `$isAdmin` / `$login` template variables that drive
+ *      `core/navbar.tpl` resolve to `false` for an unauthenticated
+ *      user, so `{if $isAdmin}…` doesn't render the admin section.
+ *
+ * If a future refactor breaks this contract (e.g. defaults `$isAdmin`
+ * to true, or stops checking `is_admin()` against the request's
+ * authentication state) the leak the issue describes comes back even
+ * though the page-handler redirect still fires for logged-in users.
+ * This test holds the chrome accountable independently.
+ */
+final class LostPasswordChromeTest extends ApiTestCase
+{
+    /**
+     * Capture every `$theme->assign()` call navbar.php makes against a
+     * stubbed Smarty so we can assert the chrome's auth-driven
+     * variables without booting the real templates.
+     *
+     * @return array<string, mixed>
+     */
+    private function captureNavbarAssigns(): array
+    {
+        $captured = [];
+
+        // Stub Smarty: we only use assign() (capture) and display() (no-op).
+        // Anonymous subclass keeps the type compatible with navbar.php's
+        // $theme->display('core/navbar.tpl') call without rendering anything.
+        // Method signatures mirror Smarty\Data::assign() and
+        // Smarty\Smarty::display() exactly so PHP's signature-compat check
+        // passes; the implementations are minimal (capture / no-op).
+        $theme = new class extends Smarty {
+            /** @var array<string, mixed> */
+            public array $captured = [];
+
+            public function assign($tpl_var, $value = null, $nocache = false, $scope = null)
+            {
+                if (is_array($tpl_var)) {
+                    foreach ($tpl_var as $k => $v) {
+                        $this->captured[(string) $k] = $v;
+                    }
+                } else {
+                    $this->captured[(string) $tpl_var] = $value;
+                }
+                return $this;
+            }
+
+            // Override display() to a no-op; we don't render the .tpl,
+            // we only need the assign() side-effects.
+            public function display($template = null, $cache_id = null, $compile_id = null)
+            {
+                return '';
+            }
+        };
+
+        global $userbank;
+        $userbank = $GLOBALS['userbank'];
+        $GLOBALS['theme'] = $theme;
+
+        // navbar.php is a procedural script that reads $userbank from
+        // globals and writes via $theme->assign(); include it so we
+        // exercise the production code path verbatim. Every test gets
+        // a fresh script-include, so we can't `require_once`.
+        require ROOT . 'pages/core/navbar.php';
+
+        $captured = $theme->captured;
+        unset($GLOBALS['theme']);
+        return $captured;
+    }
+
+    /**
+     * The unauthenticated-visitor case — the only state in which the
+     * lostpassword form actually renders. The auth-driven booleans
+     * that the chrome gates the admin section on resolve to false,
+     * the public navbar excludes the `admin` entry, and the public
+     * navbar entries themselves remain so the user can navigate away.
+     *
+     * `adminbar` itself may still hold data (navbar.php's filtering
+     * loop runs only inside `if ($userbank->is_admin())`, so the
+     * raw array stays in `$admin` for logged-out users), but
+     * `core/navbar.tpl` gates the entire admin section on `$isAdmin`
+     * — so an `isAdmin=false` assertion is the load-bearing one.
+     */
+    public function testUnauthenticatedNavbarHidesAdminSection(): void
+    {
+        // ApiTestCase::setUp() already wires an unauthenticated
+        // userbank (`new CUserManager(null)`). Belt-and-braces:
+        $GLOBALS['userbank'] = new \CUserManager(null);
+
+        $assigns = $this->captureNavbarAssigns();
+
+        $this->assertArrayHasKey('isAdmin', $assigns);
+        $this->assertArrayHasKey('login',   $assigns);
+        $this->assertArrayHasKey('navbar',  $assigns);
+
+        $this->assertFalse($assigns['isAdmin'],
+            'isAdmin must be false for an unauthenticated visitor — `core/navbar.tpl` keys the entire admin sidebar group off this boolean (#1207 AUTH-1).');
+        $this->assertFalse($assigns['login'],
+            'login must be false for an unauthenticated visitor — navbar.tpl uses it to swap the bottom-left "admin / Logout" cluster for a "Login" link.');
+
+        // Public navbar entries still ship so the user can get back to
+        // /login or /home; the leak the issue describes was specifically
+        // about the *admin* section, not the public links.
+        $this->assertNotEmpty($assigns['navbar'],
+            'Public navbar entries must remain so the user can navigate away from the lostpassword form.');
+
+        // The `admin` endpoint is filtered out of the public navbar for
+        // unauthenticated users — navbar.php gates its `permission`
+        // entry on `$userbank->is_admin()`, which is false here.
+        $endpoints = array_column($assigns['navbar'], 'endpoint');
+        $this->assertNotContains('admin', $endpoints,
+            'The `admin` nav entry must be filtered out for unauthenticated users — navbar.php gates it on $userbank->is_admin().');
+    }
+
+    /**
+     * Anti-confusion guard: a logged-in admin DOES see the admin
+     * section. This is the chrome's normal contract; we test it so a
+     * future refactor can't accidentally hide the admin section for
+     * everyone in an attempt to fix the AUTH-1 leak.
+     *
+     * (In production a logged-in admin never reaches the lostpassword
+     * page handler — the redirect in page.lostpassword.php sends them
+     * to `index.php` first. But the chrome layer doesn't know that;
+     * its contract is the same on every page.)
+     */
+    public function testAuthenticatedAdminNavbarIncludesAdminSection(): void
+    {
+        $this->loginAsAdmin();
+
+        $assigns = $this->captureNavbarAssigns();
+
+        $this->assertTrue($assigns['isAdmin']);
+        $this->assertTrue($assigns['login']);
+        $this->assertNotEmpty($assigns['adminbar'],
+            'Admin sidebar must list at least one sub-route for an ADMIN_OWNER user.');
+    }
+}

--- a/web/tests/integration/RoutingTest.php
+++ b/web/tests/integration/RoutingTest.php
@@ -1,0 +1,181 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sbpp\Tests\Integration;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use Sbpp\Tests\ApiTestCase;
+use Sbpp\View\NotFoundView;
+
+/**
+ * Issue #1207 ADM-1: `route()` (`web/includes/page-builder.php`) used
+ * to fall through `?p=admin&c=<unknown>` to the admin landing, so a
+ * typo'd or stale-bookmarked URL silently rendered a different page
+ * with no signal that the request was wrong.
+ *
+ * The fix returns the 404 page (`page.404.php` + `Sbpp\View\NotFoundView`)
+ * and sets the HTTP status to 404 for any unrecognised admin sub-route,
+ * while keeping the bare `?p=admin` landing intact for the seven valid
+ * `c=…` values.
+ *
+ * The tests load `page-builder.php` directly and exercise `route()` —
+ * the dispatcher entry point — rather than spinning a real HTTP
+ * request, so we can assert the (title, page-file, http-status) triple
+ * without booting Smarty or rendering the chrome.
+ */
+final class RoutingTest extends ApiTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->loginAsAdmin();
+        // route() shells CSRF::rejectIfInvalid() on POST; stay on GET so
+        // the routing branch under test is the one we're asserting.
+        $_SERVER['REQUEST_METHOD'] = 'GET';
+        require_once ROOT . 'includes/system-functions.php';
+        require_once ROOT . 'includes/page-builder.php';
+
+        // route() reads $userbank from globals.
+        global $userbank;
+        $userbank = $GLOBALS['userbank'];
+
+        // Reset the response code between cases. http_response_code(0)
+        // is interpreted as "current code" in PHP 8.0+, so we use 200
+        // explicitly instead.
+        http_response_code(200);
+    }
+
+    protected function tearDown(): void
+    {
+        unset($_GET['p'], $_GET['c'], $_GET['o']);
+        http_response_code(200);
+        parent::tearDown();
+    }
+
+    /**
+     * The bare admin landing keeps working: a user lands on
+     * `index.php?p=admin` and `route()` returns the AdminHomeView page.
+     */
+    public function testBareAdminLandingStillRoutesToAdminHome(): void
+    {
+        $_GET['p'] = 'admin';
+
+        [$title, $file] = route(0);
+
+        $this->assertSame('Administration', $title);
+        $this->assertSame('/page.admin.php', $file);
+        $this->assertSame(200, http_response_code(),
+            'Bare admin landing must NOT set a 404 status code.');
+    }
+
+    /**
+     * The seven valid `c=…` values still resolve to their per-area
+     * pages. This is the regression guard that keeps the 404 branch
+     * from accidentally swallowing real routes — every entry below is
+     * a `c=` value that ships in production today.
+     *
+     * @return iterable<string, array{0: string, 1: string}>
+     */
+    public static function validAdminCategories(): iterable
+    {
+        yield 'admins'   => ['admins',   '/admin.admins.php'];
+        yield 'groups'   => ['groups',   '/admin.groups.php'];
+        yield 'servers'  => ['servers',  '/admin.servers.php'];
+        yield 'bans'     => ['bans',     '/admin.bans.php'];
+        yield 'comms'    => ['comms',    '/admin.comms.php'];
+        yield 'mods'     => ['mods',     '/admin.mods.php'];
+        yield 'settings' => ['settings', '/admin.settings.php'];
+        yield 'audit'    => ['audit',    '/admin.audit.php'];
+    }
+
+    #[DataProvider('validAdminCategories')]
+    public function testValidAdminCategoriesRouteToTheirPage(string $category, string $expectedFile): void
+    {
+        $_GET['p'] = 'admin';
+        $_GET['c'] = $category;
+
+        [, $file] = route(0);
+
+        $this->assertSame($expectedFile, $file,
+            "Valid admin category '$category' must route to its expected page file.");
+        $this->assertSame(200, http_response_code(),
+            "Valid admin category '$category' must NOT set a 404 status code.");
+    }
+
+    /**
+     * The CC-1 bug: `?p=admin&c=overrides` (the "Overrides" admin card's
+     * pre-fix href) used to silently fall through to the admin landing.
+     * Now it 404s — pinning this exact URL because it's the one a user
+     * would land on if they followed the pre-#1207 card href, or have
+     * a stale bookmark.
+     */
+    public function testUnknownOverridesCategory404s(): void
+    {
+        $_GET['p'] = 'admin';
+        $_GET['c'] = 'overrides';
+
+        [$title, $file] = route(0);
+
+        $this->assertSame('Page not found', $title);
+        $this->assertSame('/page.404.php', $file);
+        $this->assertSame(404, http_response_code(),
+            'Unknown ?c= must set the HTTP status to 404 so crawlers / monitoring see the right signal.');
+    }
+
+    /**
+     * Generalisation: any unknown `c=…` 404s, not just the one URL the
+     * audit screenshot used. A typo'd `bnas` should be just as visible
+     * as a stale `overrides`.
+     *
+     * @return iterable<string, array{0: string}>
+     */
+    public static function unknownAdminCategories(): iterable
+    {
+        yield 'overrides'      => ['overrides'];
+        yield 'typo bnas'      => ['bnas'];
+        yield 'old kickit'     => ['kickit'];
+        yield 'random gibberish' => ['xyz123'];
+    }
+
+    #[DataProvider('unknownAdminCategories')]
+    public function testAnyUnknownCategory404s(string $unknownCategory): void
+    {
+        $_GET['p'] = 'admin';
+        $_GET['c'] = $unknownCategory;
+
+        [$title, $file] = route(0);
+
+        $this->assertSame('Page not found', $title);
+        $this->assertSame('/page.404.php', $file);
+        $this->assertSame(404, http_response_code());
+    }
+
+    /**
+     * The 404 page is bound to a typed View DTO — pin it so a future
+     * refactor that swaps the template (or removes the View) trips
+     * this guard before users see a missing page slot.
+     */
+    public function testNotFoundViewIsBoundToPage404Template(): void
+    {
+        $this->assertSame('page_404.tpl', NotFoundView::TEMPLATE);
+    }
+
+    /**
+     * Empty `c=` (e.g. `?p=admin&c=`) is treated as "no category"
+     * rather than "unknown category" — so the user lands on the admin
+     * home, not a 404. This matches the pre-fix behaviour for the
+     * naked-admin case and avoids 404'ing on a benign trailing
+     * separator.
+     */
+    public function testEmptyCategoryStillRoutesToAdminHome(): void
+    {
+        $_GET['p'] = 'admin';
+        $_GET['c'] = '';
+
+        [, $file] = route(0);
+
+        $this->assertSame('/page.admin.php', $file);
+        $this->assertSame(200, http_response_code());
+    }
+}

--- a/web/tests/unit/VersionTest.php
+++ b/web/tests/unit/VersionTest.php
@@ -1,0 +1,157 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sbpp\Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use Sbpp\Version;
+
+/**
+ * Regression suite for `\Sbpp\Version::resolve()` — the three-tier
+ * version resolution that drives `SB_VERSION`, the chrome footer, and
+ * the `data-version="…"` attribute (#1207 CC-5).
+ *
+ * Pre-#1207 the third-tier fallback was the literal `'N/A'`, which read
+ * like a runtime error in the footer when no `configs/version.json` was
+ * shipped (dev) AND `git describe` came back empty (also dev — the
+ * docker image doesn't ship a `git` binary and `.git` isn't bind-
+ * mounted into the web container). The fix swaps the literal for the
+ * `'dev'` sentinel so dev installs read as "you're running from
+ * source, not a tarball" instead of "something is broken".
+ *
+ * These cases pin every branch of the fallback so a future refactor
+ * can't silently regress to `'N/A'` (or worse, `''` / `null`).
+ */
+final class VersionTest extends TestCase
+{
+    /**
+     * Tier 1 — release tarball case: `configs/version.json` exists and
+     * decodes to a triple. The resolver returns the JSON contents
+     * verbatim; `dev` is whatever the JSON declares.
+     */
+    public function testTarballJsonWins(): void
+    {
+        $resolved = Version::resolve(
+            versionJsonPath: '/whatever',
+            jsonReader: static fn (): array => [
+                'version' => '2.1.0',
+                'git'     => 'abc1234',
+                'dev'     => false,
+            ],
+            // Both git callbacks must be inert when JSON wins; assert that
+            // by erroring if they fire.
+            gitDescribe: static fn (): string => self::fail('git describe must not run when version.json resolves'),
+            gitShortRev: static fn (): string => self::fail('git rev-parse must not run when version.json resolves'),
+        );
+
+        $this->assertSame('2.1.0',   $resolved['version']);
+        $this->assertSame('abc1234', $resolved['git']);
+        $this->assertFalse($resolved['dev']);
+    }
+
+    /**
+     * Tier 2 — git checkout case: no `version.json`, but `git describe`
+     * returns a tag and `git rev-parse` returns a sha. Both feed into
+     * the result; `dev` is true (we're running off a checkout, not a
+     * release tarball).
+     */
+    public function testGitDescribeUsedWhenJsonAbsent(): void
+    {
+        $resolved = Version::resolve(
+            versionJsonPath: '/whatever',
+            jsonReader: static fn (): ?array => null,
+            gitDescribe: static fn (): string => "v2.0.0-3-gabc1234\n",
+            gitShortRev: static fn (): string => "abc1234\n",
+        );
+
+        $this->assertSame('v2.0.0-3-gabc1234', $resolved['version']);
+        $this->assertSame('abc1234',           $resolved['git']);
+        $this->assertTrue($resolved['dev']);
+    }
+
+    /**
+     * Tier 2 mid-state: `git rev-parse --short HEAD` returns a sha but
+     * `git describe` is empty (rare but possible — repo has no tags
+     * yet, or `--always` would be needed for a sha-only describe).
+     * The sentinel takes the `version` slot; the sha still lands.
+     */
+    public function testGitShaWithoutTagFallsBackToDevSentinel(): void
+    {
+        $resolved = Version::resolve(
+            versionJsonPath: '/whatever',
+            jsonReader: static fn (): ?array => null,
+            gitDescribe: static fn (): string => '',
+            gitShortRev: static fn (): string => "abc1234\n",
+        );
+
+        $this->assertSame(Version::DEV_SENTINEL, $resolved['version']);
+        $this->assertSame('abc1234',             $resolved['git']);
+        $this->assertTrue($resolved['dev']);
+    }
+
+    /**
+     * Tier 3 — the canonical dev-docker case: no `version.json`, no git
+     * binary, no `.git` bind-mount. Pre-#1207 the resolver emitted
+     * `'N/A'` here; the regression guard is that the sentinel is now
+     * the project-defined `'dev'`. This is the case the chrome's
+     * `<footer data-version="dev">` hook keys off.
+     */
+    public function testDevSentinelWhenNoSourceAvailable(): void
+    {
+        $resolved = Version::resolve(
+            versionJsonPath: '/whatever',
+            jsonReader: static fn (): ?array => null,
+            gitDescribe: static fn (): string => '',
+            gitShortRev: static fn (): string => '',
+        );
+
+        $this->assertSame(Version::DEV_SENTINEL, $resolved['version']);
+        $this->assertSame(0,                     $resolved['git']);
+        $this->assertTrue($resolved['dev']);
+
+        // Pin the literal too: the CC-5 contract is specifically that the
+        // sentinel is `'dev'` (not `'unreleased'` / `'N/A'` / `''`).
+        // Telemetry, bug-report templates, and the E2E spec for the
+        // footer all key off this exact string.
+        $this->assertSame('dev', Version::DEV_SENTINEL);
+    }
+
+    /**
+     * Whitespace from `shell_exec`'s trailing newline is normalised. The
+     * resolver `trim()`s both git outputs so the resulting `version`
+     * never carries a trailing newline that would mangle the footer or
+     * the `data-version` attribute.
+     */
+    public function testGitOutputIsTrimmed(): void
+    {
+        $resolved = Version::resolve(
+            versionJsonPath: '/whatever',
+            jsonReader: static fn (): ?array => null,
+            gitDescribe: static fn (): string => "  v2.0.0  \n",
+            gitShortRev: static fn (): string => "  abc1234  \n",
+        );
+
+        $this->assertSame('v2.0.0',  $resolved['version']);
+        $this->assertSame('abc1234', $resolved['git']);
+    }
+
+    /**
+     * Robustness — an unreadable / missing `version.json` resolves to
+     * the JSON-tier returning `null`, not a fatal error. Pairs with
+     * `is_readable()` in the default reader; this test pins the same
+     * shape via the injected callback so the resolver's branches are
+     * exercised even if `is_readable()` ever changes behaviour.
+     */
+    public function testMissingVersionJsonFallsThrough(): void
+    {
+        $resolved = Version::resolve(
+            versionJsonPath: '/path/that/does/not/exist',
+            jsonReader: static fn (string $path): ?array => null,
+            gitDescribe: static fn (): string => '',
+            gitShortRev: static fn (): string => '',
+        );
+
+        $this->assertSame(Version::DEV_SENTINEL, $resolved['version']);
+    }
+}

--- a/web/themes/default/core/footer.tpl
+++ b/web/themes/default/core/footer.tpl
@@ -80,8 +80,27 @@
          style="max-height:60vh;overflow-y:auto;padding:0.5rem"></div>
 </dialog>
 
-<footer class="text-xs text-faint" style="text-align:center;padding:1rem 0">
-    <a href="https://sbpp.github.io/" target="_blank" rel="noopener">SourceBans++</a>
+{*
+    Footer (#1207 CC-5, CC-6).
+
+    `data-version="{$version}"` mirrors the resolved SB_VERSION constant
+    (the user-visible string minus the `| Git: …` suffix). Telemetry,
+    bug reports, and E2E specs key off the attribute so they can
+    distinguish dev installs (`data-version="dev"` — the third-tier
+    fallback in init.php) from release tarball installs
+    (`data-version="2.1.0"` etc.) without parsing the visible text.
+
+    Footer link points at the sbpp/sourcebans-pp repo (CC-6) instead of
+    the marketing site so a self-hoster's first instinct ("show me the
+    code") lands them on the place that hosts both the issue tracker
+    and the install instructions. Link styling is muted by default
+    (matches the surrounding footer text colour) and only reveals the
+    accent colour + underline on `:hover` / `:focus-visible` so the
+    chrome's footer reads as a single line of text instead of having
+    a stranded blue underlined word in the middle of it.
+*}
+<footer class="text-xs text-faint sbpp-footer" data-version="{$version}" style="text-align:center;padding:1rem 0">
+    <a href="https://github.com/sbpp/sourcebans-pp" target="_blank" rel="noopener">SourceBans++</a>
     {$version}{$git}
 </footer>
 

--- a/web/themes/default/css/theme.css
+++ b/web/themes/default/css/theme.css
@@ -380,3 +380,19 @@ html.dark .skel { background: linear-gradient(90deg, var(--zinc-800) 0, var(--zi
 /* Hide scrollbars on chip rows */
 .scroll-x { overflow-x: auto; scrollbar-width: none; }
 .scroll-x::-webkit-scrollbar { display: none; }
+
+/* ---- Footer (#1207 CC-6) ----
+   Footer renders inside `.text-faint` (muted by default), but a raw
+   <a> would inherit the browser-default underlined link colour and
+   stand out as a stranded blue word. Mute the link to inherit the
+   surrounding colour and only reveal the affordance on hover/focus
+   so keyboard users still get a visible focus ring. */
+.sbpp-footer a {
+    color: inherit;
+    text-decoration: none;
+}
+.sbpp-footer a:hover,
+.sbpp-footer a:focus-visible {
+    color: var(--accent);
+    text-decoration: underline;
+}

--- a/web/themes/default/page_404.tpl
+++ b/web/themes/default/page_404.tpl
@@ -1,0 +1,62 @@
+{*
+    SourceBans++ 2026 — page_404.tpl
+
+    "Page not found" page slot. Pair: web/pages/page.404.php +
+    web/includes/View/NotFoundView.php (#1207 ADM-1).
+
+    The chrome (sidebar + topbar + footer) renders normally — only
+    the page slot is the error message, so the user can navigate
+    away without backtracking. The HTTP 404 status is set in
+    route() before the chrome renders, so crawlers / monitoring
+    see the correct signal.
+
+    No View properties are declared because the message is static.
+    SmartyTemplateRule guards the template against accidentally
+    growing untyped variable references.
+
+    Testability hooks:
+      - data-testid="page-404"     — outer wrapper (E2E spec target)
+      - data-testid="page-404-home" — home link CTA
+*}
+<div class="not-found" data-testid="page-404">
+    <div class="card not-found__card">
+        <div class="card__body" style="padding:2rem;text-align:center">
+            <div class="not-found__icon" aria-hidden="true">
+                <i data-lucide="circle-help" style="width:2rem;height:2rem"></i>
+            </div>
+            <h1 class="not-found__title">Page not found</h1>
+            <p class="text-muted">
+                The page you&rsquo;re looking for doesn&rsquo;t exist or has been moved.
+                Check the URL, or jump back to a page you know.
+            </p>
+            <div class="flex justify-center gap-2 mt-6">
+                <a class="btn btn--primary"
+                   href="index.php"
+                   data-testid="page-404-home">
+                    <i data-lucide="home"></i> Back to dashboard
+                </a>
+                <a class="btn btn--secondary"
+                   href="javascript:history.back();"
+                   data-testid="page-404-back">
+                    <i data-lucide="arrow-left"></i> Go back
+                </a>
+            </div>
+        </div>
+    </div>
+</div>
+
+{literal}
+<style>
+    .not-found { display:flex; align-items:flex-start; justify-content:center; padding:3rem 1rem; }
+    .not-found__card { width:100%; max-width:32rem; }
+    .not-found__icon {
+        width: 3.5rem; height: 3.5rem; border-radius: var(--radius-xl);
+        background: var(--bg-muted); color: var(--text-muted);
+        display: grid; place-items: center; margin: 0 auto 1rem;
+    }
+    .not-found__title {
+        font-size: var(--fs-2xl); font-weight: 600; letter-spacing: -0.02em;
+        color: var(--text); margin: 0 0 0.5rem;
+    }
+</style>
+{/literal}

--- a/web/themes/default/page_admin.tpl
+++ b/web/themes/default/page_admin.tpl
@@ -21,10 +21,12 @@
     "card visible but route 403's" can't drift between the two.
 
     Comms folds into the sidebar nav (admin/comms) per the mockup,
-    not a card here. Audit is a forward-looking card gated to owners
-    until a future ticket adds the c=audit route + page; until then
-    the legacy router's `default:` case returns this same admin
-    landing, so the link is a harmless self-loop rather than a 404.
+    not a card here. Audit is owner-gated and points at the live
+    `c=audit` route (admin.audit.php), introduced ahead of this
+    landing's redesign. The legacy router's `default:` case now
+    returns a 404 for any unrecognised c=… (#1207 ADM-1), so a
+    typo'd href would surface visibly rather than silently
+    rendering this same landing.
 
     Testability hooks per the issue's "Testability hooks" rule:
       - card grid carries role="list" + aria-label
@@ -107,8 +109,13 @@
 
         {if $can_overrides}
             <li>
+                {* The overrides editor lives at the bottom of admin.admins.php's
+                   c=admins route (admin.overrides.php is `require`d there).
+                   The hash anchors to the `#overrides` block in
+                   page_admin_overrides.tpl so clicking the card lands on the
+                   intended editor instead of the admins list (#1207 ADM-1). *}
                 <a class="admin-card"
-                   href="index.php?p=admin&amp;c=admins"
+                   href="index.php?p=admin&amp;c=admins#overrides"
                    data-testid="admin-card-overrides">
                     <div class="admin-card__icon" aria-hidden="true"><i data-lucide="key-round"></i></div>
                     <div class="admin-card__title">Overrides</div>
@@ -136,7 +143,7 @@
                    data-testid="admin-card-audit">
                     <div class="admin-card__icon" aria-hidden="true"><i data-lucide="scroll-text"></i></div>
                     <div class="admin-card__title">Audit log</div>
-                    <div class="admin-card__desc">Admin actions across the panel (coming soon).</div>
+                    <div class="admin-card__desc">Admin actions across the panel.</div>
                 </a>
             </li>
         {/if}

--- a/web/themes/default/page_admin_overrides.tpl
+++ b/web/themes/default/page_admin_overrides.tpl
@@ -10,8 +10,14 @@
       - The bottom "add" row maps to `new_override_*` POST fields.
       - {csrf_field} is required because the dispatcher invokes
         CSRF::rejectIfInvalid() on every POST.
+
+    The wrapper carries `id="overrides"` (URL-safe, lowercase) so the
+    admin home's Overrides card href (`?p=admin&c=admins#overrides`,
+    #1207 ADM-1) scrolls the page to this editor instead of dropping
+    the user at the top of the admins list. `scroll-margin-top` keeps
+    the heading clear of the sticky topbar after the jump.
 *}
-<div class="tabcontent" id="Overrides">
+<div class="tabcontent" id="overrides" style="scroll-margin-top:4rem">
 {if not $permission_addadmin}
     <div class="card">
         <div class="card__body">


### PR DESCRIPTION
## Summary

Slice 3 of #1207 — routing + truthiness fixes. Addresses ADM-1, ADM-2, AUTH-1, CC-5, CC-6.

- **ADM-1** — Unrecognised `?p=admin&c=…` returns a 404 via the new `Sbpp\View\NotFoundView` (was: silently fell through to the admin landing). The admin home's Overrides card href is now `?c=admins#overrides`, anchored to the overrides editor (`page_admin_overrides.tpl` carries `id="overrides"` with `scroll-margin-top` so the heading clears the sticky topbar).
- **ADM-2** — Dropped the misleading "(coming soon)" parenthetical on the audit-log card; the `c=audit` route ships.
- **AUTH-1** — `page.lostpassword.php` redirects logged-in visitors to `index.php` before rendering, mirroring `page.login.php`'s guard. A user trying to recover their password is by definition logged out — an authenticated admin can no longer leak their admin chrome onto this surface.
- **CC-5** — Three-tier version resolution is now `Sbpp\Version::resolve()` (release tarball → git describe → the `'dev'` sentinel). Replaces the `'N/A'` literal that read like a runtime error in dev. Chrome's `<footer data-version="…">` mirrors `SB_VERSION` so telemetry / E2E specs can distinguish dev from release installs without parsing the visible string.
- **CC-6** — Footer attribution link points at `github.com/sbpp/sourcebans-pp` instead of the marketing site. Footer-local CSS mutes link chrome by default and only surfaces the accent colour on `:hover` / `:focus-visible`, so the credit reads as a single muted line instead of a stranded underlined word.

Does NOT close #1207 — that umbrella tracks the remaining slices (mobile chrome, dark-theme tokens, banlist tables, empty-state copy).

## Test plan

- [x] PHPStan clean (`./sbpp.sh phpstan`)
- [x] PHPUnit clean — 309 tests / 1274 assertions, +24 new (6 `VersionTest` + 16 `RoutingTest` + 2 `LostPasswordChromeTest`)
- [x] ts-check clean (`./sbpp.sh ts-check`)
- [x] API contract clean (`./sbpp.sh composer api-contract` — no diff)
- [x] Playwright E2E clean — `./sbpp.sh e2e` runs 10 new specs across `chromium` + `mobile-chromium` (20 cases). Full suite under `CI=1 ./sbpp.sh e2e` (workers=1, the canonical mode) passes 105 / 105.
- [x] Manual: visited `?p=admin&c=overrides` (renders 404 with HTTP 404), clicked Overrides card (lands on `?c=admins#overrides` with `#overrides` editor in DOM), opened `?p=lostpassword` from a logged-out browser (no admin chrome, Login link visible), inspected footer (`data-version="dev"`, link points at GitHub repo).

## Files touched

- `web/init.php` — version resolution moved into `Sbpp\Version::resolve()`.
- `web/includes/Version.php` — new helper class.
- `web/includes/page-builder.php` — 404 branch in the admin sub-route switch.
- `web/includes/View/NotFoundView.php` — new typed view DTO.
- `web/pages/page.404.php` — new 404 page handler.
- `web/pages/page.lostpassword.php` — redirect logged-in visitors.
- `web/themes/default/page_404.tpl` — new 404 template (chrome-wrapped).
- `web/themes/default/page_admin.tpl` — Overrides card href + audit-log copy.
- `web/themes/default/page_admin_overrides.tpl` — `id="overrides"` anchor.
- `web/themes/default/core/footer.tpl` — `data-version` attribute + GitHub href.
- `web/themes/default/css/theme.css` — `.sbpp-footer a` muted-default rules.
- `web/tests/unit/VersionTest.php` — new (6 cases).
- `web/tests/integration/RoutingTest.php` — new (16 cases).
- `web/tests/integration/LostPasswordChromeTest.php` — new (2 cases).
- `web/tests/e2e/specs/smoke/routing-truthiness.spec.ts` — new (10 cases × 2 projects).
- `ARCHITECTURE.md` — page request lifecycle (404 branch) + bootstrap (version step).
- `AGENTS.md` — "Where to find what" entries for `Sbpp\Version` + 404 routing.