### PR TITLE
fix(theme): give drawer/toast icon-only buttons the .btn base class (#1236)

### DIFF
--- a/web/themes/default/css/theme.css
+++ b/web/themes/default/css/theme.css
@@ -265,6 +265,11 @@ html.dark .theme-toggle__moon { display: inline-block; }
 .btn--danger { --btn-bg: var(--danger); --btn-color: white; --btn-bg-hover: #b91c1c; }
 .btn--sm { height: 2rem; padding: 0 0.75rem; font-size: var(--fs-xs); }
 .btn--icon { width: 2.25rem; padding: 0; }
+/* .btn--xs sizes an icon-only button down to 1.5rem so it can sit
+   inline next to a single line of text (drawer ID copy buttons —
+   #1236) without dwarfing the value it copies. Pair with .btn--icon
+   so width/padding stay locked to the square shape. */
+.btn--xs { height: 1.5rem; width: 1.5rem; min-width: 1.5rem; }
 
 /* #1207 AUTH-2 — "Continue with Steam" contrast in dark theme. The
    button is rendered as `.btn--secondary` (page_login.tpl), which in

--- a/web/themes/default/js/theme.js
+++ b/web/themes/default/js/theme.js
@@ -503,7 +503,7 @@
       +     '<div class="text-xs text-faint" style="text-transform:uppercase;letter-spacing:0.06em">Ban #' + escapeHtml(String(data.bid)) + '</div>'
       +     '<h2 class="font-semibold" style="margin:0.125rem 0 0;font-size:1.125rem">' + escapeHtml(player.name || '(unknown)') + '</h2>'
       +   '</div>'
-      +   '<button class="btn--ghost btn--icon" type="button" data-drawer-close aria-label="Close">'
+      +   '<button class="btn btn--ghost btn--icon" type="button" data-drawer-close aria-label="Close">'
       +     '<i data-lucide="x"></i>'
       +   '</button>'
       + '</header>';
@@ -605,7 +605,7 @@
       + idRows.map((row) =>
           '<dt class="text-faint">' + escapeHtml(row[0]) + '</dt>'
           + '<dd class="font-mono" style="margin:0">' + escapeHtml(row[1])
-          + '<button class="btn--ghost btn--icon" type="button" data-copy="' + escapeHtml(row[1]) + '" title="Copy" style="margin-left:0.25rem">'
+          + '<button class="btn btn--ghost btn--icon btn--xs" type="button" data-copy="' + escapeHtml(row[1]) + '" title="Copy" style="margin-left:0.25rem">'
           +   '<i data-lucide="copy" style="width:12px;height:12px"></i>'
           + '</button>'
           + '</dd>'
@@ -751,7 +751,7 @@
             +   '<span class="font-medium">' + escapeHtml(n.author || 'unknown') + '</span>'
             +   '<span style="display:flex;gap:0.5rem;align-items:center">'
             +     '<span>' + escapeHtml(n.created_human || '') + '</span>'
-            +     '<button type="button" class="btn--ghost btn--icon" data-notes-delete="' + escapeHtml(String(n.nid)) + '" aria-label="Delete note" title="Delete note">'
+            +     '<button type="button" class="btn btn--ghost btn--icon" data-notes-delete="' + escapeHtml(String(n.nid)) + '" aria-label="Delete note" title="Delete note">'
             +       '<i data-lucide="trash-2" style="width:14px;height:14px"></i>'
             +     '</button>'
             +   '</span>'
@@ -873,7 +873,7 @@
   function renderDrawerLoading() {
     return '<header class="drawer__header" style="display:flex;justify-content:space-between;align-items:center;padding:1rem 1.25rem;border-bottom:1px solid var(--border)">'
       + '<div class="skeleton" style="width:8rem;height:1.25rem"></div>'
-      + '<button class="btn--ghost btn--icon" type="button" data-drawer-close aria-label="Close">'
+      + '<button class="btn btn--ghost btn--icon" type="button" data-drawer-close aria-label="Close">'
       + '<i data-lucide="x"></i>'
       + '</button>'
       + '</header>'
@@ -893,7 +893,7 @@
   function renderDrawerError(message) {
     return '<header class="drawer__header" style="display:flex;justify-content:space-between;align-items:center;padding:1rem 1.25rem;border-bottom:1px solid var(--border)">'
       +   '<h2 class="font-semibold" style="margin:0;font-size:1rem">Couldn\u2019t load ban</h2>'
-      +   '<button class="btn--ghost btn--icon" type="button" data-drawer-close aria-label="Close">'
+      +   '<button class="btn btn--ghost btn--icon" type="button" data-drawer-close aria-label="Close">'
       +     '<i data-lucide="x"></i>'
       +   '</button>'
       + '</header>'
@@ -1155,7 +1155,7 @@
       + '<div style="flex:1;min-width:0"><div class="font-semibold text-sm">' + escapeHtml(title) + '</div>'
       + (body ? '<div class="text-xs text-muted" style="margin-top:2px">' + escapeHtml(body) + '</div>' : '')
       + '</div>'
-      + '<button class="btn--ghost btn--icon" data-toast-close><i data-lucide="x"></i></button>';
+      + '<button class="btn btn--ghost btn--icon" data-toast-close><i data-lucide="x"></i></button>';
     stack.appendChild(el);
     if (window.lucide) window.lucide.createIcons();
     setTimeout(() => el.remove(), duration);


### PR DESCRIPTION
## Summary

`web/themes/default/js/theme.js` was generating five icon-only buttons (drawer copy × 3, drawer close, notes delete, skeleton/error close, toast close) with `class=\"btn--ghost btn--icon\"` — missing the base `.btn` class. Without it, the CSS vars those modifiers set (`--btn-bg`, `--btn-border`, `--btn-color`) had no consumer and the browser default `<button>` chrome took over.

Add `btn ` to all five sites. For the three drawer-row copy buttons specifically, also add a new `.btn--xs` (1.5rem × 1.5rem) size modifier so they don't dwarf the inline ID text they sit next to.

Closes #1236

## Test plan

- [ ] Open the player drawer → SteamID / Steam3 / Community copy buttons paint as compact ghost buttons (transparent, muted icon, hover bumps to `--text`).
- [ ] Drawer close ×, notes delete, skeleton/error close, toast close all paint as ghost buttons matching the rest of the chrome's design language.
- [ ] No regression on the topbar or palette icon buttons (those stay at `.btn--icon`'s 2.25rem default).
- [ ] Light + dark mode both pass.
- [ ] \`flow-ui-drawer\` E2E screenshot will be refreshed in a follow-up screenshots PR.