### PR TITLE
fix(install): drop inline semicolon from _notes comment block (#1221)

### DIFF
--- a/web/install/includes/sql/struc.sql
+++ b/web/install/includes/sql/struc.sql
@@ -249,9 +249,13 @@ CREATE TABLE IF NOT EXISTS `{prefix}_login_tokens` (
 
 -- Player notes scratchpad surfaced by the player-detail drawer (#1165).
 -- Notes are scoped per Steam ID so an admin can pin context that survives
--- ban-row churn (a re-ban or unban makes a new bid; notes follow the
+-- ban-row churn (a re-ban or unban makes a new bid — notes follow the
 -- player). The Notes pane in the drawer is admin-only — `is_admin()`
 -- gates both the JSON actions and the tab visibility.
+-- NOTE: this comment block must contain no semicolon characters.
+-- The installer (page.4.php) splits struc.sql on every semicolon
+-- before it reaches MariaDB, so a stray one mid-comment cuts the
+-- block in half and breaks the next CREATE TABLE (#1221).
 CREATE TABLE IF NOT EXISTS `{prefix}_notes` (
     `nid` int(10) NOT NULL AUTO_INCREMENT,
     `steam_id` varchar(64) character set {charset} NOT NULL DEFAULT '',


### PR DESCRIPTION
## Summary

- Resolves the fresh-install regression in #1221: step 4 errored with `1064 … near 'notes follow the\n-- player). …'` and the `_notes` table was never created.
- Root cause is in the legacy installer (`web/install/template/page.4.php`), which splits `struc.sql` with a comment-unaware `explode(";", \$file)`. The `;` inside the `_notes` comment text on line 252 (`makes a new bid; notes follow the player`) was sliced through the middle of the comment, so MariaDB tried to parse the orphan tail as SQL.
- Fix is comment-text-only: replace the inline `;` with an em dash and add a `NOTE:` block in `struc.sql` explaining the constraint so the next maintainer doesn't re-introduce a stray `;` in this block.
- Schema is unchanged, so no paired `web/updater/data/<N>.php` migration per `AGENTS.md`.

## Why this isn't a problem on the dev / CI / E2E paths

`Sbpp\\Tests\\Fixture::executeBatch` already uses a smarter splitter (`preg_split('/;\\\\s*\\\\n/', \$sql)`) and strips leading `--` lines, and `docker/db-init/00-render-schema.sh` pipes the file through the real `mariadb` CLI parser. Both honour comment scoping, so PHPUnit / E2E / dev seeding never tripped. Only the installer wizard's `explode` did.

## Test plan

- [x] Reproduce #1221 against `main` (1 failed chunk, `sb_notes` missing) and against #1222's tip (2 failed chunks, `sb_notes` missing) using the same flow as `page.4.php`.
- [x] Verify this PR makes the installer run cleanly (0 failed chunks, `sb_notes` present).
- [x] `./sbpp.sh phpstan` — clean.
- [x] `./sbpp.sh test` — 349 tests / 1469 assertions, all green (covers the `Fixture` schema render path).