### PR TITLE
fix(theme): admin settings inputs + myaccount permissions wall (#1207 slice 8)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -375,11 +375,11 @@ of the diff ship together or not at all.
 - Pages that render multiple templates build one View per template and
   call `Renderer::render` for each.
 - Templates with non-default delimiters (currently `page_login.tpl`,
-  `page_blockit.tpl`, `page_kickit.tpl`, and `admin.rcon.tpl` using
-  `-{ … }-`) override `View::DELIMITERS`. `page_youraccount.tpl` was
-  on this list before #1123 B20 rewrote it in standard `{ }`
-  delimiters; do NOT regress it back to `-{ … }-` without a paired
-  edit here.
+  `page_blockit.tpl`, `page_kickit.tpl`, and
+  `page_admin_servers_rcon.tpl` using `-{ … }-`) override
+  `View::DELIMITERS`. `page_youraccount.tpl` was on this list before
+  #1123 B20 rewrote it in standard `{ }` delimiters; do NOT regress
+  it back to `-{ … }-` without a paired edit here.
 
 ### Permission display surfaces
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -374,8 +374,43 @@ of the diff ship together or not at all.
   templates' variables.
 - Pages that render multiple templates build one View per template and
   call `Renderer::render` for each.
-- Templates with non-default delimiters (currently only
-  `page_youraccount.tpl` using `-{ … }-`) override `View::DELIMITERS`.
+- Templates with non-default delimiters (currently `page_login.tpl`,
+  `page_blockit.tpl`, `page_kickit.tpl`, and `admin.rcon.tpl` using
+  `-{ … }-`) override `View::DELIMITERS`. `page_youraccount.tpl` was
+  on this list before #1123 B20 rewrote it in standard `{ }`
+  delimiters; do NOT regress it back to `-{ … }-` without a paired
+  edit here.
+
+### Permission display surfaces
+
+When a page surfaces the user's **own** permission flags back to them
+(currently `page_youraccount.tpl`'s "Your permissions" card), do NOT
+render a flat list of `BitToString()` output — group by category via
+`Sbpp\View\PermissionCatalog::groupedDisplayFromMask($mask)` so the
+section reads:
+
+```
+Bans            Servers
+- Add Bans      - View Servers
+- …             - …
+
+Admins          Groups          Mods            Settings
+…               …               …               …
+```
+
+The categories live in `PermissionCatalog::WEB_CATEGORIES` (Bans /
+Servers / Admins / Groups / Mods / Settings / Owner — order matters,
+it's the render order). Adding a new flag to
+`web/configs/permissions/web.json` requires a paired addition to one
+of these categories; `PermissionCatalogTest::testEveryAdminConstantBelongsToExactlyOneCategory`
+fails the gate otherwise so a new flag isn't silently invisible on
+the account page.
+
+`Perms::for()` (the permission **gate** snapshot) and
+`PermissionCatalog` (the permission **display** structure) are two
+different surfaces — don't conflate them. `Perms::for` is what page
+Views consume to gate `{if $can_add_ban}`; `PermissionCatalog` is
+what the rare display-the-user's-flags-back-to-them surfaces consume.
 
 ### `nofilter` discipline
 
@@ -545,6 +580,7 @@ audit (#1207) locked in. New CTAs:
 | Edit the player-detail drawer (open trigger, tabs, panes, lazy loaders) | `web/themes/default/js/theme.js` (`renderDrawerBody` / `loadPaneIfNeeded`) |
 | Add admin-only per-player notes | `web/api/handlers/notes.php` (CRUD) — Notes tab is gated by `bans.detail`'s `notes_visible` flag |
 | Render admin-authored Markdown to safe HTML | `web/includes/Markup/IntroRenderer.php` (`Sbpp\Markup`) |
+| Display a user's own permission flags grouped by category | `Sbpp\View\PermissionCatalog::groupedDisplayFromMask($mask)` (`web/includes/View/PermissionCatalog.php`). Adding a new flag to `web/configs/permissions/web.json` requires a paired entry in `WEB_CATEGORIES`; `PermissionCatalogTest` enforces it. |
 | Live-preview Markdown in a settings textarea | `system.preview_intro_text` JSON action + `web/themes/default/page_admin_settings_settings.tpl` (`.dash-intro-editor` / `.dash-intro-preview`) |
 | Build an empty-state surface (first-run vs filtered, primary/secondary CTAs) | `.empty-state` rules in `web/themes/default/css/theme.css` + reference shapes in `page_servers.tpl`, `page_dashboard.tpl`, `page_bans.tpl`, `page_comms.tpl`, `page_admin_audit.tpl`, `page_admin_bans_protests.tpl`, `page_admin_bans_submissions.tpl` |
 | Add a shared "1 of these required" badge for an either/or input pair | `web/themes/default/page_submitban.tpl` (`data-required-group="…"` + the inline guard script — vanilla JS `// @ts-check`, blocks submit when both are empty) |

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -362,10 +362,13 @@ Renderer::render($theme, new HomeDashboardView(
   Transitive `{include}`s are resolved on disk; the outer view must
   declare the union of variables both templates use.
 - Templates that use the non-default delimiter pair `-{ … }-` (currently
-  `page_login.tpl` and `page_youraccount.tpl`) override `View::DELIMITERS`
-  so the rule parses them correctly. Page handlers swap `setLeftDelimiter`
-  / `setRightDelimiter` around `Renderer::render()` so the chrome stays
-  on the standard pair.
+  `page_login.tpl`, `page_blockit.tpl`, `page_kickit.tpl`, and
+  `admin.rcon.tpl`) override `View::DELIMITERS` so the rule parses them
+  correctly. Page handlers swap `setLeftDelimiter` / `setRightDelimiter`
+  around `Renderer::render()` so the chrome stays on the standard pair.
+  `page_youraccount.tpl` was on this list before #1123 B20 rewrote it
+  in standard `{ }` delimiters (rationale on the
+  `Sbpp\View\YourAccountView` docblock).
 - Permission gates inside templates are declared on the View as `can_*`
   booleans. `Sbpp\View\Perms::for($userbank)` returns the full
   `array<string, bool>` map keyed by snake-case flag name (`can_owner`,

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -363,11 +363,11 @@ Renderer::render($theme, new HomeDashboardView(
   declare the union of variables both templates use.
 - Templates that use the non-default delimiter pair `-{ … }-` (currently
   `page_login.tpl`, `page_blockit.tpl`, `page_kickit.tpl`, and
-  `admin.rcon.tpl`) override `View::DELIMITERS` so the rule parses them
-  correctly. Page handlers swap `setLeftDelimiter` / `setRightDelimiter`
-  around `Renderer::render()` so the chrome stays on the standard pair.
-  `page_youraccount.tpl` was on this list before #1123 B20 rewrote it
-  in standard `{ }` delimiters (rationale on the
+  `page_admin_servers_rcon.tpl`) override `View::DELIMITERS` so the rule
+  parses them correctly. Page handlers swap `setLeftDelimiter` /
+  `setRightDelimiter` around `Renderer::render()` so the chrome stays
+  on the standard pair. `page_youraccount.tpl` was on this list before
+  #1123 B20 rewrote it in standard `{ }` delimiters (rationale on the
   `Sbpp\View\YourAccountView` docblock).
 - Permission gates inside templates are declared on the View as `can_*`
   booleans. `Sbpp\View\Perms::for($userbank)` returns the full

--- a/web/includes/View/PermissionCatalog.php
+++ b/web/includes/View/PermissionCatalog.php
@@ -1,0 +1,301 @@
+<?php
+declare(strict_types=1);
+
+namespace Sbpp\View;
+
+/**
+ * Display-side helper that groups web-permission flags into the
+ * categories the panel UI uses to scan them — Bans / Servers / Admins
+ * / Groups / Mods / Settings / Owner.
+ *
+ * Why this lives next to the View layer (not next to {@see Perms}):
+ *
+ *   - {@see Perms::for()} produces the **gate** snapshot: a flat
+ *     `['can_<flag>' => bool, …]` map every page-View consumes to
+ *     decide whether to render a button or a link. Categorisation
+ *     would be noise in that surface — every gate already knows what
+ *     it gates.
+ *   - This catalog produces the **display** structure: a list of
+ *     `{key, label, perms}` groups for the surfaces that print the
+ *     user's granted permissions back to them (currently the
+ *     "Your permissions" card on `page_youraccount.tpl`, addressed
+ *     by #1207 ADM-9). Splitting "what flags do I hold" from "what
+ *     buckets does the UI present them in" keeps `web.json` (the
+ *     source of truth for flag values) decoupled from the UX
+ *     categorisation, so a future copy-tweak that renames "Bans" to
+ *     "Bans &amp; appeals" doesn't ripple through the canonical JSON
+ *     or the SourceMod plugin's parallel parsing of web flags.
+ *
+ * Categorisation contract (every constant in
+ * `web/configs/permissions/web.json` except the meta-bucket
+ * `ALL_WEB` belongs to **exactly one** category — the
+ * `PermissionCatalogTest` integration test pins this; adding a flag
+ * to `web.json` without also adding it here breaks the test, on
+ * purpose, so a new flag isn't silently invisible on the account
+ * page).
+ *
+ * Owner bypass: the helper mirrors the convention baked into
+ * `BitToString()` and every `CheckAdminAccess(ADMIN_OWNER|…)` site —
+ * an admin holding `ADMIN_OWNER` lights up every category. The owner
+ * row itself stays in the `owner` category so the rendering can call
+ * out "yes, this admin has the keys" prominently.
+ *
+ * The `ADMIN_*` constants are defined globally by `init.php` from
+ * `web/configs/permissions/web.json`; this helper resolves them via
+ * `defined()`/`constant()` so a stripped-down test bootstrap that
+ * skips init.php still degrades gracefully (an unresolved constant
+ * is treated as not-granted instead of fatally erroring).
+ */
+final class PermissionCatalog
+{
+    /**
+     * Ordered list of UI categories. Order is the render order on
+     * the account page — bans first because most admins use the panel
+     * to triage bans; owner last as the "you have the master key"
+     * coda. The keys are stable test ids
+     * (`account-perm-cat-<key>` in the template) so e2e specs can
+     * anchor on them without depending on visible labels.
+     *
+     * The `constants` list names every `ADMIN_*` constant that should
+     * appear in the category. Strings (not int values) on purpose:
+     * `init.php` defines these constants at runtime from
+     * `web/configs/permissions/web.json`, and `web.json` is the
+     * source of truth for the int values — referencing constant
+     * **names** here means a future bit-pack reshuffle in `web.json`
+     * doesn't ripple through this file.
+     *
+     * @var list<array{key: string, label: string, constants: list<string>}>
+     */
+    public const WEB_CATEGORIES = [
+        [
+            'key'       => 'bans',
+            'label'     => 'Bans',
+            'constants' => [
+                'ADMIN_ADD_BAN',
+                'ADMIN_EDIT_OWN_BANS',
+                'ADMIN_EDIT_GROUP_BANS',
+                'ADMIN_EDIT_ALL_BANS',
+                'ADMIN_BAN_PROTESTS',
+                'ADMIN_BAN_SUBMISSIONS',
+                'ADMIN_DELETE_BAN',
+                'ADMIN_UNBAN',
+                'ADMIN_UNBAN_OWN_BANS',
+                'ADMIN_UNBAN_GROUP_BANS',
+                'ADMIN_BAN_IMPORT',
+                'ADMIN_NOTIFY_SUB',
+                'ADMIN_NOTIFY_PROTEST',
+            ],
+        ],
+        [
+            'key'       => 'servers',
+            'label'     => 'Servers',
+            'constants' => [
+                'ADMIN_LIST_SERVERS',
+                'ADMIN_ADD_SERVER',
+                'ADMIN_EDIT_SERVERS',
+                'ADMIN_DELETE_SERVERS',
+            ],
+        ],
+        [
+            'key'       => 'admins',
+            'label'     => 'Admins',
+            'constants' => [
+                'ADMIN_LIST_ADMINS',
+                'ADMIN_ADD_ADMINS',
+                'ADMIN_EDIT_ADMINS',
+                'ADMIN_DELETE_ADMINS',
+            ],
+        ],
+        [
+            'key'       => 'groups',
+            'label'     => 'Groups',
+            'constants' => [
+                'ADMIN_LIST_GROUPS',
+                'ADMIN_ADD_GROUP',
+                'ADMIN_EDIT_GROUPS',
+                'ADMIN_DELETE_GROUPS',
+            ],
+        ],
+        [
+            'key'       => 'mods',
+            'label'     => 'Mods',
+            'constants' => [
+                'ADMIN_LIST_MODS',
+                'ADMIN_ADD_MODS',
+                'ADMIN_EDIT_MODS',
+                'ADMIN_DELETE_MODS',
+            ],
+        ],
+        [
+            'key'       => 'settings',
+            'label'     => 'Settings',
+            'constants' => [
+                'ADMIN_WEB_SETTINGS',
+            ],
+        ],
+        [
+            'key'       => 'owner',
+            'label'     => 'Owner',
+            'constants' => [
+                'ADMIN_OWNER',
+            ],
+        ],
+    ];
+
+    /**
+     * Cache for the flat permission catalog read off
+     * `web/configs/permissions/web.json`. The file has ~30 rows and
+     * is read by `BitToString` + `init.php` already; caching keeps
+     * the per-request total at one decode regardless of how many
+     * View instances ask the catalog for their group list.
+     *
+     * @var array<string, array{value: int, display: string}>|null
+     */
+    private static ?array $flatCatalog = null;
+
+    /**
+     * Disallow instantiation — this is a static helper namespace.
+     */
+    private function __construct()
+    {
+    }
+
+    /**
+     * Expand a user's `extraflags` bitmask into the list of UI
+     * categories with their granted display strings. Categories
+     * without any granted permissions are filtered out so the
+     * renderer doesn't paint empty buckets — a "Bans" heading with
+     * zero rows underneath would read as "you have lost your bans
+     * permissions" rather than "this category isn't relevant to
+     * your role".
+     *
+     * Owner bypass: holding `ADMIN_OWNER` lights up every category
+     * (mirrors `BitToString`'s behaviour).
+     *
+     * @return list<array{key: string, label: string, perms: list<string>}>
+     *     Empty list when `$mask === 0` (no permissions; the template
+     *     branch above renders an "(none)" empty state then).
+     */
+    public static function groupedDisplayFromMask(int $mask): array
+    {
+        if ($mask === 0) {
+            return [];
+        }
+
+        $catalog = self::flatCatalog();
+        $owner   = self::resolveConstant('ADMIN_OWNER');
+        $allWeb  = self::resolveConstant('ALL_WEB');
+        $hasOwner = $owner !== null && ($mask & $owner) !== 0;
+
+        $out = [];
+        foreach (self::WEB_CATEGORIES as $category) {
+            $perms = [];
+            foreach ($category['constants'] as $name) {
+                $entry = $catalog[$name] ?? null;
+                if ($entry === null) {
+                    continue;
+                }
+                if ($allWeb !== null && $entry['value'] === $allWeb) {
+                    continue;
+                }
+                $isGranted = ($mask & $entry['value']) !== 0 || $hasOwner;
+                if (!$isGranted) {
+                    continue;
+                }
+                $perms[] = $entry['display'];
+            }
+            if ($perms === []) {
+                continue;
+            }
+            $out[] = [
+                'key'   => $category['key'],
+                'label' => $category['label'],
+                'perms' => $perms,
+            ];
+        }
+
+        return $out;
+    }
+
+    /**
+     * Read `web/configs/permissions/web.json` once per process and
+     * cache the keyed map. `web.json`'s shape is
+     * `{ ADMIN_FOO: { value: int, display: string }, … }`; the cache
+     * preserves that shape so callers can look up by constant name.
+     *
+     * @return array<string, array{value: int, display: string}>
+     */
+    private static function flatCatalog(): array
+    {
+        if (self::$flatCatalog !== null) {
+            return self::$flatCatalog;
+        }
+
+        $path = self::webJsonPath();
+        if ($path === null) {
+            return self::$flatCatalog = [];
+        }
+        $raw = @file_get_contents($path);
+        if ($raw === false || $raw === '') {
+            return self::$flatCatalog = [];
+        }
+        /** @var mixed $decoded */
+        $decoded = json_decode($raw, true);
+        if (!is_array($decoded)) {
+            return self::$flatCatalog = [];
+        }
+
+        $out = [];
+        foreach ($decoded as $name => $row) {
+            if (!is_string($name) || !is_array($row)) {
+                continue;
+            }
+            $value   = $row['value']   ?? null;
+            $display = $row['display'] ?? null;
+            if (!is_int($value) || !is_string($display)) {
+                continue;
+            }
+            $out[$name] = ['value' => $value, 'display' => $display];
+        }
+
+        return self::$flatCatalog = $out;
+    }
+
+    /**
+     * Resolve a top-level constant name to its int value, returning
+     * `null` if it isn't currently defined. The helper exists so the
+     * grouping logic can stay tolerant of test bootstraps that skip
+     * `init.php` (the alternative — calling `constant()` unguarded —
+     * would fatal there).
+     */
+    private static function resolveConstant(string $name): ?int
+    {
+        if (!defined($name)) {
+            return null;
+        }
+        $value = constant($name);
+        return is_int($value) ? $value : null;
+    }
+
+    /**
+     * Locate `web/configs/permissions/web.json`. Prefers the runtime
+     * `ROOT` constant set by `init.php` (so the runtime path
+     * survives self-hoster customisation of the install layout), and
+     * falls back to a path relative to this file for the test
+     * bootstrap which doesn't always bring up the full bootstrap.
+     */
+    private static function webJsonPath(): ?string
+    {
+        if (defined('ROOT')) {
+            $candidate = rtrim((string) constant('ROOT'), '/\\') . '/configs/permissions/web.json';
+            if (is_file($candidate)) {
+                return $candidate;
+            }
+        }
+        $candidate = __DIR__ . '/../../configs/permissions/web.json';
+        if (is_file($candidate)) {
+            return $candidate;
+        }
+        return null;
+    }
+}

--- a/web/includes/View/YourAccountView.php
+++ b/web/includes/View/YourAccountView.php
@@ -12,22 +12,42 @@ namespace Sbpp\View;
  * rewrote the template in **standard** `{ }` Smarty delimiters, so
  * neither a `View::DELIMITERS` override nor a per-page delimiter swap
  * is required.
+ *
+ * #1207 ADM-9 — permissions block. The pre-fix shape was a flat
+ * `web_permissions: false|list<string>` (built by `BitToString` in
+ * `system-functions.php`) which the template rendered as a 30-item
+ * `<ul>`, hard to scan. The new contract publishes a structured
+ * `web_permissions_grouped: list<{key, label, perms}>` built by
+ * {@see PermissionCatalog::groupedDisplayFromMask()}, so the template
+ * paints a `<section>` per category in a 2–3 column grid. The
+ * SourceMod side (`server_permissions`) stays a flat list — the char
+ * flags max out at ~14 single-letter entries with no natural
+ * categorisation, so a single column under the "SourceMod" heading
+ * still reads cleanly.
  */
 final class YourAccountView extends View
 {
     public const TEMPLATE = 'page_youraccount.tpl';
 
     /**
-     * @param false|list<string> $web_permissions    `false` when the admin
-     *     has no web permissions, otherwise the list of display strings.
-     * @param false|list<string> $server_permissions Same shape as above for
-     *     server permissions.
+     * @param list<array{key: string, label: string, perms: list<string>}> $web_permissions_grouped
+     *     Granted web permissions grouped by display category. Empty
+     *     list when the user has no web permissions; the template
+     *     renders a `data-testid="account-permissions-web-empty"`
+     *     branch in that case. Built by
+     *     {@see PermissionCatalog::groupedDisplayFromMask()}.
+     * @param false|list<string> $server_permissions
+     *     `false` when the admin has no SourceMod flags, otherwise
+     *     the flat list of display strings (e.g. `['Generic Admin',
+     *     'Kick', 'Ban']`). Preserves `SmFlagsToSb()`'s legacy
+     *     contract so the parallel admin-list / admin-edit surfaces
+     *     keep their existing wire shape.
      */
     public function __construct(
         public readonly bool $srvpwset,
         public readonly string $email,
         public readonly int $user_aid,
-        public readonly false|array $web_permissions,
+        public readonly array $web_permissions_grouped,
         public readonly false|array $server_permissions,
         public readonly int $min_pass_len,
     ) {

--- a/web/pages/page.youraccount.php
+++ b/web/pages/page.youraccount.php
@@ -33,11 +33,18 @@ $GLOBALS['PDO']->bind(':aid', $userbank->GetAid());
 $res      = $GLOBALS['PDO']->single();
 $srvpwset = !empty($res['srv_password']);
 
+// #1207 ADM-9: group the granted web permissions by display category
+// (Bans, Servers, Admins, …) so the "Your permissions" card renders a
+// 2–3 column grid instead of a 30-item bullet wall. The category list
+// + grouping logic lives in `Sbpp\View\PermissionCatalog`; see that
+// class's docblock for the rationale.
+$webExtraFlags = (int) $userbank->GetProperty("extraflags");
+
 \Sbpp\View\Renderer::render($theme, new \Sbpp\View\YourAccountView(
-    srvpwset:           $srvpwset,
-    email:              (string) ($res['email'] ?? ''),
-    user_aid:           (int) $userbank->GetAid(),
-    web_permissions:    BitToString($userbank->GetProperty("extraflags")),
-    server_permissions: SmFlagsToSb($userbank->GetProperty("srv_flags")),
-    min_pass_len:       (int) MIN_PASS_LENGTH,
+    srvpwset:                $srvpwset,
+    email:                   (string) ($res['email'] ?? ''),
+    user_aid:                (int) $userbank->GetAid(),
+    web_permissions_grouped: \Sbpp\View\PermissionCatalog::groupedDisplayFromMask($webExtraFlags),
+    server_permissions:      SmFlagsToSb($userbank->GetProperty("srv_flags")),
+    min_pass_len:            (int) MIN_PASS_LENGTH,
 ));

--- a/web/tests/api/__snapshots__/views/youraccount_owner.json
+++ b/web/tests/api/__snapshots__/views/youraccount_owner.json
@@ -1,0 +1,85 @@
+{
+    "ok": true,
+    "data": {
+        "srvpwset": false,
+        "email": "snapshot@example.test",
+        "user_aid": "<*>",
+        "web_permissions_grouped": [
+            {
+                "key": "bans",
+                "label": "Bans",
+                "perms": [
+                    "Add Bans",
+                    "Edit Own Bans",
+                    "Edit Group Bans",
+                    "Edit All Bans",
+                    "Ban Appeals",
+                    "Ban Reports",
+                    "Delete All Bans",
+                    "Unban All Bans",
+                    "Unban Own Bans",
+                    "Unban Group Bans",
+                    "Import Bans",
+                    "Ban Report Email Notifications",
+                    "Ban Appeal Email Notifications"
+                ]
+            },
+            {
+                "key": "servers",
+                "label": "Servers",
+                "perms": [
+                    "View Servers",
+                    "Add Servers",
+                    "Edit Servers",
+                    "Delete Servers"
+                ]
+            },
+            {
+                "key": "admins",
+                "label": "Admins",
+                "perms": [
+                    "View Admins",
+                    "Add Admins",
+                    "Edit Admins",
+                    "Delete Admins"
+                ]
+            },
+            {
+                "key": "groups",
+                "label": "Groups",
+                "perms": [
+                    "View Groups",
+                    "Add Groups",
+                    "Edit Groups",
+                    "Delete Groups"
+                ]
+            },
+            {
+                "key": "mods",
+                "label": "Mods",
+                "perms": [
+                    "View Mods",
+                    "Add Mods",
+                    "Edit Mods",
+                    "Delete Mods"
+                ]
+            },
+            {
+                "key": "settings",
+                "label": "Settings",
+                "perms": [
+                    "Web Settings"
+                ]
+            },
+            {
+                "key": "owner",
+                "label": "Owner",
+                "perms": [
+                    "Owner"
+                ]
+            }
+        ],
+        "server_permissions": false,
+        "min_pass_len": 6
+    }
+}

--- a/web/tests/e2e/specs/flows/admin-settings-token-lifetimes.spec.ts
+++ b/web/tests/e2e/specs/flows/admin-settings-token-lifetimes.spec.ts
@@ -1,0 +1,176 @@
+/**
+ * Flow: admin settings token-lifetime inputs (#1207 ADM-7).
+ *
+ * Asserts the regression the audit caught — the "Default / Remember
+ * me / Steam login" inputs on the Authentication card used to render
+ * as a 3-column grid where:
+ *   - The input boxes were narrower than their labels at desktop, and
+ *   - On mobile the help text ("Token lifetimes (in minutes)") stayed
+ *     glued to the card header instead of attaching to each input.
+ *
+ * The fix in `web/themes/default/page_admin_settings_settings.tpl`
+ * replaces the card-header chrome with a `<fieldset>` + `<legend>`,
+ * stacks the three inputs vertically (one per row, label above input,
+ * inline help text below the input), and ties each help paragraph to
+ * its input via `aria-describedby`. The vertical stack is the same
+ * shape on desktop and mobile, so the help-text-detached bug at
+ * <=768px goes away too.
+ *
+ * Selector discipline (#1123 testability hooks)
+ * ---------------------------------------------
+ * Anchored on the locked hooks already in
+ * `page_admin_settings_settings.tpl`:
+ *   - `[data-testid="settings-token-lifetimes"]` — the fieldset.
+ *   - `[data-testid="setting-row"][data-key="auth.maxlife*"]` — the
+ *     three rows, addressable by their persisted setting key.
+ *   - `[data-testid="setting-help-auth.maxlife*"]` — the help
+ *     paragraphs, asserting they're rendered inline next to each
+ *     input (NOT just on the card header).
+ *   - `aria-describedby` — the input → help-paragraph relationship,
+ *     asserting screen readers will announce the explanation as the
+ *     input's description.
+ *
+ * The spec runs on both project profiles (chromium + mobile-chromium)
+ * because the contract — vertical stack, inline help, no header-only
+ * help — is identical at every viewport width (the regression was
+ * specifically that the fix had to work BOTH on desktop AND mobile,
+ * and the previous shape failed differently in each).
+ */
+
+import { expect, test } from '../../fixtures/auth.ts';
+import { expectNoCriticalA11y } from '../../fixtures/axe.ts';
+
+test.describe('flow: admin settings token-lifetime inputs (#1207 ADM-7)', () => {
+    test.beforeEach(async ({ page }) => {
+        await page.goto('/index.php?p=admin&c=settings&section=settings');
+        await page.waitForFunction(
+            () => !document.querySelector('[data-loading="true"], [data-skeleton]:not([hidden])'),
+        );
+    });
+
+    test('three token-lifetime inputs render vertically, each with its own help paragraph', async ({ page }) => {
+        const fieldset = page.locator('[data-testid="settings-token-lifetimes"]');
+        await expect(fieldset).toBeVisible();
+        // The fieldset replaces the card-level h3 — verify the
+        // `<legend>` is the form group's a11y label and the section
+        // heading no longer lives on the card header. The legend's
+        // text must include both the section title ("Authentication")
+        // and the unit explanation ("minutes"); this is the contract
+        // the audit's screenshot regressed against.
+        const legend = fieldset.locator('legend');
+        await expect(legend).toContainText(/Authentication/);
+        await expect(legend).toContainText(/minutes/i);
+
+        const keys = ['auth.maxlife', 'auth.maxlife.remember', 'auth.maxlife.steam'];
+        for (const key of keys) {
+            const row = fieldset.locator(`[data-testid="setting-row"][data-key="${key}"]`);
+            await expect(row, `setting-row for ${key} must exist`).toBeVisible();
+
+            const input = row.locator('input[type="number"]');
+            const help  = row.locator(`[data-testid="setting-help-${key}"]`);
+            await expect(input).toBeVisible();
+            await expect(help, `inline help paragraph for ${key} must be visible next to its input`).toBeVisible();
+
+            // a11y wiring: aria-describedby must point at the help
+            // paragraph's id so SR users hear the explanation as the
+            // input's description (not as orphaned prose elsewhere).
+            const describedBy = await input.getAttribute('aria-describedby');
+            const helpId      = await help.getAttribute('id');
+            expect(describedBy, `${key} input must wire aria-describedby`).not.toBeNull();
+            expect(helpId,      `${key} help must carry an id`).not.toBeNull();
+            expect(describedBy).toBe(helpId);
+        }
+    });
+
+    test('help paragraphs sit BELOW their inputs (vertical stack, not a horizontal row)', async ({ page }) => {
+        // The pre-fix shape had the help text on the card header;
+        // even when the inputs collapsed to one column on mobile, the
+        // copy stayed at the top of the card. The fix puts each help
+        // paragraph immediately under its input, so for every row the
+        // help's top must be greater than the input's bottom (>=, not
+        // ==, because layout subpixels can reshuffle on a fractional
+        // device-pixel-ratio).
+        const keys = ['auth.maxlife', 'auth.maxlife.remember', 'auth.maxlife.steam'];
+        for (const key of keys) {
+            const row = page.locator(`[data-testid="setting-row"][data-key="${key}"]`);
+            const inputBox = await row.locator('input[type="number"]').boundingBox();
+            const helpBox  = await row.locator(`[data-testid="setting-help-${key}"]`).boundingBox();
+            expect(inputBox, `${key} input must have a layout box`).not.toBeNull();
+            expect(helpBox,  `${key} help must have a layout box`).not.toBeNull();
+            if (!inputBox || !helpBox) return;
+            expect(
+                helpBox.y,
+                `${key} help paragraph must sit below its input (input bottom=${inputBox.y + inputBox.height}, help top=${helpBox.y})`,
+            ).toBeGreaterThanOrEqual(inputBox.y + inputBox.height - 1);
+        }
+    });
+
+    test('inputs stack vertically — three rows in a single column', async ({ page }) => {
+        // The regression was specifically that the three inputs sat
+        // in a horizontal row at desktop. After the fix the rows must
+        // stack: input N+1's top is >= input N's bottom, AT EVERY
+        // viewport (desktop AND mobile — the previous mobile-only
+        // collapse was the OLD shape; the new shape is the same at
+        // both sizes).
+        const keys = ['auth.maxlife', 'auth.maxlife.remember', 'auth.maxlife.steam'];
+        const tops: number[] = [];
+        const bottoms: number[] = [];
+        for (const key of keys) {
+            const box = await page
+                .locator(`[data-testid="setting-row"][data-key="${key}"]`)
+                .boundingBox();
+            expect(box, `${key} row must be measurable`).not.toBeNull();
+            if (!box) return;
+            tops.push(box.y);
+            bottoms.push(box.y + box.height);
+        }
+        expect(
+            tops[1],
+            'auth.maxlife.remember row should sit below auth.maxlife row',
+        ).toBeGreaterThanOrEqual(bottoms[0] - 1);
+        expect(
+            tops[2],
+            'auth.maxlife.steam row should sit below auth.maxlife.remember row',
+        ).toBeGreaterThanOrEqual(bottoms[1] - 1);
+    });
+
+    test('on desktop, inputs are wider than the rendered label TEXT', async ({ page, isMobile }) => {
+        test.skip(
+            isMobile,
+            'Desktop-only invariant: at mobile widths the input clamp drops to 100% so the constraint is trivially true; the regression was specifically a desktop layout bug.',
+        );
+
+        // The audit's complaint was visual: the rendered input box
+        // looked narrower than the text rendered above it. The
+        // <label class="label"> is a `display: block` element that
+        // stretches to its container, so its bounding box width is
+        // the column width — not what the user reads. To reproduce
+        // the user's visual contract we measure the actual TEXT
+        // width by wrapping the label's text in a Range and reading
+        // its bounding client rect; the input's visible width comes
+        // from its bounding box (it's a leaf input, not a stretched
+        // block).
+        const keys = ['auth.maxlife', 'auth.maxlife.remember', 'auth.maxlife.steam'];
+        for (const key of keys) {
+            const row = page.locator(`[data-testid="setting-row"][data-key="${key}"]`);
+            const labelTextWidth = await row.locator('label.label').evaluate((el) => {
+                const range = document.createRange();
+                range.selectNodeContents(el);
+                return range.getBoundingClientRect().width;
+            });
+            const inputBox = await row.locator('input[type="number"]').boundingBox();
+            expect(inputBox, `${key} input must be measurable`).not.toBeNull();
+            if (!inputBox) return;
+            expect(
+                inputBox.width,
+                `${key} input (width=${inputBox.width}px) must be at least as wide as the rendered label text (width=${labelTextWidth}px) — the audit caught the input visibly narrower than its label.`,
+            ).toBeGreaterThanOrEqual(labelTextWidth - 1);
+        }
+    });
+
+    test('axe: no critical a11y violations on the settings page', async ({ page }, testInfo) => {
+        await expectNoCriticalA11y(page, testInfo, {
+            include: ['#form-settings-main'],
+        });
+    });
+});

--- a/web/tests/e2e/specs/flows/myaccount-permissions.spec.ts
+++ b/web/tests/e2e/specs/flows/myaccount-permissions.spec.ts
@@ -1,0 +1,182 @@
+/**
+ * Flow: myaccount "Your permissions" categorisation (#1207 ADM-9).
+ *
+ * Asserts the regression the audit caught — the "Your permissions"
+ * card on `/index.php?p=myaccount` used to render every web flag as a
+ * single 30-item bullet list next to a "None" column on the SourceMod
+ * side. With every permission sharing the same visual weight, "Add
+ * Bans" was indistinguishable from "Edit Groups" at a glance.
+ *
+ * The fix in `web/themes/default/page_youraccount.tpl` +
+ * `Sbpp\View\YourAccountView` + `Sbpp\View\PermissionCatalog`
+ * publishes a structured `web_permissions_grouped` and renders one
+ * `<section data-testid="account-perm-cat-<key>">` per category
+ * (Bans, Servers, Admins, Groups, Mods, Settings, Owner). At
+ * desktop widths the categories lay out in a 2-column grid (3
+ * columns at >=1280px); on mobile they collapse to a single column
+ * stack.
+ *
+ * Selector discipline (#1123 testability hooks)
+ * ---------------------------------------------
+ * Anchors:
+ *   - `[data-testid="account-permissions"]` — the outer card.
+ *   - `[data-testid="account-permissions-web"]` /
+ *     `[data-testid="account-permissions-server"]` — the two sides.
+ *   - `[data-testid="account-perm-cat-<key>"]` — each category
+ *     section, addressable by the catalog's stable keys (`bans`,
+ *     `servers`, `admins`, `groups`, `mods`, `settings`, `owner`,
+ *     `server`).
+ *   - `[data-perm-cat="<key>"]` — paired with the testid for CSS /
+ *     non-test consumers.
+ * NEVER asserts on visible label text as the *primary* selector;
+ * `hasText` filters are used only to disambiguate (per AGENTS.md
+ * "Playwright E2E specifics").
+ *
+ * The seeded admin/admin holds `ADMIN_OWNER` only (see
+ * `Fixture::seedAdmin()` — `extraflags = 16777216`). Owner-bypass in
+ * the catalog lights up every web category with at least one
+ * permission, so the spec asserts every `account-perm-cat-<web>` row
+ * is present and non-empty. The seeded admin has no SourceMod
+ * `srv_flags`, so the SourceMod side renders the empty state with
+ * the existing `account-permissions-server-empty` testid.
+ */
+
+import { expect, test } from '../../fixtures/auth.ts';
+import { expectNoCriticalA11y } from '../../fixtures/axe.ts';
+
+const WEB_CATEGORY_KEYS = [
+    'bans',
+    'servers',
+    'admins',
+    'groups',
+    'mods',
+    'settings',
+    'owner',
+] as const;
+
+test.describe('flow: myaccount "Your permissions" categorisation (#1207 ADM-9)', () => {
+    test.beforeEach(async ({ page }) => {
+        // Route is `?p=account` (see `page-builder.php`'s switch:
+        // it maps `account` → `page.youraccount.php`); the page
+        // itself is informally called "myaccount" because the nav
+        // entry reads "My account", but the URL parameter is the
+        // legacy `account` slug. Linking with the wrong slug 404s
+        // silently — the spec used `?p=myaccount` in an earlier
+        // draft and the resulting "no perm cat" failures were a
+        // routing tail, not a regression in the template.
+        await page.goto('/index.php?p=account');
+        await page.waitForFunction(
+            () => !document.querySelector('[data-loading="true"], [data-skeleton]:not([hidden])'),
+        );
+    });
+
+    test('owner sees every web category populated with at least one permission', async ({ page }) => {
+        const card = page.locator('[data-testid="account-permissions"]');
+        await expect(card).toBeVisible();
+
+        const webSide = card.locator('[data-testid="account-permissions-web"]');
+        await expect(webSide).toBeVisible();
+
+        // Empty-state shouldn't render for an owner — fail fast if it
+        // does, otherwise the per-category assertions below would
+        // pass vacuously (no categories to check).
+        await expect(webSide.locator('[data-testid="account-permissions-web-empty"]')).toHaveCount(0);
+
+        for (const key of WEB_CATEGORY_KEYS) {
+            const cat = webSide.locator(`[data-testid="account-perm-cat-${key}"]`);
+            await expect(cat, `web category "${key}" must render for an ADMIN_OWNER user`).toBeVisible();
+            await expect(cat).toHaveAttribute('data-perm-cat', key);
+
+            // Each category must have at least one rendered permission
+            // (`<li>` inside the `.permissions-group__list`); the
+            // catalog filters out empty categories so a visible
+            // category with zero items would be a regression in
+            // PermissionCatalog::groupedDisplayFromMask.
+            const items = cat.locator('ul.permissions-group__list > li');
+            await expect(
+                items.first(),
+                `web category "${key}" must have at least one permission listed`,
+            ).toBeVisible();
+            const count = await items.count();
+            expect(count, `web category "${key}" must list >=1 permission, got ${count}`).toBeGreaterThanOrEqual(1);
+        }
+    });
+
+    test('seeded admin SourceMod side renders the empty state (no srv_flags on the fixture)', async ({ page }) => {
+        const serverSide = page.locator('[data-testid="account-permissions-server"]');
+        await expect(serverSide).toBeVisible();
+
+        // The fixture admin holds ADMIN_OWNER on the web side but has
+        // no SourceMod `srv_flags`, so `SmFlagsToSb` returns false and
+        // the template emits the empty-state branch. The testid is
+        // the contract from the previous template shape and stays
+        // stable across the redesign.
+        await expect(serverSide.locator('[data-testid="account-permissions-server-empty"]')).toBeVisible();
+    });
+
+    test('desktop: web categories lay out in a multi-column grid', async ({ page, isMobile, viewport }) => {
+        test.skip(
+            isMobile,
+            'Multi-column layout is a desktop-only contract; the mobile path is covered by the dedicated mobile test below.',
+        );
+
+        // Skip in the unlikely event a future configuration runs the
+        // chromium project at a viewport <1024px (where the CSS
+        // collapses to a single column). Doing the skip here keeps
+        // the assertion's invariant — "we ARE at desktop" — explicit.
+        if (viewport && viewport.width < 1024) {
+            test.skip(true, `viewport.width=${viewport.width} < 1024 — multi-column layout only kicks in at >=1024px.`);
+        }
+
+        // Read every category's bounding box; if the columns reflowed
+        // to a single stack, every category's `x` would be roughly
+        // the same. With multi-column layout, at least two categories
+        // should sit at *different* x coordinates on the same row.
+        const xs: number[] = [];
+        for (const key of WEB_CATEGORY_KEYS) {
+            const box = await page
+                .locator(`[data-testid="account-perm-cat-${key}"]`)
+                .boundingBox();
+            expect(box, `${key} must be measurable`).not.toBeNull();
+            if (!box) return;
+            xs.push(box.x);
+        }
+        const distinctXs = new Set(xs.map((x) => Math.round(x)));
+        expect(
+            distinctXs.size,
+            `at desktop the web categories must occupy >=2 distinct x-positions (got ${distinctXs.size}; xs=${xs.join(',')})`,
+        ).toBeGreaterThanOrEqual(2);
+    });
+
+    test('mobile: web categories collapse to a single column', async ({ page, isMobile }) => {
+        test.skip(
+            !isMobile,
+            'Single-column collapse is a mobile contract; desktop is covered by the multi-column test above.',
+        );
+
+        // On mobile, every category sits at roughly the same x
+        // coordinate (one stack). Allow a 1px slop for subpixel
+        // rounding from the device-pixel-ratio.
+        const xs: number[] = [];
+        for (const key of WEB_CATEGORY_KEYS) {
+            const box = await page
+                .locator(`[data-testid="account-perm-cat-${key}"]`)
+                .boundingBox();
+            expect(box, `${key} must be measurable`).not.toBeNull();
+            if (!box) return;
+            xs.push(box.x);
+        }
+        const minX = Math.min(...xs);
+        const maxX = Math.max(...xs);
+        expect(
+            maxX - minX,
+            `at mobile every category must share the same x (within 1px); got minX=${minX} maxX=${maxX}`,
+        ).toBeLessThanOrEqual(1);
+    });
+
+    test('axe: no critical a11y violations on the permissions card', async ({ page }, testInfo) => {
+        await expectNoCriticalA11y(page, testInfo, {
+            include: ['[data-testid="account-permissions"]'],
+        });
+    });
+});

--- a/web/tests/integration/PermissionCatalogTest.php
+++ b/web/tests/integration/PermissionCatalogTest.php
@@ -1,0 +1,186 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sbpp\Tests\Integration;
+
+use Sbpp\Tests\ApiTestCase;
+use Sbpp\View\PermissionCatalog;
+
+/**
+ * Lock the categorisation contract for `Sbpp\View\PermissionCatalog`.
+ *
+ * The catalog is the single source of truth for grouping the
+ * `web/configs/permissions/web.json` flags into the categories the
+ * "Your permissions" card on `page_youraccount.tpl` paints (#1207
+ * ADM-9). Two invariants matter:
+ *
+ *   1. **Coverage**: every `ADMIN_*` constant in `web.json` (except
+ *      the meta-bucket `ALL_WEB`) belongs to **exactly one**
+ *      category. A new flag added to `web.json` without a matching
+ *      entry in `WEB_CATEGORIES` would silently become invisible on
+ *      the account page; this test fails on that case so the gap is
+ *      caught at PR review time.
+ *   2. **Owner bypass**: holding `ADMIN_OWNER` lights up every
+ *      category, mirroring the convention `BitToString` and
+ *      `CheckAdminAccess(ADMIN_OWNER|…)` use across the panel.
+ *      Regressing this would also regress the "Your permissions"
+ *      card for every owner-tier admin.
+ */
+final class PermissionCatalogTest extends ApiTestCase
+{
+    /**
+     * Coverage invariant: every `ADMIN_*` constant in
+     * `web/configs/permissions/web.json` belongs to **exactly one**
+     * category in `WEB_CATEGORIES`. The meta-bucket `ALL_WEB` is the
+     * only exemption — it's a convenience constant, not a flag.
+     *
+     * The web.json source is read directly so the test catches a
+     * mismatch between the JSON and the catalog at the JSON's level
+     * (i.e. a new row in JSON but no matching catalog entry) — not
+     * just a mismatch against the live constants which `init.php`
+     * defined from the same JSON.
+     */
+    public function testEveryAdminConstantBelongsToExactlyOneCategory(): void
+    {
+        $webJson = json_decode(
+            (string) file_get_contents(ROOT . 'configs/permissions/web.json'),
+            true,
+        );
+        $this->assertIsArray($webJson, 'web.json must decode as an associative array');
+
+        $jsonNames = array_keys($webJson);
+        $jsonNames = array_values(array_filter(
+            $jsonNames,
+            static fn (string $n): bool => $n !== 'ALL_WEB' && str_starts_with($n, 'ADMIN_'),
+        ));
+
+        $seen = [];
+        foreach (PermissionCatalog::WEB_CATEGORIES as $category) {
+            foreach ($category['constants'] as $name) {
+                $this->assertArrayNotHasKey(
+                    $name,
+                    $seen,
+                    "$name appears in multiple categories — it must live in exactly one bucket so the rendered permissions list doesn't double-count it.",
+                );
+                $seen[$name] = $category['key'];
+            }
+        }
+
+        $catalogNames = array_keys($seen);
+        sort($jsonNames);
+        sort($catalogNames);
+        $this->assertSame(
+            $jsonNames,
+            $catalogNames,
+            "Mismatch between web.json and PermissionCatalog::WEB_CATEGORIES — every flag in the JSON must be assigned to a category.",
+        );
+    }
+
+    /**
+     * Owner bypass: a user holding only `ADMIN_OWNER` sees every
+     * category populated. This mirrors `BitToString`'s legacy
+     * behaviour (the helper this catalog supersedes for the account
+     * page) so administrative semantics are preserved across the
+     * shape change.
+     */
+    public function testOwnerMaskPopulatesEveryCategory(): void
+    {
+        $grouped = PermissionCatalog::groupedDisplayFromMask(
+            (int) constant('ADMIN_OWNER'),
+        );
+
+        $this->assertCount(
+            count(PermissionCatalog::WEB_CATEGORIES),
+            $grouped,
+            'ADMIN_OWNER must light up every category.',
+        );
+
+        $expectedKeys = array_column(PermissionCatalog::WEB_CATEGORIES, 'key');
+        $actualKeys   = array_column($grouped, 'key');
+        $this->assertSame(
+            $expectedKeys,
+            $actualKeys,
+            'Category render order must match WEB_CATEGORIES order.',
+        );
+    }
+
+    /**
+     * Empty-mask invariant: a user with `extraflags = 0` gets an
+     * empty list, NOT a list of 7 empty categories. The template
+     * paints the `(none)` empty-state for that case, so any code
+     * that treats an empty list as "owner without categories" would
+     * mis-render — the explicit empty list is the contract.
+     */
+    public function testEmptyMaskReturnsEmptyList(): void
+    {
+        $this->assertSame(
+            [],
+            PermissionCatalog::groupedDisplayFromMask(0),
+        );
+    }
+
+    /**
+     * Narrow-mask: an admin holding only ban-add + edit-own flags
+     * sees ONLY the bans category, with exactly those two display
+     * strings. Categories that have no granted flags are dropped so
+     * the surface only paints buckets with content (otherwise an
+     * "Admins" heading with zero rows reads as "you lost your
+     * admins permissions" rather than "this category is irrelevant
+     * to your role").
+     */
+    public function testNarrowMaskOnlyPopulatesOwningCategory(): void
+    {
+        $mask = ((int) constant('ADMIN_ADD_BAN'))
+              | ((int) constant('ADMIN_EDIT_OWN_BANS'));
+        $grouped = PermissionCatalog::groupedDisplayFromMask($mask);
+
+        $this->assertCount(1, $grouped, 'mask only covers the bans category');
+        $this->assertSame('bans', $grouped[0]['key']);
+        $this->assertSame('Bans', $grouped[0]['label']);
+        $this->assertSame(['Add Bans', 'Edit Own Bans'], $grouped[0]['perms']);
+    }
+
+    /**
+     * Narrow-mask spanning two categories: a user with one bans flag
+     * + one settings flag sees both categories, in the order
+     * declared by `WEB_CATEGORIES` (bans before settings — settings
+     * sit near the end of the list because most admins don't have
+     * the flag).
+     */
+    public function testMultiCategoryNarrowMaskOrderMatchesCatalog(): void
+    {
+        $mask = ((int) constant('ADMIN_BAN_PROTESTS'))
+              | ((int) constant('ADMIN_WEB_SETTINGS'));
+        $grouped = PermissionCatalog::groupedDisplayFromMask($mask);
+
+        $this->assertSame(
+            ['bans', 'settings'],
+            array_column($grouped, 'key'),
+        );
+        $this->assertSame(['Ban Appeals'], $grouped[0]['perms']);
+        $this->assertSame(['Web Settings'], $grouped[1]['perms']);
+    }
+
+    /**
+     * `ALL_WEB` carries every flag bit but the catalog must skip it
+     * (it's the meta-bucket, not a category). Combine `ALL_WEB` with
+     * a real flag and verify only the real categories surface, with
+     * no `all_web` row leaking through.
+     */
+    public function testAllWebMaskDoesNotProduceMetaCategory(): void
+    {
+        $mask    = (int) constant('ALL_WEB');
+        $grouped = PermissionCatalog::groupedDisplayFromMask($mask);
+
+        $keys = array_column($grouped, 'key');
+        $this->assertNotContains('all_web', $keys);
+        foreach ($grouped as $group) {
+            $this->assertNotContains(
+                'All Web Permissions',
+                $group['perms'],
+                'ALL_WEB display string must never appear in any category.',
+            );
+        }
+    }
+}

--- a/web/tests/integration/YourAccountViewTest.php
+++ b/web/tests/integration/YourAccountViewTest.php
@@ -1,0 +1,149 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sbpp\Tests\Integration;
+
+use Sbpp\Tests\ApiTestCase;
+use Sbpp\Tests\Fixture;
+use Sbpp\View\PermissionCatalog;
+use Sbpp\View\YourAccountView;
+
+/**
+ * Lock the wire shape of `Sbpp\View\YourAccountView`.
+ *
+ * The view is the seam between `web/pages/page.youraccount.php`
+ * (which builds it from the DB row + the user's bitmask) and
+ * `page_youraccount.tpl` (which renders the categorised "Your
+ * permissions" block, the password forms, and the change-email
+ * form). #1207 ADM-9 swapped the previously-flat
+ * `web_permissions: list<string>` for a structured
+ * `web_permissions_grouped: list<{key, label, perms: list<string>}>`,
+ * matching the category split that lives in
+ * `Sbpp\View\PermissionCatalog::WEB_CATEGORIES`. This test pins the
+ * shape so:
+ *
+ *   1. The template's `{foreach from=$web_permissions_grouped item=group}`
+ *      loop has the keys it expects (`key`, `label`, `perms`), and
+ *   2. A future "simplifying" refactor that flattens the grouped
+ *      form back to a list (or shuffles the category order) shows
+ *      up as a red CI run, not as a stealth UX regression.
+ *
+ * Snapshot rationale: a JSON-pretty-printed dump of `get_object_vars`
+ * is dense but exhaustive — every published property is surfaced and
+ * every value is locked. The snapshot pattern (see
+ * `Sbpp\Tests\ApiTestCase::assertSnapshot`) is the same one the API
+ * contract tests use; the existing snapshot directory layout is
+ * `web/tests/api/__snapshots__/<topic>/<scenario>.json`. We file
+ * YourAccountView's snapshot under a `views/` subdirectory so it
+ * doesn't intermix with the JSON-API envelopes there.
+ */
+final class YourAccountViewTest extends ApiTestCase
+{
+    /**
+     * Snapshot the seeded admin/admin (ADMIN_OWNER) view shape.
+     *
+     * Owner-bypass means every category lights up; the snapshot
+     * captures that the order is bans → servers → admins → groups
+     * → mods → settings → owner (the catalog's source order, which
+     * is also the rendered order on the page).
+     */
+    public function testSeededAdminProducesGroupedPermissionsSnapshot(): void
+    {
+        $this->loginAsAdmin();
+        /** @var \CUserManager $userbank */
+        $userbank = $GLOBALS['userbank'];
+
+        $extraflags = (int) $userbank->GetProperty('extraflags');
+        $this->assertSame(
+            (int) constant('ADMIN_OWNER'),
+            $extraflags,
+            'The seeded admin/admin must hold ADMIN_OWNER only — see Fixture::seedAdmin().',
+        );
+
+        $view = new YourAccountView(
+            srvpwset:                false,
+            email:                   'snapshot@example.test',
+            user_aid:                Fixture::adminAid(),
+            web_permissions_grouped: PermissionCatalog::groupedDisplayFromMask($extraflags),
+            server_permissions:      false,
+            min_pass_len:            6,
+        );
+
+        // Pull the published shape exactly the way `Renderer::render`
+        // hands it to Smarty — `get_object_vars` walks public
+        // readonly properties in declaration order. Wrap it in an
+        // `ok` / `data` envelope so `assertSnapshot`'s existing
+        // JSON-pretty-print path produces a stable file.
+        $envelope = [
+            'ok'   => true,
+            'data' => get_object_vars($view),
+        ];
+        // `user_aid` is the fixture-seeded autoincrement that depends
+        // on insertion order; redact so the rest of the shape stays
+        // locked even when the seed grows extra rows.
+        $this->assertSnapshot('views/youraccount_owner', $envelope, ['data.user_aid']);
+    }
+
+    /**
+     * Hand-rolled assertion for the structured permission shape so a
+     * missing key in `web_permissions_grouped` doesn't sneak past the
+     * snapshot through a JSON round-trip artefact. Also documents
+     * the shape contract inline — future readers don't have to
+     * reverse-engineer from the snapshot file what `key`, `label`,
+     * and `perms` are supposed to be.
+     */
+    public function testWebPermissionsGroupedShapeMatchesCatalog(): void
+    {
+        $this->loginAsAdmin();
+        /** @var \CUserManager $userbank */
+        $userbank = $GLOBALS['userbank'];
+
+        $extraflags = (int) $userbank->GetProperty('extraflags');
+        $view = new YourAccountView(
+            srvpwset:                false,
+            email:                   '',
+            user_aid:                Fixture::adminAid(),
+            web_permissions_grouped: PermissionCatalog::groupedDisplayFromMask($extraflags),
+            server_permissions:      false,
+            min_pass_len:            6,
+        );
+
+        $this->assertCount(
+            count(PermissionCatalog::WEB_CATEGORIES),
+            $view->web_permissions_grouped,
+            'Owner-bypass must populate every catalog category.',
+        );
+        foreach ($view->web_permissions_grouped as $i => $group) {
+            $this->assertArrayHasKey('key',   $group, "category $i missing 'key'");
+            $this->assertArrayHasKey('label', $group, "category $i missing 'label'");
+            $this->assertArrayHasKey('perms', $group, "category $i missing 'perms'");
+            $this->assertNotEmpty(
+                $group['perms'],
+                "category {$group['key']} must have at least one perm for the owner mask.",
+            );
+        }
+    }
+
+    /**
+     * No-permission case (a freshly-created admin with `extraflags
+     * = 0`). The view publishes an empty `web_permissions_grouped`
+     * list — the template's `{if $web_permissions_grouped}` empty
+     * branch then renders the "(none)" copy with the
+     * `account-permissions-web-empty` testid the e2e suite anchors
+     * on.
+     */
+    public function testEmptyMaskPublishesEmptyList(): void
+    {
+        $view = new YourAccountView(
+            srvpwset:                false,
+            email:                   '',
+            user_aid:                0,
+            web_permissions_grouped: PermissionCatalog::groupedDisplayFromMask(0),
+            server_permissions:      false,
+            min_pass_len:            6,
+        );
+
+        $this->assertSame([], $view->web_permissions_grouped);
+    }
+}

--- a/web/themes/default/css/theme.css
+++ b/web/themes/default/css/theme.css
@@ -799,6 +799,169 @@ details.queue-row > summary > .row-actions {
   .settings-actions { margin-bottom: 2rem; }
 }
 
+/* ---- Settings fieldset (#1207 ADM-7) ----
+   Used by the "Authentication" block on the admin settings page where
+   three numeric inputs (auth.maxlife / auth.maxlife.remember /
+   auth.maxlife.steam) used to share one row. Pre-fix:
+   `.grid + grid-template-columns: repeat(3, 1fr)` left the inputs
+   narrower than their labels at desktop, and on mobile the help text
+   ("Token lifetimes (in minutes)") sat on the card header, divorced
+   from the field it qualified.
+
+   The fix replaces the `.card__header h3 + p` chrome with a real
+   `<fieldset>` + `<legend>`, stacks the three inputs vertically, and
+   ties each input to its own `.settings-fieldset__help` paragraph via
+   `aria-describedby`. The fieldset removes the browser-default
+   1px inset border + padding so it visually inherits the parent
+   `.card`'s chrome instead of double-painting it.
+
+   The `__legend` row mimics `.card__header`'s shape (title + muted
+   sub-line) so the fieldset reads as a card-section heading; the
+   `__body` re-applies the same padding `.card__body` uses so the
+   inputs sit at the same indent as sibling cards on the same form.
+
+   Inputs are width-clamped at 18rem max — wide enough that the
+   `<input type=number>` arrows + a 5-digit minute count both fit, and
+   meaningfully wider than the labels so the input never reads as a
+   smaller affordance than the prose introducing it. The clamp drops
+   to 100% at <=768px so mobile viewports never end up with an
+   18rem-locked input clipped under the chrome. */
+.settings-fieldset {
+  border: 0;
+  margin: 0;
+  padding: 0;
+  min-width: 0;
+}
+.settings-fieldset__legend {
+  display: block;
+  width: 100%;
+  padding: 1rem 1.25rem;
+  border-bottom: 1px solid var(--border);
+}
+.settings-fieldset__title {
+  display: block;
+  font-size: var(--fs-base);
+  font-weight: 600;
+  color: var(--text);
+}
+.settings-fieldset__hint {
+  display: block;
+  margin-top: 0.25rem;
+  font-size: var(--fs-xs);
+  color: var(--text-muted);
+}
+.settings-fieldset__hint code {
+  padding: 0 0.25rem;
+  border-radius: var(--radius-sm);
+  background: var(--bg-muted);
+  color: var(--text);
+  font-family: var(--font-mono);
+  font-size: 0.875em;
+}
+.settings-fieldset__body {
+  padding: 1.25rem;
+}
+.settings-fieldset__input {
+  width: 100%;
+  max-width: 18rem;
+}
+.settings-fieldset__help {
+  margin: 0.375rem 0 0;
+  font-size: var(--fs-xs);
+  color: var(--text-muted);
+  line-height: 1.45;
+}
+@media (max-width: 768px) {
+  .settings-fieldset__input { max-width: 100%; }
+}
+
+/* ---- "Your permissions" grid (#1207 ADM-9) ----
+   The pre-fix layout was a 2-column `.grid` (web side / SourceMod
+   side) where the web side was a flat 30-item bullet list, leaving
+   "Add Bans" visually equal to "Edit Groups" — hard to scan at a
+   glance and impossible to tell where bans-related flags ended and
+   admin-management ones began.
+
+   The fix splits each side into two layers:
+     - `.permissions-side` is the outer "Web" / "SourceMod" column.
+       It owns the heading + an inner grid that lays out one
+       `.permissions-group` `<section>` per category.
+     - `.permissions-group` is the per-category card. It carries
+       a small heading (`__title`) and the granted-permissions list
+       (`__list`).
+
+   Layout schedule:
+     - <1024px (mobile + small tablet): single column. The web side
+       and the SourceMod side stack; inside each side, every
+       `.permissions-group` also stacks. This is the touch-first
+       layout per #1123's mobile-first rules.
+     - >=1024px (desktop): the two sides sit side-by-side via a
+       2-column outer grid (`.permissions-card__body`), and inside
+       the web side the categories themselves expand to a 2-column
+       grid so an owner with all 7 categories doesn't end up with a
+       narrow scroll-strip.
+     - >=1280px: the web side bumps to 3 columns so a full-permissions
+       owner sees every category in one viewport without scrolling.
+
+   The `.permissions-group__title` style intentionally mirrors the
+   "uppercase muted" aesthetic of the original "WEB" / "SERVER"
+   subheaders the previous template used, so the visual hierarchy
+   feels familiar even though the structure underneath is new. */
+.permissions-card__body {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: 1fr;
+}
+.permissions-side__heading {
+  margin: 0 0 0.75rem;
+  font-size: 0.6875rem;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+.permissions-grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: 1fr;
+}
+.permissions-group {
+  margin: 0;
+  padding: 0.75rem 0.875rem;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  background: var(--bg-page);
+}
+.permissions-group__title {
+  margin: 0 0 0.375rem;
+  font-size: var(--fs-xs);
+  font-weight: 600;
+  color: var(--text);
+}
+.permissions-group__list {
+  list-style: disc;
+  margin: 0;
+  padding-left: 1.125rem;
+  font-size: var(--fs-sm);
+  color: var(--text);
+}
+.permissions-group__list li + li { margin-top: 0.125rem; }
+.permissions-empty {
+  margin: 0;
+  font-size: var(--fs-sm);
+  color: var(--text-muted);
+}
+@media (min-width: 1024px) {
+  .permissions-card__body {
+    grid-template-columns: 2fr 1fr;
+    gap: 2rem;
+  }
+  .permissions-grid--web { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+}
+@media (min-width: 1280px) {
+  .permissions-grid--web { grid-template-columns: repeat(3, minmax(0, 1fr)); }
+}
+
 /* ---- Footer (#1207 CC-6 + SET-2) ----
    The page-bottom credit footer in core/footer.tpl. A subtle
    top border + a touch more vertical padding visually separates

--- a/web/themes/default/page_admin_settings_settings.tpl
+++ b/web/themes/default/page_admin_settings_settings.tpl
@@ -124,24 +124,105 @@
                         </div>
                     </div>
 
+                    {*
+                        #1207 ADM-7: token-lifetime inputs stacked,
+                        with per-input help.
+
+                        Pre-fix shape: a 3-column `display: grid` with
+                        the labels "Default", "Remember me",
+                        "Steam login" side-by-side. The labels were
+                        unequal width and the inputs themselves were
+                        narrower than their labels at desktop
+                        ("the input boxes are narrower than their
+                        labels"); on mobile the grid collapsed to a
+                        single column but the explanatory copy
+                        ("Token lifetimes (in minutes)") stayed on
+                        the card header so the user couldn't tell
+                        which input the unit applied to.
+
+                        Fix:
+
+                          - Use a `<fieldset>` + `<legend>` so the
+                            section heading is the form group's a11y
+                            label (replacing the card-level `<h3>`
+                            chrome — the outer `.card` chrome is kept
+                            for visual consistency with sibling
+                            settings sections).
+                          - Each input lives in its own `<div
+                            data-testid="setting-row">` with a
+                            description paragraph below the input so
+                            the unit ("in minutes") and the meaning
+                            ("when the user ticks Remember me", "when
+                            signed in via the Continue with Steam
+                            button") sit next to the field they apply
+                            to. The paragraphs are tied to the
+                            inputs via `aria-describedby` so screen
+                            readers announce them as the input's
+                            description.
+                          - The labels are renamed away from
+                            "Default" / "Remember me" / "Steam login"
+                            to "Default sign-in" / "\"Remember me\"
+                            sign-in" / "Steam sign-in" so users
+                            scanning the form don't have to read the
+                            section heading to know what "Default"
+                            applies to.
+                          - The vertical stack layout works the same
+                            on desktop and mobile, so the
+                            help-text-detached-from-the-card-header
+                            bug at <=768px goes away too.
+                    *}
                     <div class="card">
-                        <div class="card__header"><div><h3>Authentication</h3><p>Token lifetimes (in minutes).</p></div></div>
-                        <div class="card__body space-y-4">
-                            <div class="grid gap-4" style="grid-template-columns:repeat(3,1fr)">
+                        <fieldset class="settings-fieldset"
+                                  data-testid="settings-token-lifetimes">
+                            <legend class="settings-fieldset__legend">
+                                <span class="settings-fieldset__title">Authentication</span>
+                                <span class="settings-fieldset__hint">Session token lifetimes, measured in minutes. Set a value to <code>0</code> to disable a sign-in path.</span>
+                            </legend>
+                            <div class="settings-fieldset__body space-y-5">
                                 <div data-testid="setting-row" data-key="auth.maxlife">
-                                    <label class="label" for="auth_maxlife">Default</label>
-                                    <input class="input" type="number" min="0" id="auth_maxlife" name="auth_maxlife" value="{$auth_maxlife}">
+                                    <label class="label" for="auth_maxlife">Default sign-in</label>
+                                    <input class="input settings-fieldset__input"
+                                           type="number" min="0"
+                                           id="auth_maxlife"
+                                           name="auth_maxlife"
+                                           value="{$auth_maxlife}"
+                                           aria-describedby="auth_maxlife_help">
+                                    <p class="settings-fieldset__help"
+                                       id="auth_maxlife_help"
+                                       data-testid="setting-help-auth.maxlife">
+                                        How long a regular sign-in session lasts before the user is signed out, in minutes.
+                                    </p>
                                 </div>
                                 <div data-testid="setting-row" data-key="auth.maxlife.remember">
-                                    <label class="label" for="auth_maxlife_remember">Remember me</label>
-                                    <input class="input" type="number" min="0" id="auth_maxlife_remember" name="auth_maxlife_remember" value="{$auth_maxlife_remember}">
+                                    <label class="label" for="auth_maxlife_remember">&ldquo;Remember me&rdquo; sign-in</label>
+                                    <input class="input settings-fieldset__input"
+                                           type="number" min="0"
+                                           id="auth_maxlife_remember"
+                                           name="auth_maxlife_remember"
+                                           value="{$auth_maxlife_remember}"
+                                           aria-describedby="auth_maxlife_remember_help">
+                                    <p class="settings-fieldset__help"
+                                       id="auth_maxlife_remember_help"
+                                       data-testid="setting-help-auth.maxlife.remember">
+                                        Used when the user ticks the &ldquo;Remember me&rdquo; checkbox on the login form. Typically much longer than the default session.
+                                    </p>
                                 </div>
                                 <div data-testid="setting-row" data-key="auth.maxlife.steam">
-                                    <label class="label" for="auth_maxlife_steam">Steam login</label>
-                                    <input class="input" type="number" min="0" id="auth_maxlife_steam" name="auth_maxlife_steam" value="{$auth_maxlife_steam}">
+                                    <label class="label" for="auth_maxlife_steam">Steam sign-in</label>
+                                    <input class="input settings-fieldset__input"
+                                           type="number" min="0"
+                                           id="auth_maxlife_steam"
+                                           name="auth_maxlife_steam"
+                                           value="{$auth_maxlife_steam}"
+                                           aria-describedby="auth_maxlife_steam_help">
+                                    <p class="settings-fieldset__help"
+                                       id="auth_maxlife_steam_help"
+                                       data-testid="setting-help-auth.maxlife.steam">
+                                        Lifetime of a session opened via the &ldquo;Continue with Steam&rdquo; button.
+                                    </p>
                                 </div>
                             </div>
-                        </div>
+                        </fieldset>
                     </div>
 
                     <div class="card">

--- a/web/themes/default/page_youraccount.tpl
+++ b/web/themes/default/page_youraccount.tpl
@@ -39,7 +39,38 @@
         <p class="text-sm text-muted m-0 mt-2">Permissions, password, server password, and email.</p>
     </header>
 
-    {* -- Permissions card --------------------------------------------- *}
+    {*
+        Permissions card (#1207 ADM-9).
+
+        Pre-fix shape: a single 30-item `<ul>` next to a "None" column
+        for the SourceMod side — every permission shared the same
+        visual weight, so "Add Bans" was indistinguishable from
+        "Edit Groups" at a glance. Redesign:
+
+          - **Web side**: rendered as `<section>` per category
+            (`$web_permissions_grouped` is built by
+            {@see Sbpp\View\PermissionCatalog::groupedDisplayFromMask}).
+            Each `<section>` carries its own
+            `data-testid="account-perm-cat-<key>"` so e2e specs can
+            assert "the Bans category has at least one row" without
+            depending on visible copy. Empty categories are filtered
+            out by the helper, so the surface only paints buckets
+            that have content.
+          - **Server side**: stays a flat list — the SourceMod char
+            flags top out at ~14 single-letter values with no
+            natural category split, so a single column under the
+            "SourceMod" heading still scans cleanly. Wrapped in the
+            same `.permissions-group` chrome as the web side for
+            visual consistency.
+
+        Layout: `.permissions-grid` is a 1-column stack at <=1023px
+        and a 2-column (web side) / 1-column (server side) grid at
+        >=1024px; the web grid expands to 3 columns at >=1280px so a
+        full-permission owner doesn't waste any horizontal real
+        estate. See the matching block in `theme.css`. Tests anchor
+        on `[data-testid="account-permissions"]` + the per-category
+        ids, never on visible labels.
+    *}
     <section class="card" data-testid="account-permissions">
         <div class="card__header">
             <div>
@@ -47,32 +78,54 @@
                 <p>The flags currently granted to your admin account.</p>
             </div>
         </div>
-        <div class="card__body">
-            <div class="grid gap-6" style="grid-template-columns:repeat(auto-fit,minmax(15rem,1fr))">
-                <div>
-                    <div class="text-xs font-semibold text-muted mb-2" style="text-transform:uppercase;letter-spacing:0.06em">Web</div>
-                    {if $web_permissions}
-                        <ul class="m-0 text-sm" style="padding-left:1.25rem">
-                            {foreach from=$web_permissions item=permission}
-                                <li>{$permission}</li>
-                            {/foreach}
-                        </ul>
-                    {else}
-                        <div class="text-sm text-muted" data-testid="account-permissions-web-empty"><em>None</em></div>
-                    {/if}
-                </div>
-                <div>
-                    <div class="text-xs font-semibold text-muted mb-2" style="text-transform:uppercase;letter-spacing:0.06em">Server</div>
-                    {if $server_permissions}
-                        <ul class="m-0 text-sm" style="padding-left:1.25rem">
-                            {foreach from=$server_permissions item=permission}
-                                <li>{$permission}</li>
-                            {/foreach}
-                        </ul>
-                    {else}
-                        <div class="text-sm text-muted" data-testid="account-permissions-server-empty"><em>None</em></div>
-                    {/if}
-                </div>
+        <div class="card__body permissions-card__body">
+            <div class="permissions-side permissions-side--web"
+                 data-testid="account-permissions-web">
+                <h4 class="permissions-side__heading">Web</h4>
+                {if $web_permissions_grouped}
+                    <div class="permissions-grid permissions-grid--web">
+                        {foreach from=$web_permissions_grouped item=group}
+                            <section class="permissions-group"
+                                     data-testid="account-perm-cat-{$group.key}"
+                                     data-perm-cat="{$group.key}">
+                                <h5 class="permissions-group__title">{$group.label}</h5>
+                                <ul class="permissions-group__list">
+                                    {foreach from=$group.perms item=permission}
+                                        <li>{$permission}</li>
+                                    {/foreach}
+                                </ul>
+                            </section>
+                        {/foreach}
+                    </div>
+                {else}
+                    <p class="permissions-empty"
+                       data-testid="account-permissions-web-empty">
+                        <em>No web permissions granted.</em>
+                    </p>
+                {/if}
+            </div>
+            <div class="permissions-side permissions-side--server"
+                 data-testid="account-permissions-server">
+                <h4 class="permissions-side__heading">SourceMod</h4>
+                {if $server_permissions}
+                    <div class="permissions-grid permissions-grid--server">
+                        <section class="permissions-group"
+                                 data-testid="account-perm-cat-server"
+                                 data-perm-cat="server">
+                            <h5 class="permissions-group__title">Game-server flags</h5>
+                            <ul class="permissions-group__list">
+                                {foreach from=$server_permissions item=permission}
+                                    <li>{$permission}</li>
+                                {/foreach}
+                            </ul>
+                        </section>
+                    </div>
+                {else}
+                    <p class="permissions-empty"
+                       data-testid="account-permissions-server-empty">
+                        <em>No SourceMod flags granted.</em>
+                    </p>
+                {/if}
             </div>
         </div>
     </section>


### PR DESCRIPTION
## Summary

Slice 8 of #1207 — admin settings + myaccount layout. Addresses ADM-7 + ADM-9.

- **ADM-7** — Replaced the 3-column "Default / Remember me / Steam login" grid on the admin settings Authentication card with a `<fieldset>` + `<legend>`, stacking the three inputs vertically; each input now has its own labeled help paragraph wired via `aria-describedby` so the unit ("in minutes") and the meaning sit next to the input it qualifies, and the input clamps at 18rem so it visibly extends past its label.
- **ADM-9** — Replaced the flat 30-item "Your permissions" web list with `<section data-testid="account-perm-cat-<key>">` rows grouped by display category (Bans / Servers / Admins / Groups / Mods / Settings / Owner) via a new `Sbpp\View\PermissionCatalog::groupedDisplayFromMask()` helper. Layout: 1-column stack on mobile, 2-column grid at ≥1024px, 3-column at ≥1280px. The catalog is the single source of truth for the categorisation; an `ADMIN_*` constant in `web.json` that's missing from `WEB_CATEGORIES` fails `PermissionCatalogTest` so the gap can't ship silently.

## Notes

- `Sbpp\View\YourAccountView` swapped `web_permissions: false|list<string>` for `web_permissions_grouped: list<{key, label, perms}>`. Snapshot test (`YourAccountViewTest`) locks the published shape.
- `Perms::for` (gate snapshot) and `PermissionCatalog` (display structure) are explicitly two different surfaces — documented in `AGENTS.md` under a new "Permission display surfaces" Conventions entry, plus a "Where to find what" row.
- Delimiter list fix: `page_youraccount.tpl` was rewritten to standard `{ }` delimiters in #1123 B20; `AGENTS.md` + `ARCHITECTURE.md` still listed it under the `-{ … }-` override. Corrected to match the live `View::DELIMITERS` overrides (`page_login.tpl`, `page_blockit.tpl`, `page_kickit.tpl`, `admin.rcon.tpl`).

## Test plan

- [x] PHPStan clean (`./sbpp.sh phpstan`)
- [x] PHPUnit clean (`./sbpp.sh test` — 324 tests, +9 new across `PermissionCatalogTest` + `YourAccountViewTest`)
- [x] ts-check clean (`./sbpp.sh ts-check`)
- [x] API contract clean (`./sbpp.sh composer api-contract` — no diff, no handler changes)
- [x] Playwright E2E clean (`CI=1 ./sbpp.sh e2e` — 152 specs, +17 across `admin-settings-token-lifetimes.spec.ts` + `myaccount-permissions.spec.ts` on chromium + mobile-chromium; `axe` critical=0 on both surfaces)
- [x] Screenshot gallery regenerated (`SCREENSHOTS=1 CI=1 ./sbpp.sh e2e --grep @screenshot` — `myaccount.png` + `admin-settings.png` updated to reflect the redesign)
- [x] Manual: admin settings token-lifetimes inputs stack with inline help, each input wider than its label text, paragraphs sit below their inputs at every viewport. myaccount permissions render in 2 columns at 1024–1279px, 3 columns at ≥1280px, single column on mobile, with one `<section>` per granted category.

Does NOT close #1207.