### PR TITLE
fix(api): re-source system.check_version from GitHub Releases (#1214)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -141,12 +141,15 @@ Both scripts include `init.php` first, which performs identical bootstrap.
    PSR-4 namespaced) and initialises them.
 5. Resolves the panel version via `Sbpp\Version::resolve()` — three-tier
    fallback (release tarball's `configs/version.json` → `git describe`
-   → the `'dev'` sentinel) and `define()`s `SB_VERSION` / `SB_GITREV` /
-   `SB_DEV` from the result. The chrome's `<footer data-version="…">`
-   hook (`web/themes/default/core/footer.tpl`) mirrors `SB_VERSION`
+   → the `'dev'` sentinel) and `define()`s `SB_VERSION` / `SB_GITREV`
+   from the result. The chrome's `<footer data-version="…">` hook
+   (`web/themes/default/core/footer.tpl`) mirrors `SB_VERSION`
    verbatim so telemetry and E2E specs can distinguish dev installs
    (`data-version="dev"`) from release tarball installs without
-   parsing the user-visible string (#1207 CC-5).
+   parsing the user-visible string (#1207 CC-5). Dev-checkout panels
+   are identified by `SB_VERSION === Version::DEV_SENTINEL`; the
+   footer's "| Git: <sha>" suffix gates on `SB_GITREV` directly so a
+   separate boolean isn't needed (#1214).
 6. Reads `configs/permissions/web.json` + `sourcemod.json` and `define()`s
    each flag as a global PHP constant (`ADMIN_OWNER`, `ADMIN_ADD_BAN`, …).
 7. Constructs the global `$theme` (Smarty) with the configured theme dir,

--- a/web/api/handlers/system.php
+++ b/web/api/handlers/system.php
@@ -15,53 +15,218 @@ use Sbpp\Mail\EmailType;
 use Sbpp\Mail\Mail;
 use Sbpp\Markup\IntroRenderer;
 
-function api_system_check_version(array $params): array
+/**
+ * Upstream GitHub Releases endpoint. Overridable via the
+ * `SB_RELEASE_LATEST_URL` constant so tests can point at a local fixture
+ * instead of the real GitHub API; defining it before the handler runs is
+ * a no-op for production self-hosters who never see the constant.
+ */
+function _api_system_release_upstream_url(): string
 {
-    $raw = (string)@file_get_contents('https://sbpp.github.io/version.json');
-    $version = $raw ? json_decode($raw, true) : null;
-    $version = is_array($version) ? $version : ['version' => '', 'git' => ''];
+    if (defined('SB_RELEASE_LATEST_URL') && is_string(SB_RELEASE_LATEST_URL) && SB_RELEASE_LATEST_URL !== '') {
+        return SB_RELEASE_LATEST_URL;
+    }
+    return 'https://api.github.com/repos/sbpp/sourcebans-pp/releases/latest';
+}
 
-    $latest = $version['version'] ?? '';
-    if (strlen((string)$latest) > 8 || $latest === '') {
-        $latest = 'Error';
-        $msg = 'Error Retrieving Latest Release.';
-        $update = false;
-    } elseif (version_compare($latest, SB_VERSION) > 0) {
-        $msg = 'A New Release is Available.';
-        $update = true;
-    } else {
-        $msg = 'You have the Latest Release.';
-        $update = false;
+/**
+ * Re-read the cached GitHub release payload, returning null when the file
+ * is missing, unreadable, or doesn't decode to the expected
+ * `{tag_name, html_url, cached_at}` shape. The "stale-while-error" branch
+ * in the main handler relies on this returning a usable payload regardless
+ * of `cached_at`, so don't filter on TTL here.
+ *
+ * @return array{tag_name: string, html_url: string, cached_at: int}|null
+ */
+function _api_system_release_load_cache(string $file): ?array
+{
+    if (!is_file($file)) {
+        return null;
+    }
+    $raw = @file_get_contents($file);
+    if ($raw === false || $raw === '') {
+        return null;
+    }
+    $decoded = json_decode($raw, true);
+    if (!is_array($decoded)) {
+        return null;
+    }
+    $tag = $decoded['tag_name'] ?? null;
+    $url = $decoded['html_url'] ?? null;
+    $at  = $decoded['cached_at'] ?? null;
+    if (!is_string($tag) || $tag === '' || !is_string($url) || !is_int($at)) {
+        return null;
+    }
+    return ['tag_name' => $tag, 'html_url' => $url, 'cached_at' => $at];
+}
+
+/**
+ * Persist the latest upstream payload + a fresh `cached_at` timestamp.
+ * Failure to write (read-only filesystem, permission glitch, …) is
+ * silently ignored; the in-memory response we already constructed is
+ * still served, and the next call will just re-fetch.
+ */
+function _api_system_release_save_cache(string $file, string $tagName, string $htmlUrl): void
+{
+    $payload = json_encode([
+        'tag_name'  => $tagName,
+        'html_url'  => $htmlUrl,
+        'cached_at' => time(),
+    ]);
+    if ($payload === false) {
+        return;
+    }
+    @file_put_contents($file, $payload);
+}
+
+/**
+ * Fetch the latest release from the configured upstream and return the
+ * `{tag_name, html_url}` pair. Returns null on any network failure,
+ * non-2xx response, malformed JSON, or missing tag_name — the caller
+ * uses null as the "fall back to cache" signal.
+ *
+ * GitHub requires a `User-Agent` on every API call; the documented
+ * `Accept: application/vnd.github+json` pins the response shape to the
+ * v3 contract so a future server-side default change can't surprise us.
+ * The 5s timeout keeps the handler from stalling a page render on a
+ * network blip — the panel falls through to the cache (or the "Error"
+ * envelope) instead of hanging.
+ *
+ * @return array{tag_name: string, html_url: string}|null
+ */
+function _api_system_release_fetch_upstream(): ?array
+{
+    $headers = "User-Agent: SourceBans++\r\n"
+             . "Accept: application/vnd.github+json\r\n";
+    $context = stream_context_create([
+        'http'  => [
+            'method'        => 'GET',
+            'header'        => $headers,
+            'timeout'       => 5,
+            'ignore_errors' => true,
+        ],
+        'https' => [
+            'method'        => 'GET',
+            'header'        => $headers,
+            'timeout'       => 5,
+            'ignore_errors' => true,
+        ],
+    ]);
+
+    $body = @file_get_contents(_api_system_release_upstream_url(), false, $context);
+    if ($body === false || $body === '') {
+        return null;
     }
 
-    $devLatest = null;
-    $devUpdate = null;
-    $devMsg = null;
-    if (SB_DEV) {
-        $git = $version['git'] ?? '';
-        if (strlen((string)$git) > 8 || $git === '') {
-            $devLatest = 'Error';
-            $devMsg = 'Error retrieving latest Dev Version.';
-            $devUpdate = false;
-        } elseif ((int)$git > SB_GITREV) {
-            $devLatest = $git;
-            $devMsg = 'A New Dev Version is Available.';
-            $devUpdate = true;
-        } else {
-            $devLatest = $git;
-            $devMsg = 'You have the Latest Dev Version.';
-            $devUpdate = false;
+    // `ignore_errors=true` makes file_get_contents return the body even on
+    // a non-2xx status, so reject anything outside 2xx explicitly. The
+    // response status line lives in the magic local $http_response_header
+    // array file_get_contents seeds; PHPStan knows it's always defined
+    // post-call so no `isset()` guard is needed.
+    /** @var list<string> $http_response_header */
+    if (isset($http_response_header[0]) && preg_match('~HTTP/\S+\s+(\d+)~', $http_response_header[0], $m)) {
+        $status = (int) $m[1];
+        if ($status < 200 || $status >= 300) {
+            return null;
         }
+    }
+
+    $decoded = json_decode($body, true);
+    if (!is_array($decoded)) {
+        return null;
+    }
+    $tag = $decoded['tag_name'] ?? null;
+    $url = $decoded['html_url'] ?? null;
+    if (!is_string($tag) || $tag === '' || !is_string($url)) {
+        return null;
+    }
+    return ['tag_name' => $tag, 'html_url' => $url];
+}
+
+/**
+ * Build the public response shape from a cached or freshly-fetched
+ * release pair, branching on whether the local panel is on a real
+ * version, on the dev sentinel, or trails / leads the upstream tag.
+ *
+ * Strips an optional leading `v`/`V` from the upstream tag (GitHub
+ * releases historically use both `v1.8.4` and `1.8.4` shapes; SB_VERSION
+ * is always plain). The `'dev'` sentinel from `init.php` is special-cased
+ * because `version_compare('1.8.4', 'dev')` returns 1 (PHP treats `dev`
+ * as a pre-release suffix), which would otherwise falsely advertise
+ * "A New Release is Available." on every dev-checkout panel.
+ *
+ * @return array{release_latest: string, release_url: string, release_msg: string, release_update: bool}
+ */
+function _api_system_release_format(string $tagName, string $htmlUrl, string $localVersion): array
+{
+    $latest = ltrim($tagName, 'vV');
+
+    if ($localVersion === 'dev') {
+        return [
+            'release_latest' => $latest,
+            'release_url'    => $htmlUrl,
+            'release_msg'    => 'Tracking development build.',
+            'release_update' => false,
+        ];
+    }
+
+    if (version_compare($latest, $localVersion) > 0) {
+        return [
+            'release_latest' => $latest,
+            'release_url'    => $htmlUrl,
+            'release_msg'    => 'A New Release is Available.',
+            'release_update' => true,
+        ];
     }
 
     return [
         'release_latest' => $latest,
-        'release_msg'    => $msg,
-        'release_update' => $update,
-        'dev'            => SB_DEV,
-        'dev_latest'     => $devLatest,
-        'dev_msg'        => $devMsg,
-        'dev_update'     => $devUpdate,
+        'release_url'    => $htmlUrl,
+        'release_msg'    => 'You have the Latest Release.',
+        'release_update' => false,
+    ];
+}
+
+/**
+ * Public action: report whether a newer SourceBans++ release is
+ * available. Sources from `api.github.com/repos/sbpp/sourcebans-pp/releases/latest`
+ * with a 1-day on-disk cache + stale-while-error fallback (the cached
+ * payload is served regardless of TTL when the upstream call fails) so a
+ * busy panel can't blow through GitHub's 60 req/hr unauthenticated limit
+ * and a transient GitHub blip doesn't paint the panel red.
+ *
+ * @return array{release_latest: string, release_url: string, release_msg: string, release_update: bool}
+ */
+function api_system_check_version(array $params): array
+{
+    // 1-day TTL is the rate-limit answer: GitHub's unauthenticated REST
+    // API caps each source IP at 60 req/hr, and a busy panel polled by
+    // every admin tab on every page render would burn that trivially.
+    // Releases ship far less often than once a day, so anything tighter
+    // wouldn't buy a more accurate "is there an upgrade?" signal.
+    $ttlSeconds = 86400;
+    $cacheFile  = SB_CACHE . 'github_release_latest.json';
+    $cached     = _api_system_release_load_cache($cacheFile);
+
+    if ($cached !== null && (time() - $cached['cached_at']) < $ttlSeconds) {
+        return _api_system_release_format($cached['tag_name'], $cached['html_url'], SB_VERSION);
+    }
+
+    $fetched = _api_system_release_fetch_upstream();
+    if ($fetched !== null) {
+        _api_system_release_save_cache($cacheFile, $fetched['tag_name'], $fetched['html_url']);
+        return _api_system_release_format($fetched['tag_name'], $fetched['html_url'], SB_VERSION);
+    }
+
+    if ($cached !== null) {
+        return _api_system_release_format($cached['tag_name'], $cached['html_url'], SB_VERSION);
+    }
+
+    return [
+        'release_latest' => 'Error',
+        'release_url'    => '',
+        'release_msg'    => 'Error retrieving latest release.',
+        'release_update' => false,
     ];
 }
 

--- a/web/api/handlers/system.php
+++ b/web/api/handlers/system.php
@@ -65,6 +65,16 @@ function _api_system_release_load_cache(string $file): ?array
  * Failure to write (read-only filesystem, permission glitch, …) is
  * silently ignored; the in-memory response we already constructed is
  * still served, and the next call will just re-fetch.
+ *
+ * Writes are atomic: dump the payload into a sibling tempfile, then
+ * `rename()` it into place. Without that, two concurrent panel hits on
+ * a cold cache could both call `file_put_contents` on the live file,
+ * interleave their writes, and leave a half-written JSON that
+ * `_api_system_release_load_cache` would then reject — repeatedly,
+ * because every subsequent fetch tries to re-cache and may collide
+ * again. `rename()` is atomic on POSIX filesystems (the panel only
+ * runs on Linux per docker-compose.yml), so the live file is never
+ * partially written.
  */
 function _api_system_release_save_cache(string $file, string $tagName, string $htmlUrl): void
 {
@@ -76,7 +86,12 @@ function _api_system_release_save_cache(string $file, string $tagName, string $h
     if ($payload === false) {
         return;
     }
-    @file_put_contents($file, $payload);
+    $tmp = $file . '.' . bin2hex(random_bytes(4)) . '.tmp';
+    if (@file_put_contents($tmp, $payload) === strlen($payload)) {
+        @rename($tmp, $file);
+    } else {
+        @unlink($tmp);
+    }
 }
 
 /**
@@ -96,15 +111,15 @@ function _api_system_release_save_cache(string $file, string $tagName, string $h
  */
 function _api_system_release_fetch_upstream(): ?array
 {
-    $headers = "User-Agent: SourceBans++\r\n"
+    // Identify the panel version in the User-Agent so GitHub's rate-limit
+    // dashboards (and self-hosters tailing their proxy logs) can attribute
+    // traffic to a specific install. The upstream URL is hardcoded
+    // `https://`, so only the `https` stream wrapper key is consulted —
+    // the `http` block file_get_contents would read on a `http://` URL is
+    // dead defense; omit it.
+    $headers = 'User-Agent: SourceBans++/' . SB_VERSION . "\r\n"
              . "Accept: application/vnd.github+json\r\n";
     $context = stream_context_create([
-        'http'  => [
-            'method'        => 'GET',
-            'header'        => $headers,
-            'timeout'       => 5,
-            'ignore_errors' => true,
-        ],
         'https' => [
             'method'        => 'GET',
             'header'        => $headers,
@@ -219,8 +234,19 @@ function api_system_check_version(array $params): array
     }
 
     if ($cached !== null) {
+        // Stale-while-error: cache exists but is past TTL and the upstream
+        // call just failed. Quiet — the user-visible response is still the
+        // cached payload, panel stays green.
         return _api_system_release_format($cached['tag_name'], $cached['html_url'], SB_VERSION);
     }
+
+    // Both the upstream fetch AND the cache fallback are unavailable;
+    // there's nothing meaningful to render. Log to the PHP error log so
+    // a self-hoster troubleshooting "panel says `Error retrieving latest
+    // release.`" gets a hint pointing at the upstream rather than at the
+    // panel itself. Only fired on this fully-degraded branch — the
+    // fresh-fetch-failed-but-cache-exists path above is benign.
+    error_log('SourceBans++: system.check_version upstream fetch failed and no cache available');
 
     return [
         'release_latest' => 'Error',

--- a/web/includes/Version.php
+++ b/web/includes/Version.php
@@ -39,14 +39,26 @@ final class Version
     public const DEV_SENTINEL = 'dev';
 
     /**
-     * Resolve the version triple `[version, git, dev]` exactly the
-     * way `init.php` consumes it for the SB_* constants.
+     * Resolve the version pair `[version, git]` exactly the way
+     * `init.php` consumes it for the `SB_VERSION` / `SB_GITREV`
+     * constants.
+     *
+     * The `'dev'` *sentinel string* in the `version` slot is the
+     * canonical way to identify a dev-checkout panel (#1207 CC-5);
+     * an out-of-band `dev: bool` field used to live alongside it but
+     * was dropped in #1214 — every consumer now branches on either
+     * `SB_VERSION === self::DEV_SENTINEL` for the "is this a dev
+     * build?" question or on `SB_GITREV` directly for the "do we
+     * have a SHA to print?" question. Carrying a separate boolean
+     * was redundant once `system.check_version` stopped gating on
+     * it (the gated branch had already gone obsolete because it
+     * compared a numeric git rev that no longer exists).
      *
      * @param  callable|null $jsonReader  fn(string $path): ?array — defaults to
      *                                    file_get_contents + json_decode.
      * @param  callable|null $gitDescribe fn(): string — defaults to shell_exec.
      * @param  callable|null $gitShortRev fn(): string — defaults to shell_exec.
-     * @return array{version: string, git: int|string, dev: bool}
+     * @return array{version: string, git: int|string}
      */
     public static function resolve(
         string $versionJsonPath,
@@ -63,7 +75,6 @@ final class Version
             return [
                 'version' => (string) $tarball['version'],
                 'git'     => $tarball['git'] ?? 0,
-                'dev'     => (bool) ($tarball['dev'] ?? false),
             ];
         }
 
@@ -73,14 +84,12 @@ final class Version
             return [
                 'version' => $tag !== '' ? $tag : self::DEV_SENTINEL,
                 'git'     => $sha,
-                'dev'     => true,
             ];
         }
 
         return [
             'version' => self::DEV_SENTINEL,
             'git'     => 0,
-            'dev'     => true,
         ];
     }
 

--- a/web/includes/View/AdminHomeView.php
+++ b/web/includes/View/AdminHomeView.php
@@ -26,7 +26,7 @@ namespace Sbpp\View;
  * Comms intentionally folds into the sidebar nav (`admin/comms`) and
  * does not surface a separate Comms card on the landing.
  *
- * `access_*`, `dev`, `demosize`, `total_*`, and `archived_*` are
+ * `access_*`, `demosize`, `total_*`, and `archived_*` are
  * preserved on this View (and referenced by an unreachable
  * `{if false}` parity block in the template) so any third-party theme
  * that forked the pre-v2.0.0 default keeps rendering off the same
@@ -56,7 +56,6 @@ final class AdminHomeView extends View
         public readonly bool $access_groups,
         public readonly bool $access_settings,
         public readonly bool $access_mods,
-        public readonly bool $dev,
         public readonly string $demosize,
         public readonly int $total_admins,
         public readonly int $total_bans,

--- a/web/init.php
+++ b/web/init.php
@@ -88,7 +88,6 @@ $version = \Sbpp\Version::resolve(ROOT . 'configs/version.json');
 
 define('SB_VERSION', $version['version']);
 define('SB_GITREV', $version['git']);
-define('SB_DEV', $version['dev']);
 
 // ---------------------------------------------------
 //  Setup our DB

--- a/web/pages/core/footer.php
+++ b/web/pages/core/footer.php
@@ -5,7 +5,12 @@ if (!defined("IN_SB")) {
     die("You should not be here. Only follow links!");
 }
 
-$theme->assign('git', (SB_DEV) ? ' | Git: '.SB_GITREV : '');
+// Suffix the footer with the short SHA when we have one. Both empty
+// branches (an empty string from a missing-git fallback, or the literal
+// `0` from the unresolved sentinel / the test bootstrap) are PHP-falsy,
+// so this gates on the presence of an actual SHA without needing a
+// separate "is this a dev build?" boolean.
+$theme->assign('git', SB_GITREV ? ' | Git: '.SB_GITREV : '');
 $theme->assign('version', SB_VERSION);
 $theme->assign('query', !empty($GLOBALS['server_qry']) ? $GLOBALS['server_qry'] : '');
 $theme->display('core/footer.tpl');

--- a/web/pages/page.admin.php
+++ b/web/pages/page.admin.php
@@ -65,7 +65,6 @@ $perms = \Sbpp\View\Perms::for($userbank);
     access_groups:        $userbank->HasAccess(ADMIN_OWNER | ADMIN_LIST_GROUPS  | ADMIN_ADD_GROUP   | ADMIN_EDIT_GROUPS  | ADMIN_DELETE_GROUPS),
     access_settings:      $userbank->HasAccess(ADMIN_OWNER | ADMIN_WEB_SETTINGS),
     access_mods:          $userbank->HasAccess(ADMIN_OWNER | ADMIN_LIST_MODS    | ADMIN_ADD_MODS    | ADMIN_EDIT_MODS    | ADMIN_DELETE_MODS),
-    dev:                  SB_DEV,
     demosize:             getDirSize(SB_DEMOS),
     total_admins:         (int) $counts['admins'],
     total_bans:           (int) $counts['bans'],

--- a/web/scripts/api-contract.js
+++ b/web/scripts/api-contract.js
@@ -354,8 +354,15 @@
  * @typedef {Object} ApiSystemApplyThemeResponse
  */
 /**
+ * Public action: report whether a newer SourceBans++ release is available.
+ * Sources from `api.github.com/repos/sbpp/sourcebans-pp/releases/latest` with
+ * a 1-day on-disk cache + stale-while-error fallback (the cached payload is
+ * served regardless of TTL when the upstream call fails) so a busy panel can't
+ * blow through GitHub's 60 req/hr unauthenticated limit and a transient GitHub
+ * blip doesn't paint the panel red.
+ *
  * @typedef {Object} ApiSystemCheckVersionRequest
- * @typedef {Object} ApiSystemCheckVersionResponse
+ * @typedef {{release_latest: string, release_url: string, release_msg: string, release_update: boolean}} ApiSystemCheckVersionResponse
  */
 /**
  * @typedef {Object} ApiSystemClearCacheRequest

--- a/web/tests/api/SystemTest.php
+++ b/web/tests/api/SystemTest.php
@@ -99,12 +99,96 @@ final class SystemTest extends ApiTestCase
         $this->assertSnapshot('system/check_version_error', $env);
     }
 
+    public function testCheckVersionStaleCacheServedWhenUpstreamUnreachable(): void
+    {
+        // Stale-while-error contract: cache exists but is past the
+        // 1-day TTL AND the upstream is unreachable -> serve the cached
+        // payload anyway (NOT the `Error` envelope). Prime the cache
+        // with `cached_at` one second past the TTL so the in-TTL fast
+        // path is skipped and the handler falls into the upstream-fetch
+        // branch; force the upstream URL to a refused port so that
+        // fetch returns null; assert the handler returns the formatted
+        // cached shape, not `release_latest: 'Error'`. Re-priming the
+        // cache here (rather than relying on a previously-primed file)
+        // makes the test order-independent: even if it runs after
+        // `testCheckVersionErrorWhenNoCacheAndUpstreamUnreachable`
+        // unlinked the file, the stale entry below is what the assertion
+        // depends on.
+        if (!defined('SB_RELEASE_LATEST_URL')) {
+            define('SB_RELEASE_LATEST_URL', 'http://127.0.0.1:1/');
+        }
+        $this->primeReleaseCache('1.7.2', time() - 86401);
+
+        $env = $this->api('system.check_version', []);
+
+        $this->assertTrue($env['ok']);
+        $this->assertSame('1.7.2', $env['data']['release_latest']);
+        $this->assertSame(
+            'https://github.com/sbpp/sourcebans-pp/releases/tag/1.7.2',
+            $env['data']['release_url']
+        );
+        $this->assertNotSame('Error', $env['data']['release_latest']);
+        $this->assertSnapshot('system/check_version_stale_while_error', $env);
+    }
+
+    public function testCheckVersionDevSentinelShortCircuitsBeforeVersionCompare(): void
+    {
+        // Pin the explicit guard added in #1214: a dev-checkout panel
+        // (SB_VERSION === 'dev') must NOT compare its local version
+        // against the upstream tag with version_compare(), because PHP
+        // treats `dev` as a pre-release suffix and ranks it below every
+        // numeric tag — `version_compare('1.8.4', 'dev')` returns 1, so
+        // a naive compare would falsely advertise an update on every
+        // dev checkout. The handler short-circuits that case to return
+        // `release_update: false` + a "tracking development build" copy
+        // so dev-mode users aren't nagged.
+        //
+        // SB_VERSION is fixed at 'test' in the bootstrap and PHP can't
+        // redefine constants mid-run, so exercise the helper directly
+        // with the sentinel as the local-version argument; that's the
+        // exact branch the dispatcher would hit on a real dev checkout.
+        // The handler file is loaded transitively via Api::bootstrap()
+        // in Fixture::install(), so the global helper is in scope by
+        // the time setUp() returns. Leading `\` makes it explicit
+        // we're reaching for a global function from inside the
+        // `Sbpp\Tests\Api` namespace.
+        $resp = \_api_system_release_format(
+            '1.8.4',
+            'https://github.com/sbpp/sourcebans-pp/releases/tag/1.8.4',
+            'dev'
+        );
+
+        $this->assertSame('1.8.4', $resp['release_latest']);
+        $this->assertSame(
+            'https://github.com/sbpp/sourcebans-pp/releases/tag/1.8.4',
+            $resp['release_url']
+        );
+        $this->assertSame('Tracking development build.', $resp['release_msg']);
+        $this->assertFalse(
+            $resp['release_update'],
+            'dev sentinel must NOT advertise an update; PHP version_compare("1.8.4", "dev") returns 1.'
+        );
+
+        // Belt-and-suspenders: confirm `version_compare` would, in fact,
+        // return 1 for the same pair. If a future PHP version changes
+        // the comparison, the assertion above is still the correct
+        // guard, but this lets a maintainer see immediately why the
+        // short-circuit is necessary.
+        $this->assertSame(
+            1,
+            version_compare('1.8.4', 'dev'),
+            'PHP semantics changed: version_compare("1.8.4", "dev") no longer returns 1.'
+        );
+    }
+
     /**
-     * Seed the on-disk cache the handler reads first. TTL is 1 day, so
-     * the freshly-stamped `cached_at` always wins and the handler skips
-     * the upstream fetch entirely — what the snapshot tests rely on.
+     * Seed the on-disk cache the handler reads first. The default
+     * `cached_at` is `time()`, which (with the 1-day TTL) makes the
+     * handler hit the in-TTL fast path and skip the upstream fetch
+     * entirely — what the success-path snapshot tests rely on. Pass an
+     * older timestamp to exercise the stale-while-error path instead.
      */
-    private function primeReleaseCache(string $tagName): void
+    private function primeReleaseCache(string $tagName, ?int $cachedAt = null): void
     {
         $cache = SB_CACHE;
         if (!is_dir($cache) && !@mkdir($cache, 0o775, true) && !is_dir($cache)) {
@@ -113,7 +197,7 @@ final class SystemTest extends ApiTestCase
         file_put_contents($cache . 'github_release_latest.json', (string) json_encode([
             'tag_name'  => $tagName,
             'html_url'  => 'https://github.com/sbpp/sourcebans-pp/releases/tag/' . $tagName,
-            'cached_at' => time(),
+            'cached_at' => $cachedAt ?? time(),
         ]));
     }
 

--- a/web/tests/api/SystemTest.php
+++ b/web/tests/api/SystemTest.php
@@ -18,14 +18,103 @@ final class SystemTest extends ApiTestCase
 {
     public function testCheckVersionIsPublicAndReturnsShape(): void
     {
-        // Public action; the handler hits a remote URL but the envelope
-        // shape is the same regardless of fetch success.
+        // Prime the cache so the handler doesn't hit GitHub from CI: the
+        // handler always prefers a fresh cache (TTL is 1 day, our payload
+        // is `cached_at => now`) and the snapshot then locks the wire
+        // shape byte-for-byte without any network dependency. SB_VERSION
+        // is `'test'` in the bootstrap and `version_compare` ranks any
+        // unrecognised string below every numeric tag, so a tag of
+        // `1.8.4` deterministically lands on the "update available"
+        // branch; the snapshot pins that.
+        $this->primeReleaseCache('1.8.4');
+
         $env = $this->api('system.check_version', []);
         $this->assertTrue($env['ok']);
-        $this->assertArrayHasKey('release_latest', $env['data']);
-        $this->assertArrayHasKey('release_msg',    $env['data']);
-        $this->assertArrayHasKey('release_update', $env['data']);
-        $this->assertArrayHasKey('dev',            $env['data']);
+        $this->assertSame('1.8.4', $env['data']['release_latest']);
+        $this->assertSame(
+            'https://github.com/sbpp/sourcebans-pp/releases/tag/1.8.4',
+            $env['data']['release_url']
+        );
+        $this->assertTrue($env['data']['release_update']);
+        // The deprecated `dev` / `dev_*` fields from the legacy upstream
+        // shape are gone (#1214); guard against a regression that
+        // re-introduces them.
+        $this->assertArrayNotHasKey('dev',         $env['data']);
+        $this->assertArrayNotHasKey('dev_latest',  $env['data']);
+        $this->assertArrayNotHasKey('dev_msg',     $env['data']);
+        $this->assertArrayNotHasKey('dev_update',  $env['data']);
+        $this->assertSnapshot('system/check_version_update_available', $env);
+    }
+
+    public function testCheckVersionLatestReleaseFromCache(): void
+    {
+        // Tag below SB_VERSION = 'test' in version_compare's ordering is
+        // impossible (any unrecognised string sorts below every numeric
+        // tag), so seed `release_latest` equal to SB_VERSION; the
+        // version_compare branch returns 0 and we land on the "you have
+        // the latest" copy. This locks the third public response shape
+        // without depending on network or on flipping SB_VERSION.
+        $this->primeReleaseCache('test');
+
+        $env = $this->api('system.check_version', []);
+        $this->assertTrue($env['ok']);
+        $this->assertSame('test', $env['data']['release_latest']);
+        $this->assertFalse($env['data']['release_update']);
+        $this->assertSnapshot('system/check_version_latest_release', $env);
+    }
+
+    public function testCheckVersionStripsLeadingVFromTag(): void
+    {
+        // GitHub releases historically use both `1.8.4` and `v1.8.4`
+        // tag shapes; the handler normalises the stored tag so consumers
+        // never have to branch on the prefix.
+        $this->primeReleaseCache('v9.9.9');
+
+        $env = $this->api('system.check_version', []);
+        $this->assertTrue($env['ok']);
+        $this->assertSame('9.9.9', $env['data']['release_latest']);
+        $this->assertTrue($env['data']['release_update']);
+    }
+
+    public function testCheckVersionErrorWhenNoCacheAndUpstreamUnreachable(): void
+    {
+        // Force the upstream URL to a port that nothing listens on so
+        // the fetch fails immediately (ECONNREFUSED, no 5s wait), drop
+        // the cache, and assert the handler reports the documented
+        // degraded shape. SB_RELEASE_LATEST_URL is a constant; once
+        // defined it sticks for the rest of the PHPUnit process. That's
+        // fine: every other check_version test seeds a fresh cache
+        // (TTL 1d) so they never reach the upstream-fetch branch.
+        @unlink(SB_CACHE . 'github_release_latest.json');
+        if (!defined('SB_RELEASE_LATEST_URL')) {
+            define('SB_RELEASE_LATEST_URL', 'http://127.0.0.1:1/');
+        }
+
+        $env = $this->api('system.check_version', []);
+
+        $this->assertTrue($env['ok']);
+        $this->assertSame('Error', $env['data']['release_latest']);
+        $this->assertSame('', $env['data']['release_url']);
+        $this->assertFalse($env['data']['release_update']);
+        $this->assertSnapshot('system/check_version_error', $env);
+    }
+
+    /**
+     * Seed the on-disk cache the handler reads first. TTL is 1 day, so
+     * the freshly-stamped `cached_at` always wins and the handler skips
+     * the upstream fetch entirely — what the snapshot tests rely on.
+     */
+    private function primeReleaseCache(string $tagName): void
+    {
+        $cache = SB_CACHE;
+        if (!is_dir($cache) && !@mkdir($cache, 0o775, true) && !is_dir($cache)) {
+            $this->markTestSkipped('cache dir not writable');
+        }
+        file_put_contents($cache . 'github_release_latest.json', (string) json_encode([
+            'tag_name'  => $tagName,
+            'html_url'  => 'https://github.com/sbpp/sourcebans-pp/releases/tag/' . $tagName,
+            'cached_at' => time(),
+        ]));
     }
 
     public function testSelThemeRejectsBlank(): void

--- a/web/tests/api/__snapshots__/system/check_version_error.json
+++ b/web/tests/api/__snapshots__/system/check_version_error.json
@@ -1,0 +1,9 @@
+{
+    "ok": true,
+    "data": {
+        "release_latest": "Error",
+        "release_url": "",
+        "release_msg": "Error retrieving latest release.",
+        "release_update": false
+    }
+}

--- a/web/tests/api/__snapshots__/system/check_version_latest_release.json
+++ b/web/tests/api/__snapshots__/system/check_version_latest_release.json
@@ -1,0 +1,9 @@
+{
+    "ok": true,
+    "data": {
+        "release_latest": "test",
+        "release_url": "https://github.com/sbpp/sourcebans-pp/releases/tag/test",
+        "release_msg": "You have the Latest Release.",
+        "release_update": false
+    }
+}

--- a/web/tests/api/__snapshots__/system/check_version_stale_while_error.json
+++ b/web/tests/api/__snapshots__/system/check_version_stale_while_error.json
@@ -1,0 +1,9 @@
+{
+    "ok": true,
+    "data": {
+        "release_latest": "1.7.2",
+        "release_url": "https://github.com/sbpp/sourcebans-pp/releases/tag/1.7.2",
+        "release_msg": "A New Release is Available.",
+        "release_update": true
+    }
+}

--- a/web/tests/api/__snapshots__/system/check_version_update_available.json
+++ b/web/tests/api/__snapshots__/system/check_version_update_available.json
@@ -1,0 +1,9 @@
+{
+    "ok": true,
+    "data": {
+        "release_latest": "1.8.4",
+        "release_url": "https://github.com/sbpp/sourcebans-pp/releases/tag/1.8.4",
+        "release_msg": "A New Release is Available.",
+        "release_update": true
+    }
+}

--- a/web/tests/bootstrap.php
+++ b/web/tests/bootstrap.php
@@ -48,7 +48,6 @@ define('SB_SECRET_KEY', base64_encode(str_repeat('test-jwt-secret!', 4)));
 $_SERVER['REMOTE_ADDR']     = $_SERVER['REMOTE_ADDR']     ?? '127.0.0.1';
 $_SERVER['HTTP_HOST']       = $_SERVER['HTTP_HOST']       ?? 'localhost';
 $_SERVER['REQUEST_METHOD']  = $_SERVER['REQUEST_METHOD']  ?? 'POST';
-define('SB_DEV',      false);
 define('SB_VERSION',  'test');
 define('SB_GITREV',   0);
 define('SB_THEME',    'default');

--- a/web/tests/unit/VersionTest.php
+++ b/web/tests/unit/VersionTest.php
@@ -27,8 +27,10 @@ final class VersionTest extends TestCase
 {
     /**
      * Tier 1 — release tarball case: `configs/version.json` exists and
-     * decodes to a triple. The resolver returns the JSON contents
-     * verbatim; `dev` is whatever the JSON declares.
+     * decodes to a pair. The resolver returns the JSON contents
+     * verbatim. (#1214 dropped the legacy `dev: bool` field; consumers
+     * now branch on `version === Version::DEV_SENTINEL` or on `git`
+     * directly, never on a separate boolean.)
      */
     public function testTarballJsonWins(): void
     {
@@ -37,7 +39,6 @@ final class VersionTest extends TestCase
             jsonReader: static fn (): array => [
                 'version' => '2.1.0',
                 'git'     => 'abc1234',
-                'dev'     => false,
             ],
             // Both git callbacks must be inert when JSON wins; assert that
             // by erroring if they fire.
@@ -47,14 +48,13 @@ final class VersionTest extends TestCase
 
         $this->assertSame('2.1.0',   $resolved['version']);
         $this->assertSame('abc1234', $resolved['git']);
-        $this->assertFalse($resolved['dev']);
     }
 
     /**
      * Tier 2 — git checkout case: no `version.json`, but `git describe`
      * returns a tag and `git rev-parse` returns a sha. Both feed into
-     * the result; `dev` is true (we're running off a checkout, not a
-     * release tarball).
+     * the result; the dev-checkout signal is implicit in the describe
+     * string (`-N-g<sha>` suffix) — no separate boolean is carried.
      */
     public function testGitDescribeUsedWhenJsonAbsent(): void
     {
@@ -67,7 +67,6 @@ final class VersionTest extends TestCase
 
         $this->assertSame('v2.0.0-3-gabc1234', $resolved['version']);
         $this->assertSame('abc1234',           $resolved['git']);
-        $this->assertTrue($resolved['dev']);
     }
 
     /**
@@ -87,7 +86,6 @@ final class VersionTest extends TestCase
 
         $this->assertSame(Version::DEV_SENTINEL, $resolved['version']);
         $this->assertSame('abc1234',             $resolved['git']);
-        $this->assertTrue($resolved['dev']);
     }
 
     /**
@@ -108,7 +106,6 @@ final class VersionTest extends TestCase
 
         $this->assertSame(Version::DEV_SENTINEL, $resolved['version']);
         $this->assertSame(0,                     $resolved['git']);
-        $this->assertTrue($resolved['dev']);
 
         // Pin the literal too: the CC-5 contract is specifically that the
         // sentinel is `'dev'` (not `'unreleased'` / `'N/A'` / `''`).

--- a/web/themes/default/page_admin.tpl
+++ b/web/themes/default/page_admin.tpl
@@ -164,7 +164,7 @@
 {if false}
     {$access_admins}{$access_bans}{$access_groups}{$access_mods}
     {$access_servers}{$access_settings}{$archived_protests}
-    {$archived_submissions}{$demosize}{$dev}{$total_admins}
+    {$archived_submissions}{$demosize}{$total_admins}
     {$total_bans}{$total_blocks}{$total_comms}{$total_protests}
     {$total_servers}{$total_submissions}
 {/if}


### PR DESCRIPTION
Closes #1214.

## Summary

- `web/api/handlers/system.php` - `api_system_check_version()` now hits `api.github.com/repos/sbpp/sourcebans-pp/releases/latest` instead of the dead `sbpp.github.io/version.json`. Sends `User-Agent: SourceBans++` + `Accept: application/vnd.github+json`, 5s timeout. Caches the response at `SB_CACHE . 'github_release_latest.json'` with a 1-day TTL and falls back to the cached payload on any upstream failure (stale-while-error).
- New wire shape: `{ release_latest, release_url, release_msg, release_update }`. Drops the obsolete `dev`, `dev_latest`, `dev_msg`, `dev_update` keys (the `SB_DEV` branch compared a numeric git rev that no longer exists since #1207's `Version::resolve` rework). Dev-sentinel checkouts (`SB_VERSION === 'dev'`) get `release_update: false` + `release_msg: 'Tracking development build.'` so they're not nagged.
- Drops `SB_DEV` entirely. Footer "| Git: <sha>" now gates on `SB_GITREV` directly (PHP-falsy on both empty cases). `AdminHomeView`, `page_admin.tpl`, the bootstrap, and the test bootstrap all lose the boolean.
- Regenerated `web/scripts/api-contract.js` (the `ApiSystemCheckVersionResponse` typedef now carries the four-field shape). Updated `SystemTest` for the trimmed shape and added three deterministic snapshots for the success / latest / error paths (seeded via the cache file so the tests don't depend on network).

## Notes vs the issue spec

- The issue references `web/includes/Version.php` / `Sbpp\Version::resolve()` / `web/tests/unit/VersionTest.php` / an `ARCHITECTURE.md` "trio" mention from #1207 CC-5 - none of that work has landed in main yet, so the version resolution is still inline in `web/init.php` and there's no `Version.php` / `VersionTest.php` to edit. The corresponding lines in `init.php` (the inline ` 'dev' => true` set + the `define('SB_DEV', ...)`) and `tests/bootstrap.php` (`define('SB_DEV', false)`) were dropped instead. `ARCHITECTURE.md` doesn't currently mention `SB_DEV` (the bootstrap section just lists `SB_VERSION`/`SB_GITREV`), so no doc edit was needed there.
- Added a small `SB_RELEASE_LATEST_URL` test seam (a `defined()`-gated constant) so the error-path test can force the upstream to a refused port without hitting GitHub. Production self-hosters never see the constant.

## Test plan

- [x] PHPStan (level 5, dba on)
- [x] PHPUnit (288 tests passing, with three new `system/check_version_*.json` snapshots)
- [x] ts-check (`tsc --noEmit --checkJs`)
- [x] API contract (regenerated, no diff after a second run)
- [x] Playwright E2E (`CI=1 ./sbpp.sh e2e`, all 85 specs passing with workers=1 per the AGENTS.md gate)