### PR TITLE
fix(admin-groups): adopt unified .empty-state pattern (#1228)

### DIFF
--- a/web/includes/View/AdminGroupsListView.php
+++ b/web/includes/View/AdminGroupsListView.php
@@ -77,6 +77,7 @@ final class AdminGroupsListView extends View
         public readonly bool $permission_editgroup,
         public readonly bool $permission_deletegroup,
         public readonly bool $permission_editadmin,
+        public readonly bool $permission_addgroup,
         public readonly int $web_group_count,
         public readonly array $web_admins,
         public readonly array $web_admins_list,

--- a/web/pages/admin.groups.php
+++ b/web/pages/admin.groups.php
@@ -193,6 +193,7 @@ echo '<div class="tabcontent" id="List groups">';
     permission_editgroup:     $userbank->HasAccess(ADMIN_OWNER | ADMIN_EDIT_GROUPS),
     permission_deletegroup:   $userbank->HasAccess(ADMIN_OWNER | ADMIN_DELETE_GROUPS),
     permission_editadmin:     $userbank->HasAccess(ADMIN_OWNER | ADMIN_EDIT_ADMINS),
+    permission_addgroup:      $userbank->HasAccess(ADMIN_OWNER | ADMIN_ADD_GROUP),
     web_group_count:          $web_group_count,
     web_admins:               $web_admins,
     web_admins_list:          $web_admins_list,

--- a/web/themes/default/page_admin_groups_add.tpl
+++ b/web/themes/default/page_admin_groups_add.tpl
@@ -15,7 +15,12 @@
 {if NOT $permission_addgroup}
     <div class="card"><div class="card__body"><p class="text-muted m-0">Access denied.</p></div></div>
 {else}
-<div class="p-6" style="max-width:48rem">
+{* #1228: `id="add-group"` is the anchor target the empty-state CTAs in
+   page_admin_groups_list.tpl jump to (`?p=admin&c=groups#add-group`).
+   The page renders both `tabcontent` divs simultaneously since #1123 D1
+   dropped the `openTab()` JS, so the fragment scrolls the user to the
+   Add form regardless of which tab they came from. *}
+<div class="p-6" id="add-group" style="max-width:48rem">
     <div class="mb-4">
         <h1 style="font-size:var(--fs-2xl);font-weight:600;margin:0">Create a group</h1>
         <p class="text-sm text-muted m-0 mt-2">Pick a name and a type. You can edit permission flags from the <strong>List groups</strong> tab once the group exists.</p>

--- a/web/themes/default/page_admin_groups_list.tpl
+++ b/web/themes/default/page_admin_groups_list.tpl
@@ -30,7 +30,28 @@
         </div>
 
         {if $web_group_count == 0}
-            <div class="card"><div class="card__body"><p class="text-muted m-0">No web admin groups exist yet. Use the <strong>Add a group</strong> tab to create one.</p></div></div>
+            {* #1228 + empty-state unification: first-run state. The CTA
+               is gated on `permission_addgroup` (ADMIN_OWNER |
+               ADMIN_ADD_GROUP) — the same flag the dispatcher gates the
+               `Add a group` form on — so a user without that flag sees
+               the body copy without the link they couldn't follow. *}
+            <div class="empty-state" data-testid="admin-groups-empty-web" data-filtered="false">
+                <span class="empty-state__icon" aria-hidden="true">
+                    <i data-lucide="users-round" style="width:18px;height:18px"></i>
+                </span>
+                <h2 class="empty-state__title">No web admin groups yet</h2>
+                <p class="empty-state__body">Web admin groups bundle panel permissions for a set of admins. Create one to assign multiple admins the same flags at once.</p>
+                {if $permission_addgroup}
+                    <div class="empty-state__actions">
+                        <a class="btn btn--primary btn--sm"
+                           href="?p=admin&amp;c=groups#add-group"
+                           data-testid="admin-groups-empty-web-add">
+                            <i data-lucide="plus" style="width:13px;height:13px"></i>
+                            Add a web admin group
+                        </a>
+                    </div>
+                {/if}
+            </div>
         {else}
         <div class="grid gap-4 admin-groups-master-detail" style="grid-template-columns:minmax(16rem,1fr) 2fr">
             {* Left rail: clickable group list. The per-row member count
@@ -155,7 +176,27 @@
         </div>
 
         {if $server_admin_group_count == 0}
-            <div class="card"><div class="card__body"><p class="text-muted m-0">No server admin groups defined.</p></div></div>
+            {* #1228 + empty-state unification: first-run state. Same
+               `permission_addgroup` gate as the web-admin-groups empty
+               above — the dispatcher only allows `groups.add` for
+               admins with `ADMIN_OWNER | ADMIN_ADD_GROUP`. *}
+            <div class="empty-state" data-testid="admin-groups-empty-server-admin" data-filtered="false">
+                <span class="empty-state__icon" aria-hidden="true">
+                    <i data-lucide="shield-check" style="width:18px;height:18px"></i>
+                </span>
+                <h2 class="empty-state__title">No server admin groups yet</h2>
+                <p class="empty-state__body">Server admin groups carry SourceMod char-flags and immunity. Create one to grant in-game admin powers to a set of admins.</p>
+                {if $permission_addgroup}
+                    <div class="empty-state__actions">
+                        <a class="btn btn--primary btn--sm"
+                           href="?p=admin&amp;c=groups#add-group"
+                           data-testid="admin-groups-empty-server-admin-add">
+                            <i data-lucide="plus" style="width:13px;height:13px"></i>
+                            Add a server admin group
+                        </a>
+                    </div>
+                {/if}
+            </div>
         {else}
             <div class="grid gap-3" style="grid-template-columns:repeat(auto-fill,minmax(20rem,1fr))">
                 {foreach from=$server_group_list item="group" name="server_admin_group"}
@@ -235,7 +276,25 @@
         </div>
 
         {if $server_group_count == 0}
-            <div class="card"><div class="card__body"><p class="text-muted m-0">No server groups defined.</p></div></div>
+            {* #1228 + empty-state unification: first-run state. Same
+               `permission_addgroup` gate as the two empties above. *}
+            <div class="empty-state" data-testid="admin-groups-empty-server" data-filtered="false">
+                <span class="empty-state__icon" aria-hidden="true">
+                    <i data-lucide="server-cog" style="width:18px;height:18px"></i>
+                </span>
+                <h2 class="empty-state__title">No server groups yet</h2>
+                <p class="empty-state__body">Server groups bundle game servers together so you can assign admins to many servers at once. Create one to start grouping your servers.</p>
+                {if $permission_addgroup}
+                    <div class="empty-state__actions">
+                        <a class="btn btn--primary btn--sm"
+                           href="?p=admin&amp;c=groups#add-group"
+                           data-testid="admin-groups-empty-server-add">
+                            <i data-lucide="plus" style="width:13px;height:13px"></i>
+                            Add a server group
+                        </a>
+                    </div>
+                {/if}
+            </div>
         {else}
             <div class="grid gap-3" style="grid-template-columns:repeat(auto-fill,minmax(20rem,1fr))">
                 {foreach from=$server_list item="group" name="server_group"}


### PR DESCRIPTION
## Summary

- Rewrites the three empty branches on `?p=admin&c=groups` (Web admin groups / Server admin groups / Server groups) to follow the unified `.empty-state` first-run pattern from AGENTS.md.
- Each branch gains an icon (`users-round` / `shield-check` / `server-cog`), short title, one-line body, and a permission-gated primary CTA pointing at the in-page Add a group form.
- Adds `data-testid=\"admin-groups-empty-{web|server-admin|server}\"` + `data-filtered=\"false\"` so future E2E specs anchor on the contract instead of visible copy.

Closes #1228

## Test plan

- [ ] On a fresh install: visit `?p=admin&c=groups` → all three sections show the unified empty-state shape (icon + title + body + CTA when permitted)
- [ ] As an admin without the relevant `ADMIN_*` flag: each section shows the body copy without the CTA
- [ ] PHPStan passes (View DTO ↔ template variable cross-check)
- [ ] PHPUnit passes