### PR TITLE
fix(admin/admins): density rework — sticky ToC + single-submit search (#1207 slice 7)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -428,6 +428,50 @@ bearing assertion that the value is already safe HTML, so:
   Reuse this pattern — never call a third-party Markdown renderer
   client-side, as it would diverge from the safe-on-render contract.
 
+### Page-level table of contents (dense admin pages)
+
+Some admin routes (`admin-admins`, the audit pegged `admin-bans` and
+`myaccount` for the same shape) cram several semi-related surfaces
+onto one long scroll. The pattern locked in by #1207 ADM-3 is a
+sticky page-level ToC: anchor sidebar at `>=1024px`, accordion
+(`<details open>`) at `<1024px`, with each section anchored via a
+unique `id="…"` + `scroll-margin-top: 4rem` so jumps clear the
+sticky topbar (3.5rem).
+
+`admin-admins` is the reference shape (see `admin.admins.toc.tpl`,
+the `.admin-admins-shell` / `.admin-admins-toc` / `.admin-admins-section`
+rules in `theme.css`, and the `<section id="…" class="admin-admins-section"
+data-testid="admin-admins-section-…">` wrapping in
+`page_admin_admins_list.tpl` / `page_admin_admins_add.tpl` /
+`page_admin_overrides.tpl`):
+
+- The ToC partial is included **once**, from the first template
+  rendered for the route (here `page_admin_admins_list.tpl`). The
+  outer `.admin-admins-shell` wrapper opens there and closes at the
+  bottom of the **last** template (`page_admin_overrides.tpl`).
+  Document the tag pairing with a Smarty comment at each end so
+  edits don't silently break the layout.
+- Each section gets `<section id="…" class="<page>-section"
+  data-testid="<page>-section-…" aria-labelledby="…-heading">` plus
+  an `<h2 id="…-heading">` so screen-readers can navigate by
+  landmark name. Reuse the `*-section` class so all sections share
+  the `scroll-margin-top` rule.
+- Permission gates on ToC entries mirror what the dispatcher would
+  render anyway (e.g. `$can_add_admins` in `admin-admins`); a ToC
+  entry for a section the dispatcher wouldn't paint is a dead link.
+- Selectors for E2E specs are `[data-testid="<page>-toc"]` (outer
+  aside), `[data-testid="<page>-toc-link-<slug>"]` (per anchor),
+  and `[data-testid="<page>-section-<slug>"]` (per section). Never
+  CSS class chains; never visible-text-as-primary. The desktop
+  contract is "scrolls to the right section" — assert via
+  `expect(section).toBeInViewport()` after the click, not against
+  a fixed `boundingBox.y` because the **last** section can never
+  reach the top of the viewport (no document below it).
+
+When the next dense page (admin-bans, myaccount) adopts this
+pattern, lift the ToC partial into a parameterized shared template
+rather than duplicating `admin.admins.toc.tpl`.
+
 ### Empty states (`first-run` vs `filtered`)
 
 Empty surfaces follow one of two shapes; pick by whether the empty
@@ -547,6 +591,8 @@ audit (#1207) locked in. New CTAs:
 | Render admin-authored Markdown to safe HTML | `web/includes/Markup/IntroRenderer.php` (`Sbpp\Markup`) |
 | Live-preview Markdown in a settings textarea | `system.preview_intro_text` JSON action + `web/themes/default/page_admin_settings_settings.tpl` (`.dash-intro-editor` / `.dash-intro-preview`) |
 | Build an empty-state surface (first-run vs filtered, primary/secondary CTAs) | `.empty-state` rules in `web/themes/default/css/theme.css` + reference shapes in `page_servers.tpl`, `page_dashboard.tpl`, `page_bans.tpl`, `page_comms.tpl`, `page_admin_audit.tpl`, `page_admin_bans_protests.tpl`, `page_admin_bans_submissions.tpl` |
+| Add a sticky page-level ToC to a dense admin route (anchor sidebar at desktop, accordion at mobile) | `web/themes/default/admin.admins.toc.tpl` is the reference partial; `.admin-admins-shell` / `.admin-admins-toc` / `.admin-admins-section` rules in `web/themes/default/css/theme.css` carry the responsive layout. See the Conventions section "Page-level table of contents (dense admin pages)" (#1207 ADM-3). |
+| Add or rename an admin-admins advanced-search filter | `web/pages/admin.admins.php` (filter-building loop + active-filter map for pagination) + `web/pages/admin.admins.search.php` (DTO population) + `web/includes/View/AdminAdminsSearchView.php` (`active_filter_*` properties) + `web/themes/default/box_admin_admins_search.tpl` (input + pre-fill). The form is single-submit AND-semantics with a backward-compat shim for legacy `advType=…&advSearch=…` URLs (#1207 ADM-4); cover new filters in `web/tests/integration/AdminAdminsSearchTest.php`. |
 | Add a shared "1 of these required" badge for an either/or input pair | `web/themes/default/page_submitban.tpl` (`data-required-group="…"` + the inline guard script — vanilla JS `// @ts-check`, blocks submit when both are empty) |
 | Bootstrap (paths, autoload, theme)     | `web/init.php`                                           |
 | Routing (`?p=…&c=…&o=…`)               | `web/includes/page-builder.php` — unrecognised admin `c=…` returns the 404 page slot via `web/pages/page.404.php` + `Sbpp\View\NotFoundView` (#1207 ADM-1) |

--- a/web/includes/View/AdminAdminsSearchView.php
+++ b/web/includes/View/AdminAdminsSearchView.php
@@ -21,10 +21,19 @@ namespace Sbpp\View;
  * pulled in by `page_admin_admins_list.tpl` via the
  * `{load_template file="admin.admins.search"}` Smarty plugin.
  *
- * The form submits as a plain `GET` to
- * `?p=admin&c=admins&advSearch=…&advType=…`, which is the wire format
- * `web/pages/admin.admins.php` already parses. No CSRF field — search
- * is read-only.
+ * The form submits as a plain `GET` to `?p=admin&c=admins` with one
+ * parameter per populated filter (`name`, `steamid`, `steam_match`,
+ * `admemail`, `webgroup`, `srvadmgroup`, `srvgroup`, `admwebflag[]`,
+ * `admsrvflag[]`, `server`). admin.admins.php AND-combines every
+ * non-empty filter — see #1207 ADM-4. No CSRF field — search is
+ * read-only.
+ *
+ * `$active_filter_*` mirror the corresponding $_GET keys so the
+ * template can pre-fill the form without splattering
+ * `$smarty.get.X|default:''` everywhere; the page handler
+ * (admin.admins.search.php) is the only place that knows whether a
+ * given $_GET shape came from a modern submit, a legacy
+ * `advType=…&advSearch=…` URL, or nothing at all.
  */
 final class AdminAdminsSearchView extends View
 {
@@ -50,11 +59,16 @@ final class AdminAdminsSearchView extends View
      * @param list<array{name: string, flag: string}>     $admwebflag_list
      *     Web permission flags as {label, ADMIN_* constant name} pairs
      *     for the "Search by web permission" multi-select. Submitted as
-     *     a comma-joined `ADMIN_*` constant-name string the consumer
-     *     handler resolves with `constant()`.
+     *     repeated `admwebflag[]=ADMIN_*` parameters; the consumer
+     *     handler resolves each via `constant()`.
      * @param list<array{name: string, flag: string}>     $admsrvflag_list
      *     SourceMod permission flags as {label, SM_* constant name}
      *     pairs for the "Search by server permission" multi-select.
+     * @param list<string> $active_filter_admwebflag Pre-filled
+     *     `admwebflag[]` values; the template `in_array`s against this
+     *     to mark the matching `<option selected>` rows.
+     * @param list<string> $active_filter_admsrvflag Pre-filled
+     *     `admsrvflag[]` values.
      */
     public function __construct(
         public readonly bool $can_editadmin,
@@ -65,6 +79,16 @@ final class AdminAdminsSearchView extends View
         public readonly array $srvgroup_list,
         public readonly array $admwebflag_list,
         public readonly array $admsrvflag_list,
+        public readonly string $active_filter_name = '',
+        public readonly string $active_filter_steamid = '',
+        public readonly string $active_filter_steam_match = '0',
+        public readonly string $active_filter_admemail = '',
+        public readonly string $active_filter_webgroup = '',
+        public readonly string $active_filter_srvadmgroup = '',
+        public readonly string $active_filter_srvgroup = '',
+        public readonly string $active_filter_server = '',
+        public readonly array $active_filter_admwebflag = [],
+        public readonly array $active_filter_admsrvflag = [],
     ) {
     }
 }

--- a/web/pages/admin.admins.php
+++ b/web/pages/admin.admins.php
@@ -31,114 +31,236 @@ new AdminTabs([
 
 $AdminsPerPage = SB_BANS_PER_PAGE;
 $page = 1;
-$join = "";
-$where = "";
-$whereParams = [];
-$advSearchString = "";
 if (isset($_GET['page']) && $_GET['page'] > 0) {
     $page = intval($_GET['page']);
 }
-if (isset($_GET['advSearch'])) {
-    $value = $_GET['advSearch'];
-    $type = $_GET['advType'];
-    switch ($type) {
-        case "name":
-            $where = " AND ADM.user LIKE ?";
-            $whereParams[] = '%' . $value . '%';
-            break;
-        case "steamid":
-            $where = " AND ADM.authid = ?";
-            $whereParams[] = $value;
-            break;
-        case "steam":
-            $where = " AND ADM.authid LIKE ?";
-            $whereParams[] = '%' . $value . '%';
-            break;
-        case "admemail":
-            $where = " AND ADM.email LIKE ?";
-            $whereParams[] = '%' . $value . '%';
-            break;
-        case "webgroup":
-            $where = " AND ADM.gid = ?";
-            $whereParams[] = $value;
-            break;
-        case "srvadmgroup":
-            $where = " AND ADM.srv_group = ?";
-            $whereParams[] = $value;
-            break;
-        case "srvgroup":
-            $where = " AND SG.srv_group_id = ?";
-            $whereParams[] = $value;
-            $join = " LEFT JOIN `" . DB_PREFIX . "_admins_servers_groups` AS SG ON SG.admin_id = ADM.aid";
-            break;
-        case "admwebflag":
-            $findflags = explode(",", $value);
-            foreach ($findflags as $flag) {
-                $flags[] = constant($flag);
-            }
-            $flagstring = implode('|', $flags);
-            $alladmins = $GLOBALS['PDO']->query("SELECT aid FROM `:prefix_admins` WHERE aid > 0")->resultset();
-            $accessAids = [];
-            foreach ($alladmins as $row) {
-                if ($userbank->HasAccess($flagstring, $row['aid'])) {
-                    $accessAids[] = (int) $row['aid'];
-                }
-            }
-            if (empty($accessAids)) {
-                $where = " AND 0";
-            } else {
-                $placeholders = implode(',', array_fill(0, count($accessAids), '?'));
-                $where = " AND ADM.aid IN($placeholders)";
-                $whereParams = array_merge($whereParams, $accessAids);
+
+/*
+ * #1207 ADM-4: collapse the eight per-row Search buttons into one
+ * combined filter form and AND the populated filters server-side.
+ *
+ * The new wire format reads each filter from its own query parameter
+ * (`name`, `steamid`, `steam_match`, `admemail`, `webgroup`,
+ * `srvadmgroup`, `srvgroup`, `admwebflag[]`, `admsrvflag[]`, `server`)
+ * so a single GET submit carries the full filter snapshot. URL-shareable
+ * searches are preserved by the legacy-shim block below: any incoming
+ * `?advType=…&advSearch=…` is translated into the new shape so old
+ * bookmarks and cross-page links keep working.
+ *
+ * Server-side filters are AND-combined: a request with two non-empty
+ * filters narrows to admins matching both, which matches the typical
+ * search-UI mental model the audit called out (an admin in group X
+ * AND with permission Y). The pre-fix shape only honoured one filter
+ * at a time and silently dropped the rest.
+ */
+$where        = "";
+$whereParams  = [];
+$joinAdminsServersGroups = false;
+$joinServersGroups       = false;
+/** @var array<string, string|list<string>> $activeFilters */
+$activeFilters = [];
+
+// Legacy `advType=…&advSearch=…` URLs still flow through any external
+// links / bookmarks. Translate them into the modern shape so the rest
+// of this handler operates on a single, consistent input source.
+if (isset($_GET['advType']) && isset($_GET['advSearch']) && $_GET['advSearch'] !== '') {
+    /** @var string $legacyType */
+    $legacyType  = (string) $_GET['advType'];
+    /** @var string $legacyValue */
+    $legacyValue = (string) $_GET['advSearch'];
+    switch ($legacyType) {
+        case 'name':
+        case 'admemail':
+        case 'webgroup':
+        case 'srvadmgroup':
+        case 'srvgroup':
+        case 'server':
+        case 'steamid':
+            if (!isset($_GET[$legacyType]) || $_GET[$legacyType] === '') {
+                $_GET[$legacyType] = $legacyValue;
             }
             break;
-        case "admsrvflag":
-            $findflags = explode(",", $value);
-            foreach ($findflags as $flag) {
-                $flags[] = constant($flag);
-            }
-            $alladmins = $GLOBALS['PDO']->query("SELECT aid, authid FROM `:prefix_admins` WHERE aid > 0")->resultset();
-            $accessAids = [];
-            foreach ($alladmins as $row) {
-                $matched = false;
-                foreach ($flags as $fla) {
-                    if ($userbank->HasAccess($fla, $row['authid'])) {
-                        $matched = true;
-                        break;
-                    }
-                }
-                if (!$matched && $userbank->HasAccess(SM_ROOT, $row['authid'])) {
-                    $matched = true;
-                }
-                if ($matched) {
-                    $accessAids[] = (int) $row['aid'];
-                }
-            }
-            if (empty($accessAids)) {
-                $where = " AND 0";
-            } else {
-                $placeholders = implode(',', array_fill(0, count($accessAids), '?'));
-                $where = " AND ADM.aid IN($placeholders)";
-                $whereParams = array_merge($whereParams, $accessAids);
+        case 'steam':
+            // The legacy form distinguished exact (`steamid`) from
+            // partial (`steam`) matches as two distinct advTypes. The
+            // modern form folds both onto `steamid` + `steam_match`.
+            if (!isset($_GET['steamid']) || $_GET['steamid'] === '') {
+                $_GET['steamid']     = $legacyValue;
+                $_GET['steam_match'] = '1';
             }
             break;
-        case "server":
-            $where = " AND (ASG.server_id = ? OR SG.server_id = ?)";
-            $whereParams[] = $value;
-            $whereParams[] = $value;
-            $join = " LEFT JOIN `" . DB_PREFIX . "_admins_servers_groups` AS ASG ON ASG.admin_id = ADM.aid LEFT JOIN `" . DB_PREFIX . "_servers_groups` AS SG ON SG.group_id = ASG.srv_group_id";
-            break;
-        default:
-            $_GET['advSearch'] = "";
-            $_GET['advType'] = "";
-            $where = "";
+        case 'admwebflag':
+        case 'admsrvflag':
+            if (!isset($_GET[$legacyType]) || $_GET[$legacyType] === '' || (is_array($_GET[$legacyType]) && empty($_GET[$legacyType]))) {
+                $_GET[$legacyType] = explode(',', $legacyValue);
+            }
             break;
     }
-        $advSearchString = "&advSearch=".$_GET['advSearch']."&advType=".$_GET['advType'];
 }
+
+// 1) Login name (substring against ADM.user).
+if (!empty($_GET['name']) && is_string($_GET['name'])) {
+    $where                  .= " AND ADM.user LIKE ?";
+    $whereParams[]           = '%' . $_GET['name'] . '%';
+    $activeFilters['name']   = (string) $_GET['name'];
+}
+
+// 2) Steam ID (exact or partial against ADM.authid).
+if (!empty($_GET['steamid']) && is_string($_GET['steamid'])) {
+    $partial = isset($_GET['steam_match']) && (string) $_GET['steam_match'] === '1';
+    if ($partial) {
+        $where        .= " AND ADM.authid LIKE ?";
+        $whereParams[] = '%' . $_GET['steamid'] . '%';
+    } else {
+        $where        .= " AND ADM.authid = ?";
+        $whereParams[] = $_GET['steamid'];
+    }
+    $activeFilters['steamid']     = (string) $_GET['steamid'];
+    $activeFilters['steam_match'] = $partial ? '1' : '0';
+}
+
+// 3) E-mail (substring, gated on the same flag the search box gates the
+// input field on so URL forgery can't bypass the visibility gate).
+if (!empty($_GET['admemail']) && is_string($_GET['admemail']) && $userbank->HasAccess(ADMIN_OWNER | ADMIN_EDIT_ADMINS)) {
+    $where                       .= " AND ADM.email LIKE ?";
+    $whereParams[]                = '%' . $_GET['admemail'] . '%';
+    $activeFilters['admemail']    = (string) $_GET['admemail'];
+}
+
+// 4) Web group (`:prefix_groups.gid` -> `:prefix_admins.gid`).
+if (!empty($_GET['webgroup']) && is_scalar($_GET['webgroup'])) {
+    $where                       .= " AND ADM.gid = ?";
+    $whereParams[]                = (int) $_GET['webgroup'];
+    $activeFilters['webgroup']    = (string) $_GET['webgroup'];
+}
+
+// 5) SourceMod admin group (matched by name against ADM.srv_group).
+if (!empty($_GET['srvadmgroup']) && is_string($_GET['srvadmgroup'])) {
+    $where                          .= " AND ADM.srv_group = ?";
+    $whereParams[]                   = $_GET['srvadmgroup'];
+    $activeFilters['srvadmgroup']    = $_GET['srvadmgroup'];
+}
+
+// 6) Server group (`:prefix_groups.gid` -> `:prefix_admins_servers_groups.srv_group_id`).
+if (!empty($_GET['srvgroup']) && is_scalar($_GET['srvgroup'])) {
+    $joinAdminsServersGroups       = true;
+    $where                        .= " AND ASG.srv_group_id = ?";
+    $whereParams[]                 = (int) $_GET['srvgroup'];
+    $activeFilters['srvgroup']     = (string) $_GET['srvgroup'];
+}
+
+// 7) Web permission flags (multi). Submitted as either `admwebflag[]=X&admwebflag[]=Y`
+// or the legacy comma-joined string. Resolve each name to its bit and
+// OR-combine into a single bitmask, then narrow ADM.aid to admins with
+// access — same per-admin permission probe the legacy code used.
+$rawWebFlags = $_GET['admwebflag'] ?? null;
+if (is_string($rawWebFlags)) {
+    $rawWebFlags = explode(',', $rawWebFlags);
+}
+if (is_array($rawWebFlags)) {
+    /** @var list<string> $webFlagNames */
+    $webFlagNames = [];
+    foreach ($rawWebFlags as $candidate) {
+        if (is_string($candidate) && preg_match('/^ADMIN_[A-Z_]+$/', $candidate) && defined($candidate)) {
+            $webFlagNames[] = $candidate;
+        }
+    }
+    if (!empty($webFlagNames)) {
+        $flagBits = array_map(fn(string $name): int => (int) constant($name), $webFlagNames);
+        $flagstring = implode('|', $flagBits);
+        $alladmins = $GLOBALS['PDO']->query("SELECT aid FROM `:prefix_admins` WHERE aid > 0")->resultset();
+        $accessAids = [];
+        foreach ($alladmins as $row) {
+            if ($userbank->HasAccess($flagstring, $row['aid'])) {
+                $accessAids[] = (int) $row['aid'];
+            }
+        }
+        if (empty($accessAids)) {
+            $where .= " AND 0";
+        } else {
+            $placeholders  = implode(',', array_fill(0, count($accessAids), '?'));
+            $where        .= " AND ADM.aid IN($placeholders)";
+            $whereParams   = array_merge($whereParams, $accessAids);
+        }
+        $activeFilters['admwebflag'] = $webFlagNames;
+    }
+}
+
+// 8) Server permission flags (multi).
+$rawSrvFlags = $_GET['admsrvflag'] ?? null;
+if (is_string($rawSrvFlags)) {
+    $rawSrvFlags = explode(',', $rawSrvFlags);
+}
+if (is_array($rawSrvFlags)) {
+    /** @var list<string> $srvFlagNames */
+    $srvFlagNames = [];
+    foreach ($rawSrvFlags as $candidate) {
+        if (is_string($candidate) && preg_match('/^SM_[A-Z_]+$/', $candidate) && defined($candidate)) {
+            $srvFlagNames[] = $candidate;
+        }
+    }
+    if (!empty($srvFlagNames)) {
+        $flagBits = array_map(fn(string $name): int => (int) constant($name), $srvFlagNames);
+        $alladmins = $GLOBALS['PDO']->query("SELECT aid, authid FROM `:prefix_admins` WHERE aid > 0")->resultset();
+        $accessAids = [];
+        foreach ($alladmins as $row) {
+            $matched = false;
+            foreach ($flagBits as $fla) {
+                if ($userbank->HasAccess($fla, $row['authid'])) {
+                    $matched = true;
+                    break;
+                }
+            }
+            if (!$matched && $userbank->HasAccess(SM_ROOT, $row['authid'])) {
+                $matched = true;
+            }
+            if ($matched) {
+                $accessAids[] = (int) $row['aid'];
+            }
+        }
+        if (empty($accessAids)) {
+            $where .= " AND 0";
+        } else {
+            $placeholders  = implode(',', array_fill(0, count($accessAids), '?'));
+            $where        .= " AND ADM.aid IN($placeholders)";
+            $whereParams   = array_merge($whereParams, $accessAids);
+        }
+        $activeFilters['admsrvflag'] = $srvFlagNames;
+    }
+}
+
+// 9) Server (`:prefix_servers.sid`). Either via direct admin->server
+// access (`ASG.server_id`) or via the server's group attachment
+// (`SGS.server_id`). Reuses the ASG join above when "server group" is
+// also active so the WHERE still ANDs cleanly.
+if (!empty($_GET['server']) && is_scalar($_GET['server'])) {
+    $joinAdminsServersGroups   = true;
+    $joinServersGroups         = true;
+    $where                    .= " AND (ASG.server_id = ? OR SGS.server_id = ?)";
+    $whereParams[]             = (int) $_GET['server'];
+    $whereParams[]             = (int) $_GET['server'];
+    $activeFilters['server']   = (string) $_GET['server'];
+}
+
+$join = "";
+if ($joinAdminsServersGroups) {
+    $join .= " LEFT JOIN `:prefix_admins_servers_groups` AS ASG ON ASG.admin_id = ADM.aid";
+}
+if ($joinServersGroups) {
+    $join .= " LEFT JOIN `:prefix_servers_groups` AS SGS ON SGS.group_id = ASG.srv_group_id";
+}
+
+// Pagination needs the active-filter snapshot baked into every "next"
+// page link so subsequent navigation preserves the search.
+// `http_build_query` handles array values (`admwebflag[]=…&admwebflag[]=…`)
+// natively, so multi-select filters round-trip without manual joining.
+$advSearchString = empty($activeFilters) ? '' : '&' . http_build_query($activeFilters);
 $admins = $GLOBALS['PDO']->query("SELECT * FROM `:prefix_admins` AS ADM".$join." WHERE ADM.aid > 0".$where." ORDER BY user LIMIT " . intval(($page-1) * $AdminsPerPage) . "," . intval($AdminsPerPage))->resultset($whereParams);
-// quick fix for the server search showing admins mulitple times.
-if (isset($_GET['advSearch']) && isset($_GET['advType']) && $_GET['advType'] == 'server') {
+// The server filter joins through `:prefix_admins_servers_groups` and
+// `:prefix_servers_groups`, which can produce duplicate ADM.aid rows
+// when an admin reaches the same server via multiple paths. Dedupe
+// here to keep the rendered list one-row-per-admin.
+if (isset($activeFilters['server'])) {
     $aadm = [];
     $num = 0;
     foreach ($admins as $aadmin) {
@@ -223,12 +345,23 @@ if (strlen($next) > 0) {
 
 $pages = ceil($admin_count / $AdminsPerPage);
 if ($pages > 1) {
-    // Issue #1113: see page.banlist.php for the layered-escape rationale.
-    $advSearchJs = htmlspecialchars(addslashes((string)($_GET['advSearch'] ?? '')), ENT_QUOTES, 'UTF-8');
-    $advTypeJs   = htmlspecialchars(addslashes((string)($_GET['advType']   ?? '')), ENT_QUOTES, 'UTF-8');
-    $admin_nav .= '&nbsp;<select onchange="changePage(this,\'A\',\'' . $advSearchJs . '\',\'' . $advTypeJs . '\');">';
+    // The dropdown's `onchange` navigates to the keyed page directly.
+    // The legacy code reached for `changePage(this, 'A', advSearch,
+    // advType)` from `sourcebans.js`, but the bulk file was removed at
+    // #1123 D1 — clicking the picker therefore raised `ReferenceError`
+    // on origin/main. Inline a vanilla snippet that builds the URL
+    // from the same `$advSearchString` the prev/next links use, so the
+    // multi-filter snapshot round-trips through the picker too.
+    //
+    // `htmlspecialchars` on the base URL is what stops the ADM-4
+    // multi-filter `&admwebflag[]=…` from breaking out of the
+    // attribute string.
+    $baseUrl    = 'index.php?p=admin&c=admins' . $advSearchString . '&page=';
+    $baseUrlAttr = htmlspecialchars($baseUrl, ENT_QUOTES, 'UTF-8');
+    $admin_nav .= '&nbsp;<select onchange="window.location.href=\'' . $baseUrlAttr . '\'+encodeURIComponent(this.value);"'
+        . ' aria-label="Jump to page">';
     for ($i = 1; $i <= $pages; $i++) {
-        if (isset($_GET['page']) && $i === $_GET['page']) {
+        if (isset($_GET['page']) && $i === (int) $_GET['page']) {
             $admin_nav .= '<option value="' . $i . '" selected="selected">' . $i . '</option>';
             continue;
         }

--- a/web/pages/admin.admins.search.php
+++ b/web/pages/admin.admins.search.php
@@ -139,13 +139,62 @@ $serverflag = [
     ['name' => 'Custom flag 6',  'flag' => 'SM_CUSTOM6'],
 ];
 
+/*
+ * #1207 ADM-4: pre-fill every input from the URL so the form reflects
+ * the request that produced the visible result list. admin.admins.php
+ * runs the legacy `advType=…&advSearch=…` shim before this file is
+ * loaded, so reading `$_GET` here picks up modern submits *and*
+ * translated legacy URLs in the same shape.
+ *
+ * Multi-select filters accept either the legacy comma-joined string
+ * (`?admwebflag=ADMIN_OWNER,ADMIN_LIST_ADMINS`, the pre-fix wire
+ * shape) or the new repeated-key array (`?admwebflag[]=ADMIN_OWNER&…`).
+ * Both are normalised to a list of validated constant names; the
+ * template uses `in_array` to mark the matching option rows.
+ */
+$rawWebFlag = $_GET['admwebflag'] ?? null;
+if (is_string($rawWebFlag)) {
+    $rawWebFlag = explode(',', $rawWebFlag);
+}
+$activeWebFlags = [];
+if (is_array($rawWebFlag)) {
+    foreach ($rawWebFlag as $f) {
+        if (is_string($f) && preg_match('/^ADMIN_[A-Z_]+$/', $f)) {
+            $activeWebFlags[] = $f;
+        }
+    }
+}
+
+$rawSrvFlag = $_GET['admsrvflag'] ?? null;
+if (is_string($rawSrvFlag)) {
+    $rawSrvFlag = explode(',', $rawSrvFlag);
+}
+$activeSrvFlags = [];
+if (is_array($rawSrvFlag)) {
+    foreach ($rawSrvFlag as $f) {
+        if (is_string($f) && preg_match('/^SM_[A-Z_]+$/', $f)) {
+            $activeSrvFlags[] = $f;
+        }
+    }
+}
+
 \Sbpp\View\Renderer::render($theme, new \Sbpp\View\AdminAdminsSearchView(
-    can_editadmin:    $userbank->HasAccess(ADMIN_EDIT_ADMINS | ADMIN_OWNER),
-    server_list:      $servers,
-    server_script:    $serverscript,
-    webgroup_list:    $webgroups,
-    srvadmgroup_list: $srvadmgroups,
-    srvgroup_list:    $srvgroups,
-    admwebflag_list:  $webflag,
-    admsrvflag_list:  $serverflag,
+    can_editadmin:             $userbank->HasAccess(ADMIN_EDIT_ADMINS | ADMIN_OWNER),
+    server_list:               $servers,
+    server_script:             $serverscript,
+    webgroup_list:             $webgroups,
+    srvadmgroup_list:          $srvadmgroups,
+    srvgroup_list:             $srvgroups,
+    admwebflag_list:           $webflag,
+    admsrvflag_list:           $serverflag,
+    active_filter_name:        is_string($_GET['name']        ?? null) ? (string) $_GET['name']        : '',
+    active_filter_steamid:     is_string($_GET['steamid']     ?? null) ? (string) $_GET['steamid']     : '',
+    active_filter_steam_match: is_scalar($_GET['steam_match'] ?? null) ? (string) $_GET['steam_match'] : '0',
+    active_filter_admemail:    is_string($_GET['admemail']    ?? null) ? (string) $_GET['admemail']    : '',
+    active_filter_webgroup:    is_scalar($_GET['webgroup']    ?? null) ? (string) $_GET['webgroup']    : '',
+    active_filter_srvadmgroup: is_string($_GET['srvadmgroup'] ?? null) ? (string) $_GET['srvadmgroup'] : '',
+    active_filter_srvgroup:    is_scalar($_GET['srvgroup']    ?? null) ? (string) $_GET['srvgroup']    : '',
+    active_filter_server:      is_scalar($_GET['server']      ?? null) ? (string) $_GET['server']      : '',
+    active_filter_admwebflag:  $activeWebFlags,
+    active_filter_admsrvflag:  $activeSrvFlags,
 ));

--- a/web/tests/e2e/pages/admin/AdminAdmins.ts
+++ b/web/tests/e2e/pages/admin/AdminAdmins.ts
@@ -10,6 +10,12 @@ import { BasePage } from '../_base.ts';
  * `$can_list_admins`; the seeded admin holds OWNER so the `<span
  * data-testid="admin-count">` lands unconditionally — that's the
  * stable terminal mark we wait on.
+ *
+ * #1207 ADM-3 / ADM-4 hooks
+ * -------------------------
+ * The page-level ToC and the rebuilt single-submit advanced search
+ * box expose stable testids; pin them on the page object so flow
+ * specs don't have to rebuild the selector tree.
  */
 export class AdminAdminsPage extends BasePage {
     constructor(page: Page) {
@@ -19,6 +25,56 @@ export class AdminAdminsPage extends BasePage {
     readonly path = '/index.php?p=admin&c=admins';
 
     get pageMounted(): Locator {
+        return this.page.locator('[data-testid="admin-count"]');
+    }
+
+    /** ADM-3 — outer page wrapper that hosts the sticky ToC sidebar. */
+    get shell(): Locator {
+        return this.page.locator('[data-testid="admin-admins-shell"]');
+    }
+
+    /** ADM-3 — the page-level ToC (anchor sidebar / accordion). */
+    get toc(): Locator {
+        return this.page.locator('[data-testid="admin-admins-toc"]');
+    }
+
+    /** ADM-3 — single ToC link by section key. */
+    tocLink(section: 'search' | 'admins' | 'add-admin' | 'overrides' | 'add-override'): Locator {
+        return this.page.locator(`[data-testid="admin-admins-toc-link-${section}"]`);
+    }
+
+    /** ADM-3 — anchored section by key (matches the link slugs above). */
+    section(section: 'search' | 'admins' | 'add-admin' | 'overrides' | 'add-override'): Locator {
+        return this.page.locator(`[data-testid="admin-admins-section-${section}"]`);
+    }
+
+    /** ADM-4 — the (single) advanced-search form. */
+    get searchForm(): Locator {
+        return this.page.locator('[data-testid="search-admins-form"]');
+    }
+
+    /** ADM-4 — the (single) submit button at the bottom of the form. */
+    get searchSubmit(): Locator {
+        return this.page.locator('[data-testid="search-admins-submit"]');
+    }
+
+    /** ADM-4 — the "Clear filters" reset link. */
+    get searchReset(): Locator {
+        return this.page.locator('[data-testid="search-admins-reset"]');
+    }
+
+    /** ADM-4 — pre-filled inputs by name. */
+    searchInput(field: 'name' | 'steamid' | 'admemail' | 'webgroup' | 'srvadmgroup' | 'srvgroup' | 'admwebflag' | 'admsrvflag' | 'server'): Locator {
+        return this.page.locator(`[data-testid="search-admins-${field}"]`);
+    }
+
+    /** Per-row admin entries in the table — count via `.count()`. */
+    get adminRows(): Locator {
+        return this.page.locator('[data-testid="admin-row"]');
+    }
+
+    /** "(N)" headcount span next to the Admins H1. */
+    get adminCount(): Locator {
         return this.page.locator('[data-testid="admin-count"]');
     }
 

--- a/web/tests/e2e/specs/flows/admin-admins-density.spec.ts
+++ b/web/tests/e2e/specs/flows/admin-admins-density.spec.ts
@@ -1,0 +1,217 @@
+/**
+ * #1207 ADM-3 + ADM-4 — admin/admins page density rework.
+ *
+ * Two findings, one slice:
+ *
+ *   - **ADM-3** — the admin/admins route stacks search + admins list
+ *     + add admin + overrides + add override on one long scroll. We
+ *     paint a sticky page-level ToC at >=1024px (anchor sidebar) and
+ *     an accordion ToC at <1024px so users can jump directly to
+ *     "Add admin" or "Overrides" without paging past the search and
+ *     listing.
+ *   - **ADM-4** — the advanced-search box used to ship 8 separate
+ *     Search buttons, each submitting one filter at a time. The
+ *     redesign collapses that to a single submit; admin.admins.php
+ *     ANDs the populated filters server-side. Legacy
+ *     `?advType=…&advSearch=…` URLs still narrow correctly via a
+ *     compatibility shim in the page handler (see
+ *     web/tests/integration/AdminAdminsSearchTest.php for the
+ *     server-side AND-semantics lock).
+ *
+ * Selector discipline
+ * -------------------
+ * Anchors are `data-testid` from the locked hooks in
+ * page_admin_admins_list.tpl, admin.admins.toc.tpl,
+ * box_admin_admins_search.tpl. Project-default storage state runs
+ * the spec as the seeded admin/admin (owner). Where this spec asserts
+ * an "in viewport after click" relationship we use Playwright's
+ * `boundingBox()` against the layout viewport rather than CSS
+ * intersection observer probes — works for both the desktop scroll
+ * shell and the mobile root scroll.
+ */
+
+import { expect, test } from '../../fixtures/auth.ts';
+import { AdminAdminsPage } from '../../pages/admin/AdminAdmins.ts';
+
+test.describe('flow: admin/admins density rework (#1207 ADM-3, ADM-4)', () => {
+
+    // ----- ADM-3 — desktop sticky anchor sidebar ----------------------
+
+    test('ADM-3 desktop: sticky anchor sidebar visible and ToC links scroll to sections', async ({ page }, testInfo) => {
+        test.skip(testInfo.project.name !== 'chromium', 'Sticky-sidebar contract is desktop-only.');
+
+        const p = new AdminAdminsPage(page);
+        await p.goto();
+        await expect(p.pageMounted).toBeVisible();
+        await expect(p.shell).toBeVisible();
+        await expect(p.toc).toBeVisible();
+
+        // Each ToC link must be present + anchored at the matching
+        // section. Tap each and assert: URL.hash flips + the section
+        // sits inside the layout viewport via boundingBox. We don't
+        // pin the section to the top because the *last* section
+        // (#add-override) can never reach the top — there isn't
+        // enough document below it to scroll it up. The contract is
+        // "scrolls to the right section", i.e. the section is now
+        // intersecting the viewport, not "section is at y=64".
+        for (const section of ['search', 'admins', 'add-admin', 'overrides', 'add-override'] as const) {
+            const link = p.tocLink(section);
+            await expect(link).toBeVisible();
+            await link.click();
+
+            await expect(page).toHaveURL(new RegExp(`#${section}$`));
+
+            const target = p.section(section);
+            // Wait for the anchor scroll to settle. `prefers-reduced-motion`
+            // is set globally so this is essentially synchronous; we
+            // still poll because the click + hash + scroll trio is
+            // microtask-ordered and `boundingBox()` runs against the
+            // post-paint geometry.
+            await expect(target).toBeInViewport();
+
+            const targetBox = await target.boundingBox();
+            const viewport = page.viewportSize();
+            expect(targetBox).not.toBeNull();
+            expect(viewport).not.toBeNull();
+            if (targetBox && viewport) {
+                // The section's bounding box must overlap the viewport:
+                // top edge above the bottom AND bottom edge below the top.
+                expect(targetBox.y).toBeLessThan(viewport.height);
+                expect(targetBox.y + targetBox.height).toBeGreaterThan(0);
+            }
+        }
+    });
+
+    // ----- ADM-3 — mobile accordion ToC -------------------------------
+
+    test('ADM-3 mobile: accordion ToC visible and tapping a row scrolls', async ({ page }, testInfo) => {
+        test.skip(testInfo.project.name !== 'mobile-chromium', 'Accordion contract is mobile-only.');
+
+        const p = new AdminAdminsPage(page);
+        await p.goto();
+        await expect(p.pageMounted).toBeVisible();
+        await expect(p.toc).toBeVisible();
+
+        // The mobile chrome is `<details open>` so the link list is
+        // visible without an extra tap. Pin the accordion summary
+        // *contains* the canonical "On this page" label so we don't
+        // tie the test to icon swaps. The summary itself must be
+        // tappable (not the desktop `display: none`).
+        const summary = p.toc.locator('summary');
+        await expect(summary).toBeVisible();
+        await expect(summary).toContainText(/On this page/i);
+
+        // Tap "Add admin" — page must scroll the section into view.
+        await p.tocLink('add-admin').click();
+        await expect(page).toHaveURL(/#add-admin$/);
+        await expect(p.section('add-admin')).toBeInViewport();
+    });
+
+    // ----- ADM-4 — single-submit search -------------------------------
+
+    test('ADM-4: single Search submit AND-combines filters in one navigation', async ({ page }, testInfo) => {
+        test.skip(testInfo.project.name !== 'chromium', 'Filter contract is desktop-only; mobile reuses the same form.');
+
+        const p = new AdminAdminsPage(page);
+        await p.goto();
+
+        // Exactly one Search submit + one reset link, sitting at the
+        // bottom of the form (collapsing 8 per-row buttons was the
+        // headline of ADM-4).
+        await expect(p.searchSubmit).toHaveCount(1);
+        await expect(p.searchReset).toHaveCount(1);
+
+        // Pre-filter: confirm the seeded admin row is there before we
+        // submit. This protects against a regression where the page
+        // misroutes the request and "0 rows" lands as a false positive.
+        await expect(p.adminCount).toContainText(/^\(\d+\)$/);
+        const baselineCount = await p.adminRows.count();
+        expect(baselineCount).toBeGreaterThanOrEqual(1);
+
+        // Two filters at once: a deliberately not-matching login
+        // ("zzznoadminmatchesthis") + a steam_match=1 (partial). The
+        // login filter narrows the result list to zero — locking the
+        // server-side AND contract — while still emitting both
+        // filters on the wire so we can assert two-param submission.
+        await p.searchInput('name').fill('zzznoadminmatchesthis');
+        await page.locator('[data-testid="search-admins-steam-match"]').selectOption('1');
+
+        // Single submit → single document navigation. Capture every
+        // document-level request kicked off after we click submit so
+        // we can assert exactly-one navigation (collapsing the
+        // 8-button-per-row chrome into one).
+        const requests: string[] = [];
+        page.on('request', (req) => {
+            if (req.resourceType() === 'document') requests.push(req.url());
+        });
+        await Promise.all([
+            page.waitForURL((url) => url.searchParams.get('name') === 'zzznoadminmatchesthis'),
+            p.searchSubmit.click(),
+        ]);
+
+        const url = new URL(page.url());
+        expect(url.searchParams.get('name')).toBe('zzznoadminmatchesthis');
+        expect(url.searchParams.get('steam_match')).toBe('1');
+        const submitNavs = requests.filter(
+            (u) => u.includes('p=admin') && u.includes('c=admins') && u.includes('name=zzznoadminmatchesthis'),
+        );
+        expect(submitNavs).toHaveLength(1);
+
+        // The result must show 0 rows — the login filter has no
+        // matches, so AND with anything else is empty too. Locks the
+        // server-side AND contract end-to-end. The PHPUnit suite
+        // covers the matrix of multi-filter cases; we only need
+        // ONE wire-level proof here that the form fires once and
+        // the server narrows correctly.
+        await expect(p.adminCount).toContainText('(0)');
+        await expect(p.adminRows).toHaveCount(0);
+    });
+
+    // ----- ADM-4 — pre-fill from URL on revisit ------------------------
+
+    test('ADM-4: filters round-trip through the URL on revisit', async ({ page }, testInfo) => {
+        test.skip(testInfo.project.name !== 'chromium', 'Pre-fill contract is project-agnostic; pinning to desktop for runtime.');
+
+        const p = new AdminAdminsPage(page);
+        await page.goto('/index.php?p=admin&c=admins&name=admin&steamid=STEAM_0:0:0&steam_match=1');
+        await expect(p.pageMounted).toBeVisible();
+
+        // The form re-paints from `$active_filter_*` on the View
+        // DTO; values land in the inputs without JS assistance.
+        await expect(p.searchInput('name')).toHaveValue('admin');
+        await expect(p.searchInput('steamid')).toHaveValue('STEAM_0:0:0');
+        const matchSelect = page.locator('[data-testid="search-admins-steam-match"]');
+        await expect(matchSelect).toHaveValue('1');
+    });
+
+    // ----- ADM-4 — Clear filters resets form state --------------------
+
+    test('ADM-4: Clear filters wipes every populated field', async ({ page }, testInfo) => {
+        test.skip(testInfo.project.name !== 'chromium', 'Reset link is project-agnostic; pinning to desktop for runtime.');
+
+        const p = new AdminAdminsPage(page);
+        await page.goto('/index.php?p=admin&c=admins&name=admin');
+        await expect(p.searchInput('name')).toHaveValue('admin');
+
+        await p.searchReset.click();
+        await page.waitForURL((url) => !url.search.includes('name='));
+        await expect(p.searchInput('name')).toHaveValue('');
+    });
+
+    // ----- ADM-3 — Add admin CTA in the page header anchors -----------
+
+    test('ADM-3: header "Add admin" CTA scrolls to the Add admin section', async ({ page }, testInfo) => {
+        test.skip(testInfo.project.name !== 'chromium', 'In-page anchor is project-agnostic; pinning to desktop for runtime.');
+
+        const p = new AdminAdminsPage(page);
+        await p.goto();
+
+        const cta = page.locator('[data-testid="admin-add-cta"]');
+        await expect(cta).toBeVisible();
+        await expect(cta).toHaveAttribute('href', '#add-admin');
+        await cta.click();
+
+        await expect(page).toHaveURL(/#add-admin$/);
+        await expect(p.section('add-admin')).toBeInViewport();
+    });
+});

--- a/web/tests/integration/AdminAdminsSearchTest.php
+++ b/web/tests/integration/AdminAdminsSearchTest.php
@@ -241,6 +241,88 @@ final class AdminAdminsSearchTest extends ApiTestCase
         $this->assertStringContainsString('>charlie<', $html, 'charlie has ADMIN_OWNER');
     }
 
+    /**
+     * Structural invariant for #1207 ADM-3: every ToC link in the
+     * rendered HTML must point at an anchored `<section>` that's
+     * actually in the DOM. The slicing brief calls this out
+     * explicitly: "The ToC entries are gated on the same permissions
+     * the dispatcher uses (no dead links)." This case locks the
+     * happy path (owner sees every entry; every entry has its
+     * matching section); the next case locks the gated path (an
+     * admin without LIST_ADMINS doesn't see Search/Admins links).
+     */
+    public function testTocLinksMatchRenderedSectionsForOwner(): void
+    {
+        $_GET = ['p' => 'admin', 'c' => 'admins'];
+
+        $html = $this->renderAdminsPage();
+
+        $this->assertSame(
+            $this->renderedSectionSlugs($html),
+            $this->renderedTocLinkSlugs($html),
+            'every ToC link must have a matching <section> in the DOM (owner sees all five sections)'
+        );
+        // Belt-and-braces: confirm the seeded owner does in fact see
+        // all five entries — guards against a future refactor that
+        // accidentally elides every entry uniformly.
+        $this->assertSame(
+            ['add-admin', 'add-override', 'admins', 'overrides', 'search'],
+            $this->renderedTocLinkSlugs($html),
+            'owner sees the full ToC'
+        );
+    }
+
+    /**
+     * #1207 ADM-3 dead-link guard: an admin who holds ADMIN_ADD_ADMINS
+     * but NOT ADMIN_LIST_ADMINS lands on this page through the "Add
+     * new admin" tab. The Search and Admins sections live inside the
+     * `{else}` arm of `{if !$can_list_admins}` in
+     * page_admin_admins_list.tpl, so they never reach the DOM for
+     * this user. The ToC must elide their links accordingly.
+     */
+    public function testTocElidesSearchAndAdminsForAddOnlyAdmin(): void
+    {
+        // Ad-hoc admin without OWNER, without LIST_ADMINS — only
+        // ADMIN_ADD_ADMINS. extraflags carries the bit directly so
+        // CUserManager::HasAccess returns true for ADD checks and
+        // false for LIST checks. gid=-1 short-circuits group-flag
+        // inheritance (matches the Fixture seed admin shape) so
+        // bareGid/powerGid flags don't bleed into the user's
+        // effective permission set and accidentally re-grant
+        // LIST_ADMINS.
+        $addOnlyAid = $this->insertAdmin(
+            'darla',
+            'STEAM_0:0:9001',
+            'darla@example.test',
+            -1,
+            ADMIN_ADD_ADMINS,
+        );
+        $this->loginAs($addOnlyAid);
+
+        $_GET = ['p' => 'admin', 'c' => 'admins'];
+
+        $html = $this->renderAdminsPage();
+
+        $tocLinks = $this->renderedTocLinkSlugs($html);
+        $sections = $this->renderedSectionSlugs($html);
+
+        // The dead-link contract: the ToC must NEVER carry an entry
+        // that the dispatcher elided.
+        $this->assertSame(
+            $sections,
+            $tocLinks,
+            'ToC and rendered sections must stay in lockstep across permission combinations'
+        );
+
+        // And the specific narrowing this test exercises: Search and
+        // Admins are out, Add admin / Overrides / Add override are
+        // in. The list is sorted (renderedTocLinkSlugs() sorts) so we
+        // can compare against a known-good ordering.
+        $this->assertSame(['add-admin', 'add-override', 'overrides'], $tocLinks);
+        $this->assertStringNotContainsString('admin-admins-toc-link-search', $html);
+        $this->assertStringNotContainsString('admin-admins-toc-link-admins"', $html);
+    }
+
     private function seedTestAdmins(): void
     {
         $pdo = Fixture::rawPdo();
@@ -352,5 +434,35 @@ final class AdminAdminsSearchTest extends ApiTestCase
     private function countAdminRows(string $html): int
     {
         return preg_match_all('/data-testid="admin-row"/', $html);
+    }
+
+    /**
+     * Extract every ToC link slug (`search`, `admins`, `add-admin`, …)
+     * from `[data-testid="admin-admins-toc-link-<slug>"]` attributes
+     * in the rendered HTML. Sorted so callers can compare against a
+     * fixed ordering without depending on emit order.
+     *
+     * @return list<string>
+     */
+    private function renderedTocLinkSlugs(string $html): array
+    {
+        preg_match_all('/data-testid="admin-admins-toc-link-([a-z-]+)"/', $html, $m);
+        $slugs = $m[1];
+        sort($slugs);
+        return array_values(array_unique($slugs));
+    }
+
+    /**
+     * Extract every section slug from `[data-testid="admin-admins-section-<slug>"]`.
+     * Pair to {@see renderedTocLinkSlugs}.
+     *
+     * @return list<string>
+     */
+    private function renderedSectionSlugs(string $html): array
+    {
+        preg_match_all('/data-testid="admin-admins-section-([a-z-]+)"/', $html, $m);
+        $slugs = $m[1];
+        sort($slugs);
+        return array_values(array_unique($slugs));
     }
 }

--- a/web/tests/integration/AdminAdminsSearchTest.php
+++ b/web/tests/integration/AdminAdminsSearchTest.php
@@ -1,0 +1,356 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sbpp\Tests\Integration;
+
+use Sbpp\Tests\ApiTestCase;
+use Sbpp\Tests\Fixture;
+use Smarty\Smarty;
+
+/**
+ * #1207 ADM-4 — admin/admins advanced search.
+ *
+ * The pre-fix box shipped 8 separate Search buttons, one per filter
+ * row, that submitted `advType=<key>&advSearch=<value>` (one filter
+ * per submit; later ones replaced earlier ones). The redesign
+ * collapses them into a single submit that sends every populated
+ * field at once and `web/pages/admin.admins.php` ANDs them together.
+ *
+ * This test locks the new contract end-to-end:
+ *
+ * 1. **AND semantics** — submitting `name=alice` AND `webgroup=42`
+ *    narrows to admins matching BOTH filters; an admin with a
+ *    matching login but the wrong web group is excluded. Pre-fix the
+ *    handler dropped the second filter on the floor.
+ * 2. **Backward compat** — `?advType=name&advSearch=alice` still
+ *    works because the legacy shim in admin.admins.php translates it
+ *    into the new `?name=alice` shape before the filters are parsed.
+ *    This pins the bookmark / external-link guarantee called out in
+ *    the slice's PR description.
+ * 3. **Unfiltered** — bare `?p=admin&c=admins` returns every seeded
+ *    admin row (regression guard against an over-eager filter).
+ *
+ * The test exercises the page handler in-process: it boots a Smarty
+ * `$theme` matching `init.php`'s wiring, captures the rendered HTML
+ * via output buffering, and counts `data-testid="admin-row"` rows.
+ * That mirrors what the user sees after the form submits and is the
+ * cheapest way to lock both the SQL building (#1207 ADM-4 redesign)
+ * and the admin.admins.search.php pre-fill behaviour against a
+ * single test surface.
+ */
+final class AdminAdminsSearchTest extends ApiTestCase
+{
+    /** @var int gid of the "Power Users" web group seeded per case. */
+    private int $powerGid = 0;
+
+    /** @var int gid of the "Bare Users" web group seeded per case. */
+    private int $bareGid  = 0;
+
+    /** @var int aid of the "alice" admin (web group: power users). */
+    private int $aliceAid = 0;
+
+    /** @var int aid of the "bob" admin (web group: bare users). */
+    private int $bobAid = 0;
+
+    /** @var int aid of the "charlie" admin (web group: power users). */
+    private int $charlieAid = 0;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->loginAsAdmin();
+        $this->seedTestAdmins();
+        $this->bootstrapSmartyTheme();
+    }
+
+    protected function tearDown(): void
+    {
+        // Pages set $_GET; clear it so the next case starts clean.
+        $_GET = [];
+        unset($GLOBALS['theme']);
+        parent::tearDown();
+    }
+
+    /**
+     * Bare `?p=admin&c=admins` returns every admin (seed + 3 test
+     * rows = 4). Regression guard: a future filter refactor that
+     * accidentally adds an `AND ADM.aid > 0` style narrowing must
+     * trip this case before users notice the empty list.
+     */
+    public function testNoFilterReturnsEveryAdmin(): void
+    {
+        $_GET = ['p' => 'admin', 'c' => 'admins'];
+
+        $html = $this->renderAdminsPage();
+
+        $this->assertSame(4, $this->extractAdminCount($html), 'unfiltered');
+        $this->assertSame(4, $this->countAdminRows($html));
+    }
+
+    /**
+     * One filter — the modern wire shape (`?name=…`). Locks a
+     * single-input substring search against ADM.user.
+     */
+    public function testSingleFilterByLoginName(): void
+    {
+        $_GET = ['p' => 'admin', 'c' => 'admins', 'name' => 'alice'];
+
+        $html = $this->renderAdminsPage();
+
+        $this->assertSame(1, $this->extractAdminCount($html));
+        $this->assertSame(1, $this->countAdminRows($html));
+        $this->assertStringContainsString('>alice<', $html, 'alice row should render');
+    }
+
+    /**
+     * The headline ADM-4 contract: two filters AND together.
+     * `name=alice` matches one row, `webgroup=$powerGid` matches two
+     * (alice + charlie) — combined, only alice survives.
+     */
+    public function testTwoFiltersAndSemantics(): void
+    {
+        $_GET = [
+            'p'        => 'admin',
+            'c'        => 'admins',
+            'name'     => 'alice',
+            'webgroup' => (string) $this->powerGid,
+        ];
+
+        $html = $this->renderAdminsPage();
+
+        $this->assertSame(1, $this->extractAdminCount($html), 'name=alice AND webgroup=power');
+        $this->assertSame(1, $this->countAdminRows($html));
+        $this->assertStringContainsString('>alice<', $html);
+        $this->assertStringNotContainsString('>charlie<', $html, 'charlie has the right web group but not the right name — must be excluded by AND.');
+    }
+
+    /**
+     * `webgroup=power` alone should still return both admins in that
+     * group. Counter-test to {@see testTwoFiltersAndSemantics} — it
+     * makes the bound on the AND case meaningful (alice and charlie
+     * both DO exist; the AND just narrows further).
+     */
+    public function testWebGroupFilterReturnsAllInGroup(): void
+    {
+        $_GET = [
+            'p'        => 'admin',
+            'c'        => 'admins',
+            'webgroup' => (string) $this->powerGid,
+        ];
+
+        $html = $this->renderAdminsPage();
+
+        $this->assertSame(2, $this->extractAdminCount($html), 'webgroup=power matches alice+charlie');
+        $this->assertStringContainsString('>alice<',   $html);
+        $this->assertStringContainsString('>charlie<', $html);
+        $this->assertStringNotContainsString('>bob<',  $html, 'bob is in bare users, not power.');
+    }
+
+    /**
+     * Backward-compat: legacy deep links of the form
+     * `?advType=name&advSearch=alice` still narrow as expected. The
+     * shim in admin.admins.php translates the legacy pair into the
+     * modern `?name=alice` shape before the filter loop runs.
+     */
+    public function testLegacyAdvTypeUrlStillWorks(): void
+    {
+        $_GET = [
+            'p'         => 'admin',
+            'c'         => 'admins',
+            'advType'   => 'name',
+            'advSearch' => 'alice',
+        ];
+
+        $html = $this->renderAdminsPage();
+
+        $this->assertSame(1, $this->extractAdminCount($html), 'legacy advType=name&advSearch=alice');
+        $this->assertStringContainsString('>alice<', $html);
+    }
+
+    /**
+     * Backward-compat with a multi-filter user that bookmarked one
+     * filter: even when `?advType=…&advSearch=…` ALSO carries a
+     * modern field (because the user pasted the bookmark and then
+     * appended a new filter), the modern field wins for its slot and
+     * the legacy pair fills the rest.
+     */
+    public function testLegacyShimDoesNotOverwriteModernFields(): void
+    {
+        $_GET = [
+            'p'         => 'admin',
+            'c'         => 'admins',
+            'advType'   => 'name',
+            'advSearch' => 'alice',           // legacy: name=alice
+            'webgroup'  => (string) $this->powerGid, // modern: webgroup=…
+        ];
+
+        $html = $this->renderAdminsPage();
+
+        $this->assertSame(1, $this->extractAdminCount($html),
+            'shim should add name=alice, modern webgroup is honoured, AND narrows to 1.');
+    }
+
+    /**
+     * Steam-ID exact / partial split. Modern shape uses
+     * `steamid=<text>&steam_match=0|1`. The filter is exact when
+     * `steam_match` is unset or `0`, partial when `1`.
+     */
+    public function testSteamIdExactMatchSplit(): void
+    {
+        $_GET = [
+            'p'           => 'admin',
+            'c'           => 'admins',
+            'steamid'     => 'STEAM_0:0:1001',
+            'steam_match' => '0',
+        ];
+        $exact = $this->renderAdminsPage();
+        $this->assertSame(1, $this->extractAdminCount($exact), 'exact match on alice steamid');
+
+        $_GET = [
+            'p'           => 'admin',
+            'c'           => 'admins',
+            'steamid'     => 'STEAM_0:0:10', // partial substring (matches 1001/1002/1003 → all 3)
+            'steam_match' => '1',
+        ];
+        $partial = $this->renderAdminsPage();
+        $this->assertSame(3, $this->extractAdminCount($partial), 'partial match on STEAM_0:0:10 substring');
+    }
+
+    /**
+     * Multi-select web flag filter accepts the modern `[]` array
+     * shape (`?admwebflag[]=ADMIN_OWNER&admwebflag[]=ADMIN_ADD_BAN`).
+     * The seed admin and one of our test admins have ADMIN_OWNER —
+     * filtering by it should narrow to those two.
+     */
+    public function testWebFlagMultiFilterArrayShape(): void
+    {
+        $_GET = [
+            'p'          => 'admin',
+            'c'          => 'admins',
+            'admwebflag' => ['ADMIN_OWNER'],
+        ];
+
+        $html = $this->renderAdminsPage();
+
+        // The seeded admin row has ADMIN_OWNER (extraflags=16777216);
+        // among our test rows charlie holds ADMIN_OWNER too. Both
+        // must show up.
+        $this->assertSame(2, $this->extractAdminCount($html), 'admwebflag[]=ADMIN_OWNER → 2 owners');
+        $this->assertStringContainsString('>admin<',   $html, 'seeded admin has ADMIN_OWNER');
+        $this->assertStringContainsString('>charlie<', $html, 'charlie has ADMIN_OWNER');
+    }
+
+    private function seedTestAdmins(): void
+    {
+        $pdo = Fixture::rawPdo();
+
+        // `:prefix_groups` has only (gid, type, name, flags) — type=1
+        // is the "web group" sentinel admin.admins.search.php filters
+        // its `webgroup_list` on.
+        $pdo->prepare(sprintf(
+            'INSERT INTO `%s_groups` (name, flags, type) VALUES (?, ?, 1)', DB_PREFIX,
+        ))->execute(['Power Users', ADMIN_LIST_ADMINS | ADMIN_ADD_BAN]);
+        $this->powerGid = (int) $pdo->lastInsertId();
+
+        $pdo->prepare(sprintf(
+            'INSERT INTO `%s_groups` (name, flags, type) VALUES (?, ?, 1)', DB_PREFIX,
+        ))->execute(['Bare Users', ADMIN_LIST_ADMINS]);
+        $this->bareGid = (int) $pdo->lastInsertId();
+
+        $this->aliceAid   = $this->insertAdmin('alice',   'STEAM_0:0:1001', 'alice@example.test',   $this->powerGid, 0);
+        $this->bobAid     = $this->insertAdmin('bob',     'STEAM_0:0:1002', 'bob@example.test',     $this->bareGid,  0);
+        $this->charlieAid = $this->insertAdmin('charlie', 'STEAM_0:0:1003', 'charlie@example.test', $this->powerGid, ADMIN_OWNER);
+    }
+
+    private function insertAdmin(string $user, string $authid, string $email, int $gid, int $extraflags): int
+    {
+        $pdo  = Fixture::rawPdo();
+        $hash = password_hash('x', PASSWORD_BCRYPT);
+        $pdo->prepare(sprintf(
+            'INSERT INTO `%s_admins` (user, authid, password, gid, email, validate, extraflags, immunity)
+             VALUES (?, ?, ?, ?, ?, NULL, ?, 25)',
+            DB_PREFIX,
+        ))->execute([$user, $authid, $hash, $gid, $email, $extraflags]);
+        return (int) $pdo->lastInsertId();
+    }
+
+    /**
+     * Spin a Smarty `$theme` matching init.php so admin.admins.php
+     * (which renders three Views) doesn't crash on `Renderer::render`.
+     * No need to wire every plugin — only the ones the rendered
+     * templates actually use during this code path.
+     */
+    private function bootstrapSmartyTheme(): void
+    {
+        require_once INCLUDES_PATH . '/SmartyCustomFunctions.php';
+        require_once INCLUDES_PATH . '/View/View.php';
+        require_once INCLUDES_PATH . '/View/Renderer.php';
+
+        // Minimal compile/cache dir so Smarty can write its compiled
+        // .tpl.php artefacts. The default cache is `web/cache/` which
+        // is owned by root inside the docker image; tests run as the
+        // host user, so use a process-private tmp path instead.
+        $compileDir = sys_get_temp_dir() . '/sbpp-test-smarty-' . getmypid();
+        if (!is_dir($compileDir)) {
+            mkdir($compileDir, 0o775, true);
+        }
+
+        $theme = new Smarty();
+        $theme->setUseSubDirs(false);
+        $theme->setCompileId('default');
+        $theme->setCaching(Smarty::CACHING_OFF);
+        $theme->setForceCompile(true);
+        $theme->setTemplateDir(SB_THEMES . SB_THEME);
+        $theme->setCompileDir($compileDir);
+        $theme->setCacheDir($compileDir);
+        $theme->setEscapeHtml(true);
+        $theme->registerPlugin(Smarty::PLUGIN_FUNCTION, 'help_icon',     'smarty_function_help_icon');
+        $theme->registerPlugin(Smarty::PLUGIN_FUNCTION, 'sb_button',     'smarty_function_sb_button');
+        $theme->registerPlugin(Smarty::PLUGIN_FUNCTION, 'load_template', 'smarty_function_load_template');
+        $theme->registerPlugin(Smarty::PLUGIN_FUNCTION, 'csrf_field',    'smarty_function_csrf_field');
+        $theme->registerPlugin(Smarty::PLUGIN_BLOCK,    'has_access',    'smarty_block_has_access');
+        $theme->registerPlugin('modifier', 'smarty_stripslashes',     'smarty_stripslashes');
+        $theme->registerPlugin('modifier', 'smarty_htmlspecialchars', 'smarty_htmlspecialchars');
+
+        $GLOBALS['theme']    = $theme;
+        $GLOBALS['username'] = 'admin';
+    }
+
+    /**
+     * Run the page handler in-process and return its rendered HTML.
+     * Wraps the include in `ob_start` so the templates' direct echos
+     * land in the returned string, not on PHPUnit's stdout.
+     */
+    private function renderAdminsPage(): string
+    {
+        ob_start();
+        try {
+            // Each include runs against the same global state; passing
+            // through a closure scopes `$theme` / `$userbank` exactly
+            // like web/index.php does at request time.
+            (function (): void {
+                global $userbank, $theme;
+                $userbank = $GLOBALS['userbank'];
+                $theme    = $GLOBALS['theme'];
+                require ROOT . 'pages/admin.admins.php';
+            })();
+        } finally {
+            $html = (string) ob_get_clean();
+        }
+        return $html;
+    }
+
+    private function extractAdminCount(string $html): int
+    {
+        if (preg_match('/data-testid="admin-count">\((\d+)\)/', $html, $m)) {
+            return (int) $m[1];
+        }
+        $this->fail('admin-count testid not found in rendered HTML');
+    }
+
+    private function countAdminRows(string $html): int
+    {
+        return preg_match_all('/data-testid="admin-row"/', $html);
+    }
+}

--- a/web/themes/default/admin.admins.toc.tpl
+++ b/web/themes/default/admin.admins.toc.tpl
@@ -20,13 +20,29 @@
     pattern (admin-bans, myaccount), promote the markup into a shared
     partial then.
 
-    Permissions: AdminTabs in admin.admins.php gates both the "Add new
-    admin" tab and the "Overrides" tab on the same flag mask
-    (ADMIN_OWNER | ADMIN_ADD_ADMINS), and AdminOverridesView's
-    `permission_addadmin` keys off the same. Until the override surface
-    grows its own permission, the ToC reuses `$can_add_admins` for all
-    three gated entries — entries for sections the dispatcher would
-    elide become dead links otherwise.
+    Permissions: every entry mirrors the gate the dispatcher uses to
+    decide whether the corresponding `<section id="…">` lands in the
+    DOM, so a ToC click never targets a non-existent anchor.
+      - `Search` / `Admins` are gated on `$can_list_admins`
+        (`ADMIN_OWNER | ADMIN_LIST_ADMINS`) — `page_admin_admins_list.tpl`
+        only renders those two sections inside the `{if !$can_list_admins}`
+        else-arm.
+      - `Add admin` / `Overrides` / `Add override` are gated on
+        `$can_add_admins` (`ADMIN_OWNER | ADMIN_ADD_ADMINS`) — the
+        AdminTabs entries for "Add new admin" + "Overrides" key off the
+        same mask, and `AdminOverridesView.permission_addadmin` matches
+        too. Until the override surface grows its own permission, one
+        flag covers all three.
+    A user with `ADMIN_ADD_ADMINS` but not `ADMIN_LIST_ADMINS` (the
+    perms are independent) lands on this page through the "Add new
+    admin" tab; the ToC rendering must still elide Search/Admins for
+    that user. The regression case is locked in
+    `web/tests/integration/AdminAdminsSearchTest.php` —
+    `testTocElidesSearchAndAdminsForAddOnlyAdmin` (and the broader
+    "every link has a section" invariant in
+    `testTocLinksMatchRenderedSectionsForOwner`); the AGENTS.md
+    "Page-level table of contents" convention captures the rule for
+    future dense pages.
 *}
 <aside class="admin-admins-toc"
        data-testid="admin-admins-toc"
@@ -41,8 +57,10 @@
         </summary>
         <nav class="admin-admins-toc__nav">
             <ul class="admin-admins-toc__list">
-                <li><a href="#search" class="admin-admins-toc__link" data-testid="admin-admins-toc-link-search">Search</a></li>
-                <li><a href="#admins" class="admin-admins-toc__link" data-testid="admin-admins-toc-link-admins">Admins</a></li>
+                {if $can_list_admins}
+                    <li><a href="#search" class="admin-admins-toc__link" data-testid="admin-admins-toc-link-search">Search</a></li>
+                    <li><a href="#admins" class="admin-admins-toc__link" data-testid="admin-admins-toc-link-admins">Admins</a></li>
+                {/if}
                 {if $can_add_admins}
                     <li><a href="#add-admin" class="admin-admins-toc__link" data-testid="admin-admins-toc-link-add-admin">Add admin</a></li>
                     <li><a href="#overrides" class="admin-admins-toc__link" data-testid="admin-admins-toc-link-overrides">Overrides</a></li>

--- a/web/themes/default/admin.admins.toc.tpl
+++ b/web/themes/default/admin.admins.toc.tpl
@@ -1,0 +1,54 @@
+{*
+    SourceBans++ 2026 — admin/admins page-level table of contents
+
+    #1207 ADM-3 — admin-admins is ~7 stacked surfaces (search + admins
+    list + add admin + overrides + add override) on one long scroll. We
+    paint a sticky anchor sidebar at >=1024px and an accordion-style
+    collapsible nav at <1024px so the user can jump to "Add admin"
+    without paging past the search and listing.
+
+    Loaded by page_admin_admins_list.tpl (the first template in the
+    page) inside the cross-template `.admin-admins-shell` wrapper. The
+    sidebar uses CSS `position: sticky` against that wrapper; the
+    sticky topbar height (3.5rem) is accounted for via top + section
+    `scroll-margin-top` in admins-toc.css.
+
+    The link list is hardcoded — these are the canonical sections of
+    admin-admins, gated only by what the dispatcher would render
+    anyway. We don't drive this from the View DTO because nothing else
+    needs the data; if more density-rework pages adopt the same
+    pattern (admin-bans, myaccount), promote the markup into a shared
+    partial then.
+
+    Permissions: AdminTabs in admin.admins.php gates both the "Add new
+    admin" tab and the "Overrides" tab on the same flag mask
+    (ADMIN_OWNER | ADMIN_ADD_ADMINS), and AdminOverridesView's
+    `permission_addadmin` keys off the same. Until the override surface
+    grows its own permission, the ToC reuses `$can_add_admins` for all
+    three gated entries — entries for sections the dispatcher would
+    elide become dead links otherwise.
+*}
+<aside class="admin-admins-toc"
+       data-testid="admin-admins-toc"
+       aria-label="Admins page sections">
+    <details class="admin-admins-toc__details" open>
+        <summary class="admin-admins-toc__summary">
+            <span class="admin-admins-toc__summary-label">
+                <i data-lucide="list" style="width:14px;height:14px"></i>
+                On this page
+            </span>
+            <i data-lucide="chevron-down" class="admin-admins-toc__chevron" style="width:14px;height:14px"></i>
+        </summary>
+        <nav class="admin-admins-toc__nav">
+            <ul class="admin-admins-toc__list">
+                <li><a href="#search" class="admin-admins-toc__link" data-testid="admin-admins-toc-link-search">Search</a></li>
+                <li><a href="#admins" class="admin-admins-toc__link" data-testid="admin-admins-toc-link-admins">Admins</a></li>
+                {if $can_add_admins}
+                    <li><a href="#add-admin" class="admin-admins-toc__link" data-testid="admin-admins-toc-link-add-admin">Add admin</a></li>
+                    <li><a href="#overrides" class="admin-admins-toc__link" data-testid="admin-admins-toc-link-overrides">Overrides</a></li>
+                    <li><a href="#add-override" class="admin-admins-toc__link" data-testid="admin-admins-toc-link-add-override">Add override</a></li>
+                {/if}
+            </ul>
+        </nav>
+    </details>
+</aside>

--- a/web/themes/default/box_admin_admins_search.tpl
+++ b/web/themes/default/box_admin_admins_search.tpl
@@ -7,37 +7,35 @@
 
     Included via {load_template file="admin.admins.search"} from
     page_admin_admins_list.tpl. Submits as a plain `GET` to
-    ?p=admin&c=admins&advSearch=…&advType=…, mirroring the wire
-    format admin.admins.php already parses.
+    ?p=admin&c=admins with one parameter per populated filter.
 
-    Wire format (kept identical to the legacy box):
-        advType=name           advSearch=<text>           (admin login)
-        advType=steam|steamid  advSearch=<text>           (partial vs exact)
-        advType=admemail       advSearch=<text>           (gated by can_edit_admins)
-        advType=webgroup       advSearch=<gid>
-        advType=srvadmgroup    advSearch=<group_name>
-        advType=srvgroup       advSearch=<gid>
-        advType=admwebflag     advSearch=<ADMIN_*>[,<ADMIN_*>…]   (multi)
-        advType=admsrvflag     advSearch=<SM_*>[,<SM_*>…]         (multi)
-        advType=server         advSearch=<sid>
+    Wire format (#1207 ADM-4 redesign — single submit, AND semantics):
+        name=<text>                login (substring)
+        steamid=<text>             Steam ID
+        steam_match=0|1            0 = exact, 1 = partial (default 0)
+        admemail=<text>            E-mail (substring, gated by can_edit_admins)
+        webgroup=<gid>             Panel group
+        srvadmgroup=<group_name>   SourceMod admin group
+        srvgroup=<gid>             Server group
+        admwebflag[]=ADMIN_*       Web permission flags (multi)
+        admsrvflag[]=SM_*          Server permission flags (multi)
+        server=<sid>               Server access
 
-    Why we drop sourcebans.js' search_admins() global
-    -------------------------------------------------
-    sourcebans.js disappears at #1123 D1, so `onclick="search_admins()"`
-    would `ReferenceError`. Each row gets its own submit button with
-    inline {literal}<script>…{/literal}` dispatch — vanilla, no globals.
-    The hidden `advType` / `advSearch` inputs are populated from the
-    row's source field on click; the form submits natively.
+    Multiple non-empty filters are combined with AND on the server side
+    (admin.admins.php). The legacy single-filter shape
+    (`?advType=name&advSearch=foo`) still works: admin.admins.php
+    translates it into the modern shape on entry so existing bookmarks
+    and external links keep narrowing the list.
 
-    Multi-select permission flags
-    -----------------------------
-    The legacy widget used MooTools' `getMultiple(this, 1|2)` to pull
-    the full selection from a `<select multiple>` `onblur`. The new
-    dispatcher reads `selectedOptions` directly when the user submits
-    the row, so the value collected is the full current selection at
-    submit time — tight and unsurprising. The wire shape (comma-joined
-    `ADMIN_*` constant names) is unchanged so admin.admins.php's
-    constant() resolution keeps working.
+    Why we drop the per-row Search buttons
+    --------------------------------------
+    The pre-fix shape had eight `<button data-search-key=…>` elements
+    populating hidden `advType` / `advSearch` inputs and submitting
+    with one filter at a time. Audit (#1207 ADM-4) called this out as
+    unusual — typical search UIs combine inputs with one submit at the
+    bottom. The new form drops the hidden proxies, gives every input
+    its native `name=` attribute, and renders one Search submit + one
+    Reset link.
 
     LoadServerHost replacement
     --------------------------
@@ -61,7 +59,8 @@
         data-testid="search-admins-admwebflag"     web-perms multi-select
         data-testid="search-admins-admsrvflag"     server-perms multi-select
         data-testid="search-admins-server"         server <select>
-        data-testid="search-admins-submit-<key>"   one per searchable field
+        data-testid="search-admins-submit"         the (one) submit button
+        data-testid="search-admins-reset"          reset / clear-filters link
 *}
 <form method="get"
       action="index.php"
@@ -70,202 +69,155 @@
       style="margin-top:1rem;margin-bottom:1rem">
     <input type="hidden" name="p" value="admin">
     <input type="hidden" name="c" value="admins">
-    <input type="hidden" name="advType" value="" data-search-type>
-    <input type="hidden" name="advSearch" value="" data-search-value>
 
     <div class="card__header">
         <div>
             <h3>Advanced search</h3>
-            <p>Filter the admin list by login name, group, permission flag, or server access.</p>
+            <p>Combine any of the filters below — the server narrows the admin list to rows matching <strong>every</strong> populated filter (AND semantics).</p>
         </div>
     </div>
 
     <div class="card__body space-y-3">
-        <div class="grid gap-3" style="grid-template-columns:12rem 1fr auto;align-items:end">
+        <div class="grid gap-3" style="grid-template-columns:12rem 1fr;align-items:end">
             <label class="label" for="search-admins-name" style="grid-column:1;align-self:end">Login name</label>
             <input class="input"
                    id="search-admins-name"
+                   name="name"
                    type="text"
                    placeholder="Substring match against the panel login&hellip;"
                    data-testid="search-admins-name"
+                   value="{$active_filter_name|escape}"
                    autocomplete="off">
-            <button type="submit"
-                    class="btn btn--secondary btn--sm"
-                    data-testid="search-admins-submit-name"
-                    data-search-key="name"
-                    data-search-from="search-admins-name">
-                <i data-lucide="search" style="width:14px;height:14px"></i> Search
-            </button>
         </div>
 
-        <div class="grid gap-3" style="grid-template-columns:12rem 1fr auto;align-items:end">
+        <div class="grid gap-3" style="grid-template-columns:12rem 1fr;align-items:end">
             <label class="label" for="search-admins-steamid" style="grid-column:1;align-self:end">Steam ID</label>
             <div class="flex gap-2" style="flex-wrap:wrap">
                 <input class="input font-mono"
                        id="search-admins-steamid"
+                       name="steamid"
                        type="text"
                        placeholder="STEAM_0:0:1234 or [U:1:1234]&hellip;"
                        data-testid="search-admins-steamid"
+                       value="{$active_filter_steamid|escape}"
                        style="flex:1;min-width:14rem"
                        autocomplete="off">
                 <select class="select"
                         id="search-admins-steam-match"
+                        name="steam_match"
                         data-testid="search-admins-steam-match"
                         aria-label="Steam ID match mode"
                         style="width:9rem">
-                    <option value="0" selected>Exact match</option>
-                    <option value="1">Partial match</option>
+                    <option value="0"{if $active_filter_steam_match != '1'} selected{/if}>Exact match</option>
+                    <option value="1"{if $active_filter_steam_match == '1'} selected{/if}>Partial match</option>
                 </select>
             </div>
-            <button type="submit"
-                    class="btn btn--secondary btn--sm"
-                    data-testid="search-admins-submit-steamid"
-                    data-search-key=""
-                    data-search-compose="steam">
-                <i data-lucide="search" style="width:14px;height:14px"></i> Search
-            </button>
         </div>
 
         {if $can_editadmin}
-            <div class="grid gap-3" style="grid-template-columns:12rem 1fr auto;align-items:end">
+            <div class="grid gap-3" style="grid-template-columns:12rem 1fr;align-items:end">
                 <label class="label" for="search-admins-admemail" style="grid-column:1;align-self:end">E-mail</label>
                 <input class="input"
                        id="search-admins-admemail"
+                       name="admemail"
                        type="email"
                        placeholder="Substring match against the panel e-mail&hellip;"
                        data-testid="search-admins-admemail"
+                       value="{$active_filter_admemail|escape}"
                        autocomplete="off">
-                <button type="submit"
-                        class="btn btn--secondary btn--sm"
-                        data-testid="search-admins-submit-admemail"
-                        data-search-key="admemail"
-                        data-search-from="search-admins-admemail">
-                    <i data-lucide="search" style="width:14px;height:14px"></i> Search
-                </button>
             </div>
         {/if}
 
-        <div class="grid gap-3" style="grid-template-columns:12rem 1fr auto;align-items:end">
+        <div class="grid gap-3" style="grid-template-columns:12rem 1fr;align-items:end">
             <div>
                 <label class="label" for="search-admins-webgroup">Web group</label>
                 <select class="select"
                         id="search-admins-webgroup"
+                        name="webgroup"
                         data-testid="search-admins-webgroup">
                     <option value="">&mdash;</option>
                     {foreach from=$webgroup_list item="webgrp"}
-                        <option value="{$webgrp.gid}">{$webgrp.name}</option>
+                        <option value="{$webgrp.gid}"{if $active_filter_webgroup == $webgrp.gid && $active_filter_webgroup != ''} selected{/if}>{$webgrp.name}</option>
                     {/foreach}
                 </select>
             </div>
             <div class="text-xs text-muted">Filter by panel group membership.</div>
-            <button type="submit"
-                    class="btn btn--secondary btn--sm"
-                    data-testid="search-admins-submit-webgroup"
-                    data-search-key="webgroup"
-                    data-search-from="search-admins-webgroup">
-                <i data-lucide="search" style="width:14px;height:14px"></i> Search
-            </button>
         </div>
 
-        <div class="grid gap-3" style="grid-template-columns:12rem 1fr auto;align-items:end">
+        <div class="grid gap-3" style="grid-template-columns:12rem 1fr;align-items:end">
             <div>
                 <label class="label" for="search-admins-srvadmgroup">SourceMod admin group</label>
                 <select class="select"
                         id="search-admins-srvadmgroup"
+                        name="srvadmgroup"
                         data-testid="search-admins-srvadmgroup">
                     <option value="">&mdash;</option>
                     {foreach from=$srvadmgroup_list item="srvadmgrp"}
-                        <option value="{$srvadmgrp.name}">{$srvadmgrp.name}</option>
+                        <option value="{$srvadmgrp.name}"{if $active_filter_srvadmgroup == $srvadmgrp.name && $active_filter_srvadmgroup != ''} selected{/if}>{$srvadmgrp.name}</option>
                     {/foreach}
                 </select>
             </div>
             <div class="text-xs text-muted">Filter by SourceMod admin-group attachment.</div>
-            <button type="submit"
-                    class="btn btn--secondary btn--sm"
-                    data-testid="search-admins-submit-srvadmgroup"
-                    data-search-key="srvadmgroup"
-                    data-search-from="search-admins-srvadmgroup">
-                <i data-lucide="search" style="width:14px;height:14px"></i> Search
-            </button>
         </div>
 
-        <div class="grid gap-3" style="grid-template-columns:12rem 1fr auto;align-items:end">
+        <div class="grid gap-3" style="grid-template-columns:12rem 1fr;align-items:end">
             <div>
                 <label class="label" for="search-admins-srvgroup">Server group</label>
                 <select class="select"
                         id="search-admins-srvgroup"
+                        name="srvgroup"
                         data-testid="search-admins-srvgroup">
                     <option value="">&mdash;</option>
                     {foreach from=$srvgroup_list item="srvgrp"}
-                        <option value="{$srvgrp.gid}">{$srvgrp.name}</option>
+                        <option value="{$srvgrp.gid}"{if $active_filter_srvgroup == $srvgrp.gid && $active_filter_srvgroup != ''} selected{/if}>{$srvgrp.name}</option>
                     {/foreach}
                 </select>
             </div>
             <div class="text-xs text-muted">Filter by server-group membership.</div>
-            <button type="submit"
-                    class="btn btn--secondary btn--sm"
-                    data-testid="search-admins-submit-srvgroup"
-                    data-search-key="srvgroup"
-                    data-search-from="search-admins-srvgroup">
-                <i data-lucide="search" style="width:14px;height:14px"></i> Search
-            </button>
         </div>
 
-        <div class="grid gap-3" style="grid-template-columns:12rem 1fr auto;align-items:end">
+        <div class="grid gap-3" style="grid-template-columns:12rem 1fr;align-items:end">
             <div>
                 <label class="label" for="search-admins-admwebflag">Web permissions</label>
                 <select class="select"
                         id="search-admins-admwebflag"
+                        name="admwebflag[]"
                         data-testid="search-admins-admwebflag"
                         size="6"
                         multiple
-                        data-search-multi
                         style="height:auto">
                     {foreach from=$admwebflag_list item="admwebflag"}
-                        <option value="{$admwebflag.flag}">{$admwebflag.name}</option>
+                        <option value="{$admwebflag.flag}"{if in_array($admwebflag.flag, $active_filter_admwebflag)} selected{/if}>{$admwebflag.name}</option>
                     {/foreach}
                 </select>
             </div>
-            <div class="text-xs text-muted">Hold <kbd data-modkey>Ctrl</kbd> to multi-select. Submits the current selection as a comma-joined list of <code>ADMIN_*</code> constant names.</div>
-            <button type="submit"
-                    class="btn btn--secondary btn--sm"
-                    data-testid="search-admins-submit-admwebflag"
-                    data-search-key="admwebflag"
-                    data-search-multi-from="search-admins-admwebflag">
-                <i data-lucide="search" style="width:14px;height:14px"></i> Search
-            </button>
+            <div class="text-xs text-muted">Hold <kbd data-modkey>Ctrl</kbd> to multi-select. Submits the current selection as repeated <code>admwebflag[]=ADMIN_*</code> parameters.</div>
         </div>
 
-        <div class="grid gap-3" style="grid-template-columns:12rem 1fr auto;align-items:end">
+        <div class="grid gap-3" style="grid-template-columns:12rem 1fr;align-items:end">
             <div>
                 <label class="label" for="search-admins-admsrvflag">Server permissions</label>
                 <select class="select"
                         id="search-admins-admsrvflag"
+                        name="admsrvflag[]"
                         data-testid="search-admins-admsrvflag"
                         size="6"
                         multiple
-                        data-search-multi
                         style="height:auto">
                     {foreach from=$admsrvflag_list item="admsrvflag"}
-                        <option value="{$admsrvflag.flag}">{$admsrvflag.name}</option>
+                        <option value="{$admsrvflag.flag}"{if in_array($admsrvflag.flag, $active_filter_admsrvflag)} selected{/if}>{$admsrvflag.name}</option>
                     {/foreach}
                 </select>
             </div>
-            <div class="text-xs text-muted">Hold <kbd data-modkey>Ctrl</kbd> to multi-select. Submits the current selection as a comma-joined list of <code>SM_*</code> constant names.</div>
-            <button type="submit"
-                    class="btn btn--secondary btn--sm"
-                    data-testid="search-admins-submit-admsrvflag"
-                    data-search-key="admsrvflag"
-                    data-search-multi-from="search-admins-admsrvflag">
-                <i data-lucide="search" style="width:14px;height:14px"></i> Search
-            </button>
+            <div class="text-xs text-muted">Hold <kbd data-modkey>Ctrl</kbd> to multi-select. Submits the current selection as repeated <code>admsrvflag[]=SM_*</code> parameters.</div>
         </div>
 
-        <div class="grid gap-3" style="grid-template-columns:12rem 1fr auto;align-items:end">
+        <div class="grid gap-3" style="grid-template-columns:12rem 1fr;align-items:end">
             <div>
                 <label class="label" for="search-admins-server">Server</label>
                 <select class="select"
                         id="search-admins-server"
+                        name="server"
                         data-testid="search-admins-server">
                     <option value="">&mdash;</option>
                     {foreach from=$server_list item="server"}
@@ -273,16 +225,20 @@
                                 data-sid="{$server.sid}"
                                 data-ip="{$server.ip}"
                                 data-port="{$server.port}"
-                                data-server-host>Loading&hellip; ({$server.ip}:{$server.port})</option>
+                                data-server-host{if $active_filter_server == $server.sid && $active_filter_server != ''} selected{/if}>Loading&hellip; ({$server.ip}:{$server.port})</option>
                     {/foreach}
                 </select>
             </div>
             <div class="text-xs text-muted">Show admins with explicit access to the selected server. Hostnames load asynchronously.</div>
+        </div>
+
+        <div class="flex gap-2 justify-end" style="border-top:1px solid var(--border);padding-top:0.75rem">
+            <a class="btn btn--ghost btn--sm"
+               href="?p=admin&amp;c=admins"
+               data-testid="search-admins-reset">Clear filters</a>
             <button type="submit"
-                    class="btn btn--secondary btn--sm"
-                    data-testid="search-admins-submit-server"
-                    data-search-key="server"
-                    data-search-from="search-admins-server">
+                    class="btn btn--primary btn--sm"
+                    data-testid="search-admins-submit">
                 <i data-lucide="search" style="width:14px;height:14px"></i> Search
             </button>
         </div>
@@ -290,23 +246,12 @@
 </form>
 
 {*
-    Inline submit dispatcher + LoadServerHost replacement.
+    LoadServerHost replacement (vanilla, post-#1123 D1).
 
-    Submit dispatcher: each per-row button declares its search
-    criterion via `data-search-key` and either points at a single
-    source field via `data-search-from`, a multi-select source via
-    `data-search-multi-from`, or composes the SteamID exact/partial
-    pair via `data-search-compose="steam"`. On click, the hidden
-    `advType` / `advSearch` inputs are populated and the form
-    submits natively (no preventDefault on the success path), so the
-    browser navigates to the consumer URL with the correct query
-    string. Empty selections cancel the submit.
-
-    LoadServerHost replacement: the legacy box appended a
-    server-built `<script>LoadServerHost(...)</script>` blob that
-    called the (now-gone) sourcebans.js helper per option. We replace
-    it with one `sb.api.call(Actions.ServersHostPlayers, {sid})` per
-    `<option data-server-host>` option, mirroring B5's pattern in
+    The legacy box appended a server-built `<script>LoadServerHost(...)</script>`
+    blob that called the (now-gone) sourcebans.js helper per option. We
+    replace it with one `sb.api.call(Actions.ServersHostPlayers, {sid})`
+    per `<option data-server-host>` option, mirroring B5's pattern in
     page_servers.tpl. Resolved hostnames replace the loading text in
     place; failures fall back to "Offline (ip:port)".
 *}
@@ -316,56 +261,6 @@
     'use strict';
     var form = document.querySelector('[data-testid="search-admins-form"]');
     if (!(form instanceof HTMLFormElement)) return;
-
-    var typeField = form.querySelector('[data-search-type]');
-    var valueField = form.querySelector('[data-search-value]');
-    if (!(typeField instanceof HTMLInputElement) || !(valueField instanceof HTMLInputElement)) return;
-
-    /**
-     * @param {Element} btn
-     * @returns {{ key: string, value: string }}
-     */
-    function readPair(btn) {
-        var compose = btn.getAttribute('data-search-compose');
-        if (compose === 'steam') {
-            var sid = document.getElementById('search-admins-steamid');
-            var match = document.getElementById('search-admins-steam-match');
-            var sval = (sid instanceof HTMLInputElement) ? sid.value.trim() : '';
-            var mval = (match instanceof HTMLSelectElement) ? match.value : '0';
-            return { key: (mval === '1' ? 'steam' : 'steamid'), value: sval };
-        }
-        var multiId = btn.getAttribute('data-search-multi-from');
-        if (multiId) {
-            var msel = document.getElementById(multiId);
-            if (msel instanceof HTMLSelectElement && msel.multiple) {
-                var values = [];
-                Array.prototype.forEach.call(msel.selectedOptions, function (o) {
-                    if (o instanceof HTMLOptionElement && o.value !== '') values.push(o.value);
-                });
-                return { key: btn.getAttribute('data-search-key') || '', value: values.join(',') };
-            }
-            return { key: '', value: '' };
-        }
-        var fromId = btn.getAttribute('data-search-from');
-        if (!fromId) return { key: '', value: '' };
-        var src = document.getElementById(fromId);
-        if (src instanceof HTMLInputElement || src instanceof HTMLSelectElement || src instanceof HTMLTextAreaElement) {
-            return { key: btn.getAttribute('data-search-key') || '', value: src.value.trim() };
-        }
-        return { key: '', value: '' };
-    }
-
-    Array.prototype.forEach.call(form.querySelectorAll('button[data-search-compose], button[data-search-from], button[data-search-multi-from]'), function (btn) {
-        btn.addEventListener('click', function (ev) {
-            var pair = readPair(btn);
-            if (pair.key === '' || pair.value === '' || pair.value.replace(/[,]/g, '') === '') {
-                ev.preventDefault();
-                return;
-            }
-            typeField.value = pair.key;
-            valueField.value = pair.value;
-        });
-    });
 
     if (typeof sb === 'undefined' || !sb || !sb.api || typeof Actions === 'undefined') {
         return;

--- a/web/themes/default/css/theme.css
+++ b/web/themes/default/css/theme.css
@@ -870,3 +870,129 @@ details.queue-row > summary > .row-actions {
   .dash-intro-editor { grid-template-columns: 1fr; }
   .dash-intro-preview { min-height: 8rem; }
 }
+
+/* ============================================================
+   #1207 ADM-3 — admin-admins page-level table of contents
+   ============================================================
+   The audit flagged admin-admins as ~7 stacked surfaces (search +
+   admins list + add admin + overrides + add override) on one long
+   scroll. The fix wraps the page in a sticky anchor sidebar at
+   >=1024px and an accordion ToC at <1024px, with each section
+   anchored via `id="…"` + `scroll-margin-top` so jumps clear the
+   sticky topbar (3.5rem).
+
+   Markup contract (see admin.admins.toc.tpl + page_admin_admins_*.tpl):
+     .admin-admins-shell           outer wrapper (grid host on desktop)
+       .admin-admins-toc           <aside> with the link list
+         .admin-admins-toc__details      <details open> on every viewport;
+                                         the open/close toggle only does
+                                         something at <1024px (mobile/
+                                         narrow-tablet accordion). At
+                                         >=1024px we force the contents
+                                         visible regardless of [open]
+                                         state — see the desktop block.
+         .admin-admins-toc__summary      mobile-only chrome (hidden on
+                                         desktop)
+         .admin-admins-toc__nav          the link container
+         .admin-admins-toc__list         <ul>
+         .admin-admins-toc__link         each <a>
+       .admin-admins-content        the cross-template content column
+         .admin-admins-section      the anchored <section>s
+         .admin-admins-section__heading  per-section <h2>
+*/
+.admin-admins-section { scroll-margin-top: 4rem; }
+.admin-admins-section__heading {
+  font-size: var(--fs-base);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--text-muted);
+  margin: 0 0 0.75rem;
+}
+.admin-admins-toc {
+  font-size: var(--fs-sm);
+  margin-bottom: 1rem;
+}
+.admin-admins-toc__details {
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  background: var(--bg-surface);
+}
+.admin-admins-toc__summary {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  padding: 0.625rem 0.875rem;
+  font-weight: 600;
+  cursor: pointer;
+  list-style: none;
+  user-select: none;
+}
+.admin-admins-toc__summary::-webkit-details-marker { display: none; }
+.admin-admins-toc__summary-label { display: inline-flex; align-items: center; gap: 0.5rem; }
+.admin-admins-toc__chevron {
+  transition: transform .15s ease;
+  color: var(--text-muted);
+}
+.admin-admins-toc__details[open] .admin-admins-toc__chevron { transform: rotate(180deg); }
+.admin-admins-toc__nav { padding: 0 0.5rem 0.5rem; }
+.admin-admins-toc__list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.125rem;
+}
+.admin-admins-toc__link {
+  display: block;
+  padding: 0.4375rem 0.625rem;
+  border-radius: var(--radius-sm);
+  color: var(--text-muted);
+  text-decoration: none;
+  transition: background-color .12s, color .12s;
+}
+.admin-admins-toc__link:hover,
+.admin-admins-toc__link:focus-visible {
+  background: var(--bg-muted);
+  color: var(--text);
+  outline: none;
+}
+@media (prefers-reduced-motion: reduce) {
+  .admin-admins-toc__chevron { transition: none; }
+  .admin-admins-toc__link    { transition: none; }
+}
+
+/* Desktop layout — anchor sidebar floats next to the content column.
+   The sidebar is `position: sticky`, scoped to the shell, so it stays
+   pinned beneath the topbar (top: 4rem) while the user scrolls
+   through the sections. We force the <details> contents visible
+   regardless of [open] so accidental "collapse" at desktop can't
+   strand the user without navigation. */
+@media (min-width: 1024px) {
+  .admin-admins-shell {
+    display: grid;
+    grid-template-columns: 14rem minmax(0, 1fr);
+    gap: 1.5rem;
+    align-items: start;
+  }
+  .admin-admins-toc {
+    position: sticky;
+    top: 4rem;
+    align-self: start;
+    margin-bottom: 0;
+  }
+  .admin-admins-toc__details {
+    border: none;
+    background: transparent;
+  }
+  .admin-admins-toc__summary { display: none; }
+  /* Keep the link list visible whether the user has toggled the
+     <details> closed or not — at desktop the sidebar is a permanent
+     navigation surface, the accordion gesture only matters at mobile. */
+  .admin-admins-toc__details .admin-admins-toc__nav { display: block !important; }
+  .admin-admins-toc__nav { padding: 0; }
+  .admin-admins-toc__link { font-size: var(--fs-sm); }
+  .admin-admins-content { min-width: 0; }
+}

--- a/web/themes/default/page_admin_admins_add.tpl
+++ b/web/themes/default/page_admin_admins_add.tpl
@@ -8,6 +8,14 @@
     the JSON-API contract identical to the default theme. The CSRF
     protection comes from {csrf_field}; xajax/sb-callback are NOT
     reintroduced.
+
+    #1207 ADM-3 — section wrapper
+    -----------------------------
+    Renders inside the cross-template `.admin-admins-shell` opened by
+    page_admin_admins_list.tpl. The `<section id="add-admin">` is the
+    anchor target for the "Add admin" entry in the page-level ToC; its
+    `scroll-margin-top` (set in admins-toc CSS) clears the sticky
+    topbar after a hash-jump.
 *}
 <div class="card-tab" id="Add new admin">
     {if !$can_add_admins}
@@ -17,8 +25,9 @@
             </div>
         </div>
     {else}
+        <section id="add-admin" class="admin-admins-section" data-testid="admin-admins-section-add-admin" aria-labelledby="add-admin-heading">
         <div class="mb-4">
-            <h1 style="font-size:var(--fs-xl);font-weight:600;margin:0">Add new admin</h1>
+            <h2 id="add-admin-heading" style="font-size:var(--fs-xl);font-weight:600;margin:0">Add new admin</h2>
             <p class="text-sm text-muted m-0 mt-2">Hover the help icons for field-level guidance.</p>
         </div>
 
@@ -211,5 +220,6 @@
 
         {* nofilter: server-built `<script>LoadServerHost('SID', 'id', 'saSID');…</script>` from `:prefix_servers.sid` integer column, no user input — see admin.admins.php. *}
         {$server_script nofilter}
+        </section>
     {/if}
 </div>

--- a/web/themes/default/page_admin_admins_list.tpl
+++ b/web/themes/default/page_admin_admins_list.tpl
@@ -17,7 +17,30 @@
     flattens the row into one table row with hover-revealed action
     buttons. Per-flag permission lists move to the edit-permissions
     page where they're actionable; the list page stays scannable.
+
+    #1207 ADM-3 — Page-level ToC + cross-template shell
+    ---------------------------------------------------
+    The audit (#1207 ADM-3) called out admin-admins as ~7 stacked
+    surfaces (search + admins list + add admin + overrides + add
+    override) on one long scroll with no internal navigation. We open
+    a `.admin-admins-shell` wrapper here that spans all three templates
+    (this one, page_admin_admins_add.tpl, page_admin_overrides.tpl) and
+    paint a sticky anchor sidebar at >=1024px / accordion at <1024px
+    inside it. The closing `</div>` lives at the bottom of
+    page_admin_overrides.tpl — keep these tags paired across edits.
+
+    Each section below is wrapped in a `<section id="…">` with
+    `scroll-margin-top` so the sticky topbar (3.5rem) clears the
+    heading after an anchor jump. The anchor IDs are referenced by the
+    ToC (rendered via {include file="admin.admins.toc.tpl"}) and by
+    other templates that link back into this page (e.g. the admin home
+    Overrides card already uses `#overrides`).
 *}
+<div class="admin-admins-shell" data-testid="admin-admins-shell">
+
+{include file="admin.admins.toc.tpl"}
+
+<div class="admin-admins-content">
 <div class="card-tab" id="List admins">
     {if !$can_list_admins}
         <div class="card">
@@ -35,17 +58,23 @@
             </div>
             {if $can_add_admins}
                 <a class="btn btn--primary btn--sm"
-                   href="?p=admin&c=admins#Add%20new%20admin"
+                   href="#add-admin"
                    data-testid="admin-add-cta"><i data-lucide="user-plus"></i> Add admin</a>
             {/if}
         </div>
 
-        {load_template file="admin.admins.search"}
+        <section id="search" class="admin-admins-section" data-testid="admin-admins-section-search" aria-labelledby="search-heading">
+            <h2 id="search-heading" class="admin-admins-section__heading">Search admins</h2>
+            {load_template file="admin.admins.search"}
+        </section>
 
-        <div class="text-xs text-muted mb-2" data-testid="admin-nav">
-            {* nofilter: server-built pagination HTML; advSearch/advType (the only $_GET inputs) are htmlspecialchars(addslashes(...))'d before interpolation in admin.admins.php — same escape pipeline as the legacy theme. *}
-            {$admin_nav nofilter}
-        </div>
+        <section id="admins" class="admin-admins-section" data-testid="admin-admins-section-admins" aria-labelledby="admins-heading">
+            <h2 id="admins-heading" class="admin-admins-section__heading">Admins list</h2>
+
+            <div class="text-xs text-muted mb-2" data-testid="admin-nav">
+                {* nofilter: server-built pagination HTML; advSearch/advType (the only $_GET inputs) are htmlspecialchars(addslashes(...))'d before interpolation in admin.admins.php — same escape pipeline as the legacy theme. *}
+                {$admin_nav nofilter}
+            </div>
 
         <div class="card" style="overflow:hidden">
             <table class="table" role="table" aria-label="Admins">
@@ -133,5 +162,7 @@
                 </tbody>
             </table>
         </div>
+        </section>
     {/if}
 </div>
+{* admin-admins-content + admin-admins-shell remain open; closed in page_admin_overrides.tpl *}

--- a/web/themes/default/page_admin_admins_list.tpl
+++ b/web/themes/default/page_admin_admins_list.tpl
@@ -72,7 +72,7 @@
             <h2 id="admins-heading" class="admin-admins-section__heading">Admins list</h2>
 
             <div class="text-xs text-muted mb-2" data-testid="admin-nav">
-                {* nofilter: server-built pagination HTML; advSearch/advType (the only $_GET inputs) are htmlspecialchars(addslashes(...))'d before interpolation in admin.admins.php — same escape pipeline as the legacy theme. *}
+                {* nofilter: server-built pagination HTML — `<displaying N - M of K results>` (integers), prev/next `<a>` from `CreateLinkR(…)`, and a page-jump `<select onchange>`. After #1207 ADM-4 every populated filter flows through `http_build_query($activeFilters)`, which percent-encodes filter values (so single quotes / angle brackets can't break out of the single-quoted `href='…'` or `onchange="… '…'…"` attributes). The page-jump `<select>` additionally `htmlspecialchars()`-escapes the base URL with `ENT_QUOTES` before interpolation. Loop counters and pre-computed page numbers are integers. No raw user input reaches the rendered string. *}
                 {$admin_nav nofilter}
             </div>
 

--- a/web/themes/default/page_admin_overrides.tpl
+++ b/web/themes/default/page_admin_overrides.tpl
@@ -11,13 +11,24 @@
       - {csrf_field} is required because the dispatcher invokes
         CSRF::rejectIfInvalid() on every POST.
 
-    The wrapper carries `id="overrides"` (URL-safe, lowercase) so the
-    admin home's Overrides card href (`?p=admin&c=admins#overrides`,
-    #1207 ADM-1) scrolls the page to this editor instead of dropping
-    the user at the top of the admins list. `scroll-margin-top` keeps
-    the heading clear of the sticky topbar after the jump.
+    #1207 ADM-3 — section wrappers + cross-template close
+    -----------------------------------------------------
+    Two anchor targets for the page-level ToC:
+      - `<section id="overrides">` — the editable table of existing
+        overrides (also reachable from the admin home's Overrides card,
+        which links to `?p=admin&c=admins#overrides`).
+      - `<section id="add-override">` — the "Add an override" form
+        below the table.
+    The Save button sits in the parent `<form>` and submits both
+    sections at once; the visual split is purely navigational.
+
+    This template is the LAST one in the cross-template
+    `.admin-admins-shell` opened by page_admin_admins_list.tpl, so the
+    matching `</div></div>` closing the `.admin-admins-content` and
+    `.admin-admins-shell` lives at the bottom of this file. Keep the
+    open/close tags paired across edits.
 *}
-<div class="tabcontent" id="overrides" style="scroll-margin-top:4rem">
+<div class="tabcontent">
 {if not $permission_addadmin}
     <div class="card">
         <div class="card__body">
@@ -45,10 +56,11 @@
     <form method="post" action="index.php?p=admin&amp;c=admins" data-testid="overrides-form">
         {csrf_field}
 
+        <section id="overrides" class="admin-admins-section" data-testid="admin-admins-section-overrides" aria-labelledby="overrides-heading">
         <div class="card mb-4">
             <div class="card__header">
                 <div>
-                    <h3>Command &amp; group overrides</h3>
+                    <h3 id="overrides-heading">Command &amp; group overrides</h3>
                     <p>
                         Override the flags required to run any SourceMod command, globally
                         or per-group, without editing plugin source. Blank out a name to
@@ -100,11 +112,13 @@
                 </table>
             </div>
         </div>
+        </section>
 
+        <section id="add-override" class="admin-admins-section" data-testid="admin-admins-section-add-override" aria-labelledby="add-override-heading">
         <div class="card mb-4">
             <div class="card__header">
                 <div>
-                    <h3>Add an override</h3>
+                    <h3 id="add-override-heading">Add an override</h3>
                     <p>Pick a type, give it a command/group name and the flags admins need to run it.</p>
                 </div>
             </div>
@@ -131,6 +145,7 @@
                 </div>
             </div>
         </div>
+        </section>
 
         <div class="flex justify-end gap-2">
             <a class="btn btn--ghost" href="javascript:history.go(-1);" data-testid="overrides-back">Back</a>
@@ -139,3 +154,6 @@
     </form>
 {/if}
 </div>
+{* Close cross-template wrappers opened in page_admin_admins_list.tpl. *}
+</div>{* /.admin-admins-content *}
+</div>{* /.admin-admins-shell *}


### PR DESCRIPTION
## Summary

Slice 7 of #1207 — admins page density rework. Addresses ADM-3 (admin-admins only — admin-bans and myaccount are out of scope), ADM-4.

- **ADM-3** — Wrap admin/admins in a sticky page-level table of contents: anchor sidebar at `>=1024px`, accordion (`<details open>`) at `<1024px`. Each of the five surfaces (Search, Admins, Add admin, Overrides, Add override) becomes an anchored `<section id="…" class="admin-admins-section" data-testid="admin-admins-section-…">` with `scroll-margin-top: 4rem` so jumps clear the sticky topbar (3.5rem).
- **ADM-4** — Collapse the eight per-row `[Search]` buttons in `box_admin_admins_search.tpl` to a single submit + a "Clear filters" reset link. Server-side, `admin.admins.php` ANDs every populated filter; pagination uses `http_build_query($activeFilters)` to round-trip filters across page jumps. Legacy `?advType=name&advSearch=foo` URLs still narrow correctly via a backward-compat shim that translates the legacy shape into the modern field names on entry — bookmarks and external links keep working.

Locked with a new PHPUnit integration test (renders the page handler with a real Smarty bootstrap and asserts the row count + content for the AND matrix and the legacy compat shim) and a new Playwright flow spec (desktop sidebar visibility + click-scrolls-to-section, mobile accordion, single-submit network count, URL pre-fill round-trip, Clear-filters reset).

Convention captured in `AGENTS.md` so the next dense admin page (admin-bans, myaccount) can reuse the ToC pattern verbatim. The "Where to find what" table grows two rows pointing at the partial + the four-file admin-admins search filter path.

## Test plan

- [x] PHPStan clean (`./sbpp.sh phpstan` — 216 files, 0 errors)
- [x] PHPUnit clean (`./sbpp.sh test` — 323 tests, 1312 assertions, includes the new 8-case `AdminAdminsSearchTest`)
- [x] ts-check clean (`./sbpp.sh ts-check`)
- [x] API contract clean (`./sbpp.sh composer api-contract` — no diff)
- [x] Playwright E2E clean (`./sbpp.sh e2e --workers=1` — 141 passed, 0 flakes; the new flow spec contributes 6 chromium + 1 mobile-chromium tests)
- [x] Screenshot gallery regenerated (admin-admins light/dark on chromium + mobile-chromium)
- [x] Manual: anchor sidebar visible at >= 1024px on admin-admins; accordion ToC at < 1024px; advanced-search single submit AND-combines filters; legacy `advType=…&advSearch=…` URLs still narrow

Does NOT close #1207.