### PR TITLE
fix(theme): banlist & queue table polish (#1207 slice 4)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -462,6 +462,7 @@ bearing assertion that the value is already safe HTML, so:
 | Add or rename a permission             | `web/configs/permissions/web.json`, then regen contract  |
 | Render a page                          | `web/pages/<page>.php` + `web/includes/View/*View.php`   |
 | Edit a template                        | `web/themes/default/*.tpl`                               |
+| Reuse the moderation-queue card layout (admin submissions / protests, mobile-stacked summary rows) | `web/themes/default/css/theme.css` (`.queue-row`, `.queue-row__body`, `.queue-row__date` — #1207 PUB-2). Apply by adding `class="queue-row …"` to the outer `<details>` and dropping the inline `flex` / `flex-shrink:0` styles from the summary children. |
 | Edit the player-detail drawer (open trigger, tabs, panes, lazy loaders) | `web/themes/default/js/theme.js` (`renderDrawerBody` / `loadPaneIfNeeded`) |
 | Add admin-only per-player notes | `web/api/handlers/notes.php` (CRUD) — Notes tab is gated by `bans.detail`'s `notes_visible` flag |
 | Render admin-authored Markdown to safe HTML | `web/includes/Markup/IntroRenderer.php` (`Sbpp\Markup`) |

--- a/web/tests/e2e/specs/flows/banlist-table-columns.spec.ts
+++ b/web/tests/e2e/specs/flows/banlist-table-columns.spec.ts
@@ -1,0 +1,151 @@
+/**
+ * Flow: banlist desktop table column geometry (#1207 PUB-1).
+ *
+ * Asserts the regression the audit caught — with realistic per-row
+ * content the banlist's auto-layout used to:
+ *   - clip the STATUS header to "STA…",
+ *   - push the per-row pill partly off the right edge,
+ *   - wrap the BANNED date over three lines.
+ *
+ * The fix in `web/themes/default/css/theme.css` pins
+ * `.col-length / .col-banned / .col-admin / .col-status / .col-actions`
+ * to `white-space: nowrap` and gives `.col-status` `width: 1%` so it
+ * shrinks to its content. A `.table-scroll` overflow-x wrapper is the
+ * fallback when the page width can't accommodate every column.
+ *
+ * Project gating
+ * --------------
+ * Desktop-only. The mobile chrome is `.ban-cards`, not the `<table>`,
+ * and `responsive/banlist.spec.ts` already covers the table-vs-cards
+ * switch. Re-running this spec under mobile-chromium would look up a
+ * `.table` that's `display:none` and silently skip every column
+ * assertion.
+ */
+
+import { expect, test } from '../../fixtures/auth.ts';
+import { truncateE2eDb } from '../../fixtures/db.ts';
+import { seedBanViaApi } from '../../fixtures/seeds.ts';
+
+test.describe('flow: banlist desktop column geometry (#1207 PUB-1)', () => {
+    test.skip(({ isMobile }) => isMobile, 'Desktop-only — mobile chrome is .ban-cards.');
+
+    test.beforeEach(async ({ page }) => {
+        await truncateE2eDb();
+        await seedBanViaApi(page, {
+            nickname: 'e2e-table-cols',
+            steam: 'STEAM_0:1:1207001',
+            reason: 'e2e: banlist column geometry seed',
+        });
+    });
+
+    test('STATUS header reads in full and the BANNED cell is one line', async ({ page }) => {
+        await page.goto('/index.php?p=banlist');
+
+        const table = page.locator('#banlist-root .table');
+        await expect(table).toBeVisible();
+
+        // The STATUS header text is "Status" capitalised by the
+        // template literal; the regression collapsed it to "STA…"
+        // because the column took on a sub-natural width. Reading
+        // the visible text is the most direct invariant: if the
+        // column shrinks back the assertion goes red.
+        const statusHeader = table.locator('th.col-status');
+        await expect(statusHeader).toBeVisible();
+        await expect(statusHeader).toHaveText(/^Status$/);
+        const headerOverflow = await statusHeader.evaluate((el) => ({
+            scrollWidth: el.scrollWidth,
+            clientWidth: el.clientWidth,
+        }));
+        expect(
+            headerOverflow.scrollWidth,
+            'STATUS header must not visually clip its content',
+        ).toBeLessThanOrEqual(headerOverflow.clientWidth + 1);
+
+        // The seeded ban's BANNED cell holds an ISO timestamp like
+        // "2026-05-05 23:05:18". Without the fix the `<time>`
+        // element wraps to three lines (date, gap, time). The cell
+        // itself stretches to the row's tallest sibling (the
+        // PLAYER column carries a 28px avatar), so we measure the
+        // `<time>` element directly — its scrollHeight is exactly
+        // one line's worth when `white-space: nowrap` is in force.
+        // Threshold: <2 * fontSize so a near-double-line wrap fails
+        // even on themes that tweak line-height.
+        const seededRow = table
+            .locator('[data-testid="ban-row"]')
+            .filter({ hasText: 'STEAM_0:1:1207001' });
+        await expect(seededRow).toBeVisible();
+
+        const bannedCell = seededRow.locator('td.col-banned');
+        await expect(bannedCell).toBeVisible();
+        const bannedTime = bannedCell.locator('time').first();
+        await expect(bannedTime).toBeVisible();
+        const bannedTimeMetrics = await bannedTime.evaluate((el) => {
+            const cs = window.getComputedStyle(el);
+            const fontSize = parseFloat(cs.fontSize);
+            return {
+                height: el.getBoundingClientRect().height,
+                fontSize,
+                scrollWidth: el.scrollWidth,
+                clientWidth: el.clientWidth,
+            };
+        });
+        expect(
+            bannedTimeMetrics.height,
+            `BANNED <time> must render on one line (got ${bannedTimeMetrics.height}px / fontSize ${bannedTimeMetrics.fontSize}px)`,
+        ).toBeLessThan(bannedTimeMetrics.fontSize * 2);
+        // And the cell doesn't introduce a horizontal scroll inside
+        // the `<time>` element — i.e. `white-space: nowrap` keeps
+        // the date in a single, fully-painted run rather than
+        // overflowing past its parent.
+        expect(
+            bannedTimeMetrics.scrollWidth,
+            'BANNED <time> content fits within its rendered width',
+        ).toBeLessThanOrEqual(bannedTimeMetrics.clientWidth + 1);
+
+        // The status pill itself stays inside its column's painted
+        // box — i.e. it doesn't bleed off the right edge of the
+        // table. The card around the table has `overflow: hidden`,
+        // so a pill that overflows would actually be CLIPPED to the
+        // viewer; the bounding-box check below catches the
+        // pre-fix shape where the pill's right edge sat past the
+        // table's right edge.
+        const pill = seededRow.locator('td.col-status .pill');
+        await expect(pill).toBeVisible();
+        const tableBox = await table.boundingBox();
+        const pillBox = await pill.boundingBox();
+        expect(tableBox, 'table renders a bounding box').not.toBeNull();
+        expect(pillBox, 'status pill renders a bounding box').not.toBeNull();
+        // The card's inner `overflow: hidden` clips negative
+        // overflow on either side; assert both edges to catch
+        // a regression in either direction.
+        expect(pillBox!.x).toBeGreaterThanOrEqual(tableBox!.x - 1);
+        expect(pillBox!.x + pillBox!.width).toBeLessThanOrEqual(
+            tableBox!.x + tableBox!.width + 1,
+        );
+    });
+
+    test('the table is wrapped in .table-scroll for narrow-viewport overflow', async ({ page }) => {
+        await page.goto('/index.php?p=banlist');
+
+        // The wrapper is the runtime escape hatch for the rare case
+        // where the natural column widths still exceed the panel
+        // (1024-1100px viewport zone after the sidebar collapses).
+        // Without it, a content-heavy row clips behind the card's
+        // `overflow: hidden`. Assert the wrapper is in the DOM
+        // immediately around the `<table>` so a future refactor
+        // can't silently drop the safety net.
+        const wrapper = page.locator('#banlist-root .table-scroll');
+        await expect(wrapper).toBeVisible();
+        await expect(wrapper.locator('> table.table')).toBeVisible();
+        const isOverflowAuto = await wrapper.evaluate((el) =>
+            window.getComputedStyle(el).overflowX,
+        );
+        // `overflow-x: auto` is the contract; CSS may resolve it as
+        // "auto" verbatim. The "scroll" fallback is also acceptable
+        // (some browsers serialize the keyword differently). What
+        // we're catching is a regression that drops the wrapper
+        // back to the default `visible`, which would re-clip the
+        // overflow case the audit found.
+        expect(['auto', 'scroll']).toContain(isOverflowAuto);
+    });
+});

--- a/web/tests/e2e/specs/responsive/admin-queue.spec.ts
+++ b/web/tests/e2e/specs/responsive/admin-queue.spec.ts
@@ -141,12 +141,9 @@ test.describe('responsive: admin moderation queue (#1207 PUB-2)', () => {
         // pre-fix layout. Each must be visible AND its bounding
         // box must sit fully inside the queue row's container —
         // the row itself ("submission-row") is where the PUB-2
-        // contract lives. We don't assert against the document /
-        // viewport here because pre-existing chrome issues
-        // (CC-1 topbar search, ADM-8 admin tab strip) leak
-        // horizontal scroll on this page and are owned by other
-        // workers in the #1207 split; locking against the row's
-        // own bounding box keeps the assertion scoped to PUB-2.
+        // contract lives, so locking the assertion to the row's
+        // own bounding box keeps this spec scoped to the
+        // card-stack invariant rather than the page-level chrome.
         const rowBox = await row.boundingBox();
         expect(rowBox, 'queue row renders a bounding box').not.toBeNull();
         for (const testid of ['row-action-ban', 'row-action-remove', 'row-action-contact']) {

--- a/web/tests/e2e/specs/responsive/admin-queue.spec.ts
+++ b/web/tests/e2e/specs/responsive/admin-queue.spec.ts
@@ -1,0 +1,182 @@
+/**
+ * Responsive: admin moderation queue card layout (#1207 PUB-2).
+ *
+ * The audit caught the moderation queue (`?p=admin&c=bans`,
+ * "Ban submissions" + "Ban protests") still rendering each row as a
+ * `<details>` packed onto a single horizontal flex line at iPhone-13
+ * width. The third action ("Contact") truncated past the right edge
+ * and the date wrapped to two lines.
+ *
+ * The fix promotes the public banlist's mobile card pattern to these
+ * queues: the summary's `[name+steam stack] [date] [actions]` layout
+ * keeps the same source order (so screen readers / keyboard nav read
+ * left-to-right desktop) but at <=768px wraps onto two visual rows so
+ * every action is reachable.
+ *
+ * Project gating
+ * --------------
+ * Mobile-chromium only. The desktop layout is unchanged at >=769px;
+ * `flows/admin-ban-lifecycle.spec.ts` already exercises the
+ * ban-action click path.
+ *
+ * Selectors
+ * ---------
+ * Per #1123, every assertion uses `data-testid` (`submission-row`,
+ * `submission-row-steam`, `row-action-ban`, `row-action-remove`,
+ * `row-action-contact`) — the testid contract is unchanged by the
+ * card-layout fix; only the surrounding CSS class set moves.
+ */
+
+import { expect, test } from '../../fixtures/auth.ts';
+import { truncateE2eDb } from '../../fixtures/db.ts';
+import { anonymousSubmit, newAnonymousContext } from '../../pages/SubmitBanFlow.ts';
+
+test.describe('responsive: admin moderation queue (#1207 PUB-2)', () => {
+    test.beforeEach(({}, testInfo) => {
+        test.skip(
+            testInfo.project.name !== 'mobile-chromium',
+            'Mobile-only contract — desktop chrome is unchanged.',
+        );
+    });
+
+    test.beforeEach(async () => {
+        await truncateE2eDb();
+    });
+
+    test('submission queue row stacks summary vertically on mobile', async ({ page, browser }, testInfo) => {
+        // Seed a submission via the live anonymous form so the queue
+        // has a row to lay out. Same shape as
+        // `flows/public-ban-submission.spec.ts` — keeps the seed
+        // reliant on the actual production code path.
+        const fx = {
+            steam: 'STEAM_0:1:1207002',
+            playerName: 'e2e-pub2-queue',
+            reason: 'e2e: PUB-2 queue card layout',
+            reporterName: 'e2e-reporter',
+            email: 'e2e-pub2@example.test',
+        };
+        const anonCtx = await newAnonymousContext(browser, testInfo.project.use);
+        try {
+            const anon = await anonCtx.newPage();
+            await anonymousSubmit(anon, fx);
+        } finally {
+            await anonCtx.close();
+        }
+
+        await page.goto('/index.php?p=admin&c=bans');
+
+        const row = page
+            .locator('[data-testid="submission-row"]')
+            .filter({ has: page.locator('[data-testid="submission-row-steam"]', { hasText: fx.steam }) });
+        await expect(row).toBeVisible();
+
+        // The card-layout class is the layout contract: theme.css's
+        // `.queue-row > summary` flex rules + the <=768px override
+        // depend on it. A regression that drops the class would
+        // silently revert to the cramped horizontal pack.
+        await expect(row).toHaveClass(/\bqueue-row\b/);
+
+        const summary = row.locator('> summary');
+        await expect(summary).toBeVisible();
+        // Inside the summary, the body / date / actions live as
+        // siblings. The mobile media query orders body=row1,
+        // date+actions=row2.
+        const body = summary.locator('.queue-row__body');
+        const date = summary.locator('.queue-row__date');
+        const actions = summary.locator('.row-actions');
+        await expect(body).toBeVisible();
+        await expect(date).toBeVisible();
+        await expect(actions).toBeVisible();
+
+        // Layout invariant: at mobile width the body's bounding box
+        // sits ABOVE both the date and the action cluster (i.e. the
+        // summary actually wraps onto a second row). We allow a 1px
+        // tolerance for sub-pixel rounding.
+        const [bodyBox, dateBox, actionsBox] = await Promise.all([
+            body.boundingBox(),
+            date.boundingBox(),
+            actions.boundingBox(),
+        ]);
+        expect(bodyBox, 'queue-row body has a bounding box').not.toBeNull();
+        expect(dateBox, 'queue-row date has a bounding box').not.toBeNull();
+        expect(actionsBox, 'queue-row actions have a bounding box').not.toBeNull();
+
+        const bodyBottom = bodyBox!.y + bodyBox!.height;
+        expect(
+            dateBox!.y,
+            'date renders below the body on mobile (queue-row card stack)',
+        ).toBeGreaterThanOrEqual(bodyBottom - 1);
+        expect(
+            actionsBox!.y,
+            'actions render below the body on mobile (queue-row card stack)',
+        ).toBeGreaterThanOrEqual(bodyBottom - 1);
+    });
+
+    test('all three row actions are visible and inside the viewport', async ({ page, browser }, testInfo) => {
+        // Re-seed: each test starts from a truncated DB.
+        const fx = {
+            steam: 'STEAM_0:1:1207003',
+            playerName: 'e2e-pub2-actions',
+            reason: 'e2e: PUB-2 actions reachable',
+            reporterName: 'e2e-reporter',
+            email: 'e2e-pub2-actions@example.test',
+        };
+        const anonCtx = await newAnonymousContext(browser, testInfo.project.use);
+        try {
+            const anon = await anonCtx.newPage();
+            await anonymousSubmit(anon, fx);
+        } finally {
+            await anonCtx.close();
+        }
+
+        await page.goto('/index.php?p=admin&c=bans');
+
+        const row = page
+            .locator('[data-testid="submission-row"]')
+            .filter({ has: page.locator('[data-testid="submission-row-steam"]', { hasText: fx.steam }) });
+        await expect(row).toBeVisible();
+
+        // Every action is a #1123 testability hook; the audit
+        // showed "Contact" truncating past the right edge in the
+        // pre-fix layout. Each must be visible AND its bounding
+        // box must sit fully inside the queue row's container —
+        // the row itself ("submission-row") is where the PUB-2
+        // contract lives. We don't assert against the document /
+        // viewport here because pre-existing chrome issues
+        // (CC-1 topbar search, ADM-8 admin tab strip) leak
+        // horizontal scroll on this page and are owned by other
+        // workers in the #1207 split; locking against the row's
+        // own bounding box keeps the assertion scoped to PUB-2.
+        const rowBox = await row.boundingBox();
+        expect(rowBox, 'queue row renders a bounding box').not.toBeNull();
+        for (const testid of ['row-action-ban', 'row-action-remove', 'row-action-contact']) {
+            const action = row.locator(`[data-testid="${testid}"]`);
+            await expect(action).toBeVisible();
+            const box = await action.boundingBox();
+            expect(box, `${testid} renders a bounding box`).not.toBeNull();
+            expect(
+                box!.x,
+                `${testid} starts inside the queue row`,
+            ).toBeGreaterThanOrEqual(rowBox!.x - 1);
+            expect(
+                box!.x + box!.width,
+                `${testid} ends inside the queue row`,
+            ).toBeLessThanOrEqual(rowBox!.x + rowBox!.width + 1);
+        }
+
+        // The summary itself doesn't horizontal-scroll either —
+        // i.e. content fits within the painted card and no inner
+        // overflow hides anything. This is the bounded version of
+        // the pre-fix bug ("Contact truncated"): the summary's
+        // scrollWidth must equal its clientWidth.
+        const summary = row.locator('> summary');
+        const summaryOverflow = await summary.evaluate((el) => ({
+            scrollWidth: el.scrollWidth,
+            clientWidth: el.clientWidth,
+        }));
+        expect(
+            summaryOverflow.scrollWidth,
+            'queue summary content fits within its rendered width',
+        ).toBeLessThanOrEqual(summaryOverflow.clientWidth + 1);
+    });
+});

--- a/web/themes/default/css/theme.css
+++ b/web/themes/default/css/theme.css
@@ -387,11 +387,13 @@ html.dark .skel { background: linear-gradient(90deg, var(--zinc-800) 0, var(--zi
    The `.queue-row__*` classes carry the layout (instead of inline
    `style="flex-shrink:0"` on each child) so the mobile media query
    can override `flex` / `order` without fighting inline-style
-   specificity. Selector targets `details.queue-row > summary` so
-   the rule reaches the queue templates only (current + archive
-   submissions and protests); the public banlist's mobile cards use
-   `<a>`, not `<details>`, so they're unaffected. */
-.queue-row > summary {
+   specificity. Selector qualifies `details.queue-row > summary` so
+   the rule only reaches `<details>` rows (current + archive
+   submissions and protests). The public banlist's mobile cards use
+   `<a class="ban-row …">`, not `<details>`, so they're unaffected
+   even if a future template typos `class="queue-row"` onto the
+   wrong element. */
+details.queue-row > summary {
   display: flex;
   align-items: center;
   gap: 0.75rem;
@@ -399,7 +401,7 @@ html.dark .skel { background: linear-gradient(90deg, var(--zinc-800) 0, var(--zi
   cursor: pointer;
   list-style: none;
 }
-.queue-row > summary::-webkit-details-marker { display: none; }
+details.queue-row > summary::-webkit-details-marker { display: none; }
 .queue-row__body { flex: 1 1 0; min-width: 0; }
 .queue-row__date {
   flex-shrink: 0;
@@ -407,7 +409,7 @@ html.dark .skel { background: linear-gradient(90deg, var(--zinc-800) 0, var(--zi
   font-size: var(--fs-xs);
   color: var(--text-muted);
 }
-.queue-row > summary > .row-actions {
+details.queue-row > summary > .row-actions {
   flex-shrink: 0;
   display: flex;
   gap: 0.25rem;
@@ -415,7 +417,7 @@ html.dark .skel { background: linear-gradient(90deg, var(--zinc-800) 0, var(--zi
 }
 
 @media (max-width: 768px) {
-  .queue-row > summary {
+  details.queue-row > summary {
     flex-wrap: wrap;
     align-items: flex-start;
   }
@@ -431,7 +433,7 @@ html.dark .skel { background: linear-gradient(90deg, var(--zinc-800) 0, var(--zi
     flex: 1 1 auto;
     align-self: center;
   }
-  .queue-row > summary > .row-actions {
+  details.queue-row > summary > .row-actions {
     order: 3;
     flex-wrap: wrap;
     justify-content: flex-end;

--- a/web/themes/default/css/theme.css
+++ b/web/themes/default/css/theme.css
@@ -311,6 +311,36 @@ html.dark .table thead tr { background: rgb(255 255 255 / 0.02); }
 .table .row-actions { opacity: 0; transition: opacity .15s; display: flex; gap: 0.25rem; justify-content: flex-end; }
 .table tbody tr:hover .row-actions { opacity: 1; }
 
+/* PUB-1 (#1207): banlist column widths + horizontal-scroll fallback.
+   With realistic per-row content the auto-layout previously
+   compressed the BANNED date to 3 lines, clipped the STATUS header
+   to "STA…", and pushed the per-row pill partly off the right edge.
+   Two-part fix:
+
+   1. Pin the timestamp / length / admin / status / actions cells to
+      one line via `white-space: nowrap` so the column never
+      compresses below its natural content width. STATUS additionally
+      uses `width: 1%` — the canonical "shrink-to-content" trick for
+      table-layout: auto: the browser obeys the smallest width it
+      can give the cell without wrapping the content, so the column
+      ends up exactly as wide as the natural content of "Status"
+      (header) / its pill, freeing the rest of the row for the
+      truncate-able Player / Reason / Server columns.
+   2. Wrap the `<table>` in `.table-scroll` (page_bans.tpl) so when
+      the parent is narrower than the natural sum of column widths
+      (1024-1100px viewport zone after the sidebar collapses, plus
+      any unusually long player / reason combos) the table scrolls
+      horizontally instead of clipping the rightmost column. The
+      card's rounded corners stay intact because the card itself
+      keeps its own `overflow: hidden`. */
+.table-scroll { overflow-x: auto; }
+.table .col-length,
+.table .col-banned,
+.table .col-admin,
+.table .col-status,
+.table .col-actions { white-space: nowrap; }
+.table .col-status { width: 1%; }
+
 /* ---- Avatar ---- */
 .avatar { display: inline-grid; place-items: center; border-radius: 50%; color: white; font-weight: 600; flex-shrink: 0; }
 
@@ -338,6 +368,76 @@ html.dark .table thead tr { background: rgb(255 255 255 / 0.02); }
 @keyframes shimmer { 0% { background-position: -200px 0; } 100% { background-position: calc(200px + 100%) 0; } }
 .skel { background: linear-gradient(90deg, var(--zinc-100) 0, var(--zinc-200) 40px, var(--zinc-100) 80px); background-size: 200px 100%; animation: shimmer 1.4s linear infinite; border-radius: var(--radius-sm); }
 html.dark .skel { background: linear-gradient(90deg, var(--zinc-800) 0, var(--zinc-700) 40px, var(--zinc-800) 80px); background-size: 200px 100%; }
+
+/* ---- Queue rows (admin submissions / protests) ----
+   PUB-2 (#1207): the admin moderation queues (page_admin_bans_*.tpl)
+   render each row as a `<details><summary>`. At desktop width the
+   row lays out as `[name+steam stack] [date] [Ban] [Remove]
+   [Contact]`; at mobile width that same horizontal pack pushes the
+   third action ("Contact") off the visible edge and forces the date
+   to wrap to two lines.
+
+   The fix promotes the public banlist's card chrome (see
+   `responsive-banlist-cards` in #1124) to these queues: at <=768px
+   the summary stacks vertically — name+steam on top, then a date /
+   action row below — so every action is reachable without a
+   horizontal scroll. The `[data-testid="row-action-*"]` hooks
+   stay primary (#1123 testability contract).
+
+   The `.queue-row__*` classes carry the layout (instead of inline
+   `style="flex-shrink:0"` on each child) so the mobile media query
+   can override `flex` / `order` without fighting inline-style
+   specificity. Selector targets `details.queue-row > summary` so
+   the rule reaches the queue templates only (current + archive
+   submissions and protests); the public banlist's mobile cards use
+   `<a>`, not `<details>`, so they're unaffected. */
+.queue-row > summary {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 1rem;
+  cursor: pointer;
+  list-style: none;
+}
+.queue-row > summary::-webkit-details-marker { display: none; }
+.queue-row__body { flex: 1 1 0; min-width: 0; }
+.queue-row__date {
+  flex-shrink: 0;
+  white-space: nowrap;
+  font-size: var(--fs-xs);
+  color: var(--text-muted);
+}
+.queue-row > summary > .row-actions {
+  flex-shrink: 0;
+  display: flex;
+  gap: 0.25rem;
+  opacity: 1;
+}
+
+@media (max-width: 768px) {
+  .queue-row > summary {
+    flex-wrap: wrap;
+    align-items: flex-start;
+  }
+  /* `body` takes the full first row; `date` and `row-actions` share
+     a second row below. `order` keeps DOM source order intact for
+     screen readers / keyboard nav while letting the visual layout
+     match the banlist card pattern. The wrap on row-actions itself
+     means a fourth/fifth action (archive flow) re-wraps onto a
+     third visual row instead of overflowing the card. */
+  .queue-row__body { flex: 1 1 100%; }
+  .queue-row__date {
+    order: 2;
+    flex: 1 1 auto;
+    align-self: center;
+  }
+  .queue-row > summary > .row-actions {
+    order: 3;
+    flex-wrap: wrap;
+    justify-content: flex-end;
+    gap: 0.375rem;
+  }
+}
 
 /* ---- Responsive ---- */
 [data-mobile-menu] { display: none; }

--- a/web/themes/default/page_admin_bans_protests.tpl
+++ b/web/themes/default/page_admin_bans_protests.tpl
@@ -51,14 +51,18 @@
         {else}
             <div class="card" style="overflow:hidden" data-testid="protests-list">
                 {foreach from=$protest_list item="protest"}
-                    <details class="ban-row ban-row--active"
+                    {* PUB-2 (#1207): `queue-row` is the layout class for
+                       the summary; `ban-row` keeps the state border-left
+                       (orange "active" stripe). theme.css owns the flex
+                       row + mobile card-stack rules — see the
+                       `.queue-row` block there. *}
+                    <details class="queue-row ban-row ban-row--active"
                              id="pid_{$protest.pid}"
                              data-testid="protest-row"
                              data-id="{$protest.pid}"
                              style="border-bottom:1px solid var(--border)">
-                        <summary class="flex items-center gap-3 p-4"
-                                 style="cursor:pointer;list-style:none">
-                            <div style="flex:1;min-width:0">
+                        <summary>
+                            <div class="queue-row__body">
                                 <div class="font-medium text-sm truncate" data-testid="protest-row-name">
                                     <a class="link"
                                        href="./index.php?p=banlist&advSearch={$protest.authid|escape:'url'}&advType=steamid"
@@ -69,10 +73,10 @@
                                     {if $protest.authid != ""}{$protest.authid|escape}{else}{$protest.ip|escape}{/if}
                                 </div>
                             </div>
-                            <div class="text-xs text-muted" style="flex-shrink:0">
+                            <div class="queue-row__date">
                                 {$protest.datesubmitted|escape}
                             </div>
-                            <div class="row-actions" style="opacity:1;flex-shrink:0">
+                            <div class="row-actions">
                                 {if $permission_editban}
                                     <button type="button"
                                             class="btn btn--ghost btn--sm"

--- a/web/themes/default/page_admin_bans_protests_archiv.tpl
+++ b/web/themes/default/page_admin_bans_protests_archiv.tpl
@@ -48,14 +48,16 @@
         {else}
             <div class="card" style="overflow:hidden" data-testid="protests-archive-list">
                 {foreach from=$protest_list_archiv item="protest"}
-                    <details class="ban-row ban-row--expired"
+                    {* PUB-2 (#1207): `queue-row` is the layout class; see
+                       the `.queue-row` block in theme.css. `ban-row--expired`
+                       keeps the gray state-border. *}
+                    <details class="queue-row ban-row ban-row--expired"
                              id="apid_{$protest.pid}"
                              data-testid="protest-archive-row"
                              data-id="{$protest.pid}"
                              style="border-bottom:1px solid var(--border)">
-                        <summary class="flex items-center gap-3 p-4"
-                                 style="cursor:pointer;list-style:none">
-                            <div style="flex:1;min-width:0">
+                        <summary>
+                            <div class="queue-row__body">
                                 <div class="font-medium text-sm truncate" data-testid="protest-archive-row-name">
                                     {if $protest.archiv != 2}
                                         <a class="link"
@@ -70,10 +72,10 @@
                                     {if $protest.authid != ""}{$protest.authid|escape}{else}{$protest.ip|escape}{/if}
                                 </div>
                             </div>
-                            <div class="text-xs text-muted" style="flex-shrink:0">
+                            <div class="queue-row__date">
                                 {$protest.datesubmitted|escape}
                             </div>
-                            <div class="row-actions" style="opacity:1;flex-shrink:0">
+                            <div class="row-actions">
                                 {if $permission_editban}
                                     <button type="button"
                                             class="btn btn--ghost btn--sm"

--- a/web/themes/default/page_admin_bans_submissions.tpl
+++ b/web/themes/default/page_admin_bans_submissions.tpl
@@ -56,14 +56,18 @@
         {else}
             <div class="card" style="overflow:hidden" data-testid="submissions-list">
                 {foreach from=$submission_list item="sub"}
-                    <details class="ban-row ban-row--active"
+                    {* PUB-2 (#1207): `queue-row` is the layout class for
+                       the summary; `ban-row` keeps the state border-left
+                       (orange "active" stripe). theme.css owns the flex
+                       row + mobile card-stack rules — see the
+                       `.queue-row` block there. *}
+                    <details class="queue-row ban-row ban-row--active"
                              id="sid_{$sub.subid}"
                              data-testid="submission-row"
                              data-id="{$sub.subid}"
                              style="border-bottom:1px solid var(--border)">
-                        <summary class="flex items-center gap-3 p-4"
-                                 style="cursor:pointer;list-style:none">
-                            <div style="flex:1;min-width:0">
+                        <summary>
+                            <div class="queue-row__body">
                                 <div class="font-medium text-sm truncate" data-testid="submission-row-name">
                                     {* nofilter: sub.name is wordwrap(htmlspecialchars($sub['name']), 55, "<br />", true) in admin.bans.php — already entity-escaped, only `<br />` reintroduced. *}
                                     {$sub.name nofilter}
@@ -72,10 +76,10 @@
                                     {if $sub.SteamId != ""}{$sub.SteamId|escape}{else}{$sub.sip|escape}{/if}
                                 </div>
                             </div>
-                            <div class="text-xs text-muted" style="flex-shrink:0">
+                            <div class="queue-row__date">
                                 {$sub.submitted|escape}
                             </div>
-                            <div class="row-actions" style="opacity:1;flex-shrink:0">
+                            <div class="row-actions">
                                 <button type="button"
                                         class="btn btn--secondary btn--sm"
                                         data-testid="row-action-ban"

--- a/web/themes/default/page_admin_bans_submissions_archiv.tpl
+++ b/web/themes/default/page_admin_bans_submissions_archiv.tpl
@@ -49,14 +49,16 @@
         {else}
             <div class="card" style="overflow:hidden" data-testid="submissions-archive-list">
                 {foreach from=$submission_list_archiv item="sub"}
-                    <details class="ban-row ban-row--expired"
+                    {* PUB-2 (#1207): `queue-row` is the layout class; see
+                       the `.queue-row` block in theme.css. `ban-row--expired`
+                       keeps the gray state-border. *}
+                    <details class="queue-row ban-row ban-row--expired"
                              id="asid_{$sub.subid}"
                              data-testid="submission-archive-row"
                              data-id="{$sub.subid}"
                              style="border-bottom:1px solid var(--border)">
-                        <summary class="flex items-center gap-3 p-4"
-                                 style="cursor:pointer;list-style:none">
-                            <div style="flex:1;min-width:0">
+                        <summary>
+                            <div class="queue-row__body">
                                 <div class="font-medium text-sm truncate" data-testid="submission-archive-row-name">
                                     {* nofilter: sub.name is wordwrap(htmlspecialchars($sub['name']), 55, "<br />", true) — already entity-escaped in admin.bans.php. *}
                                     {$sub.name nofilter}
@@ -65,10 +67,10 @@
                                     {if $sub.SteamId != ""}{$sub.SteamId|escape}{else}{$sub.sip|escape}{/if}
                                 </div>
                             </div>
-                            <div class="text-xs text-muted" style="flex-shrink:0">
+                            <div class="queue-row__date">
                                 {$sub.submitted|escape}
                             </div>
-                            <div class="row-actions" style="opacity:1;flex-shrink:0">
+                            <div class="row-actions">
                                 {if $sub.archiv != "2" AND $sub.archiv != "3"}
                                     <button type="button"
                                             class="btn btn--secondary btn--sm"

--- a/web/themes/default/page_bans.tpl
+++ b/web/themes/default/page_bans.tpl
@@ -113,8 +113,18 @@
   </form>
 
   {* -- Desktop table (>=769px). Below that, .table is hidden by
-       theme.css and .ban-cards takes over. *}
+       theme.css and .ban-cards takes over.
+
+       The `.table-scroll` wrapper inside the card is the PUB-1
+       (#1207) horizontal-overflow fallback: at 1024-1100px (after
+       the sidebar collapses) the natural column widths can exceed
+       the panel; rather than clipping STATUS / row-actions, the
+       table scrolls horizontally inside the card's rounded frame.
+       Pair with the `col-*` classes on each cell which pin the
+       always-short columns to `white-space: nowrap` so we don't
+       waste a scroll on a 3-line wrapped date. *}
   <div class="card" style="overflow:hidden">
+    <div class="table-scroll">
     <table class="table">
       <thead>
         <tr>
@@ -122,11 +132,11 @@
           <th scope="col">SteamID</th>
           <th scope="col">Reason</th>
           <th scope="col">Server</th>
-          {if !$hideadminname}<th scope="col">Admin</th>{/if}
-          <th scope="col">Length</th>
-          <th scope="col">Banned</th>
-          <th scope="col">Status</th>
-          <th scope="col" aria-label="Row actions"></th>
+          {if !$hideadminname}<th scope="col" class="col-admin">Admin</th>{/if}
+          <th scope="col" class="col-length">Length</th>
+          <th scope="col" class="col-banned">Banned</th>
+          <th scope="col" class="col-status">Status</th>
+          <th scope="col" class="col-actions" aria-label="Row actions"></th>
         </tr>
       </thead>
       <tbody>
@@ -167,17 +177,17 @@
           <td class="text-muted truncate" style="max-width:18rem">{if empty($ban.reason)}<i class="text-faint">no reason</i>{else}{$ban.reason|escape}{/if}</td>
           <td class="text-muted truncate" style="max-width:12rem">{$ban.sname|escape}</td>
           {if !$hideadminname}
-          <td class="text-muted">
+          <td class="col-admin text-muted">
             {if empty($ban.aname)}<i class="text-faint">deleted</i>{else}{$ban.aname|escape}{/if}
           </td>
           {/if}
-          <td class="tabular-nums text-muted">{if $ban.length == 0}Permanent{else}{$ban.length_human|escape}{/if}</td>
-          <td class="text-muted text-xs"><time datetime="{$ban.banned_iso}">{$ban.banned_human|escape}</time></td>
-          <td>
+          <td class="col-length tabular-nums text-muted">{if $ban.length == 0}Permanent{else}{$ban.length_human|escape}{/if}</td>
+          <td class="col-banned text-muted text-xs"><time datetime="{$ban.banned_iso}">{$ban.banned_human|escape}</time></td>
+          <td class="col-status">
             {assign var=_pill_label value=$ban.state|capitalize}
             <span class="pill pill--{$ban.state}">{$_pill_label|escape}</span>
           </td>
-          <td>
+          <td class="col-actions">
             <div class="row-actions">
               {if $view_bans}
                 {if $ban.can_edit_ban && $ban.state != 'unbanned'}
@@ -207,6 +217,7 @@
         {/foreach}
       </tbody>
     </table>
+    </div>
 
     {* -- Mobile card list (<769px). Single anchor per row so a tap
          opens the detail view; data-drawer-href layers the C1 drawer


### PR DESCRIPTION
## Summary

Slice 4 of #1207 — banlist & queue table polish. Addresses PUB-1, PUB-2.

- **PUB-1** — Public banlist's desktop table no longer wraps the BANNED date to three lines or clips the STATUS header to "STA…"; columns nowrap, STATUS shrinks-to-content, and a `.table-scroll` wrapper provides a horizontal-scroll fallback when natural column widths exceed the card.
- **PUB-2** — Admin moderation queues (`Ban submissions` and `Ban protests`, current + archive) adopt the public banlist's mobile card pattern via a new `.queue-row` block: at <=768px the summary stacks `[name+steam]` over `[date] [actions]` so all three row actions ("Ban", "Remove", "Contact") stay reachable without horizontal scroll.

Both changes keep every #1123 `data-testid` selector contract intact and resolve every colour via existing CSS tokens, so light + dark themes are unchanged on the desktop chrome.

## Test plan

- [x] PHPStan clean (`./sbpp.sh phpstan`)
- [x] PHPUnit clean (`./sbpp.sh test` — 285 tests, 1211 assertions)
- [x] ts-check clean (`./sbpp.sh ts-check`)
- [x] API contract clean (no handler changes; `./sbpp.sh composer api-contract` produces no diff)
- [x] Playwright E2E clean (chromium + mobile-chromium; 89 passed, 167 project-skipped)
- [x] Screenshot gallery regenerated; the per-PR upload follows in a comment below.
- [x] Manual: at desktop width the BANNED date renders on one line, the status pill stays inside the table; on mobile the admin submission queue uses the card layout with all three actions reachable inside the row.

## Notes

- The audit's literal suggested fix mentions "relax `min-width` on LENGTH / BANNED / ADMIN" but the existing CSS has no min-width on those columns — the equivalent fix is the `white-space: nowrap` pin we ship here, which prevents the auto-layout from compressing the columns below their natural content. The horizontal-scroll wrapper is the fallback path the audit suggested; it kicks in when the natural column widths still exceed the card (e.g. 1024–1100px viewport zone, or unusually long player + reason combos).
- The card pattern is shared across all four queue templates (current + archive submissions + protests) — the `.queue-row` selector is scoped to `details.queue-row > summary` so it doesn't accidentally apply to the public banlist's mobile cards (which use `<a>`, not `<details>`).

Does NOT close #1207.