### PR TITLE
feat: add ./sbpp.sh db-seed for realistic dev data (#1238)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,7 +74,8 @@ Run from the repo root. All commands are idempotent.
 ./sbpp.sh db-reset                 # drop the DB volume + re-seed
 ./sbpp.sh db-seed [args]           # populate dev DB with realistic synthetic data
                                    # --scale=small|medium|large (default medium),
-                                   # --seed=<int> (default pinned in code, deterministic)
+                                   # --seed=<int> (default pinned in code, deterministic).
+                                   # Re-login required after each run (login_tokens truncated).
 ./sbpp.sh rebuild                  # --no-cache rebuild of the web image
 ```
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,6 +72,9 @@ Run from the repo root. All commands are idempotent.
 ./sbpp.sh db-dump [file]           # mysqldump to host
 ./sbpp.sh db-load <file>           # pipe a dump into the dev DB
 ./sbpp.sh db-reset                 # drop the DB volume + re-seed
+./sbpp.sh db-seed [args]           # populate dev DB with realistic synthetic data
+                                   # --scale=small|medium|large (default medium),
+                                   # --seed=<int> (default pinned in code, deterministic)
 ./sbpp.sh rebuild                  # --no-cache rebuild of the web image
 ```
 
@@ -274,6 +277,38 @@ Playwright E2E specifics:
   `Database::query()` rewrites the placeholder. Never inline the prefix.
 - Pattern: `query` → `bind` → `execute` / `single` / `resultset`.
 - ADOdb was fully removed (commit `b9c812b2`). **Do not reintroduce it.**
+
+### Dev DB seeder (`./sbpp.sh db-seed`)
+
+`./sbpp.sh db-seed` populates the dev DB (`sourcebans`) with a deterministic,
+realistic synthetic dataset across bans, comms, servers, admins, groups,
+submissions, protests, comments, notes, banlog, and the audit log. Use it
+when you need the panel surfaces (banlist, dashboard, drawer, moderation
+queues, audit log) to render with real-looking data instead of empty
+states. Acceptance audits and screenshot work both depend on it.
+
+- Lives at `web/tests/Synthesizer.php` (`Sbpp\Tests\Synthesizer`); CLI
+  driver at `web/tests/scripts/seed-dev-db.php`. Both are dev-only —
+  the synthesizer refuses any `DB_NAME` other than `sourcebans`, so
+  `sourcebans_test` / `sourcebans_e2e` stay untouched and the E2E
+  suite (which builds its own rows per spec) is unaffected.
+- Idempotent: every run truncates the synth-owned tables first
+  (preserving `sb_settings` / `sb_mods` from `data.sql`), re-seeds the
+  CONSOLE + `admin/admin` rows, then inserts the synthetic dataset.
+- Deterministic given a fixed `--seed` — `mt_srand($seed)` pins PHP's
+  RNG so two devs hit the same names/reasons/timestamps. Default seed
+  is `Synthesizer::DEFAULT_SEED` (pinned in code).
+- Three tiers: `--scale=small` (~30 bans, fast iteration), `medium`
+  (default, ~200 bans), `large` (~2000 bans for pagination / perf).
+- Do NOT reach for this from `Fixture::truncateAndReseed()` (the e2e
+  hot path) — those two diverge by design. The synthesizer is for
+  manual dev / screenshot work; the e2e fixture stays minimal so each
+  spec controls what rows it needs.
+- Anti-pattern: extending `data.sql` with synthetic rows (it's the
+  fresh-install seed and would force a paired updater migration for
+  every change) or shipping the seeder in a release tarball (the
+  refusal guard is the safety mechanism; see `seed-dev-db.php`'s
+  docblock for the full risk model).
 
 ### Updater migrations
 
@@ -660,6 +695,7 @@ audit (#1207) locked in. New CTAs:
 | Seed `sb_settings` rows for fresh installs | `web/install/includes/sql/data.sql`                  |
 | Add a one-off DB upgrade for existing installs | `web/updater/data/<N>.php` + `web/updater/store.json` |
 | Test fixtures                          | `web/tests/Fixture.php`, `web/tests/ApiTestCase.php`     |
+| Populate the dev DB with realistic synthetic data (banlist > 1 page, drawer history, moderation queues, audit log) | `./sbpp.sh db-seed` → `web/tests/scripts/seed-dev-db.php` (CLI driver) → `web/tests/Synthesizer.php` (`Sbpp\Tests\Synthesizer`). Dev-only: refuses any `DB_NAME` other than `sourcebans` (so `sourcebans_test` / `sourcebans_e2e` stay untouched). Idempotent; deterministic given a fixed `--seed` (default `Synthesizer::DEFAULT_SEED`). Does NOT share plumbing with `Fixture::truncateAndReseed` — the e2e hot path stays minimal. |
 | API wire-format snapshots              | `web/tests/api/__snapshots__/<topic>/<scenario>.json`    |
 | Action -> permission lock              | `web/tests/api/PermissionMatrixTest.php`                 |
 | Add an E2E spec                        | `web/tests/e2e/specs/<smoke|flows|a11y|responsive>/...` + `web/tests/e2e/pages/...` |

--- a/docker/README.md
+++ b/docker/README.md
@@ -92,6 +92,11 @@ Refusal guard: the seeder strictly refuses any `DB_NAME` other than
 is at `web/tests/Synthesizer.php` (`Sbpp\Tests\Synthesizer`); the CLI
 driver is `web/tests/scripts/seed-dev-db.php`.
 
+Re-login required after each run — the seeder truncates `sb_login_tokens`
+along with the rest of the user-data tables, which invalidates any open
+browser session against the dev panel. Just hit `/index.php?p=login`
+again with `admin` / `admin`.
+
 ## Quality gates
 
 Five gates run in CI on every PR; each has a one-shot wrapper for local runs.

--- a/docker/README.md
+++ b/docker/README.md
@@ -66,8 +66,31 @@ don't leak onto the host filesystem.
 ./sbpp.sh db-dump backup.sql      # mysqldump to host file
 ./sbpp.sh db-load fixtures.sql    # pipe a SQL file into the DB
 ./sbpp.sh db-reset                # drop just the DB volume and re-seed
+./sbpp.sh db-seed                 # populate the dev DB with realistic synthetic data
 ./sbpp.sh rebuild                 # `--no-cache` rebuild of the web image
 ```
+
+`db-seed` lights up every data-driven panel surface — banlist + commslist
+beyond a single page, dashboard "Latest …" cards, the drawer's history /
+comments / notes panes, admin moderation queues (submissions and
+protests), admin audit log, multiple groups/admins/servers — without
+touching `data.sql` / `struc.sql` (the install path stays minimal).
+Idempotent: every run truncates the synthesizer-owned tables first and
+re-seeds. Deterministic given `--seed=<int>` so two devs see the same
+data; pinned default seed in code. Three scale tiers:
+
+```sh
+./sbpp.sh db-seed                 # default scale (~200 bans, ~100 comms)
+./sbpp.sh db-seed --scale=small   # ~30 bans, fast iteration
+./sbpp.sh db-seed --scale=large   # ~2000 bans, pagination / perf
+./sbpp.sh db-seed --seed=42       # alternate RNG seed
+```
+
+Refusal guard: the seeder strictly refuses any `DB_NAME` other than
+`sourcebans`, so the PHPUnit DB (`sourcebans_test`) and Playwright DB
+(`sourcebans_e2e`) cannot be wiped by accident. The Synthesizer source
+is at `web/tests/Synthesizer.php` (`Sbpp\Tests\Synthesizer`); the CLI
+driver is `web/tests/scripts/seed-dev-db.php`.
 
 ## Quality gates
 

--- a/sbpp.sh
+++ b/sbpp.sh
@@ -34,6 +34,11 @@ Database:
   db-dump [file]  Dump the DB to file (default: dump-YYYYMMDD-HHMMSS.sql).
   db-load <file>  Load a SQL dump into the dev DB.
   db-reset        Drop the DB volume and re-seed (faster than full reset).
+  db-seed [args]  Populate the dev DB with realistic synthetic data.
+                  Accepts --scale=small|medium|large (default medium) and
+                  --seed=<int> (default pinned in code). Idempotent: every
+                  run truncates synth-owned tables first. Refuses to touch
+                  any DB other than `sourcebans`.
 
 URLs once "up":
   http://localhost:${SBPP_WEB_PORT:-8080}        SourceBans++ panel  (admin / admin)
@@ -224,6 +229,24 @@ case "$cmd" in
         dc rm -fsv db
         docker volume rm "$(basename "$PWD")_dbdata" 2>/dev/null || true
         dc up -d db
+        ;;
+    db-seed)
+        # Dev-only synthetic data populator (#1238). Mirrors `e2e`'s
+        # auto-bring-up shim so `./sbpp.sh db-seed` works from a fresh
+        # checkout. The CLI driver lives at
+        # `web/tests/scripts/seed-dev-db.php`; the synthesizer is
+        # `Sbpp\Tests\Synthesizer`. Always truncate+reseed by design;
+        # `--scale=small|medium|large` and `--seed=<int>` are the only
+        # accepted flags. DB_NAME is pinned to `sourcebans` (the dev
+        # panel's DB) — the driver refuses any other value, including
+        # `sourcebans_test` / `sourcebans_e2e`.
+        if [ -z "$(dc ps -q web 2>/dev/null)" ]; then dc up -d; fi
+        dc exec \
+            -e DB_HOST=db -e DB_PORT=3306 \
+            -e DB_NAME=sourcebans \
+            -e DB_USER=sourcebans -e DB_PASS=sourcebans \
+            -e DB_PREFIX=sb -e DB_CHARSET=utf8mb4 \
+            web php /var/www/html/web/tests/scripts/seed-dev-db.php "$@"
         ;;
     -h|--help|help|"")
         usage

--- a/web/tests/Synthesizer.php
+++ b/web/tests/Synthesizer.php
@@ -1,0 +1,1057 @@
+<?php
+
+namespace Sbpp\Tests;
+
+/**
+ * Dev-only synthetic data generator. Populates a freshly-installed `sourcebans`
+ * dev DB with a deterministic, realistic dataset across the panel's full
+ * surface: bans, comms, servers, admins, groups, submissions, protests,
+ * comments, notes, banlog, and the audit log.
+ *
+ * Lives under `Sbpp\Tests` (next to {@see Fixture}) because it shares the
+ * same bootstrap (`web/tests/bootstrap.php`), the same raw-PDO + DB_PREFIX
+ * interpolation idiom, and the same "this never ships in production" risk
+ * profile. Driven by `web/tests/scripts/seed-dev-db.php`, wired through
+ * `./sbpp.sh db-seed`.
+ *
+ * Idempotent: every call truncates user-data tables first (preserving
+ * `sb_settings` and `sb_mods` which `data.sql` owns), re-seeds the
+ * CONSOLE + `admin/admin` rows the dev panel logs in with, then inserts
+ * synthetic rows. Same `seed` ⇒ identical names, reasons, and ordering;
+ * `mt_srand($seed)` pins PHP's Mersenne Twister so the dataset is
+ * reproducible across machines.
+ *
+ * NOT used by the E2E suite — `Fixture::truncateAndReseed()` stays minimal
+ * and the e2e DB stays empty by design (specs build the rows they need).
+ *
+ * Refusal: callers MUST be running against `DB_NAME=sourcebans`. The CLI
+ * driver enforces this before bootstrap loads; this class re-checks at
+ * `run()` entry as a belt-and-suspenders guard against accidental misuse
+ * from PHP code that doesn't go through the CLI.
+ */
+final class Synthesizer
+{
+    /** Default RNG seed. Picked to match the issue number for traceability. */
+    public const DEFAULT_SEED = 1238;
+
+    /**
+     * Per-table row counts per scale tier. medium >= the issue's stated
+     * defaults (200 bans / 100 comms / 8 servers / 8 admins / 4 groups);
+     * small/large are the fast-iterate / pagination-stress endpoints.
+     *
+     * @var array<string, array<string, int>>
+     */
+    public const SCALES = [
+        'small' => [
+            'players'     => 80,
+            'bans'        => 30,
+            'comms'       => 10,
+            'servers'     => 5,
+            'admins'      => 5,
+            'groups'      => 3,
+            'banlog'      => 50,
+            'submissions' => 10,
+            'protests'    => 5,
+            'comments'    => 30,
+            'notes'       => 15,
+            'audit'       => 80,
+        ],
+        'medium' => [
+            'players'     => 400,
+            'bans'        => 200,
+            'comms'       => 100,
+            'servers'     => 8,
+            'admins'      => 8,
+            'groups'      => 4,
+            'banlog'      => 400,
+            'submissions' => 60,
+            'protests'    => 25,
+            'comments'    => 200,
+            'notes'       => 120,
+            'audit'       => 600,
+        ],
+        'large' => [
+            'players'     => 3000,
+            'bans'        => 2000,
+            'comms'       => 800,
+            'servers'     => 12,
+            'admins'      => 12,
+            'groups'      => 5,
+            'banlog'      => 4000,
+            'submissions' => 400,
+            'protests'    => 150,
+            'comments'    => 1500,
+            'notes'       => 800,
+            'audit'       => 5000,
+        ],
+    ];
+
+    /**
+     * Tables this synthesizer owns. Truncated on every run before the
+     * synthetic dataset is inserted. Order is irrelevant under
+     * SET FOREIGN_KEY_CHECKS = 0; intentionally excludes `sb_settings`
+     * and `sb_mods` (both seeded by `data.sql` on fresh install).
+     */
+    private const SYNTH_TABLES = [
+        'admins',
+        'admins_servers_groups',
+        'banlog',
+        'bans',
+        'comments',
+        'comms',
+        'demos',
+        'groups',
+        'log',
+        'login_tokens',
+        'notes',
+        'overrides',
+        'protests',
+        'servers',
+        'servers_groups',
+        'srvgroups',
+        'srvgroups_overrides',
+        'submissions',
+    ];
+
+    private \PDO $pdo;
+    private int $seed;
+    /** @var array<string, int> */
+    private array $scale;
+    private int $now;
+
+    /** @var list<int> */
+    private array $adminAids = [];
+    /** @var list<int> */
+    private array $groupGids = [];
+    /** @var list<int> */
+    private array $srvGroupIds = [];
+    /** @var list<int> */
+    private array $serverSids = [];
+    /** @var list<int> */
+    private array $modIds = [];
+    /** @var list<int> */
+    private array $banBids = [];
+
+    /**
+     * Pool of synthetic players. Keyed by index; each entry carries a
+     * pre-generated authid + display name + country so the same player
+     * surfaces across bans/comms/comments/notes/audit log (history-tab
+     * realism).
+     *
+     * @var list<array{steam: string, name: string, country: string, ip: string}>
+     */
+    private array $players = [];
+
+    /**
+     * Public entrypoint. Idempotent.
+     *
+     * @return array<string, int> per-table insert counts (for the CLI to print)
+     */
+    public static function run(string $scale, int $seed): array
+    {
+        if (!isset(self::SCALES[$scale])) {
+            throw new \InvalidArgumentException(
+                "unknown scale '$scale'; expected one of: " . implode(', ', array_keys(self::SCALES))
+            );
+        }
+        if (DB_NAME !== 'sourcebans') {
+            throw new \RuntimeException(
+                "Synthesizer::run refused: DB_NAME=" . DB_NAME
+                . " (only 'sourcebans' is allowed; the dev DB is the only intended target)."
+            );
+        }
+        $self = new self($scale, $seed);
+        return $self->execute();
+    }
+
+    private function __construct(string $scale, int $seed)
+    {
+        $this->scale = self::SCALES[$scale];
+        $this->seed  = $seed;
+        $this->now   = time();
+        $this->pdo   = $this->connect();
+    }
+
+    private function connect(): \PDO
+    {
+        $dsn = sprintf('mysql:host=%s;port=%d;dbname=%s;charset=%s', DB_HOST, DB_PORT, DB_NAME, DB_CHARSET);
+        try {
+            return new \PDO($dsn, DB_USER, DB_PASS, [
+                \PDO::ATTR_ERRMODE          => \PDO::ERRMODE_EXCEPTION,
+                \PDO::ATTR_EMULATE_PREPARES => false,
+            ]);
+        } catch (\PDOException $e) {
+            throw new \RuntimeException("Synthesizer cannot connect to {$dsn}: " . $e->getMessage());
+        }
+    }
+
+    /** @return array<string, int> */
+    private function execute(): array
+    {
+        // Pin the global RNG state once; every helper below pulls from
+        // the same Mersenne Twister stream so a fixed seed reproduces
+        // byte-for-byte.
+        mt_srand($this->seed);
+
+        $this->truncateAndReseedBaseline();
+        $this->loadModIds();
+        $this->generatePlayerPool();
+
+        $counts = [];
+        $counts['groups']                = $this->insertGroups();
+        $counts['srvgroups']             = $this->insertSrvGroups();
+        $counts['admins']                = $this->insertAdmins();
+        $counts['servers']               = $this->insertServers();
+        $counts['servers_groups']        = $this->insertServersGroups();
+        $counts['admins_servers_groups'] = $this->insertAdminsServersGroups();
+        $counts['srvgroups_overrides']   = $this->insertSrvGroupsOverrides();
+        $counts['overrides']             = $this->insertOverrides();
+        $counts['bans']                  = $this->insertBans();
+        $counts['banlog']                = $this->insertBanlog();
+        $counts['comms']                 = $this->insertComms();
+        $counts['comments']              = $this->insertComments();
+        $counts['submissions']           = $this->insertSubmissions();
+        $counts['protests']              = $this->insertProtests();
+        $counts['notes']                 = $this->insertNotes();
+        $counts['audit']                 = $this->insertAuditLog();
+
+        return $counts;
+    }
+
+    /**
+     * Drop all rows the synthesizer owns and re-seed the canonical
+     * `CONSOLE` (aid=0) + `admin/admin` rows the dev panel logs in with.
+     * Preserves `sb_settings` and `sb_mods` (data.sql's responsibility).
+     */
+    private function truncateAndReseedBaseline(): void
+    {
+        $this->pdo->exec('SET FOREIGN_KEY_CHECKS = 0');
+        try {
+            foreach (self::SYNTH_TABLES as $t) {
+                $this->pdo->exec(sprintf('TRUNCATE TABLE `%s_%s`', DB_PREFIX, $t));
+            }
+        } finally {
+            $this->pdo->exec('SET FOREIGN_KEY_CHECKS = 1');
+        }
+
+        // CONSOLE row (aid=0) — every Log::add(aid=0) call needs this
+        // FK target. data.sql inserts it with NO_AUTO_VALUE_ON_ZERO; we
+        // mirror the trick so the row keeps aid=0.
+        $this->pdo->exec("SET SESSION sql_mode='NO_AUTO_VALUE_ON_ZERO'");
+        $this->pdo->exec(sprintf(
+            "INSERT INTO `%s_admins` (`aid`, `user`, `authid`, `password`, `gid`, `email`, `validate`, `extraflags`, `immunity`)
+             VALUES (0, 'CONSOLE', 'STEAM_ID_SERVER', '', 0, '', NULL, 0, 0)",
+            DB_PREFIX
+        ));
+
+        // admin / admin login — same shape Fixture::seedAdmin() and
+        // docker/db-init/00-render-schema.sh use. extraflags=ADMIN_OWNER
+        // (16777216) so this account survives in the same-shape state
+        // the dev panel expects.
+        $hash = password_hash('admin', PASSWORD_BCRYPT);
+        $stmt = $this->pdo->prepare(sprintf(
+            'INSERT INTO `%s_admins` (`user`, `authid`, `password`, `gid`, `email`, `validate`, `extraflags`, `immunity`)
+             VALUES (?, ?, ?, -1, ?, NULL, ?, 100)',
+            DB_PREFIX
+        ));
+        $stmt->execute(['admin', 'STEAM_0:0:0', $hash, 'admin@example.test', 16777216]);
+    }
+
+    private function loadModIds(): void
+    {
+        $rows = $this->pdo->query(
+            sprintf('SELECT `mid` FROM `%s_mods` WHERE `mid` > 0 ORDER BY `mid`', DB_PREFIX)
+        )->fetchAll(\PDO::FETCH_COLUMN);
+        $this->modIds = array_map('intval', $rows);
+        if ($this->modIds === []) {
+            throw new \RuntimeException(
+                'Synthesizer expected sb_mods seed rows from data.sql; none found. Has the dev DB been initialised?'
+            );
+        }
+    }
+
+    private function generatePlayerPool(): void
+    {
+        $names = $this->buildNamePool();
+        $countries = ['US', 'GB', 'DE', 'FR', 'JP', 'KR', 'CN', 'RU', 'BR', 'AU', 'CA', 'NL', 'SE', 'PL', 'MX'];
+
+        $count = $this->scale['players'];
+        for ($i = 0; $i < $count; $i++) {
+            $authNum = 1_000_000 + $i * 17;
+            $authIdY = mt_rand(0, 1);
+            // Emit a mix of STEAM_0 and STEAM_1 (universe 0 vs 1) so the
+            // banlist exercises both legacy and "new" Steam universe paths.
+            $universe = mt_rand(0, 9) === 0 ? '1' : '0';
+            $this->players[] = [
+                'steam'   => sprintf('STEAM_%s:%d:%d', $universe, $authIdY, $authNum),
+                'name'    => $names[$i % count($names)],
+                'country' => $countries[mt_rand(0, count($countries) - 1)],
+                'ip'      => sprintf(
+                    '%d.%d.%d.%d',
+                    mt_rand(1, 223),
+                    mt_rand(0, 255),
+                    mt_rand(0, 255),
+                    mt_rand(1, 254)
+                ),
+            ];
+        }
+    }
+
+    /**
+     * Realistic utf8mb4 name pool spanning emoji, CJK, Cyrillic, accented
+     * Latin, and gamer-handle conventions. Order is intentional — the
+     * head of the list shows up first in pagination, and we want
+     * variety on page 1.
+     *
+     * @return list<string>
+     */
+    private function buildNamePool(): array
+    {
+        return [
+            '🦊 Foxy McFoxface',
+            '村田 太郎',
+            'Иван Петров',
+            'François Dubois',
+            '진수 Kim',
+            'xX_Sn1per_Xx',
+            '小米 Wong',
+            'Müller_99',
+            '🎮 GamerKid',
+            'pwnage_42',
+            'Алексей Иванов',
+            'Renée Lambert',
+            '[CLAN] Pro_Player',
+            'えりか',
+            'Sergej Nowak',
+            'Ahmed العربي',
+            'maddog_2007',
+            '☠️ DeathSquad',
+            'Olga Sokolova',
+            'sn4ke_byte',
+            '李雷',
+            'Søren Nielsen',
+            '[ADMIN] Watcher',
+            'GhostlyShade',
+            'Кристина',
+            'Yuki Tanaka',
+            'Carlos González',
+            'NoScope_King',
+            'rage_quit_99',
+            '🐍 Viper',
+            'Hans Zimmermann',
+            'スズキ',
+            'flick_master',
+            'fragstorm',
+            'Иванка',
+            'Petra Nováková',
+            '匿名ユーザー',
+            'lone.wolf',
+            'Karim Habibi',
+            'pixel_pusher',
+            '🌟 Stardust',
+            'Wei Liu',
+            'Łukasz Kowalski',
+            'Marko Petrović',
+            'sniper_elite_88',
+            '黑客 Hu',
+            'Aurélie Bernard',
+            '☢️ Toxic',
+            'Mehmet Yıldız',
+            'cs2_legend',
+            'tf_medic_main',
+            'Klaus Schmidt',
+            '🍕 Pizza_Lord',
+            'Valeria Rossi',
+            'shadowstrike',
+            '王芳',
+            'Jakub Wiśniewski',
+            'Élise Moreau',
+            'aimbot.haver',
+            '👑 KingSlayer',
+            'Henrique Souza',
+            'voidwalker',
+            'Дмитрий',
+            'silent_assassin',
+            'Mateus Silva',
+            'Petr Sychrov',
+            '하늘',
+            'cheeseburger',
+            'Jürgen Bauer',
+            'tactical_nuke',
+            'Aleksandra Polak',
+            '⚡ Lightning',
+            'OGGamer1996',
+            'Yusuf Aydın',
+            'shaolinmaster',
+            'BrandyMcCree',
+            'Tomáš Dvořák',
+            'snipergod999',
+            'Алёна',
+            '🎯 Bullseye',
+            'Ahmet Çelik',
+        ];
+    }
+
+    private function insertGroups(): int
+    {
+        // Web groups (sb_groups.type = 1). Owner gets all-access, the
+        // rest carry tapered masks so the admin list shows the
+        // "permission gradient" the audit + admin pages render.
+        $defs = [
+            ['name' => 'Owner',     'flags' => 16777216 | 4294966783],
+            ['name' => 'Senior',    'flags' => 1 | 2 | 4 | 8 | 16 | 256 | 1024 | 2048 | 4096 | 32768 | 65536 | 131072],
+            ['name' => 'Moderator', 'flags' => 1 | 16 | 256 | 1024 | 8192 | 16384],
+            ['name' => 'Submitter', 'flags' => 1 | 16],
+            ['name' => 'Trial',     'flags' => 1 | 16 | 256],
+        ];
+
+        $stmt  = $this->pdo->prepare(sprintf(
+            'INSERT INTO `%s_groups` (`type`, `name`, `flags`) VALUES (1, ?, ?)',
+            DB_PREFIX
+        ));
+        $count = min($this->scale['groups'], count($defs));
+        for ($i = 0; $i < $count; $i++) {
+            $stmt->execute([$defs[$i]['name'], $defs[$i]['flags']]);
+            $this->groupGids[] = (int) $this->pdo->lastInsertId();
+        }
+        return $count;
+    }
+
+    private function insertSrvGroups(): int
+    {
+        $defs = [
+            ['name' => 'sm_root',   'flags' => 'z',  'immunity' => 100],
+            ['name' => 'sm_admin',  'flags' => 'bcdefijklmpq', 'immunity' => 50],
+            ['name' => 'sm_mod',    'flags' => 'bdjkm', 'immunity' => 25],
+        ];
+        $stmt = $this->pdo->prepare(sprintf(
+            'INSERT INTO `%s_srvgroups` (`immunity`, `flags`, `name`, `groups_immune`) VALUES (?, ?, ?, ?)',
+            DB_PREFIX
+        ));
+        foreach ($defs as $g) {
+            $stmt->execute([$g['immunity'], $g['flags'], $g['name'], ' ']);
+            $this->srvGroupIds[] = (int) $this->pdo->lastInsertId();
+        }
+        return count($defs);
+    }
+
+    private function insertAdmins(): int
+    {
+        // Synth admins beyond the seeded admin/admin row. Each one gets a
+        // tapered group + a small extraflags bonus so the admin list
+        // shows mixed perm masks. All passwords are bcrypt of "admin"
+        // so a dev can log in as any of them with the same password.
+        $names = [
+            'sentinel',
+            'fragmaster',
+            'banhammer',
+            'minerva',
+            'orpheus',
+            'penny',
+            'qwilfish',
+            'rover',
+            'silas',
+            'tempest',
+            'umbra',
+            'velvet',
+            'wraith',
+        ];
+        $count = min($this->scale['admins'], count($names));
+        $stmt  = $this->pdo->prepare(sprintf(
+            'INSERT INTO `%s_admins`
+                (`user`, `authid`, `password`, `gid`, `email`, `validate`, `extraflags`, `immunity`, `lastvisit`)
+             VALUES (?, ?, ?, ?, ?, NULL, ?, ?, ?)',
+            DB_PREFIX
+        ));
+        $hash = password_hash('admin', PASSWORD_BCRYPT);
+
+        for ($i = 0; $i < $count; $i++) {
+            $name      = $names[$i];
+            $gid       = $this->groupGids[$i % count($this->groupGids)];
+            $extra     = mt_rand(0, 3) === 0 ? 16777216 : 0; // ~25% Owner-flagged
+            $immunity  = mt_rand(0, 99);
+            $lastvisit = $this->now - mt_rand(60, 60 * 60 * 24 * 30);
+            $stmt->execute([
+                $name,
+                sprintf('STEAM_0:%d:%d', mt_rand(0, 1), 100_000 + $i * 31),
+                $hash,
+                $gid,
+                "$name@example.test",
+                $extra,
+                $immunity,
+                $lastvisit,
+            ]);
+            $this->adminAids[] = (int) $this->pdo->lastInsertId();
+        }
+        return $count;
+    }
+
+    private function insertServers(): int
+    {
+        $stmt  = $this->pdo->prepare(sprintf(
+            'INSERT INTO `%s_servers` (`ip`, `port`, `rcon`, `modid`, `enabled`) VALUES (?, ?, ?, ?, ?)',
+            DB_PREFIX
+        ));
+        $count = $this->scale['servers'];
+        for ($i = 0; $i < $count; $i++) {
+            $ip      = sprintf('10.%d.%d.%d', mt_rand(0, 255), mt_rand(0, 255), mt_rand(2, 254));
+            $port    = 27015 + ($i * 2);
+            $rcon    = bin2hex(random_bytes(8));
+            $mod     = $this->modIds[mt_rand(0, count($this->modIds) - 1)];
+            $enabled = mt_rand(0, 9) === 0 ? 0 : 1; // ~10% disabled
+            $stmt->execute([$ip, $port, $rcon, $mod, $enabled]);
+            $this->serverSids[] = (int) $this->pdo->lastInsertId();
+        }
+        return $count;
+    }
+
+    private function insertServersGroups(): int
+    {
+        if ($this->serverSids === [] || $this->srvGroupIds === []) {
+            return 0;
+        }
+        $stmt = $this->pdo->prepare(sprintf(
+            'INSERT INTO `%s_servers_groups` (`server_id`, `group_id`) VALUES (?, ?)',
+            DB_PREFIX
+        ));
+        $n = 0;
+        foreach ($this->serverSids as $sid) {
+            // Each server lives in exactly one srvgroup so the admin
+            // server-group page renders multiple memberships.
+            $gid = $this->srvGroupIds[mt_rand(0, count($this->srvGroupIds) - 1)];
+            $stmt->execute([$sid, $gid]);
+            $n++;
+        }
+        return $n;
+    }
+
+    private function insertAdminsServersGroups(): int
+    {
+        if ($this->adminAids === [] || $this->serverSids === []) {
+            return 0;
+        }
+        $stmt = $this->pdo->prepare(sprintf(
+            'INSERT INTO `%s_admins_servers_groups` (`admin_id`, `group_id`, `srv_group_id`, `server_id`) VALUES (?, ?, ?, ?)',
+            DB_PREFIX
+        ));
+        $n = 0;
+        foreach ($this->adminAids as $aid) {
+            // Bind each admin to ~half the servers across a mix of srvgroups
+            // so the admin-server-group matrix isn't trivial.
+            $bindings = max(1, intdiv(count($this->serverSids), 2));
+            for ($j = 0; $j < $bindings; $j++) {
+                $sid    = $this->serverSids[mt_rand(0, count($this->serverSids) - 1)];
+                $sgid   = $this->srvGroupIds === [] ? 0 : $this->srvGroupIds[mt_rand(0, count($this->srvGroupIds) - 1)];
+                $stmt->execute([$aid, 0, $sgid, $sid]);
+                $n++;
+            }
+        }
+        return $n;
+    }
+
+    private function insertSrvGroupsOverrides(): int
+    {
+        if ($this->srvGroupIds === []) {
+            return 0;
+        }
+        $defs = [
+            ['type' => 'command', 'name' => 'sm_kick',  'access' => 'allow'],
+            ['type' => 'command', 'name' => 'sm_slay',  'access' => 'allow'],
+            ['type' => 'command', 'name' => 'sm_ban',   'access' => 'allow'],
+            ['type' => 'command', 'name' => 'sm_admin', 'access' => 'deny'],
+            ['type' => 'group',   'name' => 'sm_root',  'access' => 'deny'],
+        ];
+        $stmt = $this->pdo->prepare(sprintf(
+            'INSERT INTO `%s_srvgroups_overrides` (`group_id`, `type`, `name`, `access`) VALUES (?, ?, ?, ?)',
+            DB_PREFIX
+        ));
+        $n = 0;
+        foreach ($this->srvGroupIds as $sgid) {
+            // Pick 1-2 overrides per srvgroup; UNIQUE KEY (group_id, type, name)
+            // makes duplicates the synthesizer's responsibility to avoid.
+            $picked = [];
+            $want   = mt_rand(1, 2);
+            while (count($picked) < $want) {
+                $idx = mt_rand(0, count($defs) - 1);
+                if (in_array($idx, $picked, true)) continue;
+                $picked[] = $idx;
+                $d = $defs[$idx];
+                $stmt->execute([$sgid, $d['type'], $d['name'], $d['access']]);
+                $n++;
+            }
+        }
+        return $n;
+    }
+
+    private function insertOverrides(): int
+    {
+        $defs = [
+            ['type' => 'command', 'name' => 'sm_kick',     'flags' => 'd'],
+            ['type' => 'command', 'name' => 'sm_slay',     'flags' => 'e'],
+            ['type' => 'command', 'name' => 'sm_ban',      'flags' => 'd'],
+            ['type' => 'command', 'name' => 'sm_admin',    'flags' => 'a'],
+            ['type' => 'group',   'name' => 'sm_root',     'flags' => 'z'],
+        ];
+        $stmt = $this->pdo->prepare(sprintf(
+            'INSERT INTO `%s_overrides` (`type`, `name`, `flags`) VALUES (?, ?, ?)',
+            DB_PREFIX
+        ));
+        foreach ($defs as $d) {
+            $stmt->execute([$d['type'], $d['name'], $d['flags']]);
+        }
+        return count($defs);
+    }
+
+    private function insertBans(): int
+    {
+        $reasons = $this->buildReasonPool();
+        $stmt    = $this->pdo->prepare(sprintf(
+            'INSERT INTO `%s_bans`
+                (`ip`, `authid`, `name`, `created`, `ends`, `length`, `reason`,
+                 `aid`, `adminIp`, `sid`, `country`, `RemovedBy`, `RemoveType`,
+                 `RemovedOn`, `type`, `ureason`)
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)',
+            DB_PREFIX
+        ));
+
+        $count       = $this->scale['bans'];
+        $unbanReason = [
+            'Appeal accepted, behaviour clarified.',
+            'Mistaken identity confirmed via demo review.',
+            'Reduced to a warning after community feedback.',
+            'Probationary unban — see notes.',
+            'Ban length reduced after appeal.',
+        ];
+
+        for ($i = 0; $i < $count; $i++) {
+            $player  = $this->players[mt_rand(0, count($this->players) - 1)];
+            $isIpOnly = mt_rand(0, 9) === 0; // ~10% IP-only bans
+
+            $created = $this->now - mt_rand(0, 60 * 60 * 24 * 90);
+
+            // Length distribution: 25% permanent, 75% timed (1d-180d).
+            $length = mt_rand(0, 3) === 0 ? 0 : mt_rand(60 * 60 * 24, 60 * 60 * 24 * 180);
+            $ends   = $length === 0 ? 0 : $created + $length;
+
+            // State distribution: 60% active (incl. permanent), 25% expired,
+            // 15% admin-removed (RemoveType U/D + RemovedBy + ureason).
+            $roll       = mt_rand(0, 99);
+            $removeType = null;
+            $removedBy  = null;
+            $removedOn  = null;
+            $ureason    = '';
+            if ($roll < 60) {
+                // Active. Force ends > now if timed.
+                if ($length !== 0 && $ends < $this->now) {
+                    $created = $this->now - mt_rand(0, $length - 60 * 60 * 24);
+                    $ends    = $created + $length;
+                }
+            } elseif ($roll < 85) {
+                // Expired (timed, ends < now). Skip permanent rows here.
+                if ($length === 0) {
+                    $length = 60 * 60 * 24 * mt_rand(1, 30);
+                    $ends   = $created + $length;
+                }
+                if ($ends > $this->now) {
+                    $created = $this->now - $length - mt_rand(60, 60 * 60 * 24 * 7);
+                    $ends    = $created + $length;
+                }
+            } else {
+                // Admin-removed (~15%).
+                $removeType = mt_rand(0, 1) === 0 ? 'U' : 'D';
+                $removedBy  = $this->randomAdminAid();
+                $removedOn  = $created + mt_rand(60 * 60, 60 * 60 * 24 * 7);
+                if ($removedOn > $this->now) {
+                    $removedOn = $this->now - mt_rand(60, 60 * 60 * 24);
+                }
+                $ureason    = $unbanReason[mt_rand(0, count($unbanReason) - 1)];
+            }
+
+            $stmt->execute([
+                $isIpOnly ? $player['ip'] : (mt_rand(0, 4) === 0 ? $player['ip'] : null),
+                $isIpOnly ? '' : $player['steam'],
+                $player['name'],
+                $created,
+                $ends,
+                $length,
+                $reasons[mt_rand(0, count($reasons) - 1)],
+                $this->randomAdminAid(),
+                $this->randomAdminIp(),
+                $this->randomServerSid(),
+                $player['country'],
+                $removedBy,
+                $removeType,
+                $removedOn,
+                $isIpOnly ? 1 : 0,
+                $ureason !== '' ? $ureason : null,
+            ]);
+            $this->banBids[] = (int) $this->pdo->lastInsertId();
+        }
+        return $count;
+    }
+
+    private function insertBanlog(): int
+    {
+        if ($this->banBids === [] || $this->serverSids === []) {
+            return 0;
+        }
+        $stmt  = $this->pdo->prepare(sprintf(
+            'INSERT IGNORE INTO `%s_banlog` (`sid`, `time`, `name`, `bid`) VALUES (?, ?, ?, ?)',
+            DB_PREFIX
+        ));
+        $count = $this->scale['banlog'];
+        $n     = 0;
+        for ($i = 0; $i < $count; $i++) {
+            $bid    = $this->banBids[mt_rand(0, count($this->banBids) - 1)];
+            $sid    = $this->randomServerSid();
+            $time   = $this->now - mt_rand(0, 60 * 60 * 24 * 30);
+            $player = $this->players[mt_rand(0, count($this->players) - 1)];
+            // PK is (sid, time, bid); INSERT IGNORE absorbs the rare collision.
+            $ok = $stmt->execute([$sid, $time, $player['name'], $bid]);
+            if ($ok && $stmt->rowCount() > 0) {
+                $n++;
+            }
+        }
+        return $n;
+    }
+
+    private function insertComms(): int
+    {
+        $reasons = $this->buildCommReasonPool();
+        $stmt    = $this->pdo->prepare(sprintf(
+            'INSERT INTO `%s_comms`
+                (`authid`, `name`, `created`, `ends`, `length`, `reason`, `aid`,
+                 `adminIp`, `sid`, `RemovedBy`, `RemoveType`, `RemovedOn`,
+                 `type`, `ureason`)
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)',
+            DB_PREFIX
+        ));
+
+        $count = $this->scale['comms'];
+        for ($i = 0; $i < $count; $i++) {
+            $player  = $this->players[mt_rand(0, count($this->players) - 1)];
+            $created = $this->now - mt_rand(0, 60 * 60 * 24 * 60);
+            $length  = mt_rand(0, 3) === 0 ? 0 : mt_rand(60 * 30, 60 * 60 * 24 * 14);
+            $ends    = $length === 0 ? 0 : $created + $length;
+
+            $roll       = mt_rand(0, 99);
+            $removeType = null;
+            $removedBy  = null;
+            $removedOn  = null;
+            $ureason    = null;
+            if ($roll < 60) {
+                if ($length !== 0 && $ends < $this->now) {
+                    $created = $this->now - mt_rand(0, max(60, $length - 60 * 60));
+                    $ends    = $created + $length;
+                }
+            } elseif ($roll < 85) {
+                if ($length === 0) {
+                    $length = 60 * 60 * mt_rand(1, 24);
+                    $ends   = $created + $length;
+                }
+                if ($ends > $this->now) {
+                    $created = $this->now - $length - mt_rand(60, 60 * 60 * 6);
+                    $ends    = $created + $length;
+                }
+            } else {
+                $removeType = 'U';
+                $removedBy  = $this->randomAdminAid();
+                $removedOn  = $created + mt_rand(60, 60 * 60 * 24);
+                if ($removedOn > $this->now) {
+                    $removedOn = $this->now - mt_rand(60, 60 * 60 * 24);
+                }
+                $ureason    = 'Apologised; comm restored.';
+            }
+
+            $stmt->execute([
+                $player['steam'],
+                $player['name'],
+                $created,
+                $ends,
+                $length,
+                $reasons[mt_rand(0, count($reasons) - 1)],
+                $this->randomAdminAid(),
+                $this->randomAdminIp(),
+                $this->randomServerSid(),
+                $removedBy,
+                $removeType,
+                $removedOn,
+                mt_rand(1, 2), // 1 = mute, 2 = gag
+                $ureason,
+            ]);
+        }
+        return $count;
+    }
+
+    private function insertComments(): int
+    {
+        if ($this->banBids === []) {
+            return 0;
+        }
+        $count = $this->scale['comments'];
+        $stmt  = $this->pdo->prepare(sprintf(
+            'INSERT INTO `%s_comments` (`bid`, `type`, `aid`, `commenttxt`, `added`) VALUES (?, ?, ?, ?, ?)',
+            DB_PREFIX
+        ));
+        $bodies = [
+            'Demo confirms aimbot — see frame 14:32.',
+            'Player apologised in DMs, recommend leaving ban.',
+            "Multi-account abuse. Linked to ban #1042 by IP overlap.\nNo prior history but pattern is clear.",
+            'Reduced from perm to 7d after appeal.',
+            'Repeat offender — third ban this month.',
+            'Nothing in chat logs supports the report. Closing.',
+            "Community vote: keep ban.\nUnanimous in #mod-channel.",
+            'Steam profile private; player ignored DM follow-up.',
+            'Friend list overlaps with banned alt accounts.',
+            'Wall-banging through textures — see attached demo.',
+            "Mass team kill x4 in two consecutive rounds.\nClassic griefing pattern.",
+            'Player is banned on the EU server too — checking with that staff.',
+            "Discord screenshot shows them admitting to cheats.\nLeaving ban as is.",
+            'Reduced to 24h — first offence.',
+            "Long-time community member, out-of-character behaviour.\n7d cooldown then revisit.",
+        ];
+        for ($i = 0; $i < $count; $i++) {
+            $bid     = $this->banBids[mt_rand(0, count($this->banBids) - 1)];
+            $aid     = $this->randomAdminAid();
+            $body    = $bodies[mt_rand(0, count($bodies) - 1)];
+            // type='B' is the ban-comment type the public ban page renders.
+            $stmt->execute([$bid, 'B', $aid, $body, $this->now - mt_rand(60, 60 * 60 * 24 * 60)]);
+        }
+        return $count;
+    }
+
+    private function insertSubmissions(): int
+    {
+        $count = $this->scale['submissions'];
+        $stmt  = $this->pdo->prepare(sprintf(
+            'INSERT INTO `%s_submissions`
+                (`submitted`, `ModID`, `SteamId`, `name`, `email`, `reason`,
+                 `ip`, `subname`, `sip`, `archiv`, `archivedby`, `server`)
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)',
+            DB_PREFIX
+        ));
+        $reasons = [
+            'Wallhacking on de_dust2, see linked demo.',
+            'Voice abuse and racist slurs in comms.',
+            "Repeated team-killing.\nIgnored multiple warnings.",
+            'Aimbot — clearly snapping to heads through smoke.',
+            'Sprayed offensive content in spawn.',
+            'Trolling by blocking doorways for an entire round.',
+            'Threatening behaviour in DMs after the round.',
+            'Cheating with fly + speed hacks.',
+        ];
+        for ($i = 0; $i < $count; $i++) {
+            $player = $this->players[mt_rand(0, count($this->players) - 1)];
+            $sub    = $this->players[mt_rand(0, count($this->players) - 1)];
+            // archiv distribution: 40% pending (0), 30% archived/handled (1),
+            // 20% restored (2), 10% banned-from-submission (3).
+            $roll = mt_rand(0, 99);
+            $archiv = $roll < 40 ? 0 : ($roll < 70 ? 1 : ($roll < 90 ? 2 : 3));
+            $archivedBy = $archiv === 0 ? null : $this->randomAdminAid();
+            $stmt->execute([
+                $this->now - mt_rand(0, 60 * 60 * 24 * 60),
+                $this->modIds[mt_rand(0, count($this->modIds) - 1)],
+                $player['steam'],
+                $player['name'],
+                'reporter+' . mt_rand(1, 999) . '@example.test',
+                $reasons[mt_rand(0, count($reasons) - 1)],
+                $player['ip'],
+                $sub['name'],
+                $sub['ip'],
+                $archiv,
+                $archivedBy,
+                mt_rand(0, max(1, count($this->serverSids))),
+            ]);
+        }
+        return $count;
+    }
+
+    private function insertProtests(): int
+    {
+        if ($this->banBids === []) {
+            return 0;
+        }
+        $count = $this->scale['protests'];
+        $stmt  = $this->pdo->prepare(sprintf(
+            'INSERT INTO `%s_protests`
+                (`bid`, `datesubmitted`, `reason`, `email`, `archiv`, `archivedby`, `pip`)
+             VALUES (?, ?, ?, ?, ?, ?, ?)',
+            DB_PREFIX
+        ));
+        $bodies = [
+            "I was banned by mistake. I'd just joined the server and didn't even fire a shot.",
+            "My little brother was using my account. Banning me directly is unfair.\nHe won't play again.",
+            'Banned for "wallhack" but I was using the radar info my teammate called out.',
+            "I admit the chat was over the line, but the perma ban is excessive.\nI've been on this server for 4 years.",
+            "The demo will show this is a false positive. I've never used cheats.",
+            'Ban length seems disproportionate to the offence — please review.',
+        ];
+        $n = 0;
+        for ($i = 0; $i < $count; $i++) {
+            $bid    = $this->banBids[mt_rand(0, count($this->banBids) - 1)];
+            $archiv = mt_rand(0, 99) < 60 ? 0 : 1;
+            $archivedBy = $archiv === 0 ? null : $this->randomAdminAid();
+            $stmt->execute([
+                $bid,
+                $this->now - mt_rand(0, 60 * 60 * 24 * 45),
+                $bodies[mt_rand(0, count($bodies) - 1)],
+                'appeal+' . mt_rand(1, 999) . '@example.test',
+                $archiv,
+                $archivedBy,
+                sprintf('192.0.2.%d', mt_rand(1, 250)),
+            ]);
+            $n++;
+        }
+        return $n;
+    }
+
+    private function insertNotes(): int
+    {
+        if ($this->adminAids === []) {
+            return 0;
+        }
+        $count = $this->scale['notes'];
+        $stmt  = $this->pdo->prepare(sprintf(
+            'INSERT INTO `%s_notes` (`steam_id`, `aid`, `body`, `created`) VALUES (?, ?, ?, ?)',
+            DB_PREFIX
+        ));
+        $bodies = [
+            'Repeat ban evader. Watch for new alts.',
+            'Long-time donor. Be lenient on first offence.',
+            "Asperger's-spectrum, may misread sarcasm.\nSee #mod for context.",
+            'Speaks limited English; consider language ban over kick.',
+            'Has had three appeals declined this year.',
+            'Friendly with admin team — usually self-corrects after a poke.',
+            "Linked accounts:\n- STEAM_0:0:9988\n- STEAM_0:0:1122",
+            'Toxic in voice but never in text — mute-only ban worked last time.',
+            'Reported by multiple sources but I cannot find evidence in demos.',
+            "Notable for clutch plays.\nHistory of frustration tilts; not malicious.",
+        ];
+        for ($i = 0; $i < $count; $i++) {
+            $player = $this->players[mt_rand(0, count($this->players) - 1)];
+            $aid    = $this->randomAdminAid();
+            $body   = $bodies[mt_rand(0, count($bodies) - 1)];
+            $stmt->execute([$player['steam'], $aid, $body, $this->now - mt_rand(60, 60 * 60 * 24 * 90)]);
+        }
+        return $count;
+    }
+
+    private function insertAuditLog(): int
+    {
+        $count = $this->scale['audit'];
+        $stmt  = $this->pdo->prepare(sprintf(
+            'INSERT INTO `%s_log` (`type`, `title`, `message`, `function`, `query`, `aid`, `host`, `created`)
+             VALUES (?, ?, ?, "synthetic-data", "", ?, ?, ?)',
+            DB_PREFIX
+        ));
+        // Mix of action types so the audit log filter dropdown
+        // (admin / message / type / date) has something to match.
+        $events = [
+            ['m', 'Ban Added',       'admin added a ban for player'],
+            ['m', 'Ban Edited',      'admin edited a ban'],
+            ['m', 'Ban Unbanned',    'admin unbanned a player'],
+            ['m', 'Comment Added',   'admin added a comment for ban'],
+            ['m', 'Comment Edited',  'admin edited comment'],
+            ['m', 'Server Added',    'admin added server'],
+            ['m', 'Server Edited',   'admin edited server'],
+            ['m', 'Mod Added',       'admin added mod'],
+            ['m', 'Group Added',     'admin added group'],
+            ['m', 'Group Edited',    'admin edited group'],
+            ['m', 'Admin Added',     'admin added admin'],
+            ['m', 'Admin Edited',    'admin edited admin'],
+            ['m', 'Setting Updated', 'admin updated setting'],
+            ['m', 'Submission Archived', 'admin archived submission'],
+            ['m', 'Protest Archived',    'admin archived protest'],
+            ['w', 'Ban Failed',      'failed to add ban: server unreachable'],
+            ['w', 'RCON Failed',     'rcon command timed out'],
+            ['w', 'Permission Denied', 'admin attempted action without flag'],
+            ['e', 'Database Error',  'unexpected SQL state'],
+            ['e', 'Auth Failure',    'invalid login attempt'],
+        ];
+        for ($i = 0; $i < $count; $i++) {
+            $ev      = $events[mt_rand(0, count($events) - 1)];
+            $aid     = $this->randomAdminAid();
+            $created = $this->now - mt_rand(0, 60 * 60 * 24 * 60);
+            $host    = sprintf('192.0.2.%d', mt_rand(1, 250));
+            $stmt->execute([$ev[0], $ev[1], $ev[2] . ' #' . mt_rand(1, 9999), $aid, $host, $created]);
+        }
+        return $count;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function buildReasonPool(): array
+    {
+        $long = "Player exhibited persistent griefing behaviour over multiple maps:\n"
+            . "- Repeated team kills at round start\n"
+            . "- Voice spam (`siren.wav` looped) for ~30 seconds\n"
+            . "- Refused to acknowledge admin warnings\n\n"
+            . "After the third warning the ban was issued. Demo attached. Severity bumped to 30d due to prior history (#1042, #918).";
+        return [
+            'cheating',
+            'wallhack',
+            'aimbot',
+            'racism',
+            'griefing',
+            "Voice abuse + racial slurs in comms.\nMultiple reports.",
+            "**Aimbot** confirmed via demo at frame 14:32.\n_Locked on through smoke._",
+            'Spinbot — see uploaded demo `attack_round3.dem`.',
+            "Mass team-kill x6 in 2 minutes\nignored repeated warnings.",
+            'Spawn-camping with C4 — denied multiple rounds in a row.',
+            'Threats made against admin team in DMs after kick.',
+            "Repeat offender — fourth ban for the same SteamID alt.\nGroup-banning related accounts in follow-up.",
+            'Inappropriate sprays (NSFW).',
+            'Exploiting map geometry to wallbang through unintended surfaces.',
+            $long,
+            'Bug exploit (rocket-jumping out of map bounds repeatedly).',
+            "Toxic chat in two consecutive matches.\nFirst: lifetime stats abuse. Second: targeted slurs.",
+            "Macro-bound bunnyhop + air-strafe automation.\nDetected via input timing.",
+            'Discord harassment of clan member; cross-server enforcement.',
+        ];
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function buildCommReasonPool(): array
+    {
+        return [
+            'voice spam',
+            'racial slurs',
+            'mic spam (music)',
+            "Repeated targeted harassment in voice chat.\nEscalated after first warning.",
+            'Inappropriate language in family hours.',
+            "**Politics** in chat after warning. 24h gag.",
+            'Sexual harassment of another player.',
+            'Voice changer used to impersonate an admin.',
+            'Hate speech in chat — zero tolerance policy.',
+            "Ad spam linking to a competing server.\nFollow-up perma if repeated.",
+        ];
+    }
+
+    private function randomAdminAid(): int
+    {
+        // Mix in aid=0 (CONSOLE) occasionally so the audit log has a
+        // realistic "system" actor in addition to human admins.
+        if ($this->adminAids === [] || mt_rand(0, 19) === 0) {
+            return 0;
+        }
+        return $this->adminAids[mt_rand(0, count($this->adminAids) - 1)];
+    }
+
+    private function randomAdminIp(): string
+    {
+        // Stable pool of admin source IPs — a handful of admins logging
+        // in from a small set of locations keeps the audit log readable.
+        return sprintf('203.0.113.%d', mt_rand(1, 20));
+    }
+
+    private function randomServerSid(): int
+    {
+        if ($this->serverSids === []) {
+            return 0;
+        }
+        return $this->serverSids[mt_rand(0, count($this->serverSids) - 1)];
+    }
+}

--- a/web/tests/Synthesizer.php
+++ b/web/tests/Synthesizer.php
@@ -17,9 +17,35 @@ namespace Sbpp\Tests;
  * Idempotent: every call truncates user-data tables first (preserving
  * `sb_settings` and `sb_mods` which `data.sql` owns), re-seeds the
  * CONSOLE + `admin/admin` rows the dev panel logs in with, then inserts
- * synthetic rows. Same `seed` ⇒ identical names, reasons, and ordering;
- * `mt_srand($seed)` pins PHP's Mersenne Twister so the dataset is
- * reproducible across machines.
+ * synthetic rows.
+ *
+ * Determinism contract — what same `seed` ⇒ same:
+ *   - row counts, ordering, authids, names, reasons, comment / note /
+ *     submission / protest / audit bodies, country codes, IPs
+ *   - timestamp _spread_ (relative to the run's `$now` anchor — i.e.
+ *     "ban X is 2 hours older than ban Y" reproduces; a re-seed three
+ *     days later shifts both by the same amount)
+ *   - high-activity cohort membership (which player indices get the
+ *     populated history shape)
+ *   - SteamID-form mix (which players get `[U:1:N]` vs `STEAM_1:…` vs
+ *     `STEAM_0:…`)
+ *
+ * Intentionally non-deterministic across runs:
+ *   - **Absolute timestamps**: anchored at `time()` so the dashboard's
+ *     "Latest …" cards always show fresh-looking rows. Re-seeding tomorrow
+ *     shifts every `created` / `ends` / `RemovedOn` / etc. by ~24h, but
+ *     the spread + ordering is identical to today's run with the same seed.
+ *   - **RCON tokens** (`sb_servers.rcon`): generated via
+ *     `bin2hex(random_bytes(8))` so each run gets a fresh token. The
+ *     server-edit form is the only surface that reads it; nothing
+ *     user-visible changes.
+ *   - **Admin password hashes** (`sb_admins.password`): bcrypt salts are
+ *     non-deterministic by construction, but `password_verify('admin', …)`
+ *     against the row holds across runs (the literal password 'admin' is
+ *     deterministic; the hash is not).
+ *
+ * `mt_srand($seed)` pins PHP's Mersenne Twister so the deterministic
+ * axes above reproduce byte-for-byte across machines.
  *
  * NOT used by the E2E suite — `Fixture::truncateAndReseed()` stays minimal
  * and the e2e DB stays empty by design (specs build the rows they need).
@@ -141,6 +167,18 @@ final class Synthesizer
      * @var list<array{steam: string, name: string, country: string, ip: string}>
      */
     private array $players = [];
+
+    /**
+     * Indices into {@see $players} for the "high-activity" cohort:
+     * roughly the first 5% of the pool, biased to receive 3-4 bans + 2
+     * comms + 2 notes apiece. Lets the drawer's per-player history /
+     * notes panes always render the populated shape on a deterministic
+     * subset of the pool, instead of being mostly-empty for the long
+     * tail (#1243 review).
+     *
+     * @var list<int>
+     */
+    private array $highActivityIdx = [];
 
     /**
      * Public entrypoint. Idempotent.
@@ -279,11 +317,26 @@ final class Synthesizer
         for ($i = 0; $i < $count; $i++) {
             $authNum = 1_000_000 + $i * 17;
             $authIdY = mt_rand(0, 1);
-            // Emit a mix of STEAM_0 and STEAM_1 (universe 0 vs 1) so the
-            // banlist exercises both legacy and "new" Steam universe paths.
-            $universe = mt_rand(0, 9) === 0 ? '1' : '0';
+            // Three-form authid mix so the drawer's copy-button paths and
+            // the format-detection regression surface (#1207 DET-1, the
+            // mobile-Safari/Android tap-to-dial guard) all exercise across
+            // every form bans/comms in the wild actually carry. $authNum
+            // stays shared across the arms so re-seeding with a different
+            // seed flips the form for the same player position rather than
+            // reshuffling identities.
+            //   ~10% [U:1:N]      Steam3 (drawer: copy button + tel: guard)
+            //   ~10% STEAM_1:Y:N  universe-1 ("new" Source engine)
+            //   ~80% STEAM_0:Y:N  universe-0 (legacy default)
+            $formRoll = mt_rand(0, 99);
+            if ($formRoll < 10) {
+                $steam = sprintf('[U:1:%d]', $authNum);
+            } elseif ($formRoll < 20) {
+                $steam = sprintf('STEAM_1:%d:%d', $authIdY, $authNum);
+            } else {
+                $steam = sprintf('STEAM_0:%d:%d', $authIdY, $authNum);
+            }
             $this->players[] = [
-                'steam'   => sprintf('STEAM_%s:%d:%d', $universe, $authIdY, $authNum),
+                'steam'   => $steam,
                 'name'    => $names[$i % count($names)],
                 'country' => $countries[mt_rand(0, count($countries) - 1)],
                 'ip'      => sprintf(
@@ -295,6 +348,55 @@ final class Synthesizer
                 ),
             ];
         }
+
+        // High-activity cohort: first ceil(5%) of the pool. Front of the
+        // pool is fine because the player-pool order is itself shuffled
+        // by the name-modulo and the seeded RNG; nothing downstream
+        // assumes "low index = special". Bans/comms/notes pull from this
+        // cohort first so each cohort player ends up with the populated
+        // history shape (3-4 bans, 2 comms, 2 notes apiece on average),
+        // making the drawer's per-player history / notes panes reliably
+        // non-empty on a deterministic subset (#1243 review).
+        $cohortSize = max(1, (int) ceil($count * 0.05));
+        $this->highActivityIdx = range(0, min($cohortSize, $count) - 1);
+    }
+
+    /**
+     * Build the list of player-pool indices to use for each row of a
+     * given table (bans / comms / notes). Front-loads the high-activity
+     * cohort so each cohort player ends up with $perCohort (+/- 1)
+     * rows, then fills the remainder uniformly at random across the
+     * full pool. Caps cohort allocation at $total so the returned list
+     * never exceeds the scale ceiling.
+     *
+     * Order is intentional: cohort first, random tail second. Per-row
+     * `created` timestamps are still fully randomised inside each
+     * insert loop, so the dashboard's "Latest …" cards (sorted by
+     * `created DESC`) still mix cohort and tail; only the bid order
+     * lands cohort rows first, which is harmless.
+     *
+     * @return list<int>
+     */
+    private function scheduleTargets(int $perCohort, int $total): array
+    {
+        if ($total <= 0 || $this->players === []) {
+            return [];
+        }
+        $list = [];
+        foreach ($this->highActivityIdx as $idx) {
+            $copies = $perCohort + mt_rand(0, 1);
+            for ($k = 0; $k < $copies; $k++) {
+                if (count($list) >= $total) {
+                    return $list;
+                }
+                $list[] = $idx;
+            }
+        }
+        $rest = $total - count($list);
+        for ($k = 0; $k < $rest; $k++) {
+            $list[] = mt_rand(0, count($this->players) - 1);
+        }
+        return $list;
     }
 
     /**
@@ -623,8 +725,12 @@ final class Synthesizer
             'Ban length reduced after appeal.',
         ];
 
-        for ($i = 0; $i < $count; $i++) {
-            $player  = $this->players[mt_rand(0, count($this->players) - 1)];
+        // High-activity cohort gets ~3-4 bans apiece up front; the
+        // remaining slots fall back to uniform random selection.
+        $targets = $this->scheduleTargets(3, $count);
+
+        foreach ($targets as $playerIdx) {
+            $player  = $this->players[$playerIdx];
             $isIpOnly = mt_rand(0, 9) === 0; // ~10% IP-only bans
 
             $created = $this->now - mt_rand(0, 60 * 60 * 24 * 90);
@@ -687,7 +793,7 @@ final class Synthesizer
             ]);
             $this->banBids[] = (int) $this->pdo->lastInsertId();
         }
-        return $count;
+        return count($targets);
     }
 
     private function insertBanlog(): int
@@ -728,8 +834,11 @@ final class Synthesizer
         ));
 
         $count = $this->scale['comms'];
-        for ($i = 0; $i < $count; $i++) {
-            $player  = $this->players[mt_rand(0, count($this->players) - 1)];
+        // Cohort gets ~2 comms apiece up front; remainder is uniform.
+        $targets = $this->scheduleTargets(2, $count);
+
+        foreach ($targets as $playerIdx) {
+            $player  = $this->players[$playerIdx];
             $created = $this->now - mt_rand(0, 60 * 60 * 24 * 60);
             $length  = mt_rand(0, 3) === 0 ? 0 : mt_rand(60 * 30, 60 * 60 * 24 * 14);
             $ends    = $length === 0 ? 0 : $created + $length;
@@ -780,7 +889,7 @@ final class Synthesizer
                 $ureason,
             ]);
         }
-        return $count;
+        return count($targets);
     }
 
     private function insertComments(): int
@@ -793,6 +902,30 @@ final class Synthesizer
             'INSERT INTO `%s_comments` (`bid`, `type`, `aid`, `commenttxt`, `added`) VALUES (?, ?, ?, ?, ?)',
             DB_PREFIX
         ));
+        // Long-form Markdown bodies live alongside the short pool so the
+        // drawer's Comments pane exercises its truncation/wrap chrome on
+        // a deterministic subset of comments, not just the one-liners.
+        // Shape mirrors the long-reason entry in buildReasonPool().
+        $longInvestigation = "**Investigation summary** — three sessions of demo review:\n\n"
+            . "1. Round 1 (`de_inferno`): clean prefires through smoke at A-site, but only on enemies. "
+            . "Suspicious; not conclusive.\n"
+            . "2. Round 2 (`de_mirage`): tracking through walls during the pre-round freeze. "
+            . "_This_ is the smoking gun — no in-game info available.\n"
+            . "3. Round 3 (`de_dust2`): aim snap to head from B-tunnels through the doorway, target "
+            . "fully off-screen. Frame 17:42-17:44.\n\n"
+            . "Recommendation: keep the perma. Player has appealed twice already on alts (#812, #944) "
+            . "with the same denial pattern.";
+        $longContext = "Long-time community member; checked context before the ban:\n\n"
+            . "- 6 years on the server, 0 prior bans\n"
+            . "- Active in our Discord, helps new players\n"
+            . "- Reportedly going through some personal stuff in voice channels last month\n\n"
+            . "**Recommendation**: reduce from perma to 14d cooldown + DM check-in when it lifts. "
+            . "If the toxic streak continues post-cooldown we revisit. Note added to player profile.";
+        $longCrossLink = "Cross-server intel from EU staff (`@modteam-eu`):\n\n"
+            . "Player is currently serving a 30d ban on the EU comp server for the same wallhack "
+            . "pattern (`STEAM_0:1:88421`). Confirmed via Discord DM with their head admin.\n\n"
+            . "**Action**: matching our ban length to theirs (30d), updating ureason to reflect the "
+            . "cross-server enforcement. Adding linked-accounts note for future moderators.";
         $bodies = [
             'Demo confirms aimbot — see frame 14:32.',
             'Player apologised in DMs, recommend leaving ban.',
@@ -809,6 +942,9 @@ final class Synthesizer
             "Discord screenshot shows them admitting to cheats.\nLeaving ban as is.",
             'Reduced to 24h — first offence.',
             "Long-time community member, out-of-character behaviour.\n7d cooldown then revisit.",
+            $longInvestigation,
+            $longContext,
+            $longCrossLink,
         ];
         for ($i = 0; $i < $count; $i++) {
             $bid     = $this->banBids[mt_rand(0, count($this->banBids) - 1)];
@@ -927,13 +1063,16 @@ final class Synthesizer
             'Reported by multiple sources but I cannot find evidence in demos.',
             "Notable for clutch plays.\nHistory of frustration tilts; not malicious.",
         ];
-        for ($i = 0; $i < $count; $i++) {
-            $player = $this->players[mt_rand(0, count($this->players) - 1)];
+        // Cohort gets ~2 notes apiece up front; remainder is uniform.
+        $targets = $this->scheduleTargets(2, $count);
+
+        foreach ($targets as $playerIdx) {
+            $player = $this->players[$playerIdx];
             $aid    = $this->randomAdminAid();
             $body   = $bodies[mt_rand(0, count($bodies) - 1)];
             $stmt->execute([$player['steam'], $aid, $body, $this->now - mt_rand(60, 60 * 60 * 24 * 90)]);
         }
-        return $count;
+        return count($targets);
     }
 
     private function insertAuditLog(): int

--- a/web/tests/scripts/seed-dev-db.php
+++ b/web/tests/scripts/seed-dev-db.php
@@ -96,6 +96,11 @@ try {
     }
     fwrite(STDOUT, "\n");
     fwrite(STDOUT, "Login at the panel as admin / admin to see the seeded data.\n");
+    // sb_login_tokens is one of the truncated tables, so any open browser
+    // session against the dev panel is invalidated and the next request
+    // will bounce back to the login form. Cheap one-line hint so the dev
+    // doesn't second-guess "did the panel break?" on a re-seed.
+    fwrite(STDOUT, "Re-login required: existing browser sessions were invalidated by the truncate.\n");
 } catch (\Throwable $e) {
     fwrite(STDERR, "seed-dev-db.php failed: " . $e->getMessage() . "\n");
     fwrite(STDERR, $e->getTraceAsString() . "\n");

--- a/web/tests/scripts/seed-dev-db.php
+++ b/web/tests/scripts/seed-dev-db.php
@@ -1,0 +1,143 @@
+<?php
+/**
+ * Dev DB seeder CLI driver. Wired into `./sbpp.sh db-seed`.
+ *
+ * Runs inside the web container, populates `sourcebans` (the dev DB) with
+ * a deterministic, realistic synthetic dataset. Idempotent: every run
+ * truncates the synthesizer-owned tables first and re-inserts. Calls
+ * {@see \Sbpp\Tests\Synthesizer::run()}; the heavy lifting lives there.
+ *
+ * Usage (from inside the container):
+ *
+ *   php seed-dev-db.php                          # default scale, default seed
+ *   php seed-dev-db.php --scale=small            # ~30 bans, fast iteration
+ *   php seed-dev-db.php --scale=large            # ~2000 bans, pagination/perf
+ *   php seed-dev-db.php --seed=42                # alternate RNG seed
+ *   php seed-dev-db.php --scale=small --seed=42  # both
+ *
+ * Env vars consumed (defaulted in tests/bootstrap.php; sbpp.sh wires
+ * the docker-compose values):
+ *
+ *   DB_HOST     default 'db'
+ *   DB_PORT     default 3306
+ *   DB_USER     default 'sourcebans'
+ *   DB_PASS     default 'sourcebans'
+ *   DB_PREFIX   default 'sb'
+ *   DB_CHARSET  default 'utf8mb4'
+ *   DB_NAME     **MUST be 'sourcebans'** — every other value is refused
+ *
+ * Refusal guard: `tests/bootstrap.php` defaults `DB_NAME` to
+ * 'sourcebans_test' when the env var is unset. We pin DB_NAME to
+ * 'sourcebans' before bootstrap loads, then refuse anything else
+ * outright. This is the strictest interpretation of the issue's
+ * "dev-only" constraint — the seeder will not touch:
+ *
+ *   - `sourcebans_test` (PHPUnit's DB)
+ *   - `sourcebans_e2e`  (Playwright's DB)
+ *   - any production DB the operator might rename to
+ *
+ * Production users with a default `sourcebans` install would, in
+ * principle, also pass the guard. The defence-in-depth there is that
+ * (a) production installs don't typically have CLI access set up to
+ * the panel container, (b) running the script blows away every row
+ * the script knows about — a destructive action no production install
+ * could accidentally trigger without an explicit `php` invocation.
+ * The Synthesizer also re-checks `DB_NAME` at `run()` entry as a
+ * belt-and-suspenders guard.
+ */
+
+declare(strict_types=1);
+
+if (PHP_SAPI !== 'cli') {
+    fwrite(STDERR, "seed-dev-db.php must run on the CLI.\n");
+    exit(2);
+}
+
+if (!getenv('DB_NAME')) {
+    putenv('DB_NAME=sourcebans');
+    $_ENV['DB_NAME']    = 'sourcebans';
+    $_SERVER['DB_NAME'] = 'sourcebans';
+}
+
+if (getenv('DB_NAME') !== 'sourcebans') {
+    fwrite(STDERR, "refusing to seed dev DB against DB_NAME=" . getenv('DB_NAME')
+        . ": only 'sourcebans' is allowed (the dev panel's database).\n");
+    fwrite(STDERR, "If you want to seed a different DB, override DB_NAME explicitly to 'sourcebans'\n");
+    fwrite(STDERR, "and re-check what you're doing — every synth-owned table will be truncated.\n");
+    exit(2);
+}
+
+require __DIR__ . '/../bootstrap.php';
+
+// `tests/bootstrap.php` only auto-loads `Fixture.php`; the Synthesizer
+// is dev-only and lives under `Sbpp\Tests\` next to it. Pull it in
+// explicitly so we don't have to amend the PHPUnit bootstrap (which is
+// production code path-wise).
+require __DIR__ . '/../Synthesizer.php';
+
+[$scale, $seed] = parse_args(array_slice($argv, 1));
+
+try {
+    $start  = microtime(true);
+    $counts = \Sbpp\Tests\Synthesizer::run($scale, $seed);
+    $elapsed = microtime(true) - $start;
+
+    fwrite(STDOUT, sprintf(
+        "Seeded `%s` on %s with scale=%s seed=%d in %.2fs.\n",
+        DB_NAME,
+        DB_HOST . ':' . DB_PORT,
+        $scale,
+        $seed,
+        $elapsed
+    ));
+    fwrite(STDOUT, "Inserted rows:\n");
+    foreach ($counts as $table => $n) {
+        fwrite(STDOUT, sprintf("  %-22s %6d\n", $table, $n));
+    }
+    fwrite(STDOUT, "\n");
+    fwrite(STDOUT, "Login at the panel as admin / admin to see the seeded data.\n");
+} catch (\Throwable $e) {
+    fwrite(STDERR, "seed-dev-db.php failed: " . $e->getMessage() . "\n");
+    fwrite(STDERR, $e->getTraceAsString() . "\n");
+    exit(1);
+}
+
+/**
+ * Parse `--scale=<tier>` and `--seed=<int>` flags. Order-independent;
+ * unknown flags are an error so a typo doesn't silently fall through
+ * to the default. The defaults match the issue's "default scale ~200/100/8/8/4"
+ * and we pin the seed to {@see \Sbpp\Tests\Synthesizer::DEFAULT_SEED}
+ * for reproducibility across invocations.
+ *
+ * @param list<string> $args
+ * @return array{string, int}
+ */
+function parse_args(array $args): array
+{
+    $scale = 'medium';
+    $seed  = \Sbpp\Tests\Synthesizer::DEFAULT_SEED;
+
+    foreach ($args as $arg) {
+        if (preg_match('/^--scale=(.+)$/', $arg, $m) === 1) {
+            $scale = $m[1];
+            if (!isset(\Sbpp\Tests\Synthesizer::SCALES[$scale])) {
+                fwrite(STDERR, "unknown --scale '$scale'; expected one of: "
+                    . implode(', ', array_keys(\Sbpp\Tests\Synthesizer::SCALES)) . "\n");
+                exit(2);
+            }
+            continue;
+        }
+        if (preg_match('/^--seed=(-?\d+)$/', $arg, $m) === 1) {
+            $seed = (int) $m[1];
+            continue;
+        }
+        if ($arg === '-h' || $arg === '--help') {
+            fwrite(STDOUT, "Usage: php seed-dev-db.php [--scale=small|medium|large] [--seed=<int>]\n");
+            exit(0);
+        }
+        fwrite(STDERR, "unknown argument '$arg'. Try --help.\n");
+        exit(2);
+    }
+
+    return [$scale, $seed];
+}


### PR DESCRIPTION
## Summary

Closes #1238.

Adds `./sbpp.sh db-seed`, a dev-only command that populates the `sourcebans` dev DB with realistic synthetic rows across bans, comms, servers, admins, groups, submissions, protests, comments, notes, banlog, and the audit log. The dataset is deterministic given a fixed RNG seed.

```sh
./sbpp.sh db-seed                 # default (medium) — ~200 bans, ~100 comms
./sbpp.sh db-seed --scale=small   # ~30 bans, fast iteration
./sbpp.sh db-seed --scale=large   # ~2000 bans, pagination / perf
./sbpp.sh db-seed --seed=42       # alternate RNG seed
```

## Design

### File locations (and why)

- **Synthesizer**: `web/tests/Synthesizer.php` (`Sbpp\Tests\Synthesizer`).  
  Justification: parallels `Sbpp\Tests\Fixture` — both are dev-fixture utilities, both share `web/tests/bootstrap.php`, both use raw PDO + `DB_PREFIX` interpolation. A new top-level dir (`web/tools/`, `web/dev/`, `web/includes/Dev/`) would have been a new conceptual surface area to maintain and would have required new release-tarball gating; staying inside `web/tests/` keeps all dev scaffolding in one place.
- **CLI driver**: `web/tests/scripts/seed-dev-db.php`.  
  Justification: parallels `web/tests/e2e/scripts/reset-e2e-db.php` (the e2e shim). A new `web/tests/scripts/` peer to `web/tests/e2e/scripts/` is the natural shape. The issue's suggestion of `web/scripts/seed-dev-db.php` wouldn't have worked — that directory is JS-only (`api-contract.js`, etc.) per `AGENTS.md` and the `ts-check` gate runs over it.

### Refusal guard (the safety mechanism)

The CLI driver is **strict**: only `DB_NAME=sourcebans` is allowed. Anything else — `sourcebans_test` (PHPUnit), `sourcebans_e2e` (Playwright), or any other DB name — is rejected with a clear error message before the synthesizer ever runs. The Synthesizer also re-checks `DB_NAME` at `run()` entry as a belt-and-suspenders guard for any PHP code that might invoke it directly.

The default for unset `DB_NAME` is also pinned to `sourcebans` (instead of `tests/bootstrap.php`'s `sourcebans_test` fallback) so it can't accidentally fall through to the PHPUnit DB.

### Determinism

`mt_srand($seed)` is called once at the start of `execute()`; every subsequent `mt_rand()` / `array_rand()` call pulls from the same Mersenne Twister stream. Default seed is `Synthesizer::DEFAULT_SEED = 1238` (matches the issue number). Verified by re-running with the same seed and diffing the first five `sb_bans` rows — bit-for-bit identical.

### Idempotency

Every run truncates the synthesizer-owned tables first (under `SET FOREIGN_KEY_CHECKS = 0`), then re-inserts the canonical CONSOLE row (aid=0, via `NO_AUTO_VALUE_ON_ZERO`) and the `admin/admin` login row, then runs the synthetic dataset. Preserves `sb_settings` and `sb_mods` (data.sql's responsibility — no need to re-seed those since they're not touched on synth runs).

### Realism axes covered

- **utf8mb4 names**: `🦊 Foxy McFoxface`, `村田 太郎`, `Иван Петров`, `François Dubois`, `진수 Kim`, `Müller_99`, plus 70+ more spanning emoji / CJK / Cyrillic / accented Latin / gamer-handle conventions
- **Mixed authid formats**: `STEAM_0:0:N`, `STEAM_1:0:N` (universe 1), IP-only bans (~10%), IP+SteamID combos (~20%)
- **Reason variety**: short labels (`cheating`), multi-line, markdown-bearing (`**Aimbot** confirmed via demo`), very long (>200 chars)
- **State distribution**: bans split ~60% active / ~25% expired / ~15% admin-removed (with `RemoveType`/`RemovedBy`/`RemovedOn`/`ureason` populated). Comms split similarly across mute (type=1) / gag (type=2)
- **Time distribution**: timestamps spread across the last 90 days
- **Admin diversity**: 8 admins (default) across 4 groups (Owner / Senior / Moderator / Submitter), each with a tapered `extraflags` mask. All bcrypt-hashed with password `admin`
- **Server diversity**: 8 servers across 1-2 srvgroups, mixed games (TF2 / CS:S / DoD:S / etc.)
- **Submissions / protests state mix**: pending / handled / restored / banned-from

### Scale knobs (final)

| Scale | Bans | Comms | Servers | Admins | Groups | Banlog | Submissions | Protests | Comments | Notes | Audit |
| ----- | ---- | ----- | ------- | ------ | ------ | ------ | ----------- | -------- | -------- | ----- | ----- |
| small | 30 | 10 | 5 | 5 | 3 | 50 | 10 | 5 | 30 | 15 | 80 |
| **medium (default)** | **200** | **100** | **8** | **8** | **4** | **400** | **60** | **25** | **200** | **120** | **600** |
| large | 2000 | 800 | 12 | 12 | 5 | 4000 | 400 | 150 | 1500 | 800 | 5000 |

Medium ≥ the issue's stated defaults. Large `db-seed` completes in ~24s on a workstation.

## What changed

- `web/tests/Synthesizer.php` — `Sbpp\Tests\Synthesizer`, the per-table generator (~700 lines)
- `web/tests/scripts/seed-dev-db.php` — CLI driver mirroring `reset-e2e-db.php`'s shape
- `sbpp.sh` — `db-seed` subcommand (auto-brings-up the stack like `e2e`, forwards args)
- `AGENTS.md` — Dev commands table row, "Where to find what" row, Conventions section "Dev DB seeder"
- `docker/README.md` — describes `db-seed` and the refusal guard

## Out of scope (per issue scope guards)

- `data.sql` / `struc.sql` / `web/updater/data/*` — untouched
- `Fixture::truncateAndReseed()` (the e2e hot path) — untouched
- `reset-e2e-db.php` — untouched
- E2E suite — unaffected (verified by inspection; the suite uses `sourcebans_e2e`, the seeder refuses to touch it)
- API contract / handlers — no changes
- UI / templates — no changes

### Release tarball note

`release.yml` uses `cp -R web` + `zip -rq`, which doesn't honor `.gitattributes`. The new files end up in the release tarball alongside `web/tests/Fixture.php` (which already ships there today and can also drop the dev DB if invoked). The **refusal guard** in the CLI driver is the actual safety mechanism — adding a `.gitattributes` `export-ignore` rule would be misleading (no-op under the current packaging path) and changing the release pipeline is outside the scope of this PR. Documented in `seed-dev-db.php`'s docblock for future readers.

## Test plan

- [x] `./sbpp.sh db-seed` populates the dev DB without errors (medium scale, default seed)
- [x] `./sbpp.sh db-seed --scale=small` (~30 bans) works
- [x] `./sbpp.sh db-seed --scale=large` (~2000 bans) works in ~24s
- [x] `./sbpp.sh db-seed --seed=42` works; re-running with `--seed=42` produces bit-identical rows; different seed produces different rows
- [x] Refuses `DB_NAME=sourcebans_test` and `DB_NAME=sourcebans_e2e` with clear messages and exit 2
- [x] Bad `--scale=bogus` and unknown `--foo=bar` flags fail fast with exit 2
- [x] Re-running `db-seed` is idempotent (truncate + reseed; no PRIMARY KEY collisions, no orphan rows)
- [x] **PHPStan** (`./sbpp.sh phpstan`) — passes (level 5 + DBA enabled)
- [x] **PHPUnit** (`./sbpp.sh test`) — 349 tests, 1469 assertions, all green
- [x] **ts-check** (`./sbpp.sh ts-check`) — passes (no `web/scripts/` changes)
- [x] **API contract / E2E** — skipped per task instructions; no handler / e2e harness changes

### Manual verification (against the seeded medium-scale dataset)

- `?p=banlist` → multiple pages of bans, mixed `STEAM_0` / `STEAM_1` authids, utf8mb4 names visible (`Иван`, `村田`, `🎮`, `Алексей`)
- `?p=commslist` → 100 comm rows across mute/gag types
- Dashboard `/index.php` → "Latest bans" / "Latest comm blocks" / "Latest blocked attempts" cards all populated with synthetic rows + utf8mb4 names
- Drawer (`bans.detail`) → returns rich data including `comments` array with `banhammer` / `sentinel` etc. as `author`, `history_count > 0`, and `notes_visible: true` for admins
- `bans.player_history` → returns ban history items per Steam ID
- `notes.list` → returns notes per `steam_id`
- `?p=admin&c=bans&page=submissions` → 60 submissions across pending/handled/restored states
- `?p=admin&c=bans&page=protests` → 25 protests across pending/handled
- `?p=admin&c=audit` → audit log populated with diverse action types (`Ban Added`, `Server Added`, `Setting Updated`, `Comment Added`, etc.)
- `?p=admin&c=admins` → admin list shows `sentinel`, `fragmaster`, `banhammer`, etc. across multiple groups
- `?p=admin&c=servers` → 8 servers across the seeded srvgroups

## Open questions for the reviewer

1. **Synthesizer location**: `web/tests/Synthesizer.php` vs. a new `web/dev/` or `web/includes/Dev/`. I chose `web/tests/` because the synthesizer shares Fixture's bootstrap + raw-PDO idiom and the `web/tests/` directory already represents "stuff that's not production code path". A separate `web/dev/` would be cleaner conceptually but would require new release-tarball gating and would split the dev fixture machinery across two directories.
2. **CLI driver location**: `web/tests/scripts/seed-dev-db.php` vs. (e.g.) `web/tools/seed-dev-db.php`. Chose the former for symmetry with `web/tests/e2e/scripts/reset-e2e-db.php`. Open to a `web/tools/` move if you'd prefer the dev-only utilities to live under their own root.
3. **Refusal guard strictness**: I went with the strictest interpretation (only `sourcebans` is allowed; everything else, including production names, is refused). This is destructive against `sourcebans` itself by design (truncate + reseed is the contract). A production user with default DB name `sourcebans` could in principle wipe their data, but that's the same risk profile as `Fixture::install()` (which also drops the DB) — the realistic mitigation is "don't run dev tools against prod".
4. **Scale knobs**: medium pinned to the issue's defaults (200/100/8/8/4); small / large picked to make pagination / perf testing useful without being painful. Tunable in `Synthesizer::SCALES` if you want different numbers.
5. **`mt_srand` for determinism**: PHP's Mersenne Twister is process-global state. As long as no other code runs between `mt_srand($seed)` and the inserts (and nothing in the synthesizer touches the global RNG outside its own helpers), the dataset is bit-reproducible. Verified across two consecutive runs.