### PR TITLE
fix(admin-settings/themes): inline Homepage link as metadata (#1242)

### DIFF
--- a/web/themes/default/page_admin_settings_themes.tpl
+++ b/web/themes/default/page_admin_settings_themes.tpl
@@ -126,21 +126,10 @@
                                                 </span>
                                             {/if}
                                         </div>
-                                        <p class="text-xs text-muted m-0 mt-2">by {$t.author} · v{$t.version}</p>
+                                        <p class="text-xs text-muted m-0 mt-2">by {$t.author} · v{$t.version}{if $t.link != ''} · <a href="{$t.link}" target="_blank" rel="noopener" class="text-muted" title="Open theme homepage"><i data-lucide="external-link" style="width:0.75rem;height:0.75rem;vertical-align:-1px"></i> homepage</a>{/if}</p>
                                         <p class="text-xs font-mono text-faint m-0 mt-2">{$t.dir}</p>
                                     </div>
-                                    <div class="flex items-center justify-between gap-2 mt-2" style="margin-top:auto">
-                                        {if $t.link != ''}
-                                            <a class="btn btn--ghost btn--sm"
-                                               href="{$t.link}"
-                                               target="_blank"
-                                               rel="noopener"
-                                               title="Open theme homepage">
-                                                <i data-lucide="external-link"></i> Homepage
-                                            </a>
-                                        {else}
-                                            <span></span>
-                                        {/if}
+                                    <div class="flex items-center justify-end gap-2 mt-2" style="margin-top:auto">
                                         {if $can_web_settings}
                                             {if $t.active}
                                                 <button type="button" class="btn btn--secondary btn--sm" disabled aria-pressed="true">


### PR DESCRIPTION
## Summary

The per-theme card's Homepage button used `.btn .btn--ghost .btn--sm`, whose internal padding offset its icon + text 12px right of the description text above it — a visible misalignment, most obvious in dark mode where `.btn--ghost` is borderless and the icon "floats" without chrome to justify the indent.

Adopt Option A from #1242: drop the button chrome, inline the Homepage link as muted metadata at the end of the \`by Author · vN\` description line. This matches the "Currently in use" summary at the top of the same template, which already renders the link this way. The card's primary "Use this theme" / "In use" button now sits alone on the action row.

Closes #1242

## Test plan

- [ ] Visit \`?p=admin&c=settings&section=themes\` → Homepage link sits inline with the author/version metadata; no offset against the card body's left edge.
- [ ] Themes without \`link\` set still render the description without an empty link.
- [ ] "Use this theme" / "In use" button still reads as the card's primary CTA.
- [ ] Light + dark mode both look correct.