### PR TITLE
fix(servers): hide rcon hint on first-run empty state (#1227)

### DIFF
--- a/web/themes/default/page_servers.tpl
+++ b/web/themes/default/page_servers.tpl
@@ -79,7 +79,7 @@
                 <span data-online-count>&middot; <span data-online-num>0</span> online</span>
             </p>
         </div>
-        {if $IN_SERVERS_PAGE && $access_bans}
+        {if $IN_SERVERS_PAGE && $access_bans && $server_list|@count > 0}
             <p class="text-xs text-muted m-0"
                role="note"
                data-testid="servers-rcon-hint"


### PR DESCRIPTION
## Summary

Adds `&& $server_list|@count > 0` to the rcon-hint gate in `web/themes/default/page_servers.tpl` so the "Right-click a player on an expanded card to kick, ban, or message them." hint stops rendering when no servers are configured. Per #1227, the hint described an interaction that wasn't possible on the first-run empty state.

`$server_list` is already in scope via `Sbpp\View\ServersListView`; no DTO change required.

Closes #1227

## Test plan

- [ ] Visit `?p=servers` with zero servers → hint hidden, only first-run empty state visible
- [ ] Visit `?p=servers` with ≥ 1 server → hint still visible top-right of header
- [ ] PHPStan + PHPUnit pass on CI