### PR TITLE
fix(theme): comms list affordances (#1207 slice 6)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -522,6 +522,15 @@ audit (#1207) locked in. New CTAs:
   → use `data-testid` / ARIA roles per #1123. `hasText` filters for
   disambiguation are fine; "find element by its label text" as the
   whole selector is not.
+- Hover-only row-action affordances (`.row-actions { opacity: 0 }`
+  flipped to `1` on `tbody tr:hover`) → row-level Edit / Unmute /
+  Remove (and equivalent) buttons must be visible by default at
+  every viewport. The opacity-on-hover trick was removed from the
+  comms list in #1207 ADM-5; it never worked on touch viewports
+  (no hover state) and silently regressed discoverability for
+  every keyboard / screen-reader user. New surfaces add visible
+  buttons in the same shape as `.queue-row` (admin moderation
+  queue) or the comms-list desktop table (`web/themes/default/page_comms.tpl`).
 - Removing `<meta name="format-detection" content="telephone=no…">`
   from `core/header.tpl` (or the defensive `.drawer a[href^="tel:"]`
   reset in `theme.css`) → mobile Safari + some Android Chromes
@@ -542,6 +551,7 @@ audit (#1207) locked in. New CTAs:
 | Render a page                          | `web/pages/<page>.php` + `web/includes/View/*View.php`   |
 | Edit a template                        | `web/themes/default/*.tpl`                               |
 | Reuse the moderation-queue card layout (admin submissions / protests, mobile-stacked summary rows) | `web/themes/default/css/theme.css` (`.queue-row`, `.queue-row__body`, `.queue-row__date` — #1207 PUB-2). Apply by adding `class="queue-row …"` to the outer `<details>` and dropping the inline `flex` / `flex-shrink:0` styles from the summary children. |
+| Add visible row actions to a table-rendered admin list (Edit / Unmute / Remove buttons + responsive mobile-card mirror) | `web/themes/default/page_comms.tpl` (#1207 ADM-5) is the canonical reference: `<button class="btn btn--secondary btn--sm">` / `<a class="btn btn--ghost btn--sm">` inside a `.row-actions` cell, plus `.ban-card__actions` row of identical-data-action buttons in the mobile card. Wire destructive / state-changing buttons via `data-action="…"` + `data-bid` + `data-fallback-href`; the inline page-tail JS calls `sb.api.call(Actions.PascalName)` and falls back to the GET URL if the JSON dispatcher is absent. |
 | Edit the player-detail drawer (open trigger, tabs, panes, lazy loaders) | `web/themes/default/js/theme.js` (`renderDrawerBody` / `loadPaneIfNeeded`) |
 | Add admin-only per-player notes | `web/api/handlers/notes.php` (CRUD) — Notes tab is gated by `bans.detail`'s `notes_visible` flag |
 | Render admin-authored Markdown to safe HTML | `web/includes/Markup/IntroRenderer.php` (`Sbpp\Markup`) |

--- a/web/api/handlers/_register.php
+++ b/web/api/handlers/_register.php
@@ -86,6 +86,11 @@ Api::register('comms.add',                    'api_comms_add',                  
 Api::register('comms.prepare_reblock',        'api_comms_prepare_reblock',        0, true);
 Api::register('comms.paste',                  'api_comms_paste',                  ADMIN_OWNER | ADMIN_ADD_BAN);
 Api::register('comms.prepare_block_from_ban', 'api_comms_prepare_block_from_ban', 0, true);
+// comms.unblock dispatcher gate matches the legacy GET handler: any of the
+// four "lift-a-block" flags lets the request through; the handler then
+// does the precise per-row check (own/group bans). #1207 ADM-5/ADM-6.
+Api::register('comms.unblock', 'api_comms_unblock', ADMIN_OWNER | ADMIN_UNBAN | ADMIN_UNBAN_OWN_BANS | ADMIN_UNBAN_GROUP_BANS);
+Api::register('comms.delete',  'api_comms_delete',  ADMIN_OWNER | ADMIN_DELETE_BAN);
 
 // ---- groups -----------------------------------------------------------
 Api::register('groups.add',                   'api_groups_add',                   ADMIN_OWNER | ADMIN_ADD_GROUP);

--- a/web/api/handlers/comms.php
+++ b/web/api/handlers/comms.php
@@ -107,6 +107,161 @@ function api_comms_prepare_reblock(array $params): array
     ];
 }
 
+/**
+ * Lift an active gag/mute on a comm row (#1207 ADM-5/ADM-6).
+ *
+ * Modern JSON twin of the legacy `?p=commslist&a=ungag|unmute&id=…&key=…`
+ * GET handlers in `page.commslist.php`. The legacy GET path stays put
+ * (no-JS fallback for the icon-only theme leg + third-party themes that
+ * still ship the v1.x action links), but the comms list's visible-action
+ * affordance now wires through this action so the row can update
+ * in-place + show a toast without a full page reload. Permission gate
+ * mirrors the legacy GET handler exactly:
+ *
+ *   ADMIN_OWNER | ADMIN_UNBAN     — unconditional, lift any row.
+ *   ADMIN_UNBAN_OWN_BANS          — only the row's own admin (`aid`).
+ *   ADMIN_UNBAN_GROUP_BANS        — only rows where `gid` matches the
+ *                                   caller's `gid`.
+ *
+ * The dispatcher gate is `ADMIN_OWNER | ADMIN_UNBAN |
+ * ADMIN_UNBAN_OWN_BANS | ADMIN_UNBAN_GROUP_BANS` — the broadest "any
+ * unban-ish flag" match — and the per-row precision check happens
+ * inside the handler, since the dispatcher can't see which row the
+ * caller wants to act on.
+ *
+ * Inputs:
+ *   - `bid`     (int, required) — the comm-block id.
+ *   - `ureason` (string, optional) — admin-supplied unblock reason; we
+ *     trim and store as-is. Stored raw in `ureason` (per the
+ *     "store raw, escape on display" anti-pattern); the column lives
+ *     behind the same Smarty auto-escape pipeline as `reason`.
+ *
+ * @return array{ bid: int, state: string, type: int }
+ */
+function api_comms_unblock(array $params): array
+{
+    global $userbank;
+
+    $bid = (int)($params['bid'] ?? 0);
+    if ($bid <= 0) {
+        throw new ApiError('bad_request', 'bid must be a positive integer', 'bid');
+    }
+    $ureason = trim((string)($params['ureason'] ?? ''));
+
+    $row = $GLOBALS['PDO']->query(
+        "SELECT C.bid, C.authid, C.name, C.type, C.length, C.ends, C.RemoveType, C.aid, A.gid AS gid
+         FROM `:prefix_comms` AS C
+         LEFT JOIN `:prefix_admins` AS A ON A.aid = C.aid
+         WHERE C.bid = ?"
+    )->single([$bid]);
+
+    if (!$row) {
+        throw new ApiError('not_found', 'Block not found.', null, 404);
+    }
+
+    // Mirror the legacy GET handler's per-row precision check: dispatcher
+    // already accepted the caller for "some unban flag", but we only let
+    // them through if the SPECIFIC row matches what their flag covers.
+    $rowAid = (int)($row['aid'] ?? 0);
+    $rowGid = (int)($row['gid'] ?? 0);
+    $callerGid = (int)$userbank->GetProperty('gid');
+    $allowed =
+        $userbank->HasAccess(ADMIN_OWNER | ADMIN_UNBAN)
+        || ($userbank->HasAccess(ADMIN_UNBAN_OWN_BANS)   && $rowAid === $userbank->GetAid())
+        || ($userbank->HasAccess(ADMIN_UNBAN_GROUP_BANS) && $rowGid === $callerGid);
+    if (!$allowed) {
+        throw new ApiError('forbidden', "You don't have access to this block.", null, 403);
+    }
+
+    if (!empty($row['RemoveType'])) {
+        throw new ApiError('not_active', 'Block has already been lifted.', null, 409);
+    }
+    $length = (int)$row['length'];
+    $ends   = (int)$row['ends'];
+    if ($length > 0 && $ends <= time()) {
+        throw new ApiError('not_active', 'Block has already expired.', null, 409);
+    }
+
+    $GLOBALS['PDO']->query(
+        "UPDATE `:prefix_comms` SET `RemovedBy` = ?, `RemoveType` = 'U', `RemovedOn` = UNIX_TIMESTAMP(), `ureason` = ? WHERE `bid` = ?"
+    )->execute([$userbank->GetAid(), $ureason, $bid]);
+
+    $type = (int)$row['type'];
+    $cmd  = $type === 1 ? 'sc_fw_unmute' : ($type === 2 ? 'sc_fw_ungag' : '');
+    if ($cmd !== '') {
+        $blocked = $GLOBALS['PDO']->query("SELECT sid FROM `:prefix_servers` WHERE `enabled`=1")->resultset();
+        foreach ($blocked as $tempban) {
+            rcon($cmd . ' ' . (string)$row['authid'], (int)$tempban['sid']);
+        }
+    }
+
+    $verb = $type === 1 ? 'UnMuted' : ($type === 2 ? 'UnGagged' : 'Unblocked');
+    Log::add('m', "Player $verb", "{$row['name']} ({$row['authid']}) has been " . strtolower($verb) . '.');
+
+    return [
+        'bid'   => $bid,
+        'state' => 'unmuted',
+        'type'  => $type,
+    ];
+}
+
+/**
+ * Delete a comm row (#1207 ADM-5).
+ *
+ * Modern JSON twin of `?p=commslist&a=delete&id=…&key=…`. Hard-deletes
+ * the row and, if the row was still active, runs `sc_fw_un{mute,gag}`
+ * on every enabled server so the in-game state matches.
+ *
+ * Permission gate (dispatcher-enforced) is `ADMIN_OWNER | ADMIN_DELETE_BAN`,
+ * mirroring the legacy GET handler. Note the broader "delete any
+ * comm row" reach: comm rows don't have the per-admin / per-group
+ * delete flag the bans table has, so a single dispatcher gate is enough.
+ *
+ * Input: `bid` (int, required).
+ *
+ * @return array{ bid: int, deleted: bool }
+ */
+function api_comms_delete(array $params): array
+{
+    $bid = (int)($params['bid'] ?? 0);
+    if ($bid <= 0) {
+        throw new ApiError('bad_request', 'bid must be a positive integer', 'bid');
+    }
+
+    $row = $GLOBALS['PDO']->query(
+        "SELECT name, authid, ends, length, RemoveType, type, UNIX_TIMESTAMP() AS now FROM `:prefix_comms` WHERE bid = ?"
+    )->single([$bid]);
+
+    if (!$row) {
+        throw new ApiError('not_found', 'Block not found.', null, 404);
+    }
+
+    $type = (int)$row['type'];
+    $cmd  = $type === 1 ? 'sc_fw_unmute' : ($type === 2 ? 'sc_fw_ungag' : '');
+
+    $GLOBALS['PDO']->query("DELETE FROM `:prefix_comms` WHERE `bid` = ?")->execute([$bid]);
+
+    // Lift the in-game state ONLY if the row was still active. A row that
+    // was already lifted/expired shouldn't fire an rcon command — the
+    // server already ran one when the original action lifted the row.
+    $end    = (int)$row['ends'];
+    $length = (int)$row['length'];
+    $now    = (int)$row['now'];
+    if (empty($row['RemoveType']) && $cmd !== '' && ($length === 0 || $end > $now)) {
+        $blocked = $GLOBALS['PDO']->query("SELECT sid FROM `:prefix_servers` WHERE `enabled`=1")->resultset();
+        foreach ($blocked as $tempban) {
+            rcon($cmd . ' ' . (string)$row['authid'], (int)$tempban['sid']);
+        }
+    }
+
+    Log::add('m', 'Block Deleted', "Block {$row['name']} ({$row['authid']}) has been deleted.");
+
+    return [
+        'bid'     => $bid,
+        'deleted' => true,
+    ];
+}
+
 function api_comms_paste(array $params): array
 {
     $sid  = (int)($params['sid']  ?? 0);

--- a/web/scripts/api-contract.js
+++ b/web/scripts/api-contract.js
@@ -174,6 +174,19 @@
  * @typedef {Object} ApiCommsAddResponse
  */
 /**
+ * Delete a comm row (#1207 ADM-5).  Modern JSON twin of
+ * `?p=commslist&a=delete&id=…&key=…`. Hard-deletes the row and, if the row
+ * was still active, runs `sc_fw_un{mute,gag}` on every enabled server so the
+ * in-game state matches.  Permission gate (dispatcher-enforced) is
+ * `ADMIN_OWNER | ADMIN_DELETE_BAN`, mirroring the legacy GET handler. Note the
+ * broader "delete any comm row" reach: comm rows don't have the per-admin /
+ * per-group delete flag the bans table has, so a single dispatcher gate is
+ * enough.  Input: `bid` (int, required).
+ *
+ * @typedef {Object} ApiCommsDeleteRequest
+ * @typedef {{ bid: number, deleted: boolean }} ApiCommsDeleteResponse
+ */
+/**
  * @typedef {Object} ApiCommsPasteRequest
  * @typedef {Object} ApiCommsPasteResponse
  */
@@ -197,6 +210,30 @@
 /**
  * @typedef {Object} ApiCommsPrepareReblockRequest
  * @typedef {Object} ApiCommsPrepareReblockResponse
+ */
+/**
+ * Lift an active gag/mute on a comm row (#1207 ADM-5/ADM-6).  Modern JSON twin
+ * of the legacy `?p=commslist&a=ungag|unmute&id=…&key=…` GET handlers in
+ * `page.commslist.php`. The legacy GET path stays put (no-JS fallback for the
+ * icon-only theme leg + third-party themes that still ship the v1.x action
+ * links), but the comms list's visible-action affordance now wires through
+ * this action so the row can update in-place + show a toast without a full
+ * page reload. Permission gate mirrors the legacy GET handler exactly: 
+ * ADMIN_OWNER | ADMIN_UNBAN     — unconditional, lift any row.
+ * ADMIN_UNBAN_OWN_BANS          — only the row's own admin (`aid`).
+ * ADMIN_UNBAN_GROUP_BANS        — only rows where `gid` matches the caller's
+ * `gid`.  The dispatcher gate is `ADMIN_OWNER | ADMIN_UNBAN |
+ * ADMIN_UNBAN_OWN_BANS | ADMIN_UNBAN_GROUP_BANS` — the broadest "any
+ * unban-ish flag" match — and the per-row precision check happens inside the
+ * handler, since the dispatcher can't see which row the caller wants to act
+ * on.  Inputs: - `bid`     (int, required) — the comm-block id. - `ureason`
+ * (string, optional) — admin-supplied unblock reason; we trim and store
+ * as-is. Stored raw in `ureason` (per the "store raw, escape on display"
+ * anti-pattern); the column lives behind the same Smarty auto-escape pipeline
+ * as `reason`.
+ *
+ * @typedef {Object} ApiCommsUnblockRequest
+ * @typedef {{ bid: number, state: string, type: number }} ApiCommsUnblockResponse
  */
 /**
  * @typedef {Object} ApiGroupsAddRequest
@@ -393,10 +430,12 @@ var Actions = Object.freeze({
     BlockitBlockPlayer: 'blockit.block_player',
     BlockitLoadServers: 'blockit.load_servers',
     CommsAdd: 'comms.add',
+    CommsDelete: 'comms.delete',
     CommsPaste: 'comms.paste',
     CommsPlayerHistory: 'comms.player_history',
     CommsPrepareBlockFromBan: 'comms.prepare_block_from_ban',
     CommsPrepareReblock: 'comms.prepare_reblock',
+    CommsUnblock: 'comms.unblock',
     GroupsAdd: 'groups.add',
     GroupsAddServerGroupName: 'groups.add_server_group_name',
     GroupsEdit: 'groups.edit',

--- a/web/tests/api/CommsTest.php
+++ b/web/tests/api/CommsTest.php
@@ -162,4 +162,117 @@ final class CommsTest extends ApiTestCase
         $this->assertEnvelopeError($env, 'rcon_failed');
         $this->assertSnapshot('comms/paste_rcon_failed', $env);
     }
+
+    // -- comms.unblock (#1207 ADM-5/ADM-6) ---------------------------------
+
+    public function testUnblockRejectsAnonymous(): void
+    {
+        $env = $this->api('comms.unblock', ['bid' => 1]);
+        $this->assertEnvelopeError($env, 'forbidden');
+        $this->assertSnapshot('comms/unblock_forbidden', $env);
+    }
+
+    public function testUnblockBadRequestOnMissingBid(): void
+    {
+        $this->loginAsAdmin();
+        $env = $this->api('comms.unblock', []);
+        $this->assertEnvelopeError($env, 'bad_request');
+        $this->assertSame('bid', $env['error']['field']);
+    }
+
+    public function testUnblockNotFoundForUnknownBid(): void
+    {
+        $this->loginAsAdmin();
+        $env = $this->api('comms.unblock', ['bid' => 99999]);
+        $this->assertEnvelopeError($env, 'not_found');
+    }
+
+    public function testUnblockLiftsActiveGagAndPersistsState(): void
+    {
+        $this->loginAsAdmin();
+        // Seed via the regular comms.add path so we exercise the same
+        // insert-side defaults (length seconds, aid linkage, ...) the
+        // panel writes in production.
+        $this->api('comms.add', [
+            'nickname' => 'Mouthy',
+            'type'     => 1, // gag
+            'steam'    => 'STEAM_0:0:444',
+            'length'   => 60,
+            'reason'   => 'spam',
+        ]);
+        $row = $this->row('comms', ['authid' => 'STEAM_0:0:444']);
+        $bid = (int)$row['bid'];
+
+        $env = $this->api('comms.unblock', ['bid' => $bid, 'ureason' => 'lifted by e2e']);
+        $this->assertTrue($env['ok'], json_encode($env));
+        $this->assertSame('unmuted',     $env['data']['state']);
+        $this->assertSame($bid,          (int)$env['data']['bid']);
+
+        // Persisted: RemoveType='U', RemovedBy=admin aid, ureason stored.
+        $after = $this->row('comms', ['bid' => $bid]);
+        $this->assertSame('U',                       $after['RemoveType']);
+        $this->assertSame(Fixture::adminAid(),       (int)$after['RemovedBy']);
+        $this->assertSame('lifted by e2e',           $after['ureason']);
+        $this->assertSnapshot('comms/unblock_success', $env, ['data.bid']);
+    }
+
+    public function testUnblockRejectsAlreadyLiftedRow(): void
+    {
+        $this->loginAsAdmin();
+        $this->api('comms.add', [
+            'nickname' => 'Loud',
+            'type'     => 1,
+            'steam'    => 'STEAM_0:0:445',
+            'length'   => 60,
+            'reason'   => 'shouting',
+        ]);
+        $row = $this->row('comms', ['authid' => 'STEAM_0:0:445']);
+        $bid = (int)$row['bid'];
+
+        $first = $this->api('comms.unblock', ['bid' => $bid]);
+        $this->assertTrue($first['ok']);
+
+        // Second call against the same already-lifted row should refuse.
+        $env = $this->api('comms.unblock', ['bid' => $bid]);
+        $this->assertEnvelopeError($env, 'not_active');
+    }
+
+    // -- comms.delete -------------------------------------------------------
+
+    public function testDeleteRejectsAnonymous(): void
+    {
+        $env = $this->api('comms.delete', ['bid' => 1]);
+        $this->assertEnvelopeError($env, 'forbidden');
+        $this->assertSnapshot('comms/delete_forbidden', $env);
+    }
+
+    public function testDeleteBadRequestOnMissingBid(): void
+    {
+        $this->loginAsAdmin();
+        $env = $this->api('comms.delete', []);
+        $this->assertEnvelopeError($env, 'bad_request');
+        $this->assertSame('bid', $env['error']['field']);
+    }
+
+    public function testDeleteRemovesActiveRow(): void
+    {
+        $this->loginAsAdmin();
+        $this->api('comms.add', [
+            'nickname' => 'Dropme',
+            'type'     => 2, // mute
+            'steam'    => 'STEAM_0:0:446',
+            'length'   => 60,
+            'reason'   => 'queue test',
+        ]);
+        $row = $this->row('comms', ['authid' => 'STEAM_0:0:446']);
+        $bid = (int)$row['bid'];
+
+        $env = $this->api('comms.delete', ['bid' => $bid]);
+        $this->assertTrue($env['ok'], json_encode($env));
+        $this->assertSame($bid, (int)$env['data']['bid']);
+        $this->assertTrue($env['data']['deleted']);
+
+        $this->assertNull($this->row('comms', ['bid' => $bid]));
+        $this->assertSnapshot('comms/delete_success', $env, ['data.bid']);
+    }
 }

--- a/web/tests/api/PermissionMatrixTest.php
+++ b/web/tests/api/PermissionMatrixTest.php
@@ -100,6 +100,16 @@ final class PermissionMatrixTest extends TestCase
             'comms.prepare_block_from_ban'    => ['perm' => 0, 'requireAdmin' => true,  'public' => false],
             // comms.player_history follows bans.player_history (#1165).
             'comms.player_history'            => ['perm' => 0, 'requireAdmin' => false, 'public' => true],
+            // comms.unblock + comms.delete drive the visible row actions
+            // on the comms list (#1207 ADM-5/ADM-6). Dispatcher gate for
+            // unblock is "any unban-ish flag"; the handler then enforces
+            // the per-row own/group precision check that the legacy
+            // `?p=commslist&a=ungag|unmute` GET path uses.
+            'comms.unblock'                   => [
+                'perm' => ADMIN_OWNER | ADMIN_UNBAN | ADMIN_UNBAN_OWN_BANS | ADMIN_UNBAN_GROUP_BANS,
+                'requireAdmin' => false, 'public' => false,
+            ],
+            'comms.delete'                    => ['perm' => ADMIN_OWNER | ADMIN_DELETE_BAN, 'requireAdmin' => false, 'public' => false],
 
             // -- groups.
             'groups.add'                      => ['perm' => ADMIN_OWNER | ADMIN_ADD_GROUP,    'requireAdmin' => false, 'public' => false],

--- a/web/tests/api/__snapshots__/comms/delete_forbidden.json
+++ b/web/tests/api/__snapshots__/comms/delete_forbidden.json
@@ -1,0 +1,7 @@
+{
+    "ok": false,
+    "error": {
+        "code": "forbidden",
+        "message": "No access"
+    }
+}

--- a/web/tests/api/__snapshots__/comms/delete_success.json
+++ b/web/tests/api/__snapshots__/comms/delete_success.json
@@ -1,0 +1,7 @@
+{
+    "ok": true,
+    "data": {
+        "bid": "<*>",
+        "deleted": true
+    }
+}

--- a/web/tests/api/__snapshots__/comms/unblock_forbidden.json
+++ b/web/tests/api/__snapshots__/comms/unblock_forbidden.json
@@ -1,0 +1,7 @@
+{
+    "ok": false,
+    "error": {
+        "code": "forbidden",
+        "message": "No access"
+    }
+}

--- a/web/tests/api/__snapshots__/comms/unblock_success.json
+++ b/web/tests/api/__snapshots__/comms/unblock_success.json
@@ -1,0 +1,8 @@
+{
+    "ok": true,
+    "data": {
+        "bid": "<*>",
+        "state": "unmuted",
+        "type": 1
+    }
+}

--- a/web/tests/e2e/specs/_screenshots.spec.ts
+++ b/web/tests/e2e/specs/_screenshots.spec.ts
@@ -938,10 +938,17 @@ test.describe('@screenshot flow-comms-gag-mute', () => {
             });
 
             // ---- 4. Trigger the unblock + capture the unblocked list
+            // #1207 ADM-5/6 promoted the unmute affordance to a
+            // `<button data-action="comms-unblock">`; the legacy GET
+            // URL still ships as `data-fallback-href` so non-JS
+            // callers + this gallery (which intentionally drives
+            // the GET path to keep the screenshot deterministic
+            // across runs) can navigate the same string the prior
+            // anchor's `href` carried.
             const unmuteHref = await activeRow
                 .locator('[data-testid="row-action-unmute"]')
-                .getAttribute('href');
-            expect(unmuteHref, 'unmute href present').toBeTruthy();
+                .getAttribute('data-fallback-href');
+            expect(unmuteHref, 'unmute fallback href present').toBeTruthy();
             await page.goto(`${unmuteHref}&ureason=${encodeURIComponent('e2e: lifted')}`);
 
             await page.goto('/index.php?p=commslist');

--- a/web/tests/e2e/specs/flows/comms-affordances.spec.ts
+++ b/web/tests/e2e/specs/flows/comms-affordances.spec.ts
@@ -1,0 +1,332 @@
+/**
+ * Flow + responsive coverage for the comms list affordances slice
+ * (#1207 ADM-5 / ADM-6).
+ *
+ * What this locks in
+ * ------------------
+ *
+ *  - **ADM-5 (P1)** — Edit / Unmute / Remove buttons on active comm
+ *    rows render *visibly by default* (not hover-only). The pre-fix
+ *    `.row-actions { opacity: 0 }` rule was removed from `theme.css`
+ *    in this slice; the assertions below treat "visible without
+ *    hover" as a contract by reading `getComputedStyle(...).opacity`.
+ *  - **ADM-6 (P2)** — Lifting an active block updates the row
+ *    *in-place* (no full reload): the wrapper's `data-state` flips
+ *    to `unmuted`, the status pill swaps `pill--active` →
+ *    `pill--unmuted` and renders "Unmuted", the `Unmute` button
+ *    is replaced by a `Re-apply` anchor, and a `success` toast
+ *    confirms the action.
+ *  - Same affordance set + in-place flip surfaces on the mobile
+ *    card layout (`mobile-chromium` project; the `<table>` is
+ *    `display:none` below 769px and the `.ban-cards` container
+ *    takes over per `theme.css`'s responsive block).
+ *  - Remove is a destructive action that goes through
+ *    `Actions.CommsDelete` (slice introduces it), prompts a native
+ *    `confirm()`, and on accept removes both the desktop `<tr>` and
+ *    the mobile `<div>` mirrors of the row + decrements the visible
+ *    count.
+ *
+ * Project gating
+ * --------------
+ * The spec runs on both `chromium` and `mobile-chromium` because
+ * the visible-action contract has to hold on every viewport (#1207
+ * was filed against both). `truncateE2eDb()` is parallel-project-
+ * safe at workers=1 (the named-lock in `Sbpp\Tests\Fixture::
+ * truncateAndReseed` serializes resets, and the projects run
+ * sequentially under workers=1 in CI).
+ *
+ * Selectors
+ * ---------
+ * Per #1123, every assertion uses `data-testid` (`comm-row`,
+ * `row-action-edit`, `row-action-unmute`, `row-action-delete`,
+ * `row-action-reapply`) and the row's `data-state` attribute.
+ * Toast disambiguation uses `data-kind` plus a `hasText`
+ * filter — visible text is not a primary selector.
+ *
+ * Why we delegate seeding to the JSON API
+ * ---------------------------------------
+ * Same rationale as `fixtures/seeds.ts`: driving the actual
+ * `Actions.CommsAdd` handler covers the full Smarty/CSRF/dispatcher
+ * path on every run, and a regression to the wire format surfaces
+ * here instead of silently producing a stale fixture.
+ */
+
+import { expect, test } from '../../fixtures/auth.ts';
+import { truncateE2eDb } from '../../fixtures/db.ts';
+
+const COMMSLIST_ROUTE = '/index.php?p=commslist';
+
+const FIXTURE = {
+    /** Distinct SteamID per finding so the two tests can run in either order without colliding. */
+    steamUnmute: 'STEAM_0:1:9912001',
+    steamRemove: 'STEAM_0:0:9912002',
+    nicknameUnmute: 'e2e-adm5-unmute',
+    nicknameRemove: 'e2e-adm6-remove',
+    reasonUnmute: 'e2e: ADM-5/6 unmute affordance',
+    reasonRemove: 'e2e: ADM-5/6 remove affordance',
+    /** 60 minutes — keeps the row in `state="active"` for the spec's lifetime. */
+    lengthMinutes: 60,
+};
+
+interface SeededComm {
+    steam: string;
+    nickname: string;
+}
+
+/**
+ * Seed a `gag` (type=2) row via `Actions.CommsAdd`. The handler
+ * stores the row keyed by the caller's `aid`, so it inherits the
+ * default-admin postkey we mint in `fixtures/global-setup.ts`. The
+ * page must already be authenticated; we go through the home route
+ * to make sure `window.sb.api` and `window.Actions` are mounted.
+ */
+async function seedGagViaApi(
+    page: import('@playwright/test').Page,
+    seed: { steam: string; nickname: string; reason: string; length: number },
+): Promise<SeededComm> {
+    await page.goto('/');
+    const envelope = await page.evaluate(async (args) => {
+        const w = window as unknown as {
+            sb: {
+                api: {
+                    call: (
+                        action: string,
+                        params: Record<string, unknown>,
+                    ) => Promise<{ ok: boolean; data?: unknown; error?: { code: string; message: string } }>;
+                };
+            };
+            Actions: Record<string, string>;
+        };
+        return await w.sb.api.call(w.Actions.CommsAdd, {
+            steam: args.steam,
+            nickname: args.nickname,
+            type: 2,
+            length: args.length,
+            reason: args.reason,
+        });
+    }, seed);
+
+    const env = envelope as { ok: boolean; error?: { message: string } };
+    if (!env.ok) {
+        throw new Error(`seedGagViaApi failed: ${JSON.stringify(env)}`);
+    }
+    return { steam: seed.steam, nickname: seed.nickname };
+}
+
+test.describe('flow: comms list affordances (#1207 ADM-5/ADM-6)', () => {
+    // Three tests in this file all `truncateE2eDb()` in beforeEach
+    // and seed independent rows. Without `serial` mode Playwright
+    // runs them in parallel workers locally (CI pins `workers: 1`,
+    // see playwright.config.ts), and worker B's truncate wipes
+    // worker A's seeded row mid-test → flaky `toHaveCount(0)` and
+    // `forbidden` from `comms.add` while the admin row is briefly
+    // missing during the reseed window. The named-lock in
+    // `Sbpp\Tests\Fixture::truncateAndReseed` makes the *reset*
+    // atomic per-process, but it doesn't span the gap between the
+    // truncate-and-reseed and the assertion; serial execution is
+    // the right granularity for state-mutating flow specs.
+    test.describe.configure({ mode: 'serial' });
+
+    test.beforeEach(async () => {
+        await truncateE2eDb();
+    });
+
+    test('active row exposes visible Edit/Unmute/Remove on desktop and flips in-place on Unmute', async ({
+        page,
+        isMobile,
+    }) => {
+        test.skip(isMobile, 'desktop affordance contract — mobile is covered by the card spec below');
+
+        await seedGagViaApi(page, {
+            steam: FIXTURE.steamUnmute,
+            nickname: FIXTURE.nicknameUnmute,
+            reason: FIXTURE.reasonUnmute,
+            length: FIXTURE.lengthMinutes,
+        });
+
+        await page.goto(COMMSLIST_ROUTE);
+
+        const row = page
+            .locator('[data-testid="comm-row"]')
+            .filter({ hasText: FIXTURE.steamUnmute });
+        await expect(row).toHaveCount(1);
+        await expect(row).toHaveAttribute('data-state', 'active');
+
+        // ---- ADM-5: visible without hover --------------------------------
+        // Pre-fix the `.row-actions` container had `opacity:0` and
+        // only became visible on `tbody tr:hover`. Reading
+        // `getComputedStyle().opacity === '1'` *without* hovering
+        // is the deterministic equivalent of "the action set is
+        // discoverable" — a regression that re-introduces the
+        // hover-only treatment fails this assertion immediately.
+        const actions = row.locator('.row-actions');
+        await expect(actions).toBeVisible();
+        const opacity = await actions.evaluate(
+            (el) => getComputedStyle(el).opacity,
+        );
+        expect(opacity, 'row-actions are visible without hover').toBe('1');
+
+        const editBtn = row.locator('[data-testid="row-action-edit"]');
+        const unmuteBtn = row.locator('[data-testid="row-action-unmute"]');
+        const deleteBtn = row.locator('[data-testid="row-action-delete"]');
+        await expect(editBtn).toBeVisible();
+        await expect(unmuteBtn).toBeVisible();
+        await expect(deleteBtn).toBeVisible();
+        // The visible label is part of the affordance — pre-fix
+        // these were icon-only links. Locking the text in catches
+        // a regression that drops the `<span>` while keeping the
+        // testid.
+        await expect(unmuteBtn).toContainText(/ungag|unmute|lift/i);
+        await expect(deleteBtn).toContainText(/remove/i);
+
+        // ---- ADM-6: click Unmute → in-place state flip + toast -----------
+        // The inline page-tail JS in `page_comms.tpl` intercepts
+        // the click, calls `Actions.CommsUnblock`, and on success:
+        //   - flips `data-state` and `ban-row--*` class to `unmuted`
+        //   - rewrites the status pill text to "Unmuted"
+        //   - replaces the Unmute button with a Re-apply anchor
+        //   - fires `window.SBPP.showToast` (success kind)
+        //
+        // No reload, no `setTimeout` to wait out — the browser
+        // resolves the await inside the handler synchronously
+        // relative to the toast/DOM update.
+        await unmuteBtn.click();
+
+        await expect(row).toHaveAttribute('data-state', 'unmuted');
+        // The status pill is the *last* `.pill` inside the row
+        // (column 1 has the type pill, column 8 has the status
+        // pill). We locate by the post-flip `pill--unmuted` class
+        // — the type pill in column 1 also tracks the new state
+        // class so both slots stay visually consistent.
+        const statusPills = row.locator('.pill.pill--unmuted');
+        await expect(statusPills).not.toHaveCount(0);
+        await expect(row.getByText(/^\s*Unmuted\s*$/)).toBeVisible();
+
+        // The Unmute button is gone, Re-apply takes its place.
+        await expect(row.locator('[data-testid="row-action-unmute"]')).toHaveCount(0);
+        const reapply = row.locator('[data-testid="row-action-reapply"]');
+        await expect(reapply).toBeVisible();
+        await expect(reapply).toContainText(/re-apply/i);
+        // The Re-apply anchor goes through the existing
+        // `comms.prepare_reblock` flow at `?p=admin&c=comms&rebanid=<bid>`.
+        await expect(reapply).toHaveAttribute('href', /[?&]rebanid=\d+\b/);
+
+        // Toast — anchor on the deterministic `data-kind` attribute
+        // (set by theme.js's `showToast`) and a case-insensitive
+        // title filter to disambiguate from any passive page chrome
+        // toasts.
+        const successToast = page
+            .locator('.toast[data-kind="success"]')
+            .filter({ hasText: /block lifted/i });
+        await expect(successToast).toBeVisible();
+    });
+
+    test('mobile card surfaces visible actions and flips Unmute in-place', async ({
+        page,
+        isMobile,
+    }) => {
+        test.skip(!isMobile, 'mobile card contract — desktop is covered by the table spec above');
+
+        await seedGagViaApi(page, {
+            steam: FIXTURE.steamUnmute,
+            nickname: FIXTURE.nicknameUnmute,
+            reason: FIXTURE.reasonUnmute,
+            length: FIXTURE.lengthMinutes,
+        });
+
+        await page.goto(COMMSLIST_ROUTE);
+
+        // The desktop `<table>` is `display:none` below 769px;
+        // we anchor on the `comm-card` testid which is the mobile
+        // wrapper.
+        const card = page
+            .locator('[data-testid="comm-card"]')
+            .filter({ hasText: FIXTURE.steamUnmute });
+        await expect(card).toHaveCount(1);
+        await expect(card).toHaveAttribute('data-state', 'active');
+
+        const editBtn = card.locator('[data-testid="row-action-edit-mobile"]');
+        const unmuteBtn = card.locator('[data-testid="row-action-unmute-mobile"]');
+        const deleteBtn = card.locator('[data-testid="row-action-delete-mobile"]');
+        await expect(editBtn).toBeVisible();
+        await expect(unmuteBtn).toBeVisible();
+        await expect(deleteBtn).toBeVisible();
+
+        // The summary anchor (filter-by-SteamID navigation) and
+        // the action buttons are siblings inside `comm-card` —
+        // pre-fix the entire card was a single `<a>` so action
+        // buttons couldn't live inside it without producing
+        // invalid nested-interactive HTML. The summary anchor's
+        // dedicated testid lets us assert it still works as a
+        // standalone navigation affordance.
+        await expect(card.locator('[data-testid="comm-card-link"]')).toBeVisible();
+
+        await unmuteBtn.click();
+
+        await expect(card).toHaveAttribute('data-state', 'unmuted');
+        await expect(card.locator('[data-testid="row-action-unmute-mobile"]')).toHaveCount(0);
+        const reapply = card.locator('[data-testid="row-action-reapply-mobile"]');
+        await expect(reapply).toBeVisible();
+        await expect(reapply).toHaveAttribute('href', /[?&]rebanid=\d+\b/);
+
+        const successToast = page
+            .locator('.toast[data-kind="success"]')
+            .filter({ hasText: /block lifted/i });
+        await expect(successToast).toBeVisible();
+    });
+
+    test('Remove action deletes the row in-place and decrements the count', async ({
+        page,
+        isMobile,
+    }) => {
+        // Run on desktop only — the destructive path is the same
+        // wire call (`Actions.CommsDelete`) and the count
+        // decrement lives in the same shared header. Mobile-card
+        // visibility is covered by the test above; doubling the
+        // delete on mobile would just retread the API contract.
+        test.skip(isMobile, 'delete-flow desktop covers the API contract; mobile visibility is in the card spec');
+
+        await seedGagViaApi(page, {
+            steam: FIXTURE.steamRemove,
+            nickname: FIXTURE.nicknameRemove,
+            reason: FIXTURE.reasonRemove,
+            length: FIXTURE.lengthMinutes,
+        });
+
+        await page.goto(COMMSLIST_ROUTE);
+
+        const row = page
+            .locator('[data-testid="comm-row"]')
+            .filter({ hasText: FIXTURE.steamRemove });
+        await expect(row).toHaveCount(1);
+
+        const countBefore = await page
+            .locator('[data-testid="comms-count"]')
+            .textContent();
+        const before = Number((countBefore || '').replace(/[^0-9]/g, ''));
+
+        // The inline JS prompts `window.confirm` before issuing the
+        // destructive call. Playwright dismisses dialogs by default;
+        // wire an accept handler so the click resolves the API path.
+        page.once('dialog', (d) => d.accept());
+
+        await row.locator('[data-testid="row-action-delete"]').click();
+
+        // Row is removed from the DOM; the matching `comm-card`
+        // mirror is removed too (the JS targets both via
+        // `rowsForBid`). We assert against the row anchor since
+        // we're on desktop.
+        await expect(row).toHaveCount(0);
+
+        const countAfter = await page
+            .locator('[data-testid="comms-count"]')
+            .textContent();
+        const after = Number((countAfter || '').replace(/[^0-9]/g, ''));
+        expect(after).toBe(Math.max(before - 1, 0));
+
+        const successToast = page
+            .locator('.toast[data-kind="success"]')
+            .filter({ hasText: /block removed/i });
+        await expect(successToast).toBeVisible();
+    });
+});

--- a/web/tests/e2e/specs/flows/comms-gag-mute.spec.ts
+++ b/web/tests/e2e/specs/flows/comms-gag-mute.spec.ts
@@ -175,21 +175,24 @@ test.describe('flow: comms gag → list → unblock', () => {
         await expect(publicRow).toContainText(TARGET.steam);
 
         // ============================================================
-        // 5. Unblock — follow the row's unmute anchor with `&ureason=`.
+        // 5. Unblock — follow the row's unmute fallback URL with
+        //    `&ureason=`.
         //
-        // The legacy `UnGag('id', 'key', …)` JS confirm prompt is gone
-        // post-D1 (sourcebans.js removed); the new theme renders a
-        // direct anchor whose href already carries the cid + the
-        // session's `banlist_postkey`. The server reads `ureason`
-        // from $_GET, so appending it on the client side lets us
-        // record the brief's "e2e: lifted" reason without needing a
-        // modal in the theme.
+        // #1207 ADM-5/6 promoted the icon-only `<a>` into a `<button>`
+        // wired to `Actions.CommsUnblock` for the in-place flip
+        // (visible-action affordance + toast). The legacy GET URL
+        // is still rendered as `data-fallback-href` so no-JS callers
+        // and third-party themes that strip api.js degrade gracefully
+        // — that's the same string the prior `<a>`'s `href` carried.
+        // We follow it directly here to record the brief's
+        // "e2e: lifted" reason via the `ureason` GET param without
+        // depending on a modal in the theme.
         // ============================================================
         const unmuteHref = await publicRow
             .locator('[data-testid="row-action-unmute"]')
-            .getAttribute('href');
-        expect(unmuteHref, 'unmute link exposes a key/cid query').toMatch(/[?&]a=ungag(?:&|$)/);
-        expect(unmuteHref, 'unmute link carries banlist_postkey').toMatch(/[?&]key=[^&]+/);
+            .getAttribute('data-fallback-href');
+        expect(unmuteHref, 'unmute action exposes a fallback ungag URL').toMatch(/[?&]a=ungag(?:&|$)/);
+        expect(unmuteHref, 'unmute action carries banlist_postkey').toMatch(/[?&]key=[^&]+/);
 
         // URL is already query-string-encoded; appending another `&k=v`
         // pair is safe.

--- a/web/themes/default/css/theme.css
+++ b/web/themes/default/css/theme.css
@@ -446,8 +446,14 @@ html.dark .table thead tr { background: rgb(255 255 255 / 0.02); }
 .table tbody tr { border-bottom: 1px solid var(--border); cursor: pointer; }
 .table tbody tr:hover { background: var(--bg-muted); }
 .table td { padding: 0.75rem; vertical-align: middle; }
-.table .row-actions { opacity: 0; transition: opacity .15s; display: flex; gap: 0.25rem; justify-content: flex-end; }
-.table tbody tr:hover .row-actions { opacity: 1; }
+/* #1207 ADM-5: row actions are *always* visible — the previous
+   `opacity: 0 → 1 on tr:hover` treatment was a discoverability dead
+   end (no hover on touch, hostile to `prefers-reduced-motion: reduce`,
+   and the audit's blocker for the comms list specifically). The
+   queue-row pattern (#1207 PUB-2) already drops the hover gate on
+   `<details>`-rendered queues; matching the table here means every
+   list surface in the panel exposes its actions the same way. */
+.table .row-actions { display: flex; gap: 0.25rem; justify-content: flex-end; }
 
 /* PUB-1 (#1207): banlist column widths + horizontal-scroll fallback.
    With realistic per-row content the auto-layout previously
@@ -676,6 +682,22 @@ details.queue-row > summary > .row-actions {
     justify-content: flex-end;
     gap: 0.375rem;
   }
+}
+
+/* ---- Comms mobile card actions ----
+   #1207 ADM-5: the comms list's mobile card is split into two siblings
+   — a clickable `.ban-card__summary` anchor that filters by SteamID,
+   and a `.ban-card__actions` row of Edit / Unmute / Remove / Re-apply
+   buttons. The buttons live OUTSIDE the anchor so we don't produce
+   nested-interactive HTML; the anchor's tap target stays the full
+   summary row (avatar + name + meta + chevron) so the card's primary
+   "filter by this player" affordance keeps working unchanged. */
+.ban-card__actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 0.375rem;
+  padding: 0 1rem 0.75rem;
 }
 
 /* ---- Responsive ---- */

--- a/web/themes/default/page_comms.tpl
+++ b/web/themes/default/page_comms.tpl
@@ -178,31 +178,59 @@
                         <td>
                             <span class="pill pill--{$comm.state}" style="text-transform:capitalize">{$comm.state|escape}</span>
                         </td>
-                        <td>
+                        <td class="col-actions">
                             <div class="row-actions">
                                 {if $can_edit_comm}
-                                    <a class="btn--ghost btn--icon"
+                                    <a class="btn btn--ghost btn--sm"
                                        href="{$comm.edit_url|escape}"
-                                       title="Edit"
                                        data-testid="row-action-edit">
-                                        <i data-lucide="pencil"></i>
+                                        <i data-lucide="pencil" style="width:13px;height:13px"></i>
+                                        Edit
                                     </a>
                                 {/if}
                                 {if $can_unmute_gag && $comm.unmute_url}
-                                    <a class="btn--ghost btn--icon"
-                                       href="{$comm.unmute_url|escape}"
-                                       title="{if $comm.type == 'mute'}Unmute{elseif $comm.type == 'gag'}Ungag{else}Lift block{/if}"
-                                       data-testid="row-action-unmute">
-                                        <i data-lucide="check"></i>
+                                    {* #1207 ADM-5/ADM-6: button + data-action wires to the
+                                       inline page-tail JS below, which calls
+                                       Actions.CommsUnblock and updates the row in-place
+                                       (state pill flips, action set swaps to Re-apply,
+                                       toast fires). The href fallback preserves the
+                                       legacy GET path for no-JS callers + third-party
+                                       themes that haven't migrated. *}
+                                    <button type="button"
+                                            class="btn btn--secondary btn--sm"
+                                            data-testid="row-action-unmute"
+                                            data-action="comms-unblock"
+                                            data-bid="{$comm.cid}"
+                                            data-name="{$comm.name|escape}"
+                                            data-fallback-href="{$comm.unmute_url|escape}">
+                                        <i data-lucide="check" style="width:13px;height:13px"></i>
+                                        {if $comm.type == 'mute'}Unmute{elseif $comm.type == 'gag'}Ungag{else}Lift block{/if}
+                                    </button>
+                                {elseif $can_add_comm && ($comm.state == 'unmuted' || $comm.state == 'expired')}
+                                    {* #1207 ADM-6: when a row is no longer active, swap the
+                                       lift action for Re-apply. Anchor goes through the
+                                       admin-comms add form's `rebanid` flow (which calls
+                                       comms.prepare_reblock to hydrate every field) so we
+                                       don't need a separate "re-block" handler. *}
+                                    <a class="btn btn--secondary btn--sm"
+                                       href="index.php?p=admin&amp;c=comms&amp;rebanid={$comm.cid}"
+                                       data-testid="row-action-reapply">
+                                        <i data-lucide="rotate-ccw" style="width:13px;height:13px"></i>
+                                        Re-apply
                                     </a>
                                 {/if}
                                 {if $can_delete_comm}
-                                    <a class="btn--ghost btn--icon"
-                                       href="{$comm.delete_url|escape}"
-                                       title="Delete"
-                                       data-testid="row-action-delete">
-                                        <i data-lucide="trash-2"></i>
-                                    </a>
+                                    <button type="button"
+                                            class="btn btn--ghost btn--sm"
+                                            data-testid="row-action-delete"
+                                            data-action="comms-delete"
+                                            data-bid="{$comm.cid}"
+                                            data-name="{$comm.name|escape}"
+                                            data-fallback-href="{$comm.delete_url|escape}"
+                                            style="color:var(--danger)">
+                                        <i data-lucide="trash-2" style="width:13px;height:13px"></i>
+                                        Remove
+                                    </button>
                                 {/if}
                             </div>
                         </td>
@@ -266,33 +294,93 @@
         </table>
 
         {* -- Mobile cards --------------------------------------------- *}
+        {* #1207 ADM-5: each card is now a `<div>` wrapping (a) a
+           clickable summary anchor that filters the list by the row's
+           SteamID and (b) a row-actions footer with the same
+           Edit / Unmute / Remove / Re-apply set the desktop table
+           exposes. The previous shape wrapped the whole card in a
+           single `<a>` so there was no place to put `<button>` actions
+           without producing invalid nested-interactive HTML. The
+           data-testid stays `comm-card`; the anchor's `comm-card-link`
+           sub-hook lets specs assert the navigate-to-search affordance
+           independently from the action row. *}
         <div class="ban-cards">
             {foreach $ban_list as $comm}
-                <a class="ban-row ban-row--{$comm.state} flex items-center gap-3 p-4"
-                   style="border-bottom:1px solid var(--border);text-decoration:none;color:var(--text)"
-                   href="?p=commslist&amp;searchText={$comm.steam|escape:'url'}"
-                   data-testid="comm-card"
-                   data-id="{$comm.cid}">
-                    <span class="avatar"
-                          style="width:36px;height:36px;background:hsl({$comm.avatar_hue} 55% 45%);font-size:12px">
-                        {$comm.name|truncate:2:'':true|upper|escape}
-                    </span>
-                    <div style="flex:1;min-width:0">
-                        <div class="flex items-center gap-2">
-                            <span class="font-medium text-sm truncate">
-                                {if $comm.name}{$comm.name|escape}{else}<span class="text-faint">no nickname</span>{/if}
-                            </span>
-                            <span class="pill pill--{$comm.state}">{$comm.state|escape}</span>
+                <div class="ban-row ban-row--{$comm.state} ban-card"
+                     style="border-bottom:1px solid var(--border)"
+                     data-testid="comm-card"
+                     data-id="{$comm.cid}"
+                     data-state="{$comm.state}"
+                     data-type="{$comm.type}">
+                    <a class="ban-card__summary flex items-center gap-3 p-4"
+                       style="text-decoration:none;color:var(--text)"
+                       href="?p=commslist&amp;searchText={$comm.steam|escape:'url'}"
+                       data-testid="comm-card-link">
+                        <span class="avatar"
+                              style="width:36px;height:36px;background:hsl({$comm.avatar_hue} 55% 45%);font-size:12px">
+                            {$comm.name|truncate:2:'':true|upper|escape}
+                        </span>
+                        <div style="flex:1;min-width:0">
+                            <div class="flex items-center gap-2">
+                                <span class="font-medium text-sm truncate">
+                                    {if $comm.name}{$comm.name|escape}{else}<span class="text-faint">no nickname</span>{/if}
+                                </span>
+                                <span class="pill pill--{$comm.state}">{$comm.state|escape}</span>
+                            </div>
+                            <div class="text-xs text-muted truncate" style="margin-top:0.125rem">
+                                <span style="text-transform:capitalize">{$comm.type|escape}</span>
+                                · {$comm.length_human|escape}
+                                {if $comm.sname} · {$comm.sname|escape}{/if}
+                            </div>
+                            <div class="font-mono text-xs text-faint truncate" style="margin-top:0.125rem">{$comm.steam|escape}</div>
                         </div>
-                        <div class="text-xs text-muted truncate" style="margin-top:0.125rem">
-                            <span style="text-transform:capitalize">{$comm.type|escape}</span>
-                            · {$comm.length_human|escape}
-                            {if $comm.sname} · {$comm.sname|escape}{/if}
-                        </div>
-                        <div class="font-mono text-xs text-faint truncate" style="margin-top:0.125rem">{$comm.steam|escape}</div>
+                        <i data-lucide="chevron-right"></i>
+                    </a>
+                    {if $can_edit_comm || ($can_unmute_gag && $comm.unmute_url) || ($can_add_comm && ($comm.state == 'unmuted' || $comm.state == 'expired')) || $can_delete_comm}
+                    <div class="row-actions ban-card__actions">
+                        {if $can_edit_comm}
+                            <a class="btn btn--ghost btn--sm"
+                               href="{$comm.edit_url|escape}"
+                               data-testid="row-action-edit-mobile">
+                                <i data-lucide="pencil" style="width:13px;height:13px"></i>
+                                Edit
+                            </a>
+                        {/if}
+                        {if $can_unmute_gag && $comm.unmute_url}
+                            <button type="button"
+                                    class="btn btn--secondary btn--sm"
+                                    data-testid="row-action-unmute-mobile"
+                                    data-action="comms-unblock"
+                                    data-bid="{$comm.cid}"
+                                    data-name="{$comm.name|escape}"
+                                    data-fallback-href="{$comm.unmute_url|escape}">
+                                <i data-lucide="check" style="width:13px;height:13px"></i>
+                                {if $comm.type == 'mute'}Unmute{elseif $comm.type == 'gag'}Ungag{else}Lift block{/if}
+                            </button>
+                        {elseif $can_add_comm && ($comm.state == 'unmuted' || $comm.state == 'expired')}
+                            <a class="btn btn--secondary btn--sm"
+                               href="index.php?p=admin&amp;c=comms&amp;rebanid={$comm.cid}"
+                               data-testid="row-action-reapply-mobile">
+                                <i data-lucide="rotate-ccw" style="width:13px;height:13px"></i>
+                                Re-apply
+                            </a>
+                        {/if}
+                        {if $can_delete_comm}
+                            <button type="button"
+                                    class="btn btn--ghost btn--sm"
+                                    data-testid="row-action-delete-mobile"
+                                    data-action="comms-delete"
+                                    data-bid="{$comm.cid}"
+                                    data-name="{$comm.name|escape}"
+                                    data-fallback-href="{$comm.delete_url|escape}"
+                                    style="color:var(--danger)">
+                                <i data-lucide="trash-2" style="width:13px;height:13px"></i>
+                                Remove
+                            </button>
+                        {/if}
                     </div>
-                    <i data-lucide="chevron-right"></i>
-                </a>
+                    {/if}
+                </div>
             {foreachelse}
                 {* #1207: the desktop `<table>` is `display:none` on
                    mobile (theme.css responsive block), so its empty
@@ -387,6 +475,192 @@
     <input type="hidden" form="comms-filters" name="_searchlink" value="{$searchlink|escape}" data-testid="comms-searchlink-shadow">
 
 </div>
+
+{* ============================================================
+   #1207 ADM-5/ADM-6 — comms row-action wiring (inline page-tail JS).
+
+   Click delegation per anti-pattern: every action button in the rows
+   above (desktop table + mobile cards) carries `data-action="comms-*"`
+   plus `data-bid` / `data-name` / `data-fallback-href`. The handler
+   intercepts those clicks, calls `sb.api.call(Actions.PascalName, …)`,
+   and updates the row in-place on success (state pill flips, action
+   set re-renders, `window.SBPP.showToast` confirms). The fallback
+   href is followed as a navigation when the JSON dispatcher is
+   missing entirely (e.g. third-party theme with stripped api.js) —
+   that's the legacy GET URL the `?p=commslist&a=…` handler in
+   page.commslist.php still serves.
+
+   No `// @ts-check` here because the file is rendered by Smarty;
+   ts-check only runs against `.js` sources in `web/scripts`. The
+   shape mirrors the inline handler in page_admin_bans_submissions.tpl
+   (#1207 PUB-2 reference).
+   ============================================================ *}
+{literal}
+<script>
+(function () {
+    'use strict';
+
+    /** @returns {{call: (a:string,p?:object)=>Promise<any>}|null} */
+    function api()     { return (window.sb && window.sb.api) || null; }
+    /** @returns {Record<string,string>|null} */
+    function actions() { return /** @type {any} */ (window).Actions || null; }
+    function toast(kind, title, body) {
+        var sbpp = /** @type {any} */ (window).SBPP;
+        if (sbpp && typeof sbpp.showToast === 'function') {
+            sbpp.showToast({ kind: kind, title: title, body: body || '' });
+        }
+    }
+
+    /**
+     * Find every DOM node that mirrors the same comm-block id — the
+     * desktop `<tr data-testid="comm-row">` and the mobile
+     * `<div data-testid="comm-card">` both render the same row.
+     * theme.css's `@media (max-width: 768px)` block hides the
+     * `<table>` via `display: none` rather than removing the DOM,
+     * so an in-place state update has to flip both copies (only one
+     * is visible per viewport, but stale state in the hidden one
+     * silently breaks the next viewport switch in the E2E spec).
+     * @param {string} bid
+     * @returns {Element[]}
+     */
+    function rowsForBid(bid) {
+        var sel = '[data-testid="comm-row"][data-id="' + bid + '"], '
+                + '[data-testid="comm-card"][data-id="' + bid + '"]';
+        return Array.prototype.slice.call(document.querySelectorAll(sel));
+    }
+
+    /**
+     * Update both copies of the row from `active|permanent` → `unmuted`:
+     *  - `data-state` on the wrapper.
+     *  - `ban-row--<state>` class on the wrapper.
+     *  - The status pill in column 8 (desktop) / inline pill (mobile)
+     *    has its `pill--<state>` class swapped AND its visible label
+     *    rewritten. The type pill in column 1 also carries the
+     *    `pill--<state>` class for the colored border treatment, but
+     *    its text is the type label — we leave the text alone.
+     *  - The Unmute button is replaced by a Re-apply anchor (for
+     *    callers with the add_comm flag) so the row's "make this
+     *    block live again" affordance lands in the same slot.
+     * @param {Element} row
+     * @returns {void}
+     */
+    function flipRowToUnmuted(row) {
+        var prev = (row.getAttribute('data-state') || '').toLowerCase();
+        row.setAttribute('data-state', 'unmuted');
+        row.classList.remove('ban-row--active', 'ban-row--permanent', 'ban-row--expired');
+        row.classList.add('ban-row--unmuted');
+        Array.prototype.forEach.call(row.querySelectorAll('.pill'), function (pill) {
+            // Only the *status* pill carries the previous state as its
+            // visible label; type pills (column 1) say "mute"/"gag" and
+            // we leave their text intact. The class swap applies to
+            // both — the colored border treatment comes from
+            // `pill--<state>` and both pills should track the new
+            // state for the visual hierarchy to stay consistent.
+            pill.classList.remove('pill--active', 'pill--permanent', 'pill--expired');
+            pill.classList.add('pill--unmuted');
+            var txt = (pill.textContent || '').trim().toLowerCase();
+            if (txt === prev || txt === 'active' || txt === 'permanent' || txt === 'expired') {
+                // Preserve any leading <i> icon — only the trailing
+                // text node carries the state label. Walk children
+                // backwards to find it.
+                var lastText = null;
+                for (var i = pill.childNodes.length - 1; i >= 0; i--) {
+                    var n = pill.childNodes[i];
+                    if (n.nodeType === 3) { lastText = n; break; }
+                }
+                if (lastText) lastText.textContent = ' Unmuted';
+                else pill.textContent = 'Unmuted';
+            }
+        });
+        Array.prototype.forEach.call(
+            row.querySelectorAll('[data-action="comms-unblock"]'),
+            function (btn) {
+                var bid = btn.getAttribute('data-bid') || '';
+                var a = document.createElement('a');
+                a.className = 'btn btn--secondary btn--sm';
+                var isMobile = (btn.getAttribute('data-testid') || '').indexOf('mobile') !== -1;
+                a.setAttribute('data-testid', isMobile ? 'row-action-reapply-mobile' : 'row-action-reapply');
+                a.setAttribute('href', 'index.php?p=admin&c=comms&rebanid=' + encodeURIComponent(bid));
+                a.innerHTML = '<i data-lucide="rotate-ccw" style="width:13px;height:13px"></i> Re-apply';
+                btn.parentNode.replaceChild(a, btn);
+            }
+        );
+        if (window.lucide) window.lucide.createIcons();
+    }
+
+    /**
+     * @param {Element} row
+     * @returns {void}
+     */
+    function removeRow(row) { if (row.parentNode) row.parentNode.removeChild(row); }
+
+    /** @returns {void} */
+    function decrementCount() {
+        var el = document.querySelector('[data-testid="comms-count"]');
+        if (!el) return;
+        var n = Number((el.textContent || '').replace(/[^0-9]/g, ''));
+        if (!Number.isFinite(n) || n <= 0) return;
+        el.textContent = (n - 1).toLocaleString();
+    }
+
+    document.addEventListener('click', function (e) {
+        var t = /** @type {Element|null} */ (e.target);
+        if (!t || !t.closest) return;
+        var btn = /** @type {HTMLElement|null} */ (t.closest('[data-action]'));
+        if (!btn) return;
+        var act = btn.getAttribute('data-action');
+        if (act !== 'comms-unblock' && act !== 'comms-delete') return;
+        e.preventDefault();
+
+        var bid = btn.getAttribute('data-bid') || '';
+        var name = btn.getAttribute('data-name') || ('block #' + bid);
+        var fallback = btn.getAttribute('data-fallback-href') || '';
+        var a = api(), A = actions();
+        if (!a || !A || !bid) {
+            // No JSON dispatcher available (e.g. third-party theme that
+            // stripped api.js). Fall back to the legacy GET URL — same
+            // outcome, full page reload.
+            if (fallback) window.location.href = fallback;
+            return;
+        }
+
+        if (act === 'comms-delete') {
+            if (!window.confirm('Delete the block for "' + name + '"?')) return;
+            /** @type {HTMLButtonElement} */ (btn).disabled = true;
+            a.call(A.CommsDelete, { bid: Number(bid) }).then(function (r) {
+                if (!r || r.ok === false) {
+                    /** @type {HTMLButtonElement} */ (btn).disabled = false;
+                    var msg = (r && r.error && r.error.message) || 'Unknown error';
+                    toast('error', 'Delete failed', msg);
+                    return;
+                }
+                rowsForBid(bid).forEach(removeRow);
+                decrementCount();
+                toast('success', 'Block removed', 'The block for ' + name + ' has been deleted.');
+            });
+            return;
+        }
+
+        // comms-unblock — lift an active block. We don't prompt for an
+        // unblock reason here; the legacy GET path didn't either (only
+        // sourcebans.js's UnGag()/UnMute() confirm prompts did, and
+        // those went away with #1123 D1). Admins who need a recorded
+        // reason can use the edit form instead.
+        /** @type {HTMLButtonElement} */ (btn).disabled = true;
+        a.call(A.CommsUnblock, { bid: Number(bid), ureason: '' }).then(function (r) {
+            if (!r || r.ok === false) {
+                /** @type {HTMLButtonElement} */ (btn).disabled = false;
+                var msg = (r && r.error && r.error.message) || 'Unknown error';
+                toast('error', 'Unblock failed', msg);
+                return;
+            }
+            rowsForBid(bid).forEach(flipRowToUnmuted);
+            toast('success', 'Block lifted', name + ' has been unblocked.');
+        });
+    });
+})();
+</script>
+{/literal}
 
 {* ============================================================
    Manifest of properties only consumed by themes/default/page_comms.tpl.


### PR DESCRIPTION
## Summary

Slice 6 of #1207 — comms list affordances. Addresses ADM-5, ADM-6.

- **ADM-5** — Edit / Unmute / Remove on the comms list are visible by default at every viewport. The `.row-actions { opacity:0 → 1 on hover }` trick is gone (it never worked on touch, and was hostile to reduced-motion / keyboard / screen-reader users). The desktop `<td class="col-actions">` and the new mobile `.ban-card__actions` row both expose explicit text-labelled buttons.
- **ADM-6** — Lifting an active block updates the row in place: `data-state` → `unmuted`, status pill swaps `pill--active` → `pill--unmuted` and reads "Unmuted", the `Unmute` button is replaced by a `Re-apply` anchor (threaded through the existing `comms.prepare_reblock` flow), and a `success` toast confirms via `window.SBPP.showToast`. New JSON twins `comms.unblock` + `comms.delete` drive the click handlers; the legacy `?p=commslist&a=ungag|unmute|delete&id=…&key=…` GET URL ships as `data-fallback-href` so no-JS callers + third-party themes that strip api.js still work.

Mobile cards were split from a single card-wrapping `<a>` into a `.ban-card` div with a clickable `.ban-card__summary` anchor + a sibling `.ban-card__actions` row, so each action is its own `<button>` / `<a>` instead of nested-interactive HTML.

## Test plan

- [x] PHPStan clean (`./sbpp.sh phpstan`)
- [x] PHPUnit clean (`./sbpp.sh test` — 325 tests, 1332 assertions)
- [x] ts-check clean (`./sbpp.sh ts-check`)
- [x] API contract clean (`./sbpp.sh composer api-contract`; the regenerated `web/scripts/api-contract.js` is in this PR)
- [x] Playwright E2E clean (`CI=1 ./sbpp.sh e2e` — 138 passed; new `flows/comms-affordances.spec.ts` covers desktop visible-actions + in-place flip + Re-apply, mobile-card mirror, and Remove)
- [x] Screenshot gallery regenerated and pushed (see comment with the per-PR table; `flow-comms-gag-mute-list-active`/`-list-unblocked` now show the visible action buttons + the Re-apply swap)
- [x] Manual: comms list row Edit / Unmute / Remove buttons visible without hover; clicking Unmute updates row in-place + toast; row's `unmuted` state hides Unmute and surfaces Re-apply

Does NOT close #1207 — umbrella tracks remaining slices.