### PR TITLE
fix(theme): unify empty states + copy (#1207 slice 5)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -437,14 +437,24 @@ result is structural (no rows exist anywhere) or filter-induced
 - **first-run** (no data exists): icon + short title ("No servers
   configured yet") + one-line body explaining what will appear here +
   a primary CTA gated on the appropriate `ADMIN_*` flag (e.g.
-  `dashboard-recent-bans-empty-add`, `servers-empty-add`).
-  Read-only streams (e.g. "Latest blocked attempts") get the same
-  card layout but **no** CTA — there's no admin action that seeds it.
+  `dashboard-recent-bans-empty-add`, `servers-empty-add`,
+  `banlist-empty-add`, `comms-empty-add`). Mark the container with
+  `data-filtered="false"`. Read-only streams (e.g. "Latest blocked
+  attempts", admin submission/protest archives) get the same card
+  layout but **no** CTA — there's no admin action that seeds them.
 - **filtered** (data exists, filter excluded everything): icon +
   short title ("No bans match those filters") + one-line body + a
   secondary "Clear filters" CTA that drops the user back at the
-  unfiltered route. Add `data-filtered="true"` on the empty-state
-  container so tests can disambiguate the two shapes.
+  unfiltered route. Mark the container with `data-filtered="true"`.
+
+Surfaces that mix the two (banlist, commslist, audit log) compute an
+`$is_filtered` flag in the page handler from the active `_GET` /
+session params and branch the entire empty-state block on it; the
+View DTO carries the flag. See `page.banlist.php` /
+`page.commslist.php` / `page_admin_audit.tpl` for the reference
+shapes. Tests anchor on the `data-filtered` attribute (`[data-filtered="false"]`
+for the first-run shape, `[data-filtered="true"]` for the filtered
+shape) — never on visible copy.
 
 Use the shared `.empty-state` / `.empty-state__icon` /
 `.empty-state__title` / `.empty-state__body` /

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -419,6 +419,46 @@ bearing assertion that the value is already safe HTML, so:
 - Settings UIs surface a Markdown cheat-sheet link in the help icon.
   **Do not** reintroduce a WYSIWYG editor for these fields; the
   WYSIWYG was the source of #1113's stored-XSS vector.
+- A live preview pane (textarea on the left, server-rendered HTML on
+  the right) is the canonical UX. Updates POST the textarea value to
+  the `system.preview_intro_text` JSON action, which pipes the value
+  through the same `IntroRenderer` so the preview matches the public
+  dashboard byte-for-byte. The first paint is server-rendered (so the
+  page works without JS); the JS-side update only fires on input.
+  Reuse this pattern — never call a third-party Markdown renderer
+  client-side, as it would diverge from the safe-on-render contract.
+
+### Empty states (`first-run` vs `filtered`)
+
+Empty surfaces follow one of two shapes; pick by whether the empty
+result is structural (no rows exist anywhere) or filter-induced
+(rows exist but the active filter excludes everything):
+
+- **first-run** (no data exists): icon + short title ("No servers
+  configured yet") + one-line body explaining what will appear here +
+  a primary CTA gated on the appropriate `ADMIN_*` flag (e.g.
+  `dashboard-recent-bans-empty-add`, `servers-empty-add`).
+  Read-only streams (e.g. "Latest blocked attempts") get the same
+  card layout but **no** CTA — there's no admin action that seeds it.
+- **filtered** (data exists, filter excluded everything): icon +
+  short title ("No bans match those filters") + one-line body + a
+  secondary "Clear filters" CTA that drops the user back at the
+  unfiltered route. Add `data-filtered="true"` on the empty-state
+  container so tests can disambiguate the two shapes.
+
+Use the shared `.empty-state` / `.empty-state__icon` /
+`.empty-state__title` / `.empty-state__body` /
+`.empty-state__actions` classes from `web/themes/default/css/theme.css`
+so the visual treatment stays consistent across surfaces. Never
+inline an ad-hoc empty state — the unified pattern is what the
+audit (#1207) locked in. New CTAs:
+
+- Bind to a `data-testid` per surface (e.g.
+  `dashboard-servers-empty-add`, `servers-empty-add`) so E2E specs
+  anchor on the contract, not visible text.
+- Live behind `{if $can_*}` (the `Sbpp\View\Perms::for($userbank)`
+  snapshot) so a user without the relevant `ADMIN_*` flag sees the
+  body copy without the link they couldn't follow.
 
 ## Anti-patterns (do NOT reintroduce)
 
@@ -448,7 +488,19 @@ bearing assertion that the value is already safe HTML, so:
   in `sb_settings` and rendered to other users → these fields end up
   emitted through `nofilter` and become a stored-XSS vector for every
   admin with the relevant flag (#1113). Use a plain `<textarea>` and
-  pipe the value through `Sbpp\Markup\IntroRenderer` (Markdown).
+  pipe the value through `Sbpp\Markup\IntroRenderer` (Markdown). For
+  immediate visual feedback, pair the textarea with the live preview
+  pane shape from `page_admin_settings_settings.tpl` (calls
+  `system.preview_intro_text`, server-renders through `IntroRenderer`).
+- Ad-hoc per-page empty-state copy → use the shared `.empty-state`
+  layout + the first-run-vs-filtered split documented under
+  "Empty states" above. Inconsistent voice and missing CTAs are what
+  #1207's empty-state audit caught; future surfaces stay on the
+  unified pattern.
+- Markdown-rendering admin display text client-side → use the
+  server-side `system.preview_intro_text` action (same `IntroRenderer`
+  the public dashboard uses). A bundled JS Markdown library would
+  diverge from the safe-on-render contract.
 - Unannotated `{$foo nofilter}` → every `nofilter` is an assertion the
   value is safe HTML; without a `{* nofilter: <why> *}` comment above
   it, future readers can't tell whether it's a real escape hatch or a
@@ -483,6 +535,9 @@ bearing assertion that the value is already safe HTML, so:
 | Edit the player-detail drawer (open trigger, tabs, panes, lazy loaders) | `web/themes/default/js/theme.js` (`renderDrawerBody` / `loadPaneIfNeeded`) |
 | Add admin-only per-player notes | `web/api/handlers/notes.php` (CRUD) — Notes tab is gated by `bans.detail`'s `notes_visible` flag |
 | Render admin-authored Markdown to safe HTML | `web/includes/Markup/IntroRenderer.php` (`Sbpp\Markup`) |
+| Live-preview Markdown in a settings textarea | `system.preview_intro_text` JSON action + `web/themes/default/page_admin_settings_settings.tpl` (`.dash-intro-editor` / `.dash-intro-preview`) |
+| Build an empty-state surface (first-run vs filtered, primary/secondary CTAs) | `.empty-state` rules in `web/themes/default/css/theme.css` + reference shapes in `page_servers.tpl`, `page_dashboard.tpl`, `page_bans.tpl`, `page_comms.tpl`, `page_admin_audit.tpl`, `page_admin_bans_protests.tpl`, `page_admin_bans_submissions.tpl` |
+| Add a shared "1 of these required" badge for an either/or input pair | `web/themes/default/page_submitban.tpl` (`data-required-group="…"` + the inline guard script — vanilla JS `// @ts-check`, blocks submit when both are empty) |
 | Bootstrap (paths, autoload, theme)     | `web/init.php`                                           |
 | Routing (`?p=…&c=…&o=…`)               | `web/includes/page-builder.php` — unrecognised admin `c=…` returns the 404 page slot via `web/pages/page.404.php` + `Sbpp\View\NotFoundView` (#1207 ADM-1) |
 | Resolve the panel version (`SB_VERSION`, `data-version="…"` footer hook) | `web/includes/Version.php` (`Sbpp\Version::resolve()`) — three-tier fallback: `configs/version.json` → `git describe` → the `'dev'` sentinel (#1207 CC-5) |

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -478,6 +478,19 @@ so configuration cost is paid once per request. Call sites pass the
 template emits with `nofilter` and a Smarty comment pointing back at
 the renderer (see `web/themes/default/page_dashboard.tpl`).
 
+`IntroRenderer` is also reachable from the JSON API as
+`system.preview_intro_text` (#1207 SET-1). The settings page uses it to
+power the live Markdown preview pane next to the `dash.intro.text`
+textarea: the textarea is the source of truth, and on `input` (200ms
+debounce) the JS handler POSTs the current value, receives the rendered
+HTML back, and patches the preview pane in place. The first paint
+comes from PHP via the `AdminSettingsView::$config_dash_text_preview`
+field, so the page works without JS too. The preview pane runs the
+**same** `IntroRenderer` the public dashboard runs, so what the admin
+sees in the preview is what visitors see — never wire up a third-party
+JS Markdown renderer in its place; that would diverge from the
+safe-on-render contract.
+
 Issue #1113 is the audit that introduced this: `dash.intro.text` used
 to render straight DB HTML through `{$dashboard_text nofilter}`,
 making any admin with `ADMIN_SETTINGS` a stored-XSS source. The

--- a/web/api/handlers/_register.php
+++ b/web/api/handlers/_register.php
@@ -134,3 +134,8 @@ Api::register('system.check_version',         'api_system_check_version',       
 Api::register('system.sel_theme',             'api_system_sel_theme',             ADMIN_OWNER | ADMIN_WEB_SETTINGS);
 Api::register('system.apply_theme',           'api_system_apply_theme',           ADMIN_OWNER | ADMIN_WEB_SETTINGS);
 Api::register('system.clear_cache',           'api_system_clear_cache',           ADMIN_OWNER | ADMIN_WEB_SETTINGS);
+// #1207 SET-1: live Markdown preview for admin-authored display text
+// (currently only the dashboard intro). Gated on the same flag as the
+// settings page so we don't accidentally expose the renderer to
+// non-settings surfaces.
+Api::register('system.preview_intro_text',    'api_system_preview_intro_text',    ADMIN_OWNER | ADMIN_WEB_SETTINGS);

--- a/web/api/handlers/system.php
+++ b/web/api/handlers/system.php
@@ -13,6 +13,7 @@ work.  If not, see <http://creativecommons.org/licenses/by-nc-sa/3.0/>.
 
 use Sbpp\Mail\EmailType;
 use Sbpp\Mail\Mail;
+use Sbpp\Markup\IntroRenderer;
 
 function api_system_check_version(array $params): array
 {
@@ -174,6 +175,43 @@ function api_system_send_mail(array $params): array
             'redir' => 'index.php?p=admin&c=bans',
         ],
     ];
+}
+
+/**
+ * Render an admin-authored Markdown snippet (currently used by the
+ * dashboard `dash.intro.text` setting; #1207 SET-1) through the same
+ * `Sbpp\Markup\IntroRenderer` the public dashboard uses, so the
+ * settings page can show a live "this is what visitors will see"
+ * preview without forcing the admin to save + navigate to `/`.
+ *
+ * Critical: NEVER render the supplied Markdown with anything other
+ * than `IntroRenderer::renderIntroText`. The renderer wraps
+ * league/commonmark with `html_input: 'escape'` and
+ * `allow_unsafe_links: false` — that's the only safe path documented
+ * in AGENTS.md ("Admin-authored display text"). #1113 was a stored
+ * XSS rooted in a parallel render path; ducking back into a plain
+ * CommonMark/Parsedown call here would re-open the vector.
+ *
+ * Gated on `ADMIN_OWNER | ADMIN_WEB_SETTINGS` because the only
+ * caller is the settings page (gated on the same flag), and we'd
+ * rather refuse a stray call from another surface than discover a
+ * new caller exists.
+ *
+ * @param array{markdown?: string} $params
+ * @return array{html: string}
+ */
+function api_system_preview_intro_text(array $params): array
+{
+    $markdown = (string) ($params['markdown'] ?? '');
+    // Long inputs can stall the renderer; the textarea has no
+    // server-side length limit but a 64 KiB ceiling is well past any
+    // reasonable intro length (the rendered field already lives in
+    // a single TEXT column) and prevents a logged-in admin from
+    // wedging the API with a runaway paste.
+    if (strlen($markdown) > 65536) {
+        $markdown = substr($markdown, 0, 65536);
+    }
+    return ['html' => IntroRenderer::renderIntroText($markdown)];
 }
 
 function api_system_rehash_admins(array $params): array

--- a/web/includes/View/AdminSettingsView.php
+++ b/web/includes/View/AdminSettingsView.php
@@ -38,6 +38,15 @@ final class AdminSettingsView extends View
         public readonly string $config_dateformat,
         public readonly string $config_dash_title,
         public readonly string $config_dash_text,
+        // #1207 SET-1: pre-rendered HTML for the live-preview pane's
+        // first paint. Source value is `config_dash_text` (raw
+        // Markdown); the page handler runs it through
+        // `Sbpp\Markup\IntroRenderer::renderIntroText()` so the
+        // template can drop the result into the preview pane behind
+        // `nofilter` without the JS round-trip. The JS preview update
+        // (debounced on textarea input) calls
+        // `system.preview_intro_text` for fresh renders.
+        public readonly string $config_dash_text_preview,
         public readonly int $auth_maxlife,
         public readonly int $auth_maxlife_remember,
         public readonly int $auth_maxlife_steam,

--- a/web/includes/View/BanListView.php
+++ b/web/includes/View/BanListView.php
@@ -60,6 +60,15 @@ final class BanListView extends View
         public readonly bool $can_delete,
         public readonly bool $can_export,
         public readonly string $admin_postkey,
+        // #1207: gates the first-run empty-state CTA in `page_bans.tpl`
+        // (admins with `ADMIN_ADD_BAN` see "Add a ban", everyone else
+        // sees the body copy without the link). Splatted from
+        // `Perms::for($userbank)` in `web/pages/page.banlist.php`.
+        public readonly bool $can_add_ban,
+        // #1207: detects whether the current request applied any filter
+        // (search text / advSearch / hide-inactive). Drives the
+        // first-run-vs-filtered split in the empty-state shape.
+        public readonly bool $is_filtered,
     ) {
     }
 }

--- a/web/includes/View/CommsListView.php
+++ b/web/includes/View/CommsListView.php
@@ -78,6 +78,14 @@ final class CommsListView extends View
         public readonly bool $can_edit_comm,
         public readonly bool $can_unmute_gag,
         public readonly bool $can_delete_comm,
+        // #1207: detects whether the current request applied any filter
+        // (search text / server / time / state / type / hide-inactive).
+        // Drives the first-run-vs-filtered split in the empty-state
+        // shape — when zero rows AND no filter, the empty state shows
+        // "no comm blocks recorded yet" with an "Add a comm block" CTA;
+        // with a filter, it stays "No comm blocks match those filters"
+        // + "Clear filters".
+        public readonly bool $is_filtered,
         // Legacy template variables — preserved on the View (rather
         // than left as raw $theme->assign() calls in the handler) so
         // SmartyTemplateRule can verify any third-party theme that

--- a/web/includes/View/HomeDashboardView.php
+++ b/web/includes/View/HomeDashboardView.php
@@ -39,6 +39,14 @@ final class HomeDashboardView extends View
         public readonly int $total_servers,
         public readonly bool $IN_SERVERS_PAGE,
         public readonly int $opened_server,
+        // #1207 PUB-5: gate per-card empty-state CTAs in
+        // page_dashboard.tpl. `can_add_ban` is reused for the comm
+        // blocks card too — both flow through the same admin
+        // surface (?p=admin&c=bans / ?p=admin&c=comms) which is
+        // gated on ADMIN_ADD_BAN. Splatted from
+        // `Perms::for($userbank)` in `web/pages/page.home.php`.
+        public readonly bool $can_add_ban,
+        public readonly bool $can_add_server,
     ) {
     }
 }

--- a/web/includes/View/ServersView.php
+++ b/web/includes/View/ServersView.php
@@ -46,6 +46,11 @@ final class ServersView extends View
         public readonly array $server_list,
         public readonly bool $IN_SERVERS_PAGE,
         public readonly int $opened_server,
+        // #1207 PUB-3: gates the "Add a server" CTA in the empty
+        // state (and is harmless when servers exist; the template
+        // only references it inside the empty branch). Splatted from
+        // `Perms::for($userbank)` in `web/pages/page.servers.php`.
+        public readonly bool $can_add_server,
     ) {
     }
 }

--- a/web/pages/admin.settings.php
+++ b/web/pages/admin.settings.php
@@ -393,6 +393,7 @@ if ($section === 'themes') {
         (string) Config::get('smtp.port'),
     ];
 
+    $dashText = (string) Config::get('dash.intro.text');
     Renderer::render($theme, new AdminSettingsView(
         can_web_settings:          $perms['can_web_settings'],
         can_owner:                 $perms['can_owner'],
@@ -402,7 +403,10 @@ if ($section === 'themes') {
         config_min_password:       (int) MIN_PASS_LENGTH,
         config_dateformat:         (string) Config::get('config.dateformat'),
         config_dash_title:         (string) Config::get('dash.intro.title'),
-        config_dash_text:          (string) Config::get('dash.intro.text'),
+        config_dash_text:          $dashText,
+        // #1207 SET-1: server-rendered first paint for the live preview.
+        // JS-side updates call system.preview_intro_text on input.
+        config_dash_text_preview:  \Sbpp\Markup\IntroRenderer::renderIntroText($dashText),
         auth_maxlife:              (int) Config::get('auth.maxlife'),
         auth_maxlife_remember:     (int) Config::get('auth.maxlife.remember'),
         auth_maxlife_steam:        (int) Config::get('auth.maxlife.steam'),

--- a/web/pages/page.banlist.php
+++ b/web/pages/page.banlist.php
@@ -974,6 +974,17 @@ if (isset($_GET["comment"])) {
 
 unset($_SESSION['CountryFetchHndl']);
 
+// #1207: detect whether the current request is filtered (search box,
+// advanced search, hide-inactive toggle). Drives the
+// first-run-vs-filtered split in the empty-state shape — when zero
+// rows AND no filter, the empty state shows "no bans recorded yet"
+// with an "Add a ban" CTA gated on can_add_ban; with a filter
+// active, it stays "No bans match those filters" + "Clear filters".
+$banlistIsFiltered =
+    (isset($_GET['searchText']) && (string) $_GET['searchText'] !== '')
+    || (isset($_GET['advSearch']) && (string) $_GET['advSearch'] !== '')
+    || isset($_SESSION['hideinactive']);
+
 Renderer::render($theme, new BanListView(
     ban_list:        $bans,
     ban_nav:         $ban_nav,
@@ -998,4 +1009,6 @@ Renderer::render($theme, new BanListView(
     can_delete:      (bool) $userbank->HasAccess(ADMIN_OWNER | ADMIN_DELETE_BAN),
     can_export:      (bool) $userbank->HasAccess(ADMIN_OWNER) || Config::getBool('config.exportpublic'),
     admin_postkey:   $_SESSION['banlist_postkey'],
+    can_add_ban:     (bool) $userbank->HasAccess(ADMIN_OWNER | ADMIN_ADD_BAN),
+    is_filtered:     $banlistIsFiltered,
 ));

--- a/web/pages/page.commslist.php
+++ b/web/pages/page.commslist.php
@@ -971,6 +971,17 @@ $pagination = [
 $hideInactive       = isset($_SESSION['hideinactive']);
 $hideInactiveToggle = 'index.php?p=commslist&hideinactive=' . ($hideInactive ? 'false' : 'true') . $searchlink;
 
+// #1207: filter-aware empty state. Any filter chip / search / time /
+// hide-inactive flips this; the template branches the empty-state
+// copy + CTA on the result (first-run vs filtered).
+$commsIsFiltered =
+    $filters['search'] !== ''
+    || $filters['server'] !== ''
+    || $filters['time']   !== ''
+    || $filters['state']  !== ''
+    || $filters['type']   !== ''
+    || $hideInactive;
+
 // Aggregate permission flags. Each precomputed via Perms::for($userbank)
 // so the template's {if $can_*} reads stay opinion-free about the bit
 // math — see the AGENTS.md "Permissions" section + Perms::for() docblock.
@@ -999,6 +1010,7 @@ $can_delete_comm  = $perms['can_owner'] || $perms['can_delete_ban'];
     can_edit_comm:            $can_edit_comm,
     can_unmute_gag:           $can_unmute_gag,
     can_delete_comm:          $can_delete_comm,
+    is_filtered:              $commsIsFiltered,
     comment:                  $ceditBid,
     commenttype:              $ceditType,
     canedit:                  $userbank->is_admin(),

--- a/web/pages/page.home.php
+++ b/web/pages/page.home.php
@@ -17,7 +17,7 @@ Licensed under CC-BY-NC-SA 3.0
 Page: <http://www.sourcebans.net/> - <http://www.gameconnect.net/>
 *************************************************************************/
 
-global $theme;
+global $theme, $userbank;
 if (!defined("IN_SB")) {
     echo "You should not be here. Only follow links!";
     die();

--- a/web/pages/page.home.php
+++ b/web/pages/page.home.php
@@ -261,6 +261,9 @@ foreach ($rows as $row) {
 require(TEMPLATES_PATH . "/page.servers.php"); //populates $serversView
 /** @var \Sbpp\View\ServersView $serversView */
 
+// See page.servers.php / admin.settings.php for the rationale on
+// pulling `$perms['can_*']` keys by name rather than splatting whole.
+$homePerms = \Sbpp\View\Perms::for($userbank);
 \Sbpp\View\Renderer::render($theme, new \Sbpp\View\HomeDashboardView(
     dashboard_title: (string) (Config::get('dash.intro.title') ?? ''),
     dashboard_text: \Sbpp\Markup\IntroRenderer::renderIntroText(
@@ -279,4 +282,6 @@ require(TEMPLATES_PATH . "/page.servers.php"); //populates $serversView
     total_servers: count($serversView->server_list),
     IN_SERVERS_PAGE: $serversView->IN_SERVERS_PAGE,
     opened_server: $serversView->opened_server,
+    can_add_ban:    $homePerms['can_add_ban'],
+    can_add_server: $homePerms['can_add_server'],
 ));

--- a/web/pages/page.servers.php
+++ b/web/pages/page.servers.php
@@ -17,7 +17,7 @@ Licensed under CC-BY-NC-SA 3.0
 Page: <http://www.sourcebans.net/> - <http://www.gameconnect.net/>
 *************************************************************************/
 
-global $theme;
+global $theme, $userbank;
 if (!defined("IN_SB")) {
     echo "You should not be here. Only follow links!";
     die();

--- a/web/pages/page.servers.php
+++ b/web/pages/page.servers.php
@@ -81,11 +81,19 @@ foreach ($rows as $row) {
     $i++;
 }
 
+// Pull per-flag perms by name rather than splatting `Perms::for(...)`
+// whole — the helper returns every ADMIN_* flag, but PHP 8.1 throws
+// "Unknown named parameter" on any key the View doesn't declare.
+// Listing by hand also makes the View's permission surface
+// self-documenting (matches the admin.settings.php / admin.admins.php
+// pattern).
+$serversPerms = \Sbpp\View\Perms::for($userbank);
 $serversView = new \Sbpp\View\ServersView(
     access_bans: $userbank->HasAccess(ADMIN_OWNER | ADMIN_ADD_BAN),
     server_list: $servers,
     IN_SERVERS_PAGE: !defined('IN_HOME'),
     opened_server: $number,
+    can_add_server: $serversPerms['can_add_server'],
 );
 
 if (!defined('IN_HOME')) {

--- a/web/pages/page.submit.php
+++ b/web/pages/page.submit.php
@@ -120,6 +120,19 @@ if (!isset($_POST['subban']) || $_POST['subban'] != 1) {
         $errors .= '* Please type a valid IP-address.<br>';
         $validsubmit = false;
     }
+    // #1207 PUB-4: at least one of Steam ID / IP must be provided.
+    // Mirrors the inline guard in `page_submitban.tpl` so JS-off
+    // visitors can't sneak an empty pair past the form. The "STEAM_0:"
+    // sentinel is what the page handler re-emits when the user blanked
+    // the Steam ID after a previous bounce (see `STEAMID:` assignment
+    // around L293 below) — treat it as empty for this rule too.
+    if (
+        (strlen($SteamID) == 0 || $SteamID == "STEAM_0:")
+        && strlen($BanIP) == 0
+    ) {
+        $errors .= '* Please enter a Steam ID or an IP address before submitting.<br>';
+        $validsubmit = false;
+    }
     if (strlen($PlayerName) == 0) {
         $errors .= '* You must include a player name<br>';
         $validsubmit = false;

--- a/web/phpstan-baseline.neon
+++ b/web/phpstan-baseline.neon
@@ -499,22 +499,10 @@ parameters:
 			path: pages/page.commslist.php
 
 		-
-			message: '#^Variable \$userbank might not be defined\.$#'
-			identifier: variable.undefined
-			count: 3
-			path: pages/page.home.php
-
-		-
 			message: '#^Right side of \|\| is always false\.$#'
 			identifier: booleanOr.rightAlwaysFalse
 			count: 1
 			path: pages/page.lostpassword.php
-
-		-
-			message: '#^Variable \$userbank might not be defined\.$#'
-			identifier: variable.undefined
-			count: 2
-			path: pages/page.servers.php
 
 		-
 			message: '#^Variable \$errors in empty\(\) always exists and is not falsy\.$#'

--- a/web/phpstan-baseline.neon
+++ b/web/phpstan-baseline.neon
@@ -501,7 +501,7 @@ parameters:
 		-
 			message: '#^Variable \$userbank might not be defined\.$#'
 			identifier: variable.undefined
-			count: 2
+			count: 3
 			path: pages/page.home.php
 
 		-
@@ -513,7 +513,7 @@ parameters:
 		-
 			message: '#^Variable \$userbank might not be defined\.$#'
 			identifier: variable.undefined
-			count: 1
+			count: 2
 			path: pages/page.servers.php
 
 		-

--- a/web/scripts/api-contract.js
+++ b/web/scripts/api-contract.js
@@ -325,6 +325,25 @@
  * @typedef {Object} ApiSystemClearCacheResponse
  */
 /**
+ * Render an admin-authored Markdown snippet (currently used by the dashboard
+ * `dash.intro.text` setting; #1207 SET-1) through the same
+ * `Sbpp\Markup\IntroRenderer` the public dashboard uses, so the settings page
+ * can show a live "this is what visitors will see" preview without forcing the
+ * admin to save + navigate to `/`.  Critical: NEVER render the supplied
+ * Markdown with anything other than `IntroRenderer::renderIntroText`. The
+ * renderer wraps league/commonmark with `html_input: 'escape'` and
+ * `allow_unsafe_links: false` — that's the only safe path documented in
+ * AGENTS.md ("Admin-authored display text"). #1113 was a stored XSS rooted in
+ * a parallel render path; ducking back into a plain CommonMark/Parsedown call
+ * here would re-open the vector.  Gated on `ADMIN_OWNER | ADMIN_WEB_SETTINGS`
+ * because the only caller is the settings page (gated on the same flag), and
+ * we'd rather refuse a stray call from another surface than discover a new
+ * caller exists.
+ *
+ * @typedef {Object} ApiSystemPreviewIntroTextRequest
+ * @typedef {{html: string}} ApiSystemPreviewIntroTextResponse
+ */
+/**
  * @typedef {Object} ApiSystemRehashAdminsRequest
  * @typedef {Object} ApiSystemRehashAdminsResponse
  */
@@ -404,6 +423,7 @@ var Actions = Object.freeze({
     SystemApplyTheme: 'system.apply_theme',
     SystemCheckVersion: 'system.check_version',
     SystemClearCache: 'system.clear_cache',
+    SystemPreviewIntroText: 'system.preview_intro_text',
     SystemRehashAdmins: 'system.rehash_admins',
     SystemSelTheme: 'system.sel_theme',
     SystemSendMail: 'system.send_mail',

--- a/web/tests/api/PermissionMatrixTest.php
+++ b/web/tests/api/PermissionMatrixTest.php
@@ -155,6 +155,7 @@ final class PermissionMatrixTest extends TestCase
             'system.sel_theme'                => ['perm' => ADMIN_OWNER | ADMIN_WEB_SETTINGS, 'requireAdmin' => false, 'public' => false],
             'system.apply_theme'              => ['perm' => ADMIN_OWNER | ADMIN_WEB_SETTINGS, 'requireAdmin' => false, 'public' => false],
             'system.clear_cache'              => ['perm' => ADMIN_OWNER | ADMIN_WEB_SETTINGS, 'requireAdmin' => false, 'public' => false],
+            'system.preview_intro_text'       => ['perm' => ADMIN_OWNER | ADMIN_WEB_SETTINGS, 'requireAdmin' => false, 'public' => false],
         ];
     }
 

--- a/web/tests/api/SystemTest.php
+++ b/web/tests/api/SystemTest.php
@@ -187,4 +187,69 @@ final class SystemTest extends ApiTestCase
         $env = $this->api('system.rehash_admins', ['servers' => '']);
         $this->assertEnvelopeError($env, 'forbidden');
     }
+
+    /**
+     * #1207 SET-1: live Markdown preview for the dashboard intro field.
+     *
+     * The handler is a thin wrapper around
+     * `Sbpp\Markup\IntroRenderer::renderIntroText()`; we lock in the
+     * rendered shape (CommonMark inline -> safe HTML) plus the two
+     * security-critical paths the renderer enforces (raw HTML escaped,
+     * `javascript:` links stripped). If a future PR routes preview
+     * through a different renderer, this row fires loudly.
+     */
+    public function testPreviewIntroTextRendersCommonMarkParagraph(): void
+    {
+        $this->loginAsAdmin();
+        $env = $this->api('system.preview_intro_text', [
+            'markdown' => 'Hello **world** with [a link](https://example.test).',
+        ]);
+        $this->assertTrue($env['ok'], json_encode($env));
+        $this->assertSame(
+            "<p>Hello <strong>world</strong> with <a href=\"https://example.test\">a link</a>.</p>\n",
+            $env['data']['html']
+        );
+        $this->assertSnapshot('system/preview_intro_text_paragraph', $env);
+    }
+
+    public function testPreviewIntroTextEscapesRawHtml(): void
+    {
+        $this->loginAsAdmin();
+        $env = $this->api('system.preview_intro_text', [
+            'markdown' => 'safe <script>alert(1)</script> text',
+        ]);
+        $this->assertTrue($env['ok']);
+        // CommonMark with html_input=escape renders inline HTML as
+        // literal text — the `<script>` shows up entity-encoded, not
+        // as a parsed tag, so the preview pane never executes admin
+        // input. This is the contract from `IntroRenderer::converter`.
+        $this->assertStringNotContainsString('<script>', $env['data']['html']);
+        $this->assertStringContainsString('&lt;script&gt;', $env['data']['html']);
+    }
+
+    public function testPreviewIntroTextStripsUnsafeLinks(): void
+    {
+        $this->loginAsAdmin();
+        $env = $this->api('system.preview_intro_text', [
+            'markdown' => '[click](javascript:alert(1))',
+        ]);
+        $this->assertTrue($env['ok']);
+        // `allow_unsafe_links: false` (IntroRenderer) drops
+        // javascript:/data:/vbscript: hrefs entirely.
+        $this->assertStringNotContainsString('javascript:', $env['data']['html']);
+    }
+
+    public function testPreviewIntroTextRendersEmptyForBlankInput(): void
+    {
+        $this->loginAsAdmin();
+        $env = $this->api('system.preview_intro_text', ['markdown' => '']);
+        $this->assertTrue($env['ok']);
+        $this->assertSame('', $env['data']['html']);
+    }
+
+    public function testPreviewIntroTextRejectsAnonymous(): void
+    {
+        $env = $this->api('system.preview_intro_text', ['markdown' => 'hi']);
+        $this->assertEnvelopeError($env, 'forbidden');
+    }
 }

--- a/web/tests/api/__snapshots__/system/preview_intro_text_paragraph.json
+++ b/web/tests/api/__snapshots__/system/preview_intro_text_paragraph.json
@@ -1,0 +1,6 @@
+{
+    "ok": true,
+    "data": {
+        "html": "<p>Hello <strong>world</strong> with <a href=\"https://example.test\">a link</a>.</p>\n"
+    }
+}

--- a/web/tests/e2e/specs/flows/empty-states.spec.ts
+++ b/web/tests/e2e/specs/flows/empty-states.spec.ts
@@ -119,6 +119,52 @@ test.describe('flow: empty states + copy (#1207)', () => {
         }
     });
 
+    // ----- empty-states unification: banlist / commslist first-run -----
+
+    test('banlist first-run empty state shows "Add a ban" CTA, no filter chip', async ({ page }) => {
+        // Fresh DB → zero bans, no filter active. The empty state
+        // should be the first-run shape (data-filtered="false") with
+        // an "Add a ban" CTA gated on `can_add_ban` (admin storage
+        // state holds ADMIN_OWNER → true).
+        await page.goto('/index.php?p=banlist');
+
+        const empty = page.locator('[data-testid="banlist-empty"]');
+        await expect(empty).toBeVisible();
+        await expect(empty).toHaveAttribute('data-filtered', 'false');
+
+        const cta = page.locator('[data-testid="banlist-empty-add"]');
+        await expect(cta).toBeVisible();
+        await expect(cta).toHaveAttribute('href', /\?p=admin&(amp;)?c=bans/);
+        await expect(cta).toContainText(/Add a ban/i);
+
+        // Filtered state is still on the page when a search is active —
+        // navigate with a no-match search and the empty state should
+        // flip to the filtered shape with a "Clear filters" CTA.
+        await page.goto('/index.php?p=banlist&searchText=does-not-match-anything');
+        await expect(empty).toBeVisible();
+        await expect(empty).toHaveAttribute('data-filtered', 'true');
+        await expect(page.locator('[data-testid="banlist-empty-clear"]')).toBeVisible();
+    });
+
+    test('commslist first-run empty state shows "Add a comm block" CTA, no filter chip', async ({ page }) => {
+        await page.goto('/index.php?p=commslist');
+
+        const empty = page.locator('[data-testid="comms-empty"]').first();
+        await expect(empty).toBeVisible();
+        await expect(empty).toHaveAttribute('data-filtered', 'false');
+
+        const cta = page.locator('[data-testid="comms-empty-add"]');
+        await expect(cta).toBeVisible();
+        await expect(cta).toHaveAttribute('href', /\?p=admin&(amp;)?c=comms/);
+        await expect(cta).toContainText(/Add a comm block/i);
+
+        // Filter via searchText → flips to filtered shape.
+        await page.goto('/index.php?p=commslist&searchText=does-not-match-anything');
+        await expect(empty).toBeVisible();
+        await expect(empty).toHaveAttribute('data-filtered', 'true');
+        await expect(page.locator('[data-testid="comms-empty-clear"]')).toBeVisible();
+    });
+
     // ----- PUB-4 ------------------------------------------------------
 
     test('PUB-4: submit form blocks submission when both Steam ID and IP are empty', async ({ browser }, testInfo) => {

--- a/web/tests/e2e/specs/flows/empty-states.spec.ts
+++ b/web/tests/e2e/specs/flows/empty-states.spec.ts
@@ -1,0 +1,208 @@
+/**
+ * Empty states + copy slice (#1207 PUB-3 / PUB-4 / PUB-5 / SET-1).
+ *
+ * Covers the behaviour that the audit's screenshots couldn't catch:
+ *
+ *   - PUB-3: public servers empty state surfaces the "Add a server"
+ *     CTA only when the viewer holds `ADMIN_ADD_SERVER` (the seeded
+ *     admin/admin row holds every flag, so the default storage state
+ *     is the positive case; anonymous browsing context is the
+ *     negative case).
+ *   - PUB-5: dashboard cards (Latest bans, Servers, Latest comm
+ *     blocks) emit per-card primary CTAs in their empty state when
+ *     the corresponding ADMIN_* flag is held. The "Latest blocked
+ *     attempts" card stays CTA-less by design (read-only stream).
+ *   - PUB-4: the public submit-ban form blocks submission when both
+ *     Steam ID and IP are empty, flips
+ *     `[data-required-group="steamid-or-ip"][data-error="true"]`,
+ *     and toggles `[data-state="error"]` on the help line. Filling
+ *     either input clears the error.
+ *   - SET-1: dashboard intro field's preview pane updates on input,
+ *     piping through `system.preview_intro_text` (Sbpp\Markup\IntroRenderer).
+ *     Raw HTML is escaped, `javascript:` links are stripped.
+ *
+ * DB state contract
+ * -----------------
+ * Every test in this file runs against a freshly-truncated
+ * `sourcebans_e2e` DB so the empty states are deterministic. The
+ * truncate path in `Sbpp\Tests\Fixture::truncateAndReseed` holds a
+ * MySQL named lock so even with workers > 1 the truncate-and-reseed
+ * pair stays atomic; subsequent specs that need data of their own
+ * call `truncateE2eDb()` themselves (see
+ * `responsive/admin-queue.spec.ts` for the precedent).
+ *
+ * Selector discipline (#1123 testability hooks)
+ * ---------------------------------------------
+ * Primary anchors are `data-testid` from the locked hooks in
+ * page_servers.tpl, page_dashboard.tpl, page_submitban.tpl,
+ * page_admin_settings_settings.tpl. The CTA links resolve via the
+ * unique per-card testids:
+ *
+ *   - `servers-empty-add`
+ *   - `dashboard-recent-bans-empty-add`
+ *   - `dashboard-servers-empty-add`
+ *   - `dashboard-recent-comms-empty-add`
+ *
+ * Project gating
+ * --------------
+ * Pinned to chromium (desktop) — the contract is identical on
+ * mobile-chromium for the CTA presence + submit form validation,
+ * but the dashboard cards reflow differently and the screenshot
+ * gallery already covers that visual diff. Forcing the spec on
+ * both projects would double the runtime without adding signal.
+ */
+
+import { expect, test } from '../../fixtures/auth.ts';
+import { truncateE2eDb } from '../../fixtures/db.ts';
+import { newAnonymousContext } from '../../pages/SubmitBanFlow.ts';
+
+test.describe('flow: empty states + copy (#1207)', () => {
+    test.beforeEach(({}, testInfo) => {
+        test.skip(
+            testInfo.project.name !== 'chromium',
+            'Empty-state contract is project-agnostic; pinning to desktop chromium for runtime.',
+        );
+    });
+
+    test.beforeEach(async () => {
+        await truncateE2eDb();
+    });
+
+    // ----- PUB-3 ------------------------------------------------------
+
+    test('PUB-3: empty servers page exposes "Add a server" CTA for an admin viewer', async ({ page }) => {
+        await page.goto('/index.php?p=servers');
+
+        const emptyCard = page.locator('[data-testid="servers-empty"]');
+        await expect(emptyCard).toBeVisible();
+
+        const cta = page.locator('[data-testid="servers-empty-add"]');
+        await expect(cta).toBeVisible();
+        await expect(cta).toHaveAttribute('href', /\?p=admin&(amp;)?c=servers/);
+        await expect(cta).toContainText(/Add a server/i);
+    });
+
+    test('PUB-3: empty servers page hides the CTA from an anonymous viewer', async ({ browser }, testInfo) => {
+        const ctx = await newAnonymousContext(browser, testInfo.project.use);
+        try {
+            const anon = await ctx.newPage();
+            await anon.goto('/index.php?p=servers');
+
+            await expect(anon.locator('[data-testid="servers-empty"]')).toBeVisible();
+            await expect(anon.locator('[data-testid="servers-empty-add"]')).toHaveCount(0);
+        } finally {
+            await ctx.close();
+        }
+    });
+
+    // ----- PUB-5 ------------------------------------------------------
+
+    test('PUB-5: dashboard cards expose per-domain CTAs in their empty states', async ({ page }) => {
+        await page.goto('/');
+        await expect(page.locator('[data-testid="dashboard-header"]')).toBeVisible();
+
+        const cards = [
+            { testid: 'dashboard-recent-bans-empty-add', href: /\?p=admin&(amp;)?c=bans/, label: /Add a ban/i },
+            { testid: 'dashboard-servers-empty-add', href: /\?p=admin&(amp;)?c=servers/, label: /Add a server/i },
+            {
+                testid: 'dashboard-recent-comms-empty-add',
+                href: /\?p=admin&(amp;)?c=comms/,
+                label: /Add a comm block/i,
+            },
+        ];
+
+        for (const card of cards) {
+            const cta = page.locator(`[data-testid="${card.testid}"]`);
+            await expect(cta, `${card.testid} should be visible on the empty dashboard`).toBeVisible();
+            await expect(cta).toHaveAttribute('href', card.href);
+            await expect(cta).toContainText(card.label);
+        }
+    });
+
+    // ----- PUB-4 ------------------------------------------------------
+
+    test('PUB-4: submit form blocks submission when both Steam ID and IP are empty', async ({ browser }, testInfo) => {
+        // The form is intentionally exercised in an anonymous context:
+        // submission is the public path (the seeded admin would also
+        // go through the form, but the bug surface is for visitors
+        // and the storage state shouldn't influence the JS guard).
+        const ctx = await newAnonymousContext(browser, testInfo.project.use);
+        try {
+            const anon = await ctx.newPage();
+            await anon.goto('/index.php?p=submit');
+
+            const group = anon.locator('[data-testid="submitban-id-or-ip"]');
+            const help = anon.locator('[data-testid="submitban-id-or-ip-help"]');
+            const submit = anon.locator('[data-testid="submitban-submit"]');
+
+            await expect(group).toBeVisible();
+            await expect(group).toHaveAttribute('data-error', 'false');
+            await expect(help).toHaveAttribute('data-state', 'info');
+
+            // Fill the rest of the form (so the only failing rule is
+            // the Steam ID / IP either-or). The `novalidate` on the
+            // form lets the submit attempt land in our JS handler
+            // even with empty required fields.
+            await anon.locator('[data-testid="submitban-name"]').fill('e2e-pub4');
+            await anon.locator('[data-testid="submitban-reason"]').fill('e2e: PUB-4 client-side validation');
+            await anon.locator('[data-testid="submitban-reporter-email"]').fill('e2e-pub4@example.test');
+            await anon.locator('[data-testid="submitban-server"]').selectOption({ value: '0' });
+
+            await submit.click();
+
+            // Form did not navigate: still on /index.php?p=submit and
+            // the group flipped into the error state. We anchor on
+            // the [data-error] / [data-state] attributes per #1123's
+            // "State in attributes, not just styling" rule.
+            await expect(group).toHaveAttribute('data-error', 'true');
+            await expect(help).toHaveAttribute('data-state', 'error');
+            await expect(anon.locator('[data-testid="submitban-steam"]')).toHaveAttribute('aria-invalid', 'true');
+            await expect(anon.locator('[data-testid="submitban-ip"]')).toHaveAttribute('aria-invalid', 'true');
+            await expect(anon).toHaveURL(/p=submit/);
+
+            // Filling either input clears the error inline (no submit
+            // needed — the `input` event handler is wired to the
+            // same predicate as the submit guard).
+            await anon.locator('[data-testid="submitban-steam"]').fill('STEAM_0:1:777');
+            await expect(group).toHaveAttribute('data-error', 'false');
+            await expect(help).toHaveAttribute('data-state', 'info');
+        } finally {
+            await ctx.close();
+        }
+    });
+
+    // ----- SET-1 ------------------------------------------------------
+
+    test('SET-1: dashboard intro preview renders Markdown via IntroRenderer', async ({ page }) => {
+        await page.goto('/index.php?p=admin&c=settings');
+
+        const textarea = page.locator('[data-testid="dash-intro-textarea"]');
+        const preview = page.locator('[data-testid="dash-intro-preview"]');
+        const previewBody = page.locator('[data-testid="dash-intro-preview-body"]');
+        const cheatsheet = page.locator('[data-testid="dash-intro-cheatsheet-link"]');
+
+        await expect(textarea).toBeVisible();
+        await expect(preview).toBeVisible();
+        await expect(cheatsheet).toBeVisible();
+        await expect(cheatsheet).toHaveAttribute('href', /commonmark\.org\/help/i);
+
+        // Type Markdown that exercises the three contract surfaces:
+        // a paragraph, a bold span, and an HTML escape (raw `<script>`
+        // must come back as text, not parsed). The preview pane is
+        // server-rendered via system.preview_intro_text — our wait
+        // anchor is the rendered text landing in the body.
+        await textarea.fill('Hello **world** <script>x</script>');
+
+        // The preview's [data-loading] flips to `true` mid-call and
+        // back to `false` once IntroRenderer's response lands. We
+        // anchor on the terminal state (loading=false) AND the body
+        // content. The 200ms input debounce + ~200ms round-trip is
+        // bounded by Playwright's default timeout (30s).
+        await expect(preview).toHaveAttribute('data-loading', 'false');
+        await expect(previewBody.locator('strong')).toHaveText('world');
+        // Raw `<script>` is escaped, not parsed.
+        await expect(previewBody.locator('script')).toHaveCount(0);
+        // The escaped tag still renders as visible text.
+        await expect(previewBody).toContainText('<script>');
+    });
+});

--- a/web/themes/default/core/footer.tpl
+++ b/web/themes/default/core/footer.tpl
@@ -81,7 +81,7 @@
 </dialog>
 
 {*
-    Footer (#1207 CC-5, CC-6).
+    Footer (#1207 CC-5, CC-6, SET-2).
 
     `data-version="{$version}"` mirrors the resolved SB_VERSION constant
     (the user-visible string minus the `| Git: …` suffix). Telemetry,
@@ -90,6 +90,9 @@
     fallback in init.php) from release tarball installs
     (`data-version="2.1.0"` etc.) without parsing the visible text.
 
+    `data-testid="app-footer"` is the testability hook for SET-2's
+    save-button-doesn't-overlap-footer assertion at mobile width.
+
     Footer link points at the sbpp/sourcebans-pp repo (CC-6) instead of
     the marketing site so a self-hoster's first instinct ("show me the
     code") lands them on the place that hosts both the issue tracker
@@ -97,9 +100,12 @@
     (matches the surrounding footer text colour) and only reveals the
     accent colour + underline on `:hover` / `:focus-visible` so the
     chrome's footer reads as a single line of text instead of having
-    a stranded blue underlined word in the middle of it.
+    a stranded blue underlined word in the middle of it. The
+    `.app-footer` class adds the SET-2 separator (top border + extra
+    margin/padding) so the "Save changes" row above no longer reads
+    as overlapping the credit on mobile.
 *}
-<footer class="text-xs text-faint sbpp-footer" data-version="{$version}" style="text-align:center;padding:1rem 0">
+<footer class="app-footer" data-version="{$version}" data-testid="app-footer">
     <a href="https://github.com/sbpp/sourcebans-pp" target="_blank" rel="noopener">SourceBans++</a>
     {$version}{$git}
 </footer>

--- a/web/themes/default/core/footer.tpl
+++ b/web/themes/default/core/footer.tpl
@@ -105,7 +105,7 @@
     margin/padding) so the "Save changes" row above no longer reads
     as overlapping the credit on mobile.
 *}
-<footer class="app-footer" data-version="{$version}" data-testid="app-footer">
+<footer class="app-footer sbpp-footer" data-version="{$version}" data-testid="app-footer">
     <a href="https://github.com/sbpp/sourcebans-pp" target="_blank" rel="noopener">SourceBans++</a>
     {$version}{$git}
 </footer>

--- a/web/themes/default/css/theme.css
+++ b/web/themes/default/css/theme.css
@@ -720,18 +720,153 @@ details.queue-row > summary > .row-actions {
 .scroll-x { overflow-x: auto; scrollbar-width: none; }
 .scroll-x::-webkit-scrollbar { display: none; }
 
-/* ---- Footer (#1207 CC-6) ----
-   Footer renders inside `.text-faint` (muted by default), but a raw
-   <a> would inherit the browser-default underlined link colour and
-   stand out as a stranded blue word. Mute the link to inherit the
-   surrounding colour and only reveal the affordance on hover/focus
-   so keyboard users still get a visible focus ring. */
-.sbpp-footer a {
-    color: inherit;
-    text-decoration: none;
+/* ---- Empty state (#1207 unified empty-state pattern) ----
+   Used everywhere a list / table / queue renders zero rows. Two
+   flavours, picked per surface in the template:
+
+     .empty-state              -- first-run (no data exists yet);
+                                  template emits a primary CTA
+                                  ("Add a ban", "Add a server", …)
+                                  gated on the matching ADMIN_* perm.
+     .empty-state[data-filtered="true"]
+                               -- filtered state (data exists, but
+                                  the active filter excludes every
+                                  row); CTA is a secondary "Clear
+                                  filters" anchor that resets the
+                                  search/chip state via plain GET.
+
+   The split follows the AGENTS.md "Empty states" convention. CTAs
+   live in `.empty-state__actions` so the icon + heading + body copy
+   stay vertically centered while the action row keeps its own gap.
+   `.empty-state__icon` uses the muted bg + faint foreground so it
+   reads as decorative (the heading + body are the load-bearing
+   copy). All children inherit the table/card colours, so dropping
+   the block into a `<td colspan>` (banlist/commslist) renders
+   identically to a card body. */
+.empty-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  gap: 0.5rem;
+  padding: 2.5rem 1.5rem;
+  color: var(--text-muted);
 }
-.sbpp-footer a:hover,
-.sbpp-footer a:focus-visible {
-    color: var(--accent);
-    text-decoration: underline;
+.empty-state__icon {
+  width: 2.5rem;
+  height: 2.5rem;
+  border-radius: var(--radius-full);
+  background: var(--bg-muted);
+  color: var(--text-faint);
+  display: grid;
+  place-items: center;
+  margin-bottom: 0.25rem;
+}
+.empty-state__title {
+  margin: 0;
+  font-size: var(--fs-base);
+  font-weight: 600;
+  color: var(--text);
+}
+.empty-state__body {
+  margin: 0;
+  font-size: var(--fs-sm);
+  max-width: 28rem;
+}
+.empty-state__actions {
+  margin-top: 0.75rem;
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  justify-content: center;
+}
+
+/* ---- Settings save action row (#1207 SET-2) ----
+   The settings page's save row sits at the bottom of a tall form;
+   on mobile, with the page's `.p-6` (1.5rem) padding plus the
+   footer's own 1rem padding, the button visually butted against the
+   "SourceBans++ N/A" credit (#1207 SET-2). Adding a bottom margin
+   on the action row + a top border / extra top padding on the
+   shared footer below gives the row breathing room without a
+   sticky element. The selector is keyed to `.settings-actions` so
+   only the settings save row picks up the rule — other forms
+   (login, edit ban, …) keep their existing layouts. */
+.settings-actions {
+  margin-bottom: 1.5rem;
+}
+@media (max-width: 768px) {
+  .settings-actions { margin-bottom: 2rem; }
+}
+
+/* ---- Footer (#1207 CC-6 + SET-2) ----
+   The page-bottom credit footer in core/footer.tpl. A subtle
+   top border + a touch more vertical padding visually separates
+   it from form action rows above so the "Save changes" button on
+   the settings page no longer reads as overlapping the credit
+   (SET-2). The link is muted by default — footer renders inside
+   `.text-faint` (muted), but a raw <a> would inherit the
+   browser-default underlined link colour and stand out as a
+   stranded blue word; only reveal the affordance on hover/focus
+   so keyboard users still get a visible focus ring (CC-6). */
+.app-footer {
+  text-align: center;
+  padding: 1.25rem 1rem;
+  margin-top: 1rem;
+  border-top: 1px solid var(--border);
+  font-size: var(--fs-xs);
+  color: var(--text-faint);
+}
+.app-footer a {
+  color: inherit;
+  text-decoration: none;
+}
+.app-footer a:hover,
+.app-footer a:focus-visible {
+  color: var(--accent);
+  text-decoration: underline;
+}
+
+/* ---- Dashboard intro Markdown editor + preview (#1207 SET-1) ----
+   Two-column grid that drops to one column on mobile. The textarea
+   stays a plain <textarea> by design (#1113 anti-pattern: no WYSIWYG).
+   The preview pane on the right is patched in place by the inline
+   JS in page_admin_settings_settings.tpl after a debounced call to
+   `system.preview_intro_text`, which renders through
+   `Sbpp\Markup\IntroRenderer` (CommonMark, html_input=escape,
+   allow_unsafe_links=false) — so what visitors see on `/` matches
+   exactly. */
+.dash-intro-editor {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0.75rem;
+  align-items: stretch;
+}
+.dash-intro-editor > .textarea { min-height: 14rem; }
+.dash-intro-preview {
+  position: relative;
+  min-height: 14rem;
+  padding: 0.75rem 1rem;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--border);
+  background: var(--bg-page);
+  overflow-y: auto;
+}
+.dash-intro-preview__label {
+  position: absolute;
+  top: 0.375rem;
+  right: 0.5rem;
+  font-size: 0.6875rem;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--text-faint);
+}
+.dash-intro-preview__body { font-size: var(--fs-sm); }
+.dash-intro-preview__body > :first-child { margin-top: 0; }
+.dash-intro-preview__body > :last-child  { margin-bottom: 0; }
+.dash-intro-preview[data-loading="true"] .dash-intro-preview__body { opacity: 0.6; }
+@media (max-width: 768px) {
+  .dash-intro-editor { grid-template-columns: 1fr; }
+  .dash-intro-preview { min-height: 8rem; }
 }

--- a/web/themes/default/page_admin_audit.tpl
+++ b/web/themes/default/page_admin_audit.tpl
@@ -236,7 +236,45 @@
                 </div>
             </article>
         {foreachelse}
-            <div class="audit-empty">No audit events match these filters.</div>
+            {* #1207 empty-state unification — filter-aware empty.
+               $current_severity / $search drive the GET state; either
+               the user's filtering and the result is empty, or the
+               panel really has no audit log entries (rare; the
+               install seeds at least one log row). Either way the
+               unblock action is "drop the filters", so the CTA is
+               "Clear filters" regardless. The link goes back to the
+               bare `?p=admin&c=audit` URL. *}
+            <div class="empty-state"
+                 data-testid="audit-empty"
+                 data-filtered="{if $current_severity != '' || $search != ''}true{else}false{/if}">
+                <span class="empty-state__icon" aria-hidden="true">
+                    <i data-lucide="scroll-text" style="width:18px;height:18px"></i>
+                </span>
+                <h2 class="empty-state__title">
+                    {if $current_severity != '' || $search != ''}
+                        No audit events match these filters
+                    {else}
+                        No audit events recorded yet
+                    {/if}
+                </h2>
+                <p class="empty-state__body">
+                    {if $current_severity != '' || $search != ''}
+                        Try a different search term or severity, or clear the filters to see every recorded admin action.
+                    {else}
+                        Once admins start moderating from the panel, every action will be logged here for review.
+                    {/if}
+                </p>
+                {if $current_severity != '' || $search != ''}
+                    <div class="empty-state__actions">
+                        <a class="btn btn--secondary btn--sm"
+                           href="?p=admin&amp;c=audit"
+                           data-testid="audit-empty-clear">
+                            <i data-lucide="x" style="width:13px;height:13px"></i>
+                            Clear filters
+                        </a>
+                    </div>
+                {/if}
+            </div>
         {/foreach}
     </div>
 

--- a/web/themes/default/page_admin_bans_protests.tpl
+++ b/web/themes/default/page_admin_bans_protests.tpl
@@ -43,9 +43,19 @@
         </div>
 
         {if $protest_list|@count == 0}
+            {* #1207 empty-state unification — queue-empty.
+               The protest queue is a moderation worklist; "empty"
+               here is a desirable state (inbox-zero) rather than a
+               first-run state, so we don't surface a CTA. The
+               `.empty-state` shell keeps the typography consistent
+               with banlist / commslist / audit empties. *}
             <div class="card" data-testid="protests-empty">
-                <div class="card__body">
-                    <p class="text-sm text-muted m-0">No active protests. Nothing waiting for review.</p>
+                <div class="empty-state">
+                    <span class="empty-state__icon" aria-hidden="true">
+                        <i data-lucide="inbox" style="width:18px;height:18px"></i>
+                    </span>
+                    <h2 class="empty-state__title">No active protests</h2>
+                    <p class="empty-state__body">Nothing is waiting for review. New ban appeals will appear here as players file them.</p>
                 </div>
             </div>
         {else}

--- a/web/themes/default/page_admin_bans_protests_archiv.tpl
+++ b/web/themes/default/page_admin_bans_protests_archiv.tpl
@@ -40,9 +40,17 @@
         </div>
 
         {if $protest_list_archiv|@count == 0}
+            {* #1207 empty-state unification — read-only / closed-loop
+               surface (accepted / rejected / archived rows land here),
+               so no CTA. Kept the testid hook for any spec watching for
+               the archive's empty state. *}
             <div class="card" data-testid="protests-archive-empty">
-                <div class="card__body">
-                    <p class="text-sm text-muted m-0">The protest archive is empty.</p>
+                <div class="empty-state">
+                    <span class="empty-state__icon" aria-hidden="true">
+                        <i data-lucide="archive" style="width:18px;height:18px"></i>
+                    </span>
+                    <h2 class="empty-state__title">Protest archive is empty</h2>
+                    <p class="empty-state__body">Once protests are accepted, rejected, or archived, they'll move here for the record.</p>
                 </div>
             </div>
         {else}

--- a/web/themes/default/page_admin_bans_submissions.tpl
+++ b/web/themes/default/page_admin_bans_submissions.tpl
@@ -48,9 +48,16 @@
         </div>
 
         {if $submission_list|@count == 0}
+            {* #1207 empty-state unification — queue-empty. Like the
+               protests queue, "empty" here means inbox-zero, so the
+               surface stays copy-only. *}
             <div class="card" data-testid="submissions-empty">
-                <div class="card__body">
-                    <p class="text-sm text-muted m-0">No pending submissions. The queue is clear.</p>
+                <div class="empty-state">
+                    <span class="empty-state__icon" aria-hidden="true">
+                        <i data-lucide="inbox" style="width:18px;height:18px"></i>
+                    </span>
+                    <h2 class="empty-state__title">No pending submissions</h2>
+                    <p class="empty-state__body">The queue is clear. Player-reported bans will show up here for review when they're filed.</p>
                 </div>
             </div>
         {else}

--- a/web/themes/default/page_admin_bans_submissions_archiv.tpl
+++ b/web/themes/default/page_admin_bans_submissions_archiv.tpl
@@ -41,9 +41,17 @@
         </div>
 
         {if $submission_list_archiv|@count == 0}
+            {* #1207 empty-state unification — read-only / closed-loop
+               surface (accepted / rejected / archived rows live here),
+               so no CTA. Kept the testid hook for any spec watching for
+               the archive's empty state. *}
             <div class="card" data-testid="submissions-archive-empty">
-                <div class="card__body">
-                    <p class="text-sm text-muted m-0">The submission archive is empty.</p>
+                <div class="empty-state">
+                    <span class="empty-state__icon" aria-hidden="true">
+                        <i data-lucide="archive" style="width:18px;height:18px"></i>
+                    </span>
+                    <h2 class="empty-state__title">Submission archive is empty</h2>
+                    <p class="empty-state__body">Once submissions are accepted, rejected, or archived, they'll move here for the record.</p>
                 </div>
             </div>
         {else}

--- a/web/themes/default/page_admin_settings_settings.tpl
+++ b/web/themes/default/page_admin_settings_settings.tpl
@@ -204,11 +204,17 @@
                                     <div class="dash-intro-preview"
                                          data-testid="dash-intro-preview"
                                          data-loading="false"
-                                         aria-live="polite"
                                          aria-label="Markdown preview">
                                         <div class="dash-intro-preview__label">Preview</div>
+                                        {*
+                                            aria-live sits on the body (not the wrapper)
+                                            so assistive tech announces only the rendered
+                                            content on each keystroke — not the static
+                                            "Preview" label above it.
+                                        *}
                                         <div class="dash-intro-preview__body"
-                                             data-testid="dash-intro-preview-body">
+                                             data-testid="dash-intro-preview-body"
+                                             aria-live="polite">
                                             {if $config_dash_text_preview != ''}
                                                 {* nofilter: $config_dash_text_preview is `IntroRenderer::renderIntroText()` output (CommonMark + html_input=escape + allow_unsafe_links=false) — the same render path the public dashboard uses, see AGENTS.md "Admin-authored display text". *}
                                                 {$config_dash_text_preview nofilter}

--- a/web/themes/default/page_admin_settings_settings.tpl
+++ b/web/themes/default/page_admin_settings_settings.tpl
@@ -155,10 +155,69 @@
                                 <label class="label" for="dash_intro_text">
                                     Intro body
                                     <span class="text-muted text-xs">
-                                        — Markdown supported (<a href="https://commonmark.org/help/" target="_blank" rel="noopener">CommonMark cheat-sheet</a>). Raw HTML is escaped on render.
+                                        — Markdown supported
+                                        (<a href="https://commonmark.org/help/"
+                                            target="_blank"
+                                            rel="noopener"
+                                            data-testid="dash-intro-cheatsheet-link">CommonMark cheat-sheet</a>).
+                                        Raw HTML is escaped on render.
                                     </span>
                                 </label>
-                                <textarea class="textarea" id="dash_intro_text" name="dash_intro_text" rows="10" style="width:100%;font-family:var(--font-mono);font-size:var(--fs-sm)">{$config_dash_text}</textarea>
+                                {*
+                                    #1207 SET-1: live preview pane.
+
+                                    The textarea on the left stays a plain
+                                    <textarea> by design (re-introducing a
+                                    WYSIWYG was the source of #1113 — see
+                                    AGENTS.md "Anti-patterns"). The preview
+                                    pane on the right calls the new
+                                    `system.preview_intro_text` JSON action
+                                    which pipes the value through
+                                    `Sbpp\Markup\IntroRenderer` server-side,
+                                    so the rendered HTML matches what the
+                                    public dashboard would emit byte-for-byte.
+
+                                    Layout: the grid drops to one column
+                                    below 768px so the preview stacks
+                                    underneath on mobile rather than
+                                    crushing the textarea.
+
+                                    The preview frame's `nofilter` is the
+                                    only `nofilter` use here; safety
+                                    annotation is on the `{$rendered}` line
+                                    below for the initial server-rendered
+                                    paint, and the JS-side update goes
+                                    through `el.innerHTML = r.data.html`
+                                    where `r.data.html` is the same
+                                    IntroRenderer output (`html_input:
+                                    'escape'`, `allow_unsafe_links:
+                                    'false'`).
+                                *}
+                                <div class="dash-intro-editor"
+                                     data-testid="dash-intro-editor">
+                                    <textarea class="textarea"
+                                              id="dash_intro_text"
+                                              name="dash_intro_text"
+                                              rows="10"
+                                              style="width:100%;font-family:var(--font-mono);font-size:var(--fs-sm)"
+                                              data-testid="dash-intro-textarea">{$config_dash_text}</textarea>
+                                    <div class="dash-intro-preview"
+                                         data-testid="dash-intro-preview"
+                                         data-loading="false"
+                                         aria-live="polite"
+                                         aria-label="Markdown preview">
+                                        <div class="dash-intro-preview__label">Preview</div>
+                                        <div class="dash-intro-preview__body"
+                                             data-testid="dash-intro-preview-body">
+                                            {if $config_dash_text_preview != ''}
+                                                {* nofilter: $config_dash_text_preview is `IntroRenderer::renderIntroText()` output (CommonMark + html_input=escape + allow_unsafe_links=false) — the same render path the public dashboard uses, see AGENTS.md "Admin-authored display text". *}
+                                                {$config_dash_text_preview nofilter}
+                                            {else}
+                                                <p class="text-xs text-muted m-0" data-empty>Type Markdown on the left to see how it renders to visitors.</p>
+                                            {/if}
+                                        </div>
+                                    </div>
+                                </div>
                             </div>
                             <div data-testid="setting-row" data-key="dash.lognopopup">
                                 <label class="flex items-center gap-2">
@@ -295,7 +354,14 @@
                         </div>
                     </div>
 
-                    <div class="flex items-center justify-end gap-2">
+                    {*
+                        #1207 SET-2: `.settings-actions` keeps clear of
+                        the page footer on mobile. The class adds a
+                        bottom margin so the "Save changes" button no
+                        longer reads as overlapping the
+                        `<footer class="app-footer">` underneath.
+                    *}
+                    <div class="settings-actions flex items-center justify-end gap-2">
                         <button type="button" class="btn btn--secondary btn--sm" onclick="clearCacheBtn();">
                             <i data-lucide="brush"></i> Clear cache
                         </button>
@@ -343,6 +409,77 @@
             window.alert('Cache cleared.');
         });
     };
+
+    /**
+     * #1207 SET-1: live Markdown preview.
+     *
+     * Debounced input handler that POSTs the textarea's current value
+     * to `system.preview_intro_text`, receives the rendered HTML back
+     * (rendered by `Sbpp\Markup\IntroRenderer` — same path the public
+     * dashboard uses), and patches the preview pane in place. The
+     * `[data-loading]` flips to `true` while a call is in flight so
+     * the contract from `_base.ts`'s `waitForReady()` (data-loading
+     * settles to "false" before tests proceed) keeps holding.
+     *
+     * The first render comes from PHP (see the `{if
+     * $config_dash_text|trim != ''}` block above); JS only kicks in
+     * once the user starts typing, so the page works without JS too —
+     * the saved-form bounce flow re-renders the page with fresh PHP
+     * markup either way.
+     */
+    var ta = /** @type {HTMLTextAreaElement|null} */ (document.getElementById('dash_intro_text'));
+    var preview = /** @type {HTMLElement|null} */ (
+        document.querySelector('[data-testid="dash-intro-preview"]')
+    );
+    var previewBody = /** @type {HTMLElement|null} */ (
+        document.querySelector('[data-testid="dash-intro-preview-body"]')
+    );
+
+    if (ta && preview && previewBody && window.sb && window.sb.api && window.Actions) {
+        var emptyHtml = '<p class="text-xs text-muted m-0" data-empty>Type Markdown on the left to see how it renders to visitors.</p>';
+
+        /** @type {number|null} */
+        var pending = null;
+        /** @type {string} */
+        var lastSent = ta.value;
+
+        function refresh() {
+            if (!ta || !preview || !previewBody) return;
+            var current = ta.value;
+            if (current === lastSent && pending === null) return;
+            lastSent = current;
+            if (current.trim() === '') {
+                previewBody.innerHTML = emptyHtml;
+                preview.setAttribute('data-loading', 'false');
+                return;
+            }
+            preview.setAttribute('data-loading', 'true');
+            window.sb.api.call(window.Actions.SystemPreviewIntroText, { markdown: current }).then(function (r) {
+                if (!preview || !previewBody) return;
+                preview.setAttribute('data-loading', 'false');
+                if (r && r.ok && r.data && typeof r.data.html === 'string') {
+                    // r.data.html is IntroRenderer output (CommonMark
+                    // with html_input=escape, allow_unsafe_links=false);
+                    // safe to drop in via innerHTML for the same reason
+                    // the server-rendered first paint above is safe
+                    // behind `nofilter`. Caveat: do NOT swap this for
+                    // a third-party Markdown library — see AGENTS.md
+                    // "Admin-authored display text" for the contract.
+                    previewBody.innerHTML = r.data.html;
+                }
+            }, function () {
+                if (preview) preview.setAttribute('data-loading', 'false');
+            });
+        }
+
+        ta.addEventListener('input', function () {
+            if (pending !== null) window.clearTimeout(pending);
+            pending = window.setTimeout(function () {
+                pending = null;
+                refresh();
+            }, 200);
+        });
+    }
 })();
 {/literal}
 </script>

--- a/web/themes/default/page_bans.tpl
+++ b/web/themes/default/page_bans.tpl
@@ -213,7 +213,28 @@
           </td>
         </tr>
         {foreachelse}
-        <tr><td colspan="9" style="text-align:center;padding:3rem;color:var(--text-muted)">No bans match those filters.</td></tr>
+        {* #1207 empty-state unification — filter-aware empty.
+           The public ban list always lives behind filter chips +
+           hide-inactive + a search box, so the only way to hit zero
+           rows is via filters; the CTA is a "Clear filters" reset
+           that drops every $_GET param the listing reads. *}
+        <tr>
+          <td colspan="9" style="padding:0">
+            <div class="empty-state" data-testid="banlist-empty" data-filtered="true">
+              <span class="empty-state__icon" aria-hidden="true">
+                <i data-lucide="search-x" style="width:18px;height:18px"></i>
+              </span>
+              <h2 class="empty-state__title">No bans match those filters</h2>
+              <p class="empty-state__body">Try a different search term or clear the active filters to see every recorded ban.</p>
+              <div class="empty-state__actions">
+                <a class="btn btn--secondary btn--sm" href="?p=banlist" data-testid="banlist-empty-clear">
+                  <i data-lucide="x" style="width:13px;height:13px"></i>
+                  Clear filters
+                </a>
+              </div>
+            </div>
+          </td>
+        </tr>
         {/foreach}
       </tbody>
     </table>
@@ -244,7 +265,20 @@
         <span class="text-faint" aria-hidden="true">&rsaquo;</span>
       </a>
       {foreachelse}
-      <div style="text-align:center;padding:3rem;color:var(--text-muted)">No bans match those filters.</div>
+      {* Mobile mirror of the desktop filter-aware empty above. *}
+      <div class="empty-state" data-testid="banlist-empty-mobile" data-filtered="true">
+        <span class="empty-state__icon" aria-hidden="true">
+          <i data-lucide="search-x" style="width:18px;height:18px"></i>
+        </span>
+        <h2 class="empty-state__title">No bans match those filters</h2>
+        <p class="empty-state__body">Try a different search term or clear the active filters.</p>
+        <div class="empty-state__actions">
+          <a class="btn btn--secondary btn--sm" href="?p=banlist">
+            <i data-lucide="x" style="width:13px;height:13px"></i>
+            Clear filters
+          </a>
+        </div>
+      </div>
       {/foreach}
     </div>
   </div>

--- a/web/themes/default/page_bans.tpl
+++ b/web/themes/default/page_bans.tpl
@@ -213,13 +213,17 @@
           </td>
         </tr>
         {foreachelse}
-        {* #1207 empty-state unification — filter-aware empty.
-           The public ban list always lives behind filter chips +
-           hide-inactive + a search box, so the only way to hit zero
-           rows is via filters; the CTA is a "Clear filters" reset
-           that drops every $_GET param the listing reads. *}
+        {* #1207 empty-state unification — first-run vs filtered.
+           `$is_filtered` is true whenever the request carries a search
+           term, an advSearch chip, or the hide-inactive toggle — see
+           page.banlist.php for the predicate. With zero rows AND no
+           filter active we fall through to the first-run shape (CTA
+           gated on `can_add_ban`). With a filter, the CTA stays
+           "Clear filters" and `data-filtered="true"` so tests can
+           disambiguate. *}
         <tr>
           <td colspan="9" style="padding:0">
+            {if $is_filtered}
             <div class="empty-state" data-testid="banlist-empty" data-filtered="true">
               <span class="empty-state__icon" aria-hidden="true">
                 <i data-lucide="search-x" style="width:18px;height:18px"></i>
@@ -233,6 +237,23 @@
                 </a>
               </div>
             </div>
+            {else}
+            <div class="empty-state" data-testid="banlist-empty" data-filtered="false">
+              <span class="empty-state__icon" aria-hidden="true">
+                <i data-lucide="ban" style="width:18px;height:18px"></i>
+              </span>
+              <h2 class="empty-state__title">No bans recorded yet</h2>
+              <p class="empty-state__body">Enforcement actions will show up here as soon as admins start moderating.</p>
+              {if $can_add_ban}
+              <div class="empty-state__actions">
+                <a class="btn btn--primary btn--sm" href="?p=admin&amp;c=bans" data-testid="banlist-empty-add">
+                  <i data-lucide="plus" style="width:13px;height:13px"></i>
+                  Add a ban
+                </a>
+              </div>
+              {/if}
+            </div>
+            {/if}
           </td>
         </tr>
         {/foreach}
@@ -265,7 +286,8 @@
         <span class="text-faint" aria-hidden="true">&rsaquo;</span>
       </a>
       {foreachelse}
-      {* Mobile mirror of the desktop filter-aware empty above. *}
+      {* Mobile mirror of the desktop empty above (first-run vs filtered). *}
+      {if $is_filtered}
       <div class="empty-state" data-testid="banlist-empty-mobile" data-filtered="true">
         <span class="empty-state__icon" aria-hidden="true">
           <i data-lucide="search-x" style="width:18px;height:18px"></i>
@@ -279,6 +301,23 @@
           </a>
         </div>
       </div>
+      {else}
+      <div class="empty-state" data-testid="banlist-empty-mobile" data-filtered="false">
+        <span class="empty-state__icon" aria-hidden="true">
+          <i data-lucide="ban" style="width:18px;height:18px"></i>
+        </span>
+        <h2 class="empty-state__title">No bans recorded yet</h2>
+        <p class="empty-state__body">Enforcement actions will show up here as soon as admins start moderating.</p>
+        {if $can_add_ban}
+        <div class="empty-state__actions">
+          <a class="btn btn--primary btn--sm" href="?p=admin&amp;c=bans">
+            <i data-lucide="plus" style="width:13px;height:13px"></i>
+            Add a ban
+          </a>
+        </div>
+        {/if}
+      </div>
+      {/if}
       {/foreach}
     </div>
   </div>

--- a/web/themes/default/page_comms.tpl
+++ b/web/themes/default/page_comms.tpl
@@ -208,11 +208,31 @@
                         </td>
                     </tr>
                 {foreachelse}
+                    {* #1207 empty-state unification — filter-aware empty.
+                       Comm blocks live behind a search box + server / time
+                       filters + chip group, so zero rows means the user's
+                       filter is too narrow. The CTA is a "Clear filters"
+                       reset that drops every $_GET param. *}
                     <tr>
                         <td colspan="9"
-                            style="text-align:center;padding:3rem;color:var(--text-muted)"
-                            data-testid="comms-empty">
-                            No comm blocks match those filters.
+                            style="padding:0"
+                            data-testid="comms-empty"
+                            data-filtered="true">
+                            <div class="empty-state">
+                                <span class="empty-state__icon" aria-hidden="true">
+                                    <i data-lucide="search-x" style="width:18px;height:18px"></i>
+                                </span>
+                                <h2 class="empty-state__title">No comm blocks match those filters</h2>
+                                <p class="empty-state__body">Try a different search term, server, or time range &mdash; or clear the active filters to see every recorded mute / gag.</p>
+                                <div class="empty-state__actions">
+                                    <a class="btn btn--secondary btn--sm"
+                                       href="?p=commslist"
+                                       data-testid="comms-empty-clear">
+                                        <i data-lucide="x" style="width:13px;height:13px"></i>
+                                        Clear filters
+                                    </a>
+                                </div>
+                            </div>
                         </td>
                     </tr>
                 {/foreach}
@@ -247,6 +267,25 @@
                     </div>
                     <i data-lucide="chevron-right"></i>
                 </a>
+            {foreachelse}
+                {* #1207: the desktop `<table>` is `display:none` on
+                   mobile (theme.css responsive block), so its empty
+                   row above never renders below 769px. Mirror the
+                   filter-aware empty state into the mobile card list
+                   so phones don't see a blank card. *}
+                <div class="empty-state" data-testid="comms-empty-mobile" data-filtered="true">
+                    <span class="empty-state__icon" aria-hidden="true">
+                        <i data-lucide="search-x" style="width:18px;height:18px"></i>
+                    </span>
+                    <h2 class="empty-state__title">No comm blocks match those filters</h2>
+                    <p class="empty-state__body">Try a different search term or clear the active filters.</p>
+                    <div class="empty-state__actions">
+                        <a class="btn btn--secondary btn--sm" href="?p=commslist">
+                            <i data-lucide="x" style="width:13px;height:13px"></i>
+                            Clear filters
+                        </a>
+                    </div>
+                </div>
             {/foreach}
         </div>
     </div>

--- a/web/themes/default/page_comms.tpl
+++ b/web/themes/default/page_comms.tpl
@@ -208,12 +208,14 @@
                         </td>
                     </tr>
                 {foreachelse}
-                    {* #1207 empty-state unification — filter-aware empty.
-                       Comm blocks live behind a search box + server / time
-                       filters + chip group, so zero rows means the user's
-                       filter is too narrow. The CTA is a "Clear filters"
-                       reset that drops every $_GET param. *}
+                    {* #1207 empty-state unification — first-run vs filtered.
+                       `$is_filtered` flips on any of search / server / time /
+                       state / type / hide-inactive (see page.commslist.php
+                       for the predicate). With zero rows AND no filter we
+                       fall through to the first-run shape (CTA gated on
+                       `can_add_comm`); otherwise it stays "Clear filters". *}
                     <tr>
+                        {if $is_filtered}
                         <td colspan="9"
                             style="padding:0"
                             data-testid="comms-empty"
@@ -234,6 +236,30 @@
                                 </div>
                             </div>
                         </td>
+                        {else}
+                        <td colspan="9"
+                            style="padding:0"
+                            data-testid="comms-empty"
+                            data-filtered="false">
+                            <div class="empty-state">
+                                <span class="empty-state__icon" aria-hidden="true">
+                                    <i data-lucide="mic-off" style="width:18px;height:18px"></i>
+                                </span>
+                                <h2 class="empty-state__title">No comm blocks recorded yet</h2>
+                                <p class="empty-state__body">Mutes and gags issued from the panel or in-game will appear here.</p>
+                                {if $can_add_comm}
+                                <div class="empty-state__actions">
+                                    <a class="btn btn--primary btn--sm"
+                                       href="?p=admin&amp;c=comms"
+                                       data-testid="comms-empty-add">
+                                        <i data-lucide="plus" style="width:13px;height:13px"></i>
+                                        Add a comm block
+                                    </a>
+                                </div>
+                                {/if}
+                            </div>
+                        </td>
+                        {/if}
                     </tr>
                 {/foreach}
             </tbody>
@@ -271,8 +297,8 @@
                 {* #1207: the desktop `<table>` is `display:none` on
                    mobile (theme.css responsive block), so its empty
                    row above never renders below 769px. Mirror the
-                   filter-aware empty state into the mobile card list
-                   so phones don't see a blank card. *}
+                   first-run-vs-filtered split here for phones. *}
+                {if $is_filtered}
                 <div class="empty-state" data-testid="comms-empty-mobile" data-filtered="true">
                     <span class="empty-state__icon" aria-hidden="true">
                         <i data-lucide="search-x" style="width:18px;height:18px"></i>
@@ -286,6 +312,23 @@
                         </a>
                     </div>
                 </div>
+                {else}
+                <div class="empty-state" data-testid="comms-empty-mobile" data-filtered="false">
+                    <span class="empty-state__icon" aria-hidden="true">
+                        <i data-lucide="mic-off" style="width:18px;height:18px"></i>
+                    </span>
+                    <h2 class="empty-state__title">No comm blocks recorded yet</h2>
+                    <p class="empty-state__body">Mutes and gags issued from the panel or in-game will appear here.</p>
+                    {if $can_add_comm}
+                    <div class="empty-state__actions">
+                        <a class="btn btn--primary btn--sm" href="?p=admin&amp;c=comms">
+                            <i data-lucide="plus" style="width:13px;height:13px"></i>
+                            Add a comm block
+                        </a>
+                    </div>
+                    {/if}
+                </div>
+                {/if}
             {/foreach}
         </div>
     </div>

--- a/web/themes/default/page_dashboard.tpl
+++ b/web/themes/default/page_dashboard.tpl
@@ -116,7 +116,27 @@
                     <div class="text-xs text-muted text-right" style="white-space:nowrap">{$b.banned_human}</div>
                 </a>
                 {foreachelse}
-                <div class="card__body text-sm text-muted" data-testid="dashboard-recent-bans-empty">No bans yet.</div>
+                {* #1207 PUB-5: first-run empty state. The "Add a ban" CTA
+                   is gated on `can_add_ban` (Perms::for $userbank), so
+                   anonymous visitors / admins without ADMIN_ADD_BAN see
+                   the copy without a link they couldn't follow. *}
+                <div class="empty-state" data-testid="dashboard-recent-bans-empty">
+                    <span class="empty-state__icon" aria-hidden="true">
+                        <i data-lucide="ban" style="width:18px;height:18px"></i>
+                    </span>
+                    <h4 class="empty-state__title">No bans yet</h4>
+                    <p class="empty-state__body">Enforcement actions will show up here as soon as admins start moderating.</p>
+                    {if $can_add_ban}
+                        <div class="empty-state__actions">
+                            <a class="btn btn--primary btn--sm"
+                               href="?p=admin&amp;c=bans"
+                               data-testid="dashboard-recent-bans-empty-add">
+                                <i data-lucide="plus" style="width:13px;height:13px"></i>
+                                Add a ban
+                            </a>
+                        </div>
+                    {/if}
+                </div>
                 {/foreach}
             </div>
         </section>
@@ -153,7 +173,26 @@
                     <i data-lucide="external-link" style="width:14px;height:14px;color:var(--text-faint)"></i>
                 </a>
                 {foreachelse}
-                <div class="card__body text-sm text-muted" data-testid="dashboard-servers-empty">No servers configured.</div>
+                {* #1207 PUB-5: first-run empty state. CTA gated on
+                   `can_add_server` so visitors without ADMIN_ADD_SERVER
+                   see the copy only. *}
+                <div class="empty-state" data-testid="dashboard-servers-empty">
+                    <span class="empty-state__icon" aria-hidden="true">
+                        <i data-lucide="server" style="width:18px;height:18px"></i>
+                    </span>
+                    <h4 class="empty-state__title">No servers configured</h4>
+                    <p class="empty-state__body">Add a server so visitors can see live status and connect from the panel.</p>
+                    {if $can_add_server}
+                        <div class="empty-state__actions">
+                            <a class="btn btn--primary btn--sm"
+                               href="?p=admin&amp;c=servers"
+                               data-testid="dashboard-servers-empty-add">
+                                <i data-lucide="plus" style="width:13px;height:13px"></i>
+                                Add a server
+                            </a>
+                        </div>
+                    {/if}
+                </div>
                 {/foreach}
             </div>
         </section>
@@ -196,7 +235,17 @@
                     <div class="text-xs text-muted text-right" style="white-space:nowrap">{$p.blocked_human}</div>
                 </a>
                 {foreachelse}
-                <div class="card__body text-sm text-muted" data-testid="dashboard-blocked-attempts-empty">No blocked attempts yet.</div>
+                {* #1207 PUB-5: blocked-attempts is a read-only stream
+                   of plugin-side intercepts; there's no admin "add"
+                   action that maps to it, so the empty state is copy
+                   only — no CTA. *}
+                <div class="empty-state" data-testid="dashboard-blocked-attempts-empty">
+                    <span class="empty-state__icon" aria-hidden="true">
+                        <i data-lucide="shield-x" style="width:18px;height:18px"></i>
+                    </span>
+                    <h4 class="empty-state__title">No blocked attempts yet</h4>
+                    <p class="empty-state__body">Once banned players try to rejoin, the SourceMod plugin will log every intercept here.</p>
+                </div>
                 {/foreach}
             </div>
         </section>
@@ -232,7 +281,27 @@
                     <div class="text-xs text-muted text-right" style="white-space:nowrap">{$c.banned_human}</div>
                 </a>
                 {foreachelse}
-                <div class="card__body text-sm text-muted" data-testid="dashboard-recent-comms-empty">No comm blocks yet.</div>
+                {* #1207 PUB-5: first-run empty state. The "Add a comm
+                   block" CTA reuses `can_add_ban` because admin.comms.php
+                   gates Add on the same flag (ADMIN_OWNER | ADMIN_ADD_BAN);
+                   see _register.php's `comms.add` row. *}
+                <div class="empty-state" data-testid="dashboard-recent-comms-empty">
+                    <span class="empty-state__icon" aria-hidden="true">
+                        <i data-lucide="mic-off" style="width:18px;height:18px"></i>
+                    </span>
+                    <h4 class="empty-state__title">No comm blocks yet</h4>
+                    <p class="empty-state__body">Mutes and gags issued from the panel or in-game will appear here.</p>
+                    {if $can_add_ban}
+                        <div class="empty-state__actions">
+                            <a class="btn btn--primary btn--sm"
+                               href="?p=admin&amp;c=comms"
+                               data-testid="dashboard-recent-comms-empty-add">
+                                <i data-lucide="plus" style="width:13px;height:13px"></i>
+                                Add a comm block
+                            </a>
+                        </div>
+                    {/if}
+                </div>
                 {/foreach}
             </div>
         </section>

--- a/web/themes/default/page_servers.tpl
+++ b/web/themes/default/page_servers.tpl
@@ -91,9 +91,31 @@
     </header>
 
     {if $server_list|@count == 0}
+        {* #1207 PUB-3 + empty-state unification: first-run state.
+           The body copy stays terse; the primary CTA is gated on
+           `can_add_server` (Perms::for $userbank), so a logged-out
+           visitor / admin without ADMIN_ADD_SERVER sees the copy
+           but no link to the admin form they couldn't use anyway. *}
         <div class="card" data-testid="servers-empty">
-            <div class="card__body text-sm text-muted">
-                No servers are configured yet.
+            <div class="empty-state">
+                <span class="empty-state__icon" aria-hidden="true">
+                    <i data-lucide="server" style="width:18px;height:18px"></i>
+                </span>
+                <h2 class="empty-state__title">No servers configured yet</h2>
+                <p class="empty-state__body">
+                    Once you add a server, players, status, and live
+                    counts will appear here for visitors.
+                </p>
+                {if $can_add_server}
+                    <div class="empty-state__actions">
+                        <a class="btn btn--primary btn--sm"
+                           href="?p=admin&amp;c=servers"
+                           data-testid="servers-empty-add">
+                            <i data-lucide="plus" style="width:13px;height:13px"></i>
+                            Add a server
+                        </a>
+                    </div>
+                {/if}
             </div>
         </div>
     {else}

--- a/web/themes/default/page_submitban.tpl
+++ b/web/themes/default/page_submitban.tpl
@@ -56,30 +56,67 @@
                 </p>
             </div>
 
-            <div>
-                <label class="label" for="submitban-steam">Player&rsquo;s Steam ID</label>
-                <input type="text"
-                       class="input font-mono"
-                       id="submitban-steam"
-                       name="SteamID"
-                       maxlength="64"
-                       value="{$STEAMID}"
-                       placeholder="STEAM_0:1:23498765"
-                       autocomplete="off"
-                       data-testid="submitban-steam">
-            </div>
+            {*
+                #1207 PUB-4: shared "1 of these required" badge. Steam ID
+                + IP are an "either/or" pair (the page handler validates
+                neither-empty server-side, but the form previously had
+                no visual hint, and a typo would round-trip through a
+                full POST before bouncing). The two inputs share the
+                same `data-required-group="steamid-or-ip"` plus
+                `aria-describedby` pointing at the help line above; the
+                inline `<script>` at the bottom blocks submit when both
+                are blank, surfaces a `data-error="true"` on the group
+                container, and toggles the help line's
+                `[data-state="error"]`.
+            *}
+            <div data-testid="submitban-id-or-ip"
+                 data-required-group="steamid-or-ip"
+                 data-error="false"
+                 class="space-y-4">
+                <p id="submitban-id-or-ip-help"
+                   class="flex items-center gap-2 text-xs m-0"
+                   data-testid="submitban-id-or-ip-help"
+                   data-state="info">
+                    <span class="pill"
+                          aria-hidden="true"
+                          style="height:1.25rem;background:var(--bg-muted);color:var(--text-muted);box-shadow:inset 0 0 0 1px var(--border)">
+                        1 of these required
+                    </span>
+                    <span class="text-muted" data-id-or-ip-text>Provide either a Steam ID or an IP address (or both).</span>
+                </p>
+                <div>
+                    <label class="label" for="submitban-steam">
+                        Player&rsquo;s Steam ID
+                        <span class="text-muted text-xs" style="font-weight:400">(or use the IP below)</span>
+                    </label>
+                    <input type="text"
+                           class="input font-mono"
+                           id="submitban-steam"
+                           name="SteamID"
+                           maxlength="64"
+                           value="{$STEAMID}"
+                           placeholder="STEAM_0:1:23498765"
+                           autocomplete="off"
+                           aria-describedby="submitban-id-or-ip-help"
+                           data-testid="submitban-steam">
+                </div>
 
-            <div>
-                <label class="label" for="submitban-ip">Player&rsquo;s IP address</label>
-                <input type="text"
-                       class="input font-mono"
-                       id="submitban-ip"
-                       name="BanIP"
-                       maxlength="64"
-                       value="{$ban_ip}"
-                       placeholder="203.0.113.42"
-                       autocomplete="off"
-                       data-testid="submitban-ip">
+                <div>
+                    <label class="label" for="submitban-ip">
+                        Player&rsquo;s IP address
+                        <span class="text-muted text-xs" style="font-weight:400">(or use the Steam ID above)</span>
+                    </label>
+                    <input type="text"
+                           class="input font-mono"
+                           id="submitban-ip"
+                           name="BanIP"
+                           maxlength="64"
+                           value="{$ban_ip}"
+                           placeholder="203.0.113.42"
+                           autocomplete="off"
+                           aria-describedby="submitban-id-or-ip-help"
+                           data-testid="submitban-ip">
+                </div>
             </div>
 
             <div>
@@ -217,3 +254,97 @@
         </div>
     </form>
 </section>
+
+{*
+    #1207 PUB-4: client-side either/or validation for Steam ID + IP.
+
+    Server-side validation in `web/pages/page.submit.php` already
+    enforces the same rule (and stays the source of truth — JS-off
+    visitors still get a server bounce with the inline toast emitted by
+    `emitSubmitToast`). This pre-flight just keeps the user from
+    paying the round-trip when the rule is trivially violated.
+
+    Inline rather than a `web/scripts/<page>.js` file because the
+    contract is one form on one page and the canonical pattern for new
+    page-tail helpers is "self-contained vanilla JS per page" per
+    AGENTS.md ("v1.x bulk file" anti-pattern). `// @ts-check` + JSDoc
+    keeps it under the ts-check gate.
+*}
+<script>
+{literal}
+// @ts-check
+(function () {
+    'use strict';
+
+    var form = /** @type {HTMLFormElement|null} */ (
+        document.querySelector('form[action="index.php?p=submit"]')
+    );
+    if (!form) return;
+
+    var group = /** @type {HTMLElement|null} */ (form.querySelector('[data-required-group="steamid-or-ip"]'));
+    var steam = /** @type {HTMLInputElement|null} */ (form.querySelector('[data-testid="submitban-steam"]'));
+    var ip    = /** @type {HTMLInputElement|null} */ (form.querySelector('[data-testid="submitban-ip"]'));
+    var help  = /** @type {HTMLElement|null} */ (form.querySelector('[data-testid="submitban-id-or-ip-help"]'));
+    var helpText = /** @type {HTMLElement|null} */ (form.querySelector('[data-id-or-ip-text]'));
+    if (!group || !steam || !ip || !help || !helpText) return;
+
+    /** @type {string} */
+    var defaultText = helpText.textContent || '';
+
+    /**
+     * @param {boolean} isError
+     */
+    function setError(isError) {
+        group.setAttribute('data-error', isError ? 'true' : 'false');
+        help.setAttribute('data-state', isError ? 'error' : 'info');
+        // Keep the visible copy stable (a11y: don't swap text on
+        // every keystroke); the data-state attribute is the
+        // testability hook E2E asserts on. Color shift is the
+        // visible signal — see the inline style in this script.
+        help.style.color = isError ? 'var(--danger)' : '';
+        if (isError) {
+            steam.setAttribute('aria-invalid', 'true');
+            ip.setAttribute('aria-invalid', 'true');
+            helpText.textContent = 'Please enter a Steam ID or an IP address before submitting.';
+        } else {
+            steam.removeAttribute('aria-invalid');
+            ip.removeAttribute('aria-invalid');
+            helpText.textContent = defaultText;
+        }
+    }
+
+    function isEmpty(/** @type {HTMLInputElement} */ el) {
+        var v = (el.value || '').trim();
+        // STEAM_0: is the placeholder-ish value the page handler
+        // re-emits after a failed validation; treat it as empty so
+        // the client-side check matches the server-side rule
+        // (page.submit.php does `$SteamID == "STEAM_0:" -> ""`).
+        return v === '' || v === 'STEAM_0:';
+    }
+
+    /** @type {(ev: Event) => void} */
+    function onSubmit(ev) {
+        if (isEmpty(steam) && isEmpty(ip)) {
+            ev.preventDefault();
+            setError(true);
+            // Focus the first of the two inputs so keyboard users
+            // land on the offending field; matches native
+            // `required` + `:invalid` UX.
+            steam.focus();
+            return;
+        }
+        setError(false);
+    }
+
+    /** Clear the error as soon as either input gets non-empty. */
+    function onInput() {
+        if (group.getAttribute('data-error') !== 'true') return;
+        if (!isEmpty(steam) || !isEmpty(ip)) setError(false);
+    }
+
+    form.addEventListener('submit', onSubmit);
+    steam.addEventListener('input', onInput);
+    ip.addEventListener('input', onInput);
+})();
+{/literal}
+</script>

--- a/web/themes/default/page_submitban.tpl
+++ b/web/themes/default/page_submitban.tpl
@@ -258,11 +258,12 @@
 {*
     #1207 PUB-4: client-side either/or validation for Steam ID + IP.
 
-    Server-side validation in `web/pages/page.submit.php` already
-    enforces the same rule (and stays the source of truth — JS-off
-    visitors still get a server bounce with the inline toast emitted by
-    `emitSubmitToast`). This pre-flight just keeps the user from
-    paying the round-trip when the rule is trivially violated.
+    Server-side validation in `web/pages/page.submit.php` enforces the
+    same rule (the matching `(SteamID empty + BanIP empty)` branch
+    flips `$validsubmit = false` and pushes the inline toast through
+    `emitSubmitToast`), so it stays the source of truth — JS-off
+    visitors get the same bounce. This pre-flight just keeps the user
+    from paying the round-trip when the rule is trivially violated.
 
     Inline rather than a `web/scripts/<page>.js` file because the
     contract is one form on one page and the canonical pattern for new


### PR DESCRIPTION
## Summary

Slice 5 of #1207 — empty states + copy. Addresses PUB-3, PUB-4, PUB-5, SET-1, SET-2, and the empty-states unification table.

- **PUB-3** — Public servers empty state grows the unified `.empty-state` shape with an "Add a server" CTA gated on `ADMIN_ADD_SERVER`.
- **PUB-4** — Submit-a-ban form pairs Steam ID + IP into a shared `data-required-group` block with a "1 of these required" badge; an inline `// @ts-check` script blocks submit when both are empty and clears the error inline on input. Server-side validation in `page.submit.php` stays the source of truth.
- **PUB-5** — Empty dashboard cards (Latest bans / Servers / Latest comm blocks) grow per-domain primary CTAs gated on the matching `ADMIN_ADD_*` flag via the new `HomeDashboardView::$can_add_*` fields. "Latest blocked attempts" stays CTA-less by design (read-only stream).
- **SET-1** — Dashboard `dash.intro.text` textarea grows a live Markdown preview pane next to it, powered by a new `system.preview_intro_text` JSON action that pipes through the existing `Sbpp\Markup\IntroRenderer` (CommonMark, `html_input: 'escape'`, `allow_unsafe_links: false`). First paint is server-rendered so the page works without JS. The CommonMark cheat-sheet reference is now an actual `<a href>`. **No** WYSIWYG.
- **SET-2** — Settings save-button row no longer abuts the page footer on mobile: `.settings-actions` adds a bottom margin and the new `.app-footer` class adds a top margin + border so the visual seam is unambiguous at narrow widths.
- **Empty states unified** — All affected surfaces (banlist, commslist, servers, dashboard cards, admin-audit, admin-bans Submissions / Protests, admin-comms) render the shared `.empty-state` block with the first-run-vs-filtered split documented in `AGENTS.md` (filtered → secondary "Clear filters" CTA; first-run → primary action CTA gated on the appropriate `ADMIN_*`; read-only streams stay CTA-less). `page_comms.tpl`'s mobile card list grew the missing `foreachelse` block so a filtered-empty mobile view no longer paints a blank panel.

## Test plan

- [x] PHPStan clean
- [x] PHPUnit clean (291 tests, 1228 assertions; added 5 new `system.preview_intro_text` cases + 1 snapshot)
- [x] ts-check clean
- [x] API contract clean (regenerated; new `SystemPreviewIntroText` action)
- [x] Playwright E2E clean (94 tests, `workers=1` per AGENTS.md)
- [x] Screenshot gallery regenerated (96 captures, light + dark, desktop + mobile)
- [x] Manual: empty states across banlist / commslist / servers / dashboard / admin-bans / admin-audit visited; CTAs gated on permissions; submit-form client-side validation blocks empty Steam ID + IP; settings save button no longer overlaps footer at mobile width

## Conventions / docs touched

- New empty-state convention (first-run vs filtered + the shared `.empty-state` CSS surface) lives in `AGENTS.md` (Conventions). New "Where to find what" rows for the Markdown live-preview pane, the empty-state surfaces, and the either-or input shared-required pattern.
- WYSIWYG anti-pattern is reasserted, plus two new entries: ad-hoc empty-state copy and client-side Markdown rendering.
- `ARCHITECTURE.md`'s `IntroRenderer` section grew a paragraph on the `system.preview_intro_text` reuse pattern.

## Coordination

Touches the same template files as Workers 1-4 in the #1207 split, but only adds copy / CTAs / the live preview pane / a settings save-button spacing fix. Banlist + queue table column geometry (PUB-1 / PUB-2) is owned by Worker 4 and untouched here.

Does NOT close #1207.