### PR TITLE
fix: login breadcrumb + admin home cards mobile (#1207 slice 10)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -183,6 +183,16 @@ After `init.php` returns, callers may rely on these globals:
 3. `build(title, page)` includes `pages/core/header.php`,
    `pages/core/navbar.php`, `pages/core/title.php`, then the page file,
    then `pages/core/footer.php`.
+   - `pages/core/title.php` runs **before** the page handler, so it
+     can't read a `$breadcrumb` the page handler will assign later.
+     Instead it builds the default 2-segment "Home > $title" breadcrumb
+     itself and dispatches by `?p=…` slug to `Sbpp\View\*View::breadcrumb()`
+     for routes whose audience makes the "Home" prefix misleading
+     (currently `login` and `lostpassword`, where logged-out visitors
+     have no meaningful Home — #1207 AUTH-3). View DTOs that want to
+     publish a non-default breadcrumb shape expose a static
+     `breadcrumb(): array` returning the same `[ ['title' => ..., 'url' => ...] ]`
+     structure `core/title.tpl` consumes.
 4. The page file (e.g. `pages/page.home.php`) queries the DB and renders
    either:
    - **Legacy:** ad-hoc `$theme->assign(...)` chains followed by

--- a/web/includes/View/LoginView.php
+++ b/web/includes/View/LoginView.php
@@ -58,4 +58,32 @@ final class LoginView extends View
         public readonly string $redir,
     ) {
     }
+
+    /**
+     * Breadcrumb shape for the login page (#1207 AUTH-3).
+     *
+     * Single-segment "Sign in" rather than the default
+     * "Home > $title" pair. A logged-out visitor doesn't have a
+     * meaningful "Home" — the link in the default breadcrumb just
+     * bounces them back to the public dashboard, which isn't where
+     * they arrived to be. The single-segment shape preserves the
+     * breadcrumb's a11y contract (`<a aria-current="page">` is still
+     * the last element so `core/title.tpl`'s testability hook is
+     * unchanged) without offering a misleading parent link.
+     *
+     * `core/title.php` consults this via `$_GET['p'] === 'login'`
+     * BEFORE the page handler runs (per the page-builder lifecycle:
+     * header → navbar → title → page → footer), which is why the
+     * shape lives on the View as a static rather than as an
+     * instance property — the View instance doesn't exist yet at
+     * breadcrumb-emit time.
+     *
+     * @return list<array{title: string, url: string}>
+     */
+    public static function breadcrumb(): array
+    {
+        return [
+            ['title' => 'Sign in', 'url' => 'index.php?p=login'],
+        ];
+    }
 }

--- a/web/includes/View/LostPasswordView.php
+++ b/web/includes/View/LostPasswordView.php
@@ -23,4 +23,27 @@ namespace Sbpp\View;
 final class LostPasswordView extends View
 {
     public const TEMPLATE = 'page_lostpassword.tpl';
+
+    /**
+     * Breadcrumb shape for the lost-password page (#1207 AUTH-3).
+     *
+     * Single-segment "Reset password" rather than the default
+     * "Home > $title" pair. Same reasoning as
+     * {@see LoginView::breadcrumb()}: a visitor recovering their
+     * password is by definition logged out and has no meaningful
+     * "Home" — the default breadcrumb's prefix link just bounces
+     * them back to the public dashboard, which isn't useful.
+     *
+     * `core/title.php` consults this via `$_GET['p'] === 'lostpassword'`
+     * BEFORE the page handler runs, so the shape lives on the View
+     * as a static method.
+     *
+     * @return list<array{title: string, url: string}>
+     */
+    public static function breadcrumb(): array
+    {
+        return [
+            ['title' => 'Reset password', 'url' => 'index.php?p=lostpassword'],
+        ];
+    }
 }

--- a/web/pages/core/title.php
+++ b/web/pages/core/title.php
@@ -12,11 +12,12 @@ global $theme;
 // AFTER `$breadcrumb` has already been emitted to the wire.
 //
 // `$page_slug` (NOT `$page`) on purpose: this file is `require_once`'d
-// from `Sbpp\PageBuilder::build($title, $page)` where `$page` is the
-// path to the page handler this title block will be followed by. A
-// `$page = …` assignment here would overwrite that parameter via the
-// shared scope and the next `require_once(TEMPLATES_PATH.$page)`
-// would resolve to garbage (e.g. `pages` + `login` = `pageslogin`).
+// from the global `build($title, $page)` helper in
+// `web/includes/page-builder.php`, where `$page` is the path to the
+// page handler this title block will be followed by. A `$page = …`
+// assignment here would overwrite that parameter via the shared
+// scope and the next `require_once(TEMPLATES_PATH.$page)` would
+// resolve to garbage (e.g. `pages` + `login` = `pageslogin`).
 $page_slug = (string) ($_GET['p'] ?? '');
 $breadcrumb = match ($page_slug) {
     'login' => \Sbpp\View\LoginView::breadcrumb(),

--- a/web/pages/core/title.php
+++ b/web/pages/core/title.php
@@ -1,16 +1,37 @@
 <?php
 global $theme;
 
-$breadcrumb = [
-    [
-        'title' => 'Home',
-        'url' => 'index.php?p=home'
+// #1207 AUTH-3: pages whose audience is logged-out by definition
+// (login + lostpassword) publish their own breadcrumb shape on the
+// matching View DTO so we don't render a misleading "Home > Login"
+// — clicking "Home" just lands the visitor on the public dashboard
+// they didn't intend to visit. The default 2-segment breadcrumb
+// stays for every other route. The dispatch happens here (not in
+// the page handler) because the lifecycle is
+// header → navbar → title → page → footer; the page handler runs
+// AFTER `$breadcrumb` has already been emitted to the wire.
+//
+// `$page_slug` (NOT `$page`) on purpose: this file is `require_once`'d
+// from `Sbpp\PageBuilder::build($title, $page)` where `$page` is the
+// path to the page handler this title block will be followed by. A
+// `$page = …` assignment here would overwrite that parameter via the
+// shared scope and the next `require_once(TEMPLATES_PATH.$page)`
+// would resolve to garbage (e.g. `pages` + `login` = `pageslogin`).
+$page_slug = (string) ($_GET['p'] ?? '');
+$breadcrumb = match ($page_slug) {
+    'login' => \Sbpp\View\LoginView::breadcrumb(),
+    'lostpassword' => \Sbpp\View\LostPasswordView::breadcrumb(),
+    default => [
+        [
+            'title' => 'Home',
+            'url' => 'index.php?p=home',
+        ],
+        [
+            'title' => $title,
+            'url' => 'index.php?p=' . urlencode($page_slug),
+        ],
     ],
-    [
-        'title' => $title,
-        'url' => 'index.php?p=' . urlencode((string) ($_GET['p'] ?? ''))
-    ]
-];
+};
 
 $theme->assign('board_name', Config::get('template.title'));
 $theme->assign('title', $title);

--- a/web/tests/e2e/specs/_screenshots.spec.ts
+++ b/web/tests/e2e/specs/_screenshots.spec.ts
@@ -60,6 +60,13 @@ interface RouteSpec {
 
 const ROUTES: RouteSpec[] = [
     { name: 'login', path: '/index.php?p=login', auth: false },
+    // #1207 AUTH-3 (slice 10): lostpassword renders the same single-
+    // segment breadcrumb pattern login does. Capturing it here gives
+    // the maintainer visual confirmation of the AUTH-3 fix on the
+    // recovery surface alongside login. `auth: false` because the
+    // page handler bounces logged-in visitors (per the AUTH-1 guard
+    // shipped in slice 3) — anonymous context only.
+    { name: 'lostpassword', path: '/index.php?p=lostpassword', auth: false },
 ];
 
 const THEMES = ['light', 'dark'] as const;

--- a/web/tests/e2e/specs/responsive/admin-home.spec.ts
+++ b/web/tests/e2e/specs/responsive/admin-home.spec.ts
@@ -1,0 +1,181 @@
+/**
+ * Issue #1207 ADM-10: admin home cards arrange as a 2-column grid at mobile.
+ *
+ * Pre-fix the admin landing's `.admin-cards` grid used
+ * `repeat(auto-fill, minmax(15rem, 1fr))` universally. At iPhone-13
+ * width (390px) only one 240px column fits the available content
+ * area, so the 8 admin entry-point cards stack vertically and
+ * produce ~680px of scroll for what should be 2-3 rows of tiles.
+ *
+ * Fix: a mobile-scoped media query in `web/themes/default/page_admin.tpl`
+ * (`@media (max-width: 767.98px)`) overrides the grid to
+ * `repeat(2, minmax(0, 1fr))` so the cards always render in 2
+ * columns at <768px, with `gap: 0.75rem` to keep the tiles from
+ * crowding each other. Tablet (768–1023px) and desktop (>=1024px)
+ * keep the auto-fill behaviour above so wider viewports still get
+ * 2-3-4 columns depending on available width.
+ *
+ * Selectors use the `data-testid="admin-card-<area>"` hooks the
+ * template already emits (#1207 ADM-1's overrides slice and the
+ * routing-truthiness spec lock them); no class-chain or
+ * visible-text primary selectors per AGENTS.md.
+ *
+ * Per-project assertions: this spec splits into two non-overlapping
+ * tests guarded by `testInfo.project.name`. The mobile assertion
+ * locks the 2-column shape; the desktop assertion locks the
+ * "didn't regress to 1-col" invariant by asserting >=3 cards on the
+ * first visible row at the chromium project's Desktop Chrome
+ * viewport (1280×720). Without the desktop counterpart a
+ * future careless edit could collapse the desktop grid to 1-col
+ * and the mobile spec wouldn't notice.
+ */
+
+import { test, expect } from '../../fixtures/auth.ts';
+
+/**
+ * Read the rendered top/left/width of every visible card on the
+ * admin landing. Returned in DOM order (which matches the visual
+ * order under the default `auto-flow: row`). The bounding boxes
+ * are floating-point — callers tolerate a small (<= 5px) y-axis
+ * variation when checking "same row" so sub-pixel layout differences
+ * don't flake the assertion.
+ */
+async function readCardBoxes(
+    page: import('@playwright/test').Page,
+): Promise<Array<{ id: string; x: number; y: number; w: number; h: number }>> {
+    return await page.evaluate(() => {
+        return Array.from(
+            document.querySelectorAll<HTMLElement>('[data-testid^="admin-card-"]'),
+        )
+            .filter((el) => {
+                const r = el.getBoundingClientRect();
+                return r.width > 0 && r.height > 0;
+            })
+            .map((el) => {
+                const r = el.getBoundingClientRect();
+                return {
+                    id: el.getAttribute('data-testid') ?? '',
+                    x: r.left,
+                    y: r.top,
+                    w: r.width,
+                    h: r.height,
+                };
+            });
+    });
+}
+
+/**
+ * Group cards into visual rows. Two cards belong to the same row
+ * when their top edges differ by less than `tolerance` pixels —
+ * guarding sub-pixel layout differences (and the small extra padding
+ * a focus ring might add) without admitting a stacked layout that
+ * happens to differ by < 5px (the cards are >= ~120px tall in
+ * either layout).
+ */
+function rowsOf(
+    boxes: Array<{ x: number; y: number; w: number; h: number }>,
+    tolerance = 5,
+): Array<typeof boxes> {
+    const rows: Array<typeof boxes> = [];
+    for (const box of boxes) {
+        const row = rows.find((r) => Math.abs(r[0].y - box.y) < tolerance);
+        if (row) row.push(box);
+        else rows.push([box]);
+    }
+    // Sort each row left-to-right so column-position assertions can
+    // reason about adjacency without re-sorting per call site.
+    for (const r of rows) r.sort((a, b) => a.x - b.x);
+    return rows;
+}
+
+test.describe('#1207 ADM-10: admin home cards mobile grid', () => {
+    test('mobile: cards render in a 2-column grid at iPhone-13 width', async ({ page }, testInfo) => {
+        test.skip(
+            testInfo.project.name !== 'mobile-chromium',
+            'Mobile-only assertion — see file-level comment.',
+        );
+
+        await page.goto('/index.php?p=admin');
+
+        // Anchor on a card every seeded ADMIN_OWNER admin renders;
+        // `admin-card-bans` is the most permissively-gated tile and
+        // the one `pages/admin/AdminHome.ts` uses as its mounted
+        // signal, so it's available for any future non-OWNER fixture.
+        await expect(page.locator('[data-testid="admin-card-bans"]')).toBeVisible();
+
+        const boxes = await readCardBoxes(page);
+        // The seeded admin holds ADMIN_OWNER, so every $can_<area>
+        // boolean resolves to true and all 8 cards render. If a
+        // future change adds/removes a card the count assertion
+        // here forces a paired test update — better than silently
+        // shipping a stale grid expectation.
+        expect(boxes.length).toBe(8);
+
+        const rows = rowsOf(boxes);
+
+        // Every row must hold exactly 2 cards (the grid is
+        // `repeat(2, minmax(0, 1fr))` at <768px). 8 cards / 2 cols
+        // = 4 rows. Pinning the row count locks the layout shape;
+        // pinning each row's width locks the "they're balanced
+        // halves" invariant (`auto-fill` on a future regression
+        // could leave a half-empty row).
+        expect(rows.length, `cards must arrange into 4 rows of 2 (got ${rows.length})`).toBe(4);
+        for (const row of rows) {
+            expect(row.length, `each row must have 2 cards (got ${row.length})`).toBe(2);
+        }
+
+        // Column-position invariants on the first row:
+        //   - the two cards are side-by-side (cardA.right <= cardB.left + small gap)
+        //   - both cards have non-trivial width (>= 100px so a future
+        //     `width: 0` regression fails this gate)
+        const [cardA, cardB] = rows[0];
+        expect(cardB.x).toBeGreaterThan(cardA.x + cardA.w - 1);
+        expect(cardA.w).toBeGreaterThanOrEqual(100);
+        expect(cardB.w).toBeGreaterThanOrEqual(100);
+
+        // 44x44 tap-target floor (WCAG 2.1 AAA / Apple HIG / Material).
+        // Same threshold the topbar palette-trigger spec locks.
+        for (const box of boxes) {
+            expect(box.w, `card ${box.id} width >= 44px`).toBeGreaterThanOrEqual(44);
+            expect(box.h, `card ${box.id} height >= 44px`).toBeGreaterThanOrEqual(44);
+        }
+
+        // Page-level: the admin landing must not introduce horizontal
+        // overflow at iPhone-13 width. Mirrors the topbar-CC1 spec's
+        // body-overflow guard so a future card-padding bump doesn't
+        // silently re-open the same scroll regression.
+        await expect.poll(() => page.evaluate(() =>
+            document.documentElement.scrollWidth - document.documentElement.clientWidth
+        )).toBeLessThanOrEqual(1);
+    });
+
+    test('desktop: cards remain in a multi-column grid at Desktop Chrome width', async ({ page }, testInfo) => {
+        test.skip(
+            testInfo.project.name !== 'chromium',
+            'Desktop-only regression guard — see file-level comment.',
+        );
+
+        await page.goto('/index.php?p=admin');
+        await expect(page.locator('[data-testid="admin-card-bans"]')).toBeVisible();
+
+        const boxes = await readCardBoxes(page);
+        expect(boxes.length).toBe(8);
+
+        const rows = rowsOf(boxes);
+
+        // Desktop Chrome's default viewport (devices['Desktop Chrome'])
+        // is 1280×720. Available content width after the sidebar
+        // (~256px) and admin-home padding (~24px each side) is
+        // ~975px; with the existing `repeat(auto-fill, minmax(15rem, 1fr))`
+        // rule (15rem = 240px) the first row holds 4 cards. We assert
+        // >= 3 to leave headroom for sidebar-width drift between
+        // chrome revisions; the regression we're guarding against
+        // is "fell back to 1-col mobile stack on desktop", which a
+        // >= 3 floor catches without coupling to the exact column
+        // count the existing rule produces today.
+        expect(
+            rows[0].length,
+            `desktop must keep multi-column layout (>= 3 on first row, got ${rows[0].length})`,
+        ).toBeGreaterThanOrEqual(3);
+    });
+});

--- a/web/tests/e2e/specs/smoke/breadcrumb.spec.ts
+++ b/web/tests/e2e/specs/smoke/breadcrumb.spec.ts
@@ -1,0 +1,123 @@
+/**
+ * Issue #1207 AUTH-3: login + lostpassword breadcrumb is single-segment.
+ *
+ * Pre-fix the chrome breadcrumb on every page rendered as
+ * `Home > $title` — including the login and lost-password pages.
+ * That's misleading for those two surfaces: the visitor is logged
+ * out by definition (the page handlers redirect any authenticated
+ * caller to `index.php`), so the "Home" prefix is a link to the
+ * public dashboard they didn't arrive to visit.
+ *
+ * Fix: `core/title.php` consults `Sbpp\View\LoginView::breadcrumb()` /
+ * `Sbpp\View\LostPasswordView::breadcrumb()` for `$_GET['p'] === 'login'`
+ * / `'lostpassword'` respectively, both of which return a
+ * single-segment breadcrumb (`[{title: 'Sign in', url: ...}]` /
+ * `[{title: 'Reset password', url: ...}]`). Every other route keeps
+ * the default 2-segment shape.
+ *
+ * Selectors follow #1123's testability hooks:
+ *   - the breadcrumb container is `nav[aria-label="Breadcrumb"]` (set
+ *     in `core/title.tpl`);
+ *   - the active segment carries `aria-current="page"` so screen
+ *     readers and tests can point at it without parsing visible text.
+ *
+ * Both `chromium` and `mobile-chromium` run the same assertions —
+ * the chrome contract is the same on both viewports (the topbar's
+ * mobile collapse from CC-1 hides the search label, not the
+ * breadcrumb).
+ */
+
+import { test, expect } from '../../fixtures/auth.ts';
+
+test.describe('#1207 AUTH-3: login + lostpassword breadcrumb', () => {
+    // Per-describe override: log out for this whole block. The
+    // project-default storageState carries the seeded admin's
+    // session cookie, which would (per the AUTH-1 redirect guard
+    // shipped in slice 3) bounce the browser back to `index.php`
+    // before the breadcrumb ever rendered. This block exercises
+    // the logged-out path that real users hit on these surfaces.
+    test.use({ storageState: { cookies: [], origins: [] } });
+
+    test('login renders a single-segment "Sign in" breadcrumb', async ({ page }) => {
+        await page.goto('/index.php?p=login');
+
+        // The form's email/username/password trio is the
+        // deterministic terminal mark for the logged-out path —
+        // if the redirect guard had bounced us, we'd be on the
+        // dashboard with no `login-username` input in the DOM.
+        await expect(page.locator('[data-testid="login-username"]')).toBeVisible();
+
+        const breadcrumb = page.locator('nav[aria-label="Breadcrumb"]');
+        await expect(breadcrumb).toBeVisible();
+
+        // Single-segment: exactly one `<a>` inside the breadcrumb.
+        // The pre-fix shape rendered two anchors ("Home" + the page
+        // title), so this count guards against accidentally falling
+        // back to the default 2-segment branch in `core/title.php`.
+        const links = breadcrumb.locator('a');
+        await expect(links).toHaveCount(1);
+
+        // The active segment is the last one (aria-current="page"),
+        // which on a single-segment breadcrumb is also the only one.
+        // We pin BOTH the visible text ("Sign in", per the issue's
+        // suggested copy) and the href so a future copy/href edit
+        // either lands together or fails loudly here. The "Login"
+        // string the legacy breadcrumb rendered must NOT come back.
+        const active = breadcrumb.locator('a[aria-current="page"]');
+        await expect(active).toHaveCount(1);
+        await expect(active).toHaveText('Sign in');
+        await expect(active).toHaveAttribute('href', 'index.php?p=login');
+        await expect(breadcrumb).not.toContainText(/^Home/);
+    });
+
+    test('lostpassword renders a single-segment "Reset password" breadcrumb', async ({ page }) => {
+        await page.goto('/index.php?p=lostpassword');
+
+        // Same deterministic mark as the login spec above — the
+        // form's email input is server-rendered if and only if the
+        // logged-out branch took.
+        await expect(page.locator('[data-testid="lostpw-email"]')).toBeVisible();
+
+        const breadcrumb = page.locator('nav[aria-label="Breadcrumb"]');
+        await expect(breadcrumb).toBeVisible();
+
+        const links = breadcrumb.locator('a');
+        await expect(links).toHaveCount(1);
+
+        const active = breadcrumb.locator('a[aria-current="page"]');
+        await expect(active).toHaveCount(1);
+        await expect(active).toHaveText('Reset password');
+        await expect(active).toHaveAttribute('href', 'index.php?p=lostpassword');
+        // "Lost your password" was the pre-fix breadcrumb title (from
+        // page-builder's route() return value). The new breadcrumb
+        // shape replaces it with the canonical "Reset password" copy
+        // — guard the regression both ways.
+        await expect(breadcrumb).not.toContainText('Lost your password');
+        await expect(breadcrumb).not.toContainText(/^Home/);
+    });
+});
+
+test.describe('#1207 AUTH-3: regression — other routes keep the 2-segment breadcrumb', () => {
+    // Inherits the project-default authenticated session from
+    // `fixtures/global-setup.ts` — every other route renders for
+    // the seeded admin without redirecting. We pin one public route
+    // (banlist) so the fix can't accidentally widen the
+    // single-segment branch to ALL pages.
+    test('banlist still renders Home > Ban List', async ({ page }) => {
+        await page.goto('/index.php?p=banlist');
+
+        const breadcrumb = page.locator('nav[aria-label="Breadcrumb"]');
+        await expect(breadcrumb).toBeVisible();
+
+        // Pre-fix shape: 2 anchors. The active one is the last
+        // (aria-current="page") and reads "Ban List"; the first is
+        // "Home" linking back to the dashboard. The new dispatch in
+        // `core/title.php` falls through to this default branch for
+        // every `$_GET['p']` other than login / lostpassword.
+        const links = breadcrumb.locator('a');
+        await expect(links).toHaveCount(2);
+
+        await expect(breadcrumb.locator('a').first()).toHaveText('Home');
+        await expect(breadcrumb.locator('a[aria-current="page"]')).toHaveText('Ban List');
+    });
+});

--- a/web/themes/default/page_admin.tpl
+++ b/web/themes/default/page_admin.tpl
@@ -190,6 +190,22 @@
         margin: 0;
         padding: 0;
     }
+    /* #1207 ADM-10: at <768px the auto-fill grid above only fits a
+       single 15rem column so the 8 admin cards stack vertically and
+       produce a long scroll. Force 2 columns at mobile instead — at
+       the iPhone-13's 375px viewport this lands ~165px-wide cards
+       (full-width minus 1rem body padding minus 0.75rem gap, halved)
+       with ~120px+ height each (2.25rem icon + 1.25rem padding +
+       title + description), well above the 44x44 tap-target floor.
+       Tablet (768–1023px) and desktop (>=1024px) keep the auto-fill
+       behaviour above so wider viewports still get 2-3-4 columns
+       depending on how much sidebar-less width is available. */
+    @media (max-width: 767.98px) {
+        .admin-cards {
+            grid-template-columns: repeat(2, minmax(0, 1fr));
+            gap: 0.75rem;
+        }
+    }
 
     .admin-card {
         display: block;


### PR DESCRIPTION
## Summary

Slice 10 of #1207 — polish. Addresses AUTH-3, ADM-10.

- **AUTH-3** — Login & lostpassword now publish a single-segment breadcrumb (`"Sign in"` / `"Reset password"`) via `Sbpp\View\LoginView::breadcrumb()` / `LostPasswordView::breadcrumb()`, dispatched from `core/title.php`. The misleading `"Home > Login"` link that bounced logged-out visitors to the public dashboard is gone; every other route keeps the default 2-segment shape.
- **ADM-10** — `.admin-cards` gets a `@media (max-width: 767.98px)` override that swaps the auto-fill grid for `repeat(2, minmax(0, 1fr))` with `gap: 0.75rem`. At iPhone-13 width the 8 admin entry-point cards now arrange in 4 rows of 2 (~165×120px tiles, well above the 44×44 floor) instead of stacking. Tablet and desktop are unchanged.

## Implementation notes

- The breadcrumb dispatch lives in `core/title.php` (not the page handler) because the page-builder lifecycle runs `header → navbar → title → page → footer` — the page handler runs **after** `$breadcrumb` is emitted to the wire, so the View has to expose its breadcrumb shape statically (`LoginView::breadcrumb(): array`) for the title block to consult before the View instance exists.
- `core/title.php`'s local breadcrumb-slug variable is `$page_slug`, not `$page` — the file is `require_once`'d inside `Sbpp\PageBuilder::build($title, $page)` and `$page` is the path to the page handler we're about to include. Shadowing it would resolve `pages` + `login` = `pageslogin` and the next `require_once(TEMPLATES_PATH.$page)` would fatal.
- ADM-10 uses vanilla CSS in the existing `<style>` block of `page_admin.tpl`. No new files; `data-testid` attributes are unchanged.
- `_screenshots.spec.ts` now covers `lostpassword` alongside `login` so the gallery captures both fixed surfaces.

## Test plan

- [x] PHPStan clean (`./sbpp.sh phpstan`)
- [x] PHPUnit clean (`./sbpp.sh test`)
- [x] ts-check clean (`./sbpp.sh ts-check`)
- [x] API contract clean (`./sbpp.sh composer api-contract` — no diff)
- [x] Playwright E2E clean (chromium + mobile-chromium, axe critical = 0)
- [x] Screenshot gallery regenerated (`SCREENSHOTS=1 CI=1 ./sbpp.sh e2e --grep @screenshot` — 100/120 passed, 20 skipped are desktop-only flow specs)
- [x] Manual: login + lostpassword breadcrumb single-segment with `aria-current="page"`; admin home renders 2-col grid at 375px viewport

## Coverage added

- `web/tests/e2e/specs/smoke/breadcrumb.spec.ts` — logged-out single-segment assertion for login + lostpassword, plus a banlist regression spec for the default 2-segment branch.
- `web/tests/e2e/specs/responsive/admin-home.spec.ts` — mobile 4-row × 2-col layout + 44×44 tap-target floor + horizontal-overflow guard, paired with a desktop ≥3-card regression guard so the desktop grid can't silently collapse.

Does NOT close #1207 — keep the umbrella open until the maintainer triages.