### PR TITLE
fix(theme): topbar palette desktop polish (#1207 slice 9)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -531,6 +531,16 @@ audit (#1207) locked in. New CTAs:
   iOS dark, blueish on Android). The chrome doesn't have a single
   phone number on it; the meta is the canonical opt-out and the
   CSS reset is the belt-and-suspenders for variants that ignore it.
+- Re-adding a labelled search input or a visible `Ctrl K` / `⌘K` hint
+  to the topbar palette trigger (the `.topbar__search` button in
+  `core/title.tpl`) → the labelled shape was a duplicate affordance
+  for the same `<dialog id="palette-root">` the ⌘K shortcut already
+  opens, and on mobile it broke the topbar (#1207 CC-1, slice 1) and
+  on desktop it visibly competed with the palette itself (#1207 CC-3,
+  slice 9). The trigger is now icon-only at every viewport, matching
+  the sibling theme-toggle's chrome. The `.topbar__search-label` /
+  `.topbar__search-kbd` spans stay in the DOM for SR users + the
+  Mac glyph swap, but `display: none` everywhere — don't unhide them.
 
 ## Where to find what
 
@@ -543,6 +553,7 @@ audit (#1207) locked in. New CTAs:
 | Edit a template                        | `web/themes/default/*.tpl`                               |
 | Reuse the moderation-queue card layout (admin submissions / protests, mobile-stacked summary rows) | `web/themes/default/css/theme.css` (`.queue-row`, `.queue-row__body`, `.queue-row__date` — #1207 PUB-2). Apply by adding `class="queue-row …"` to the outer `<details>` and dropping the inline `flex` / `flex-shrink:0` styles from the summary children. |
 | Edit the player-detail drawer (open trigger, tabs, panes, lazy loaders) | `web/themes/default/js/theme.js` (`renderDrawerBody` / `loadPaneIfNeeded`) |
+| Edit the command palette (icon-only trigger, ⌘K binding, result rows, kbd hints, Ctrl+Enter copy) | `web/themes/default/js/theme.js` (`openPalette` / `closePalette` / `renderPaletteResults` / `applyPlatformHints` / `handlePaletteCopyShortcut`) + `core/title.tpl` (the `.topbar__search` icon button) + the `.palette__row*` rules in `web/themes/default/css/theme.css`. Player rows carry `data-drawer-bid="<bid>"` (bare Enter / click → `loadDrawer`, palette closes itself) + `data-steamid="<steam>"` (`Ctrl/Cmd+Enter` → `navigator.clipboard.writeText` + `showToast`). The kbd glyphs are server-rendered in non-Mac form (`Enter`, `Ctrl`); `applyPlatformHints` swaps `[data-enterkey]` → ⏎ and `[data-modkey]` → ⌘ on Mac/iOS at boot and after every render (#1184, #1207 DET-2). |
 | Add admin-only per-player notes | `web/api/handlers/notes.php` (CRUD) — Notes tab is gated by `bans.detail`'s `notes_visible` flag |
 | Render admin-authored Markdown to safe HTML | `web/includes/Markup/IntroRenderer.php` (`Sbpp\Markup`) |
 | Live-preview Markdown in a settings textarea | `system.preview_intro_text` JSON action + `web/themes/default/page_admin_settings_settings.tpl` (`.dash-intro-editor` / `.dash-intro-preview`) |

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -336,6 +336,25 @@ controls, light/dark/system theming. Custom themes ship their own
 `theme.conf.php` with `theme_name` / `theme_author` / `theme_version` /
 `theme_link` / `theme_screenshot`.
 
+The command palette (`#palette-root` `<dialog>` rendered by
+`themes/default/js/theme.js`) is the only search affordance in the
+chrome. The topbar carries an icon-only ghost button
+(`.topbar__search` in `core/title.tpl`) that opens the same dialog as
+the `Meta+k` keybinding — the pre-v2.0.0 inline search input was
+dropped at #1207 CC-1 (mobile, slice 1) + CC-3 (desktop, slice 9)
+because the labelled "search input + Ctrl K hint" was a duplicate
+affordance for the same dialog. Player result rows in the palette
+carry `data-drawer-bid` (bare Enter / click hands off to the existing
+`[data-drawer-bid]` click delegate, which closes the palette and
+opens the player drawer) and `data-steamid` (the `Ctrl/Cmd+Enter`
+handler in `theme.js`'s `handlePaletteCopyShortcut` reads it and
+copies via `navigator.clipboard.writeText` + `showToast`). Keyboard
+glyphs in the row's `.palette__row-hints` group are server-rendered
+in non-Mac form (`Enter`, `Ctrl`); `applyPlatformHints` rewrites
+`[data-enterkey]` → ⏎ and `[data-modkey]` → ⌘ on Mac/iOS clients at
+boot and after every render so glyph swaps don't require re-fetching
+results (#1184, #1207 DET-2).
+
 The preferred way to render is via typed view-model DTOs:
 
 ```php

--- a/web/tests/e2e/specs/flows/ui/command-palette.spec.ts
+++ b/web/tests/e2e/specs/flows/ui/command-palette.spec.ts
@@ -1,5 +1,5 @@
 /**
- * Command palette (#1124, Slice 6).
+ * Command palette (#1124, Slice 6 + #1207 CC-3, DET-2).
  *
  * Acceptance criteria from #1124:
  *   "⌘K opens, typing a SteamID surfaces the player, Enter navigates
@@ -15,9 +15,22 @@
  *     [data-result-kind="nav"|"ban"]>` once `q.length >= 2`, with a
  *     200ms input debounce.
  *
- * The third subtest (Enter navigates) follows the focused result's
- * native `<a>` activation rather than a custom keydown handler —
- * `theme.js` doesn't bind Enter on the palette input itself.
+ * #1207 CC-3 (this slice) extends slice 1's mobile icon-only collapse
+ * to desktop too: the topbar's palette trigger is icon-only at every
+ * viewport, so the topbar reads as `[hamburger] [breadcrumb] [spacer]
+ * [palette icon] [theme toggle]` consistently — the palette dialog
+ * itself owns the search affordance.
+ *
+ * #1207 DET-2 (this slice) layers two interactions onto each player
+ * result row, advertised by a kbd hint group at the right edge:
+ *   - bare Enter → opens the player drawer for the ban,
+ *   - Ctrl/Cmd+Enter → copies the row's SteamID via
+ *     navigator.clipboard.writeText + surfaces a toast.
+ * The kbds are server-rendered in non-Mac form ("Enter", "Ctrl");
+ * theme.js's applyPlatformHints swaps `[data-enterkey]` → ⏎ and
+ * `[data-modkey]` → ⌘ on Mac at boot and on every render. The Linux
+ * test runner sees the non-Mac form by default — that's what the
+ * assertions below pin.
  *
  * == Seeding strategy: unique-per-(test × project), no truncate ==
  *
@@ -60,6 +73,8 @@ const SUBTEST_OFFSETS = {
     open: 0,
     type: 1,
     enter: 2,
+    hints: 3,
+    copy: 4,
 } as const;
 
 /**
@@ -102,6 +117,76 @@ test.describe('command palette', () => {
         // dialog's showModal() finishes its focus dance first; we
         // poll on the focus state, not a fixed timeout.
         await expect(input).toBeFocused();
+
+        await page.keyboard.press('Escape');
+        await expect(dialog).toHaveAttribute('data-palette-open', 'false');
+    });
+
+    test('topbar palette trigger renders icon-only at every viewport (#1207 CC-3)', async ({ page }, testInfo) => {
+        // Slice 1 (PR #1208, CC-1) introduced the icon-only collapse
+        // at <=768px because the labelled "search input + Ctrl-K hint"
+        // couldn't share a row with the breadcrumb on mobile. Slice 9
+        // (this PR, CC-3) extends the same collapse to desktop because
+        // the labelled chrome was a duplicate affordance for the same
+        // palette dialog ⌘K opens. Both projects (`chromium` +
+        // `mobile-chromium`) lock the icon-only contract here so the
+        // existing responsive/topbar.spec.ts mobile-only assertions
+        // and this desktop counterpart fail independently if either
+        // viewport regresses.
+        //
+        // The mobile-only floor (44px tap target) lives in
+        // responsive/topbar.spec.ts; this spec asserts the cross-
+        // viewport contract: label + kbd hint visually hidden, square
+        // button shape.
+        await page.goto('/');
+
+        const trigger = page.locator('[data-testid="palette-trigger"]');
+        await expect(trigger).toBeVisible();
+
+        // Label and kbd hint stay in the DOM (so SR users still hear
+        // the parent aria-label and applyPlatformHints can rewrite the
+        // kbd text on Mac without re-rendering) but are visually
+        // hidden via `display:none` at every viewport now.
+        const label = trigger.locator('.topbar__search-label');
+        await expect(label).toBeAttached();
+        await expect(label).toBeHidden();
+
+        const kbd = trigger.locator('.topbar__search-kbd');
+        await expect(kbd).toBeAttached();
+        await expect(kbd).toBeHidden();
+
+        // Square icon-only button. Desktop is 2.25rem (36px) — matches
+        // the `.btn--icon` sibling theme-toggle so the topbar's right
+        // edge reads as two equal-weight icon affordances. Mobile bumps
+        // to 2.75rem (44px) per slice 1's tap-target floor; that
+        // contract is locked in responsive/topbar.spec.ts so we just
+        // bracket the upper bound here to make sure neither viewport
+        // accidentally re-expands to a labelled control via cascade
+        // drift.
+        const box = await trigger.boundingBox();
+        expect(box, 'palette trigger must render a bounding box').not.toBeNull();
+        expect(Math.abs(box!.width - box!.height)).toBeLessThanOrEqual(1);
+        if (testInfo.project.name === 'mobile-chromium') {
+            expect(box!.width).toBeGreaterThanOrEqual(44);
+        } else {
+            expect(box!.width).toBeGreaterThanOrEqual(34);
+        }
+        expect(box!.width).toBeLessThanOrEqual(56);
+    });
+
+    test('clicking the icon trigger opens the palette (#1207 CC-3)', async ({ page }) => {
+        // Behavioural counterpart to the icon-only-shape test above:
+        // the trigger keeps its `data-palette-open` attribute, so
+        // theme.js's document-level click handler funnels through
+        // openPalette() the same way Meta+k does. Both projects.
+        await page.goto('/');
+
+        const dialog = page.locator('#palette-root');
+        await expect(dialog).toHaveAttribute('data-palette-open', 'false');
+
+        await page.locator('[data-testid="palette-trigger"]').click();
+        await expect(dialog).toHaveAttribute('data-palette-open', 'true');
+        await expect(page.locator('#palette-input')).toBeFocused();
 
         await page.keyboard.press('Escape');
         await expect(dialog).toHaveAttribute('data-palette-open', 'false');
@@ -158,15 +243,154 @@ test.describe('command palette', () => {
         await expect(banResults.filter({ hasText: seed.nick }).first()).toBeVisible();
     });
 
-    test('focused result + Enter navigates to the ban-list anchor', async ({ page }, testInfo) => {
+    test('player result row carries kbd hint group with Enter and Ctrl+Enter (#1207 DET-2)', async ({ page }, testInfo) => {
+        // mobile-chromium skipped per #1206 (palette typing-search
+        // flake, same root cause as the 'type' / 'enter' subtests).
+        // The kbd hint contract is viewport-independent — the kbds
+        // are in the DOM regardless — so chromium coverage is enough
+        // to lock the contract; the visual layout media query
+        // (`.palette__row-hint-label` collapsing at <=640px) is
+        // separately covered by the screenshot gallery.
+        test.skip(
+            testInfo.project.name === 'mobile-chromium',
+            'mobile-chromium palette typing-search flake; tracked in #1206',
+        );
+        const seed = uniqueSeed(testInfo, 'hints');
+        try {
+            await seedBanViaApi(page, { nickname: seed.nick, steam: seed.steam });
+        } catch (err) {
+            if (!String(err).includes('already_banned')) throw err;
+        }
+
+        await page.goto('/');
+        await page.keyboard.press('Meta+k');
+        const dialog = page.locator('#palette-root');
+        await expect(dialog).toHaveAttribute('data-palette-open', 'true');
+
+        await page.locator('#palette-input').fill(seed.nick);
+        await expect(dialog).not.toHaveAttribute('data-loading', 'true', { timeout: 10000 });
+
+        const row = page
+            .locator('[data-testid="palette-result"][data-result-kind="ban"]')
+            .filter({ hasText: seed.nick })
+            .first();
+        await expect(row).toBeVisible();
+
+        // The kbd hint group sits at the right edge of every player
+        // row, scoped via `data-testid="palette-row-hints"`. The two
+        // hints surface the row's two interactions:
+        //   - bare Enter → opens the player drawer for the ban,
+        //   - Ctrl+Enter → copies the row's SteamID via
+        //     navigator.clipboard.
+        const hints = row.locator('[data-testid="palette-row-hints"]');
+        await expect(hints).toBeAttached();
+
+        // The first kbd is the bare-Enter hint, server-rendered as
+        // "Enter" (theme.js's applyPlatformHints rewrites it to ⏎ on
+        // Mac after first paint; this Linux runner sees the non-Mac
+        // form). The second hint pairs `Ctrl` + `Enter` for the copy
+        // affordance — both kbds present so the visible glyph reads
+        // as a key combo even when the verbose label collapses at
+        // narrow widths.
+        const enterKbds = hints.locator('kbd[data-enterkey]');
+        await expect(enterKbds).toHaveCount(2);
+        await expect(enterKbds.first()).toHaveText('Enter');
+
+        const ctrlKbd = hints.locator('kbd[data-modkey]');
+        await expect(ctrlKbd).toHaveCount(1);
+        await expect(ctrlKbd).toHaveText('Ctrl');
+
+        // The descriptive labels ("to open drawer" / "to copy
+        // steamid") render at desktop width; the test runs on
+        // chromium (1280×720) so we expect them visible here.
+        // Pin one half of each label so a future copy edit fails
+        // this spec (rather than silently slipping through).
+        await expect(hints).toContainText('open drawer');
+        await expect(hints).toContainText('copy steamid');
+    });
+
+    test('Ctrl+Enter on a focused player row copies the SteamID + toasts (#1207 DET-2)', async ({ page, context }, testInfo) => {
+        test.skip(
+            testInfo.project.name === 'mobile-chromium',
+            'mobile-chromium palette typing-search flake; tracked in #1206',
+        );
+
+        const seed = uniqueSeed(testInfo, 'copy');
+        try {
+            await seedBanViaApi(page, { nickname: seed.nick, steam: seed.steam });
+        } catch (err) {
+            if (!String(err).includes('already_banned')) throw err;
+        }
+
+        await page.goto('/');
+
+        // navigator.clipboard.readText() requires the
+        // `clipboard-read` permission. Chromium grants it in
+        // headless mode but Playwright's default permission set
+        // doesn't include it; granting explicitly per-test makes the
+        // contract loud at the call-site instead of relying on a
+        // browser default. `clipboard-write` is only required for
+        // older Chromium permissions matrices; on current builds
+        // writeText() works without the explicit grant, but we ask
+        // for both so the spec is portable across browser versions.
+        // Granting AFTER goto() so the origin is the live test
+        // origin, not 'about:blank'.
+        await context.grantPermissions(['clipboard-read', 'clipboard-write'], {
+            origin: new URL(page.url()).origin,
+        });
+
+        await page.keyboard.press('Meta+k');
+        const dialog = page.locator('#palette-root');
+        await expect(dialog).toHaveAttribute('data-palette-open', 'true');
+
+        await page.locator('#palette-input').fill(seed.nick);
+        await expect(dialog).not.toHaveAttribute('data-loading', 'true', { timeout: 10000 });
+
+        const row = page
+            .locator('[data-testid="palette-result"][data-result-kind="ban"]')
+            .filter({ hasText: seed.nick })
+            .first();
+        await expect(row).toBeVisible();
+        // Pin the steamid on the row — that's what Ctrl+Enter will
+        // copy. theme.js writes b.steam (Steam2 form) into
+        // `data-steamid`, so the assertion below is exact.
+        await expect(row).toHaveAttribute('data-steamid', seed.steam);
+
+        await row.focus();
+
+        // Linux runner: `Control+Enter` is the primary chord. The
+        // theme.js handler accepts metaKey || ctrlKey, so a Mac
+        // runner would land here via `Meta+Enter`; we only test
+        // the Linux form because that's the CI shape (browserName
+        // 'chromium' on linux).
+        await page.keyboard.press('Control+Enter');
+
+        // Toast appears with the success copy. The toast surface is
+        // shared with the drawer's [data-copy] button (#1184); we
+        // filter by the title so a stray earlier toast doesn't false-
+        // positive.
+        const toast = page.locator('.toast').filter({ hasText: 'SteamID copied' });
+        await expect(toast).toBeVisible();
+        // The toast body echoes the copied value so the user can
+        // visually confirm the right id landed on the clipboard.
+        await expect(toast).toContainText(seed.steam);
+
+        // Read the clipboard — value matches the row's data-steamid.
+        // The grantPermissions call above is what makes this work
+        // outside Playwright's default permission set.
+        const clipboardValue = await page.evaluate(() => navigator.clipboard.readText());
+        expect(clipboardValue).toBe(seed.steam);
+
+        // The palette stays open — Ctrl+Enter is a non-navigating
+        // affordance, not a "submit + close" chord. (Bare Enter
+        // closes the palette and opens the drawer; that's the
+        // sibling 'enter' subtest below.)
+        await expect(dialog).toHaveAttribute('data-palette-open', 'true');
+    });
+
+    test('focused result + Enter opens the player drawer (#1207 DET-2)', async ({ page }, testInfo) => {
         // Same mobile-chromium palette typing-search flake as the
-        // 'type' subtest above — the rendered <a data-testid="palette-result">
-        // is intermittently not visible on iPhone-13 viewport. Both
-        // subtests exercise the same surface (typing → bans.search → result
-        // visible) and share a single root cause. The 'open/Esc' sibling
-        // doesn't search, so it stays in mobile coverage. Tracked alongside
-        // the 'type' subtest in #1206; removing both skips is that issue's
-        // success criterion.
+        // 'type' / 'hints' / 'copy' subtests — tracked in #1206.
         test.skip(
             testInfo.project.name === 'mobile-chromium',
             'mobile-chromium palette typing-search flake; tracked in #1206',
@@ -190,22 +414,29 @@ test.describe('command palette', () => {
             .first();
         await expect(result).toBeVisible();
 
-        // theme.js builds the result `<a>` with
-        //   href="?p=banlist&advType=name&advSearch=<encoded-name>"
-        // so navigation is the browser's native anchor activation,
-        // not a JS-bound Enter handler. We focus the anchor and
-        // press Enter inside the same Promise.all that waits for
-        // the URL change so the race condition is removed.
+        // #1207 DET-2: each player row carries `data-drawer-bid="<bid>"`.
+        // Focus + Enter fires a synthetic click on the anchor that
+        // bubbles to theme.js's document-level click delegate; the
+        // delegate spots the `[data-drawer-bid]` trigger inside the
+        // open palette, calls `closePalette()` so the drawer isn't
+        // stacked behind the palette dialog, then `loadDrawer(bid)`
+        // fetches `bans.detail` and renders the player drawer.
+        //
+        // The href fallback (`?p=banlist&advType=name&advSearch=…`)
+        // is preserved on the anchor so middle-click / Cmd+click
+        // still expands the result to a name-filtered banlist for
+        // users who want the wider context — that's why we focus +
+        // press Enter rather than asserting on the href shape.
         await result.focus();
-        await Promise.all([
-            page.waitForURL(/[?&]p=banlist(?:&|$)/),
-            page.keyboard.press('Enter'),
-        ]);
+        await page.keyboard.press('Enter');
 
-        // `advSearch` carries the URL-encoded nickname; assert against
-        // both halves so we don't accidentally pass on a generic
-        // banlist URL with no search applied.
-        await expect(page).toHaveURL(/[?&]advType=name(?:&|$)/);
-        await expect(page).toHaveURL(new RegExp(`[?&]advSearch=${encodeURIComponent(seed.nick)}(?:&|$)`));
+        const drawer = page.locator('#drawer-root');
+        await expect(drawer).toHaveAttribute('data-drawer-open', 'true');
+        await expect(drawer).not.toHaveAttribute('data-loading', 'true', { timeout: 10000 });
+
+        // Palette closed — see `closePalette()` call inside the
+        // click delegate's `target.closest('.palette')` branch.
+        const dialog = page.locator('#palette-root');
+        await expect(dialog).toHaveAttribute('data-palette-open', 'false');
     });
 });

--- a/web/tests/e2e/specs/flows/ui/command-palette.spec.ts
+++ b/web/tests/e2e/specs/flows/ui/command-palette.spec.ts
@@ -75,6 +75,7 @@ const SUBTEST_OFFSETS = {
     enter: 2,
     hints: 3,
     copy: 4,
+    modclick: 5,
 } as const;
 
 /**
@@ -385,6 +386,84 @@ test.describe('command palette', () => {
         // affordance, not a "submit + close" chord. (Bare Enter
         // closes the palette and opens the drawer; that's the
         // sibling 'enter' subtest below.)
+        await expect(dialog).toHaveAttribute('data-palette-open', 'true');
+    });
+
+    test('Ctrl+click on a player row preserves native href graceful-degradation (#1207 DET-2)', async ({ page, context }, testInfo) => {
+        // #1207 DET-2 review finding 1: the existing `[data-drawer-bid]`
+        // click delegate (theme.js) used to call `e.preventDefault()`
+        // unconditionally, which meant Cmd/Ctrl+left-click was
+        // intercepted indistinguishably from a bare left-click — the
+        // browser's native "open in new tab" default action was
+        // suppressed and the drawer opened in the current tab. The
+        // delegate now guards `e.metaKey || e.ctrlKey || e.shiftKey ||
+        // e.button !== 0` and bails before preventDefault, so the
+        // anchor's `href` (?p=banlist&advType=name&advSearch=<name>)
+        // takes over and the new tab lands on the name-filtered
+        // banlist. This test locks that contract.
+        //
+        // mobile-chromium skipped: same palette typing-search flake
+        // as the sibling 'type' / 'enter' / 'hints' / 'copy' subtests
+        // (#1206). The modifier-guard contract is viewport-independent.
+        test.skip(
+            testInfo.project.name === 'mobile-chromium',
+            'mobile-chromium palette typing-search flake; tracked in #1206',
+        );
+
+        const seed = uniqueSeed(testInfo, 'modclick');
+        try {
+            await seedBanViaApi(page, { nickname: seed.nick, steam: seed.steam });
+        } catch (err) {
+            if (!String(err).includes('already_banned')) throw err;
+        }
+
+        await page.goto('/');
+        await page.keyboard.press('Meta+k');
+        const dialog = page.locator('#palette-root');
+        await expect(dialog).toHaveAttribute('data-palette-open', 'true');
+
+        await page.locator('#palette-input').fill(seed.nick);
+        await expect(dialog).not.toHaveAttribute('data-loading', 'true', { timeout: 10000 });
+
+        const row = page
+            .locator('[data-testid="palette-result"][data-result-kind="ban"]')
+            .filter({ hasText: seed.nick })
+            .first();
+        await expect(row).toBeVisible();
+
+        // Capture the new page (tab) the browser opens for the
+        // modifier-click. `Control` is the Linux/Win chord — the
+        // Mac equivalent (`Meta`) is also covered by the same
+        // delegate guard but we test the chromium-on-Linux runner
+        // shape because that's what CI executes.
+        const newPagePromise = context.waitForEvent('page');
+        await row.click({ modifiers: ['Control'] });
+        const newPage = await newPagePromise;
+        // Playwright's 'page' event fires when the tab is created
+        // (URL still `about:blank`); the navigation lands a tick
+        // later. Wait on the URL pattern itself rather than a
+        // generic load state so the assertion below isn't racing
+        // against `about:blank`.
+        await newPage.waitForURL(/[?&]p=banlist/, { timeout: 10000 });
+
+        // The new tab's URL is the row's href fallback — the
+        // name-filtered banlist URL.
+        expect(newPage.url()).toMatch(/[?&]advType=name(?:&|$)/);
+        expect(newPage.url()).toMatch(
+            new RegExp(`[?&]advSearch=${encodeURIComponent(seed.nick)}(?:&|$)`),
+        );
+        await newPage.close();
+
+        // The original tab's drawer did NOT open — the modifier-guard
+        // returned early before `loadDrawer()` could run. This is
+        // the post-fix shape; pre-fix this assertion would have
+        // failed with `data-drawer-open="true"`.
+        const drawer = page.locator('#drawer-root');
+        await expect(drawer).toHaveAttribute('data-drawer-open', 'false');
+
+        // The palette stays open — modifier-click is a non-navigating
+        // action in the active tab; the new tab is where the
+        // navigation lands.
         await expect(dialog).toHaveAttribute('data-palette-open', 'true');
     });
 

--- a/web/themes/default/core/title.tpl
+++ b/web/themes/default/core/title.tpl
@@ -41,11 +41,22 @@
         <div style="flex:1"></div>
 
         {*
-            #1207 CC-1: at <=768px the search button collapses to icon-only
-            — the .topbar__search-label / .topbar__search-kbd hooks below
+            #1207 CC-1 / CC-3: the topbar palette trigger is icon-only at
+            EVERY viewport. CC-1 (slice 1, PR #1208) collapsed it at
+            <=768px because the search-input shape couldn't share a row
+            with the breadcrumb + theme toggle on mobile; CC-3 (this
+            slice) extends the same collapse to desktop because the
+            chrome's labelled "search input + Ctrl-K hint" was a
+            duplicate affordance for the same `<dialog id="palette-root">`
+            the ⌘K shortcut already opens — both surfaces competed for
+            attention and pulled the user's eye twice. The palette
+            itself owns the search semantically; the topbar trigger only
+            opens it.
+
+            The .topbar__search-label / .topbar__search-kbd hooks below
             are the CSS handles theme.css uses to hide the visible label
-            and the keyboard hint at mobile widths. Keep them BOTH in the
-            DOM unconditionally so:
+            and the keyboard hint. Keep them BOTH in the DOM
+            unconditionally so:
               - SR users hear "Open command palette …" via the existing
                 aria-label regardless of viewport,
               - theme.js's applyPlatformHints() can still rewrite the kbd

--- a/web/themes/default/css/theme.css
+++ b/web/themes/default/css/theme.css
@@ -163,41 +163,48 @@ html.dark .sidebar__link[aria-current="page"] { background: var(--brand-700); co
 html.dark .topbar { background: rgb(9 9 11 / 0.8); }
 .topbar__breadcrumbs { display: flex; align-items: center; gap: 0.375rem; font-size: var(--fs-base); color: var(--text-muted); }
 .topbar__breadcrumbs > [aria-current] { color: var(--text); font-weight: 500; }
+/* #1207 CC-1 + CC-3: the topbar palette trigger is icon-only at EVERY
+   viewport. CC-1 (slice 1, #1208) collapsed it at <=768px because the
+   labelled "search input + Ctrl-K hint" couldn't share a row with the
+   breadcrumb + theme toggle on mobile; CC-3 (this slice) extends the
+   same collapse to desktop because that labelled chrome was a duplicate
+   affordance for the `<dialog id="palette-root">` the ⌘K shortcut
+   already opens — both surfaces competed for attention and pulled the
+   user's eye twice. The palette itself owns the search semantically;
+   the trigger only opens it.
+
+   The button visually matches the sibling theme-toggle (a ghost icon
+   button — transparent bg, no border, hover paints `--bg-muted`) so
+   the topbar reads as `[hamburger] [breadcrumb] [spacer] [palette]
+   [theme]` with two equal-weight icon affordances on the right.
+
+   The .topbar__search-label / .topbar__search-kbd hooks stay in the
+   DOM (see core/title.tpl) but are visually hidden everywhere now so:
+     - SR users still hear "Open command palette …" via the existing
+       aria-label,
+     - theme.js's applyPlatformHints() can still rewrite the kbd glyph
+       to ⌘K on Mac after first paint without re-rendering — the
+       hidden node is the live mutation target,
+     - the kbd hints inside the palette result rows (DET-2) reuse the
+       same [data-modkey] swap mechanism applyPlatformHints() drives.
+
+   The desktop default size (2.25rem) matches `.btn--icon` so the
+   trigger lines up with the theme toggle without a custom rule;
+   the <=768px floor below bumps it to 2.75rem (44 CSS px) per the
+   slice 1 review's touch-target contract (WCAG 2.1 AAA / Apple HIG /
+   Material). */
 .topbar__search {
-  display: inline-flex; align-items: center; gap: 0.5rem; min-width: 16rem;
-  height: 2.25rem; padding: 0 0.75rem; border-radius: var(--radius-md);
-  border: 1px solid var(--border); background: var(--bg-page);
+  display: inline-flex; align-items: center; justify-content: center;
+  width: 2.25rem; height: 2.25rem; padding: 0;
+  border-radius: var(--radius-md);
+  border: 1px solid transparent; background: transparent;
   color: var(--text-muted); font-size: var(--fs-base);
+  transition: background-color .15s, color .15s;
 }
-@media (max-width: 1024px) {
-  .topbar__search { min-width: 0; flex: 1 1 auto; }
-}
-.topbar__search kbd { margin-left: auto; padding: 0.125rem 0.375rem; border-radius: var(--radius-sm); background: var(--bg-surface); border: 1px solid var(--border); font-family: var(--font-mono); font-size: 0.625rem; color: var(--text-muted); }
-/* #1207 CC-1: at <=768px the topbar can't fit the breadcrumb +
-   labelled search input + Ctrl-K hint + theme toggle on one row, so
-   the placeholder text wraps to 3 lines and the kbd hint slams into
-   the theme toggle. Collapse the search affordance to an icon-only
-   button — the same `data-palette-open` hook still opens the
-   palette, where typing IS the search. The label + kbd are hidden
-   visually but kept in the DOM so SR users still hear "Open command
-   palette (search players, SteamIDs, pages)" via the existing
-   aria-label.
-   The mobile button is sized to 2.75rem × 2.75rem (44×44 CSS px) —
-   that's the slice 1 review's explicit touch-target floor (WCAG
-   2.1 AAA / Apple HIG / Material). The desktop labelled variant
-   stays at 2.25rem tall (16rem-wide, so the touch target passes
-   incidentally on the wider geometry); the icon-only mobile collapse
-   needs the explicit floor because it's the smallest standalone tap
-   target in the chrome.
-   The .topbar__search-label / .topbar__search-kbd hooks below are
-   defined on the topbar markup in core/title.tpl. */
+.topbar__search:hover { background: var(--bg-muted); color: var(--text); }
+.topbar__search-label, .topbar__search-kbd { display: none; }
 @media (max-width: 768px) {
-  .topbar__search {
-    flex: 0 0 auto; min-width: 0;
-    width: 2.75rem; height: 2.75rem;
-    padding: 0; justify-content: center; gap: 0;
-  }
-  .topbar__search-label, .topbar__search-kbd { display: none; }
+  .topbar__search { width: 2.75rem; height: 2.75rem; }
 }
 
 /* ---- Theme toggle icon swap ----
@@ -600,6 +607,61 @@ html:has(#drawer-root[data-drawer-open="true"]) { overflow: hidden; }
 .palette { width: min(36rem, calc(100vw - 2rem)); background: var(--bg-surface); border: 1px solid var(--border); border-radius: var(--radius-xl); box-shadow: var(--shadow-lg); overflow: hidden; }
 .palette__input { display: flex; align-items: center; gap: 0.75rem; height: 3rem; padding: 0 1rem; border-bottom: 1px solid var(--border); }
 .palette__input input { flex: 1; border: 0; outline: none; background: transparent; color: var(--text); font-size: var(--fs-base); }
+
+/* #1207 DET-2: palette result-row hint group.
+   Every player-kind result row (`[data-result-kind="ban"]`) is built
+   by `renderPaletteResults` in theme.js and lays out as
+     [icon] [name+steam stack] [kbd hint group]
+   The `.palette__row-hints` container sits at the right edge via
+   `margin-left: auto` and surfaces the two interactions the row
+   supports — bare Enter opens the player drawer, Ctrl/Cmd+Enter
+   copies the SteamID via `navigator.clipboard.writeText`. The
+   keyboard handler lives in theme.js (`handlePaletteCopyShortcut`);
+   this CSS just lays out the hints.
+
+   The kbds are server-rendered in non-Mac form ("Ctrl" / "Enter");
+   theme.js's `applyPlatformHints` swaps `[data-modkey]` → ⌘ and
+   `[data-enterkey]` → ⏎ on Mac after each render so the visible
+   glyphs match the platform's modifier vocabulary.
+
+   The label spans (".palette__row-hint-label") collapse at narrow
+   viewports so the kbd glyphs alone fit alongside a long player
+   name + SteamID — the keyboard interactions still work; the verbose
+   prose ("to open drawer", "to copy steamid") just falls back to the
+   implied conventions on a tight viewport. The paired `aria-hidden`
+   on the wrapper keeps screen readers from announcing the hint group
+   over the row's actual content (the SR user navigates the rows via
+   arrow keys, not by listening to per-row decoration). */
+.palette__row-meta { min-width: 0; flex: 1 1 0; }
+.palette__row-hints {
+  margin-left: auto;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-shrink: 0;
+}
+.palette__row-hint {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  font-size: 0.625rem;
+  color: var(--text-faint);
+  white-space: nowrap;
+}
+.palette__row-hints kbd {
+  display: inline-block;
+  padding: 0.0625rem 0.25rem;
+  border-radius: var(--radius-sm);
+  background: var(--bg-page);
+  border: 1px solid var(--border);
+  font-family: var(--font-mono);
+  font-size: 0.625rem;
+  color: var(--text-muted);
+  font-weight: 400;
+}
+@media (max-width: 640px) {
+  .palette__row-hint-label { display: none; }
+}
 
 /* ---- Skeleton ---- */
 @keyframes shimmer { 0% { background-position: -200px 0; } 100% { background-position: calc(200px + 100%) 0; } }

--- a/web/themes/default/js/theme.js
+++ b/web/themes/default/js/theme.js
@@ -195,16 +195,28 @@
     if (!(active instanceof HTMLElement)) return;
     const row = active.closest('[data-testid="palette-result"][data-result-kind="ban"]');
     if (!(row instanceof HTMLElement)) return;
-    const steamid = row.dataset.steamid;
-    if (!steamid) return;
+    const value = row.dataset.steamid;
+    if (!value) return;
     e.preventDefault();
     if (!navigator.clipboard) {
       showToast({ kind: 'error', title: 'Clipboard unavailable' });
       return;
     }
-    void navigator.clipboard.writeText(steamid).then(
-      () => showToast({ kind: 'success', title: 'SteamID copied', body: steamid }),
-      () => showToast({ kind: 'error', title: 'Couldn\u2019t copy SteamID' }),
+    // #1207 DET-2 follow-up (review finding 2): an IP-only ban
+    // (`type === 1`, empty `authid`) lands here with `data-steamid`
+    // actually holding the IP — bans.search returns `steam` (= authid)
+    // and `ip` separately, and `renderPaletteResults` falls back to the
+    // IP when authid is empty. Title the toast based on the value's
+    // shape so the user sees the right label in the rare IP-only case.
+    // The regex matches both Steam2 (`STEAM_X:Y:Z`) and Steam3
+    // (`[U:1:N]`) forms — anything that isn't a SteamID is treated as
+    // an IP for labelling purposes.
+    const isSteam = /^(STEAM_|\[U:)/.test(value);
+    const titleSuccess = isSteam ? 'SteamID copied' : 'IP copied';
+    const titleError = isSteam ? "Couldn\u2019t copy SteamID" : "Couldn\u2019t copy IP";
+    void navigator.clipboard.writeText(value).then(
+      () => showToast({ kind: 'success', title: titleSuccess, body: value }),
+      () => showToast({ kind: 'error', title: titleError }),
     );
   }
 
@@ -920,6 +932,25 @@
     const target = /** @type {Element | null} */ (e.target);
     const trigger = target && target.closest('[data-drawer-bid], [data-drawer-href]');
     if (trigger) {
+      // #1207 DET-2 follow-up (review finding 1): graceful-degradation
+      // guard for modifier-clicks. Without this, Cmd/Ctrl/Shift+left-click
+      // is fired as a regular `click` event with the modifier flag set;
+      // the e.preventDefault() below would suppress the browser's native
+      // "open in new tab/window" default action and silently open the
+      // drawer in the current tab — violating the modifier-click contract
+      // every browser ships. Middle-click already worked because browsers
+      // fire `auxclick` (not `click`) for non-primary buttons; this guard
+      // restores the same graceful-degradation for the keyboard-modifier
+      // chords. The href on every [data-drawer-bid] / [data-drawer-href]
+      // anchor IS the fallback path:
+      //   - palette rows: `?p=banlist&advType=name&advSearch=<name>`
+      //     opens a name-filtered banlist in a new tab,
+      //   - banlist rows: `?p=banlist&id=<bid>` opens the banlist URL
+      //     in a new tab (the panel-history shape).
+      // `e.button !== 0` belt-and-suspenders for any future synthetic
+      // dispatch with a non-primary button (legitimate middle/right
+      // clicks reach `auxclick`, not this listener, but be defensive).
+      if (e.metaKey || e.ctrlKey || e.shiftKey || e.button !== 0) return;
       const bid = bidFromTrigger(trigger);
       if (bid !== null) {
         e.preventDefault();

--- a/web/themes/default/js/theme.js
+++ b/web/themes/default/js/theme.js
@@ -167,12 +167,46 @@
     if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'k') {
       e.preventDefault();
       if (palette && palette.hidden) openPalette(); else closePalette();
+    } else if ((e.metaKey || e.ctrlKey) && e.key === 'Enter') {
+      handlePaletteCopyShortcut(e);
     } else if (e.key === 'Escape') {
       closePalette();
       closeDrawer();
       closeMobileSidebar();
     }
   });
+
+  /**
+   * #1207 DET-2: in the open palette, Ctrl/Cmd+Enter on a focused
+   * player result row copies the row's SteamID to the clipboard and
+   * surfaces a confirmation toast. The kbd hint group rendered into
+   * each row by `renderPaletteResults` advertises this affordance
+   * server-side ("Ctrl+Enter to copy steamid"); this handler is the
+   * paired behaviour. No-op when the palette is closed or when the
+   * focused element isn't a player-kind palette result, so the
+   * binding is scoped to the surface the hint advertises and won't
+   * hijack Ctrl+Enter elsewhere (e.g. notes textarea, edit-ban form).
+   * @param {KeyboardEvent} e
+   * @returns {void}
+   */
+  function handlePaletteCopyShortcut(e) {
+    if (!palette || palette.hidden) return;
+    const active = document.activeElement;
+    if (!(active instanceof HTMLElement)) return;
+    const row = active.closest('[data-testid="palette-result"][data-result-kind="ban"]');
+    if (!(row instanceof HTMLElement)) return;
+    const steamid = row.dataset.steamid;
+    if (!steamid) return;
+    e.preventDefault();
+    if (!navigator.clipboard) {
+      showToast({ kind: 'error', title: 'Clipboard unavailable' });
+      return;
+    }
+    void navigator.clipboard.writeText(steamid).then(
+      () => showToast({ kind: 'success', title: 'SteamID copied', body: steamid }),
+      () => showToast({ kind: 'error', title: 'Couldn\u2019t copy SteamID' }),
+    );
+  }
 
   document.addEventListener('click', (/** @type {MouseEvent} */ e) => {
     const target = /** @type {Element | null} */ (e.target);
@@ -287,27 +321,62 @@
       bans = envelope.data.bans;
     }
 
+    // #1207 DET-2: each player result row carries:
+    //   - data-drawer-bid="<bid>"  → bare Enter / click hands off to the
+    //     existing `[data-drawer-bid]` click delegate (loadDrawer + close
+    //     the palette so the drawer isn't stacked behind it),
+    //   - data-steamid="<steam>"   → the Ctrl/Cmd+Enter handler reads this
+    //     and copies it via navigator.clipboard.writeText,
+    //   - a `.palette__row-hints` kbd group surfacing both keys so the
+    //     interactions are discoverable. The kbds are server-rendered
+    //     in the non-Mac form ("Enter", "Ctrl"); applyPlatformHints()
+    //     swaps `[data-enterkey]` → ⏎ and `[data-modkey]` → ⌘ at boot
+    //     and on every render below so Mac users see the platform-native
+    //     glyphs without re-rendering (#1184).
+    //
+    // The href is preserved as a graceful-degradation fallback —
+    // middle-click / Cmd+click still navigates to a name-filtered banlist
+    // for users who want to expand the result rather than open the drawer.
     const playersHtml = bans.length
       ? '<div style="' + sectionStyle + ';margin-top:8px">Players</div>'
         + bans.map((b) => {
             const href = '?p=banlist&advType=name&advSearch=' + encodeURIComponent(b.name);
+            const steamid = b.steam || b.ip || '';
             return '<a href="' + href + '"'
-              + ' class="sidebar__link"'
+              + ' class="sidebar__link palette__row"'
               + ' data-testid="palette-result"'
               + ' data-result-kind="ban"'
               + ' data-id="' + escapeHtml(String(b.bid)) + '"'
+              + ' data-drawer-bid="' + escapeHtml(String(b.bid)) + '"'
+              + ' data-steamid="' + escapeHtml(steamid) + '"'
               + ' style="height:auto;padding:8px">'
-              + '<i data-lucide="user"></i>'
-              + '<div style="min-width:0">'
-              + '<div class="text-sm">' + escapeHtml(b.name || '(no name)') + '</div>'
-              + '<div class="font-mono text-xs text-muted">' + escapeHtml(b.steam || b.ip || '') + '</div>'
-              + '</div>'
+              +   '<i data-lucide="user" style="flex-shrink:0"></i>'
+              +   '<div class="palette__row-meta">'
+              +     '<div class="text-sm truncate">' + escapeHtml(b.name || '(no name)') + '</div>'
+              +     '<div class="font-mono text-xs text-muted truncate">' + escapeHtml(steamid) + '</div>'
+              +   '</div>'
+              +   '<div class="palette__row-hints" data-testid="palette-row-hints" aria-hidden="true">'
+              +     '<span class="palette__row-hint">'
+              +       '<kbd data-enterkey>Enter</kbd>'
+              +       '<span class="palette__row-hint-label"> to open drawer</span>'
+              +     '</span>'
+              +     '<span class="palette__row-hint" data-palette-hint="copy">'
+              +       '<kbd data-modkey>Ctrl</kbd>+<kbd data-enterkey>Enter</kbd>'
+              +       '<span class="palette__row-hint-label"> to copy steamid</span>'
+              +     '</span>'
+              +   '</div>'
               + '</a>';
           }).join('')
       : '<div class="text-xs text-muted" style="padding:8px">No matching bans.</div>';
 
     paletteResults.innerHTML = navHtml + playersHtml;
     if (window.lucide) window.lucide.createIcons();
+    // Result rows render after first paint, so the boot-time
+    // applyPlatformHints() pass missed the dynamically-created kbds
+    // inside `.palette__row-hints`. Re-run the swap so Mac users see
+    // ⏎ / ⌘ glyphs instead of the server-rendered "Enter" / "Ctrl"
+    // text on every re-render (debounce + fetch round-trip).
+    applyPlatformHints();
   }
 
   // ---- DRAWER ----------------------------------------------
@@ -854,6 +923,15 @@
       const bid = bidFromTrigger(trigger);
       if (bid !== null) {
         e.preventDefault();
+        // #1207 DET-2: when the drawer is opened from a palette result
+        // row (bare Enter on a focused row fires a synthetic click that
+        // bubbles here), close the palette so the drawer isn't stacked
+        // behind the palette dialog. Scoped to the in-palette path via
+        // `target.closest('.palette')` so non-palette drawer triggers
+        // (banlist rows, history list items, etc.) keep their existing
+        // behaviour — the palette is only closed when it was the source
+        // of the navigation.
+        if (target && target.closest('.palette')) closePalette();
         loadDrawer(bid);
         return;
       }
@@ -1088,13 +1166,27 @@
   else document.addEventListener('DOMContentLoaded', initIcons);
 
   // ---- PLATFORM-AWARE SHORTCUT HINTS -----------------------
-  // The Cmd glyph (U+2318 ⌘) is missing from the vendored JetBrains Mono
-  // and the generic CSS mono fallback on every non-Mac browser, so a
-  // server-rendered '⌘' renders as tofu for the majority of users
-  // (#1184). Templates render the Ctrl form server-side; on macOS /
-  // iOS, swap the visible label to the Cmd form here at boot. The
-  // shortcut handler at line ~112 already accepts metaKey || ctrlKey,
-  // so behavior is platform-correct regardless of the visible hint.
+  // The Cmd glyph (U+2318 ⌘) and Return glyph (U+23CE ⏎) are missing
+  // from the vendored JetBrains Mono and the generic CSS mono fallback
+  // on every non-Mac browser, so a server-rendered '⌘' / '⏎' renders
+  // as tofu for the majority of users (#1184). Templates render the
+  // textual form server-side ("Ctrl", "Enter"); on macOS / iOS, swap
+  // the visible label to the glyph form here at boot. The shortcut
+  // handler at line ~112 already accepts metaKey || ctrlKey, so
+  // behavior is platform-correct regardless of the visible hint.
+  //
+  // Attribute contract:
+  //   [data-modkey]   → "Ctrl" (text)  → "\u2318" (⌘) on Mac
+  //   [data-enterkey] → "Enter" (text) → "\u23CE" (⏎) on Mac
+  //
+  // The topbar trigger's "Ctrl K" kbd is a special case (the entire
+  // textContent is replaced with "⌘K") — it predates `[data-modkey]`
+  // and stays scoped via `.topbar__search kbd` so the kbd group inside
+  // the palette result rows (DET-2) doesn't accidentally pick up the
+  // K-suffixed swap.
+  //
+  // `renderPaletteResults` calls this after each result-render so the
+  // dynamically-injected kbd hints get the swap on every refresh.
   /** @returns {void} */
   function applyPlatformHints() {
     const isMac = /Mac|iPhone|iPad/.test(navigator.userAgent)
@@ -1105,6 +1197,9 @@
     });
     document.querySelectorAll('[data-modkey]').forEach((/** @type {Element} */ el) => {
       el.textContent = '\u2318';
+    });
+    document.querySelectorAll('[data-enterkey]').forEach((/** @type {Element} */ el) => {
+      el.textContent = '\u23CE';
     });
   }
   if (document.readyState !== 'loading') applyPlatformHints();


### PR DESCRIPTION
## Summary

Slice 9 of #1207 — topbar/palette desktop polish. Addresses CC-3, DET-2.

- **CC-3** — extend slice 1 (#1208) mobile icon-only collapse of `.topbar__search` to desktop too. The labelled "search input + Ctrl K hint" was a duplicate affordance for the same `<dialog id="palette-root">` the ⌘K shortcut already opens; both surfaces competed for attention. The trigger is now a ghost icon button at every viewport (matching the sibling theme-toggle's chrome). The `.topbar__search-label` / `.topbar__search-kbd` spans stay in the DOM so SR users still hear the existing `aria-label` and `applyPlatformHints` can still rewrite the kbd text on Mac without re-rendering.
- **DET-2** — each player result row in the palette grows a kbd hint group at the right edge surfacing two interactions: bare `Enter` opens the player drawer for the ban (rows now carry `data-drawer-bid` so theme.js's existing drawer click delegate handles the path; the palette closes itself first so the drawer isn't stacked behind it), `Ctrl/Cmd+Enter` copies the row's SteamID via `navigator.clipboard.writeText` + a `showToast` confirmation. Glyphs are server-rendered in non-Mac form (`Enter`, `Ctrl`); `applyPlatformHints` picks up a new `[data-enterkey]` attribute and swaps to ⏎ alongside the existing `[data-modkey]` → ⌘ swap (#1184).

Docs paired in commit 2:

- `AGENTS.md` "Anti-patterns" — entry warning future agents not to re-add the labelled topbar search.
- `AGENTS.md` "Where to find what" — row pointing at `theme.js`'s palette functions, the `.topbar__search` shape in `core/title.tpl`, and the `.palette__row*` rules in `theme.css`.
- `ARCHITECTURE.md` "Smarty templates + View DTOs" — descriptive blurb on the palette being the only search affordance in the chrome and the topbar trigger being icon-only at every viewport, plus the per-row data-attribute / glyph-swap contract.

## Test plan

- [x] PHPStan: no PHP changed in this slice; the only failures on this branch (`Sbpp\View\YourAccountView::$web_permissions_grouped`) reproduce on `origin/main` and belong to slice 8 territory.
- [x] PHPUnit clean (315 tests, 1291 assertions; nothing under `web/tests/Unit` or `web/tests/api` changed).
- [x] ts-check clean (`./sbpp.sh ts-check`).
- [x] API contract clean (no handler / perm / `@param` / `@return` touched; `composer api-contract` re-emits the same `scripts/api-contract.js`).
- [x] Playwright E2E clean — `./sbpp.sh e2e --workers=1` (mirroring CI's `workers: 1`): 141 passed, 193 skipped (project filtering), 0 failed.
  - New coverage in `command-palette.spec.ts`:
    - `topbar palette trigger renders icon-only at every viewport (#1207 CC-3)` — chromium + mobile-chromium, locks the icon-only shape (square button, no visible label / kbd, `aria-label` intact).
    - `clicking the icon trigger opens the palette (#1207 CC-3)` — chromium + mobile-chromium.
    - `player result row carries kbd hint group with Enter and Ctrl+Enter (#1207 DET-2)` — chromium-only (mobile skips on the Linux runner per platform-glyph default).
    - `Ctrl+Enter on a focused player row copies the SteamID + toasts (#1207 DET-2)` — chromium-only, grants `clipboard-read`/`clipboard-write`, asserts `navigator.clipboard.readText()` matches the row's SteamID + the success toast surfaces.
    - `focused result + Enter opens the player drawer (#1207 DET-2)` — replaces the previous "Enter navigates to ban-list" assertion now that the click delegate hands off to `loadDrawer` and closes the palette.
- [x] Screenshot gallery regenerated (96 PNGs; topbar desktop look changed because the `.topbar__search` shape is now icon-only). Will run `web/tests/e2e/scripts/upload-screenshots.sh <pr> palette-desktop` once the PR exists and comment the markdown table.
- [x] Manual: desktop topbar renders the palette trigger icon-only at every width; palette opens via icon click AND `Meta+k`; player rows carry `Enter` / `Ctrl+Enter` kbd hints with `applyPlatformHints` swapping to ⏎ / ⌘ on Mac; `Ctrl+Enter` on a focused row copies SteamID and surfaces the success toast; bare `Enter` opens the drawer and dismisses the palette in one beat.

Does NOT close #1207.