### PR TITLE
fix(sidebar): single-active-row + row gap + balanced icons + uniform username (#1233, #1234, #1237)

### DIFF
--- a/web/pages/core/navbar.php
+++ b/web/pages/core/navbar.php
@@ -84,9 +84,18 @@ $admin = [
     ]
 ];
 
-$active = $_GET['p'] ?? null;
+$active    = $_GET['p'] ?? null;
+$activeCat = $_GET['c'] ?? null;
 foreach ($navbar as $key => $tab) {
-    $navbar[$key]['state'] = ($active === $tab['endpoint']) ? 'active' : 'nonactive';
+    $isActive = ($active === $tab['endpoint']);
+    // The 'admin' parent is the leaf only when no sub-route is selected.
+    // On ?p=admin&c=<sub> the sub-route's own entry owns the active
+    // state; otherwise both rows would carry aria-current="page", which
+    // misreports the current location to assistive tech (#1233).
+    if ($tab['endpoint'] === 'admin' && $activeCat !== null && $activeCat !== '') {
+        $isActive = false;
+    }
+    $navbar[$key]['state'] = $isActive ? 'active' : 'nonactive';
 
     if (!$tab['permission']) {
         unset($navbar[$key]);

--- a/web/themes/default/core/navbar.tpl
+++ b/web/themes/default/core/navbar.tpl
@@ -69,15 +69,13 @@
         {/if}
     </nav>
 
-    <div style="border-top: 1px solid var(--border); padding: 0.5rem;">
+    <div style="border-top: 1px solid var(--border); padding: 0.5rem; display: flex; flex-direction: column; gap: 0.125rem;">
         {if $login}
             <a class="sidebar__link"
                href="index.php?p=account"
                data-testid="nav-account">
                 <i data-lucide="user"></i>
-                <div style="flex:1;min-width:0">
-                    <div class="font-semibold text-xs truncate">{$username}</div>
-                </div>
+                <div class="truncate" style="flex:1;min-width:0">{$username}</div>
             </a>
             <a class="sidebar__link"
                href="index.php?p=logout"

--- a/web/themes/default/css/theme.css
+++ b/web/themes/default/css/theme.css
@@ -116,14 +116,20 @@ a { color: inherit; text-decoration: none; }
 }
 .sidebar__brand { height: 3.5rem; padding: 0 1rem; display: flex; align-items: center; gap: 0.625rem; border-bottom: 1px solid var(--border); }
 .sidebar__brand-mark { width: 1.75rem; height: 1.75rem; border-radius: var(--radius-md); background: var(--brand-600); color: white; display: grid; place-items: center; font-weight: 700; font-size: var(--fs-sm); }
-.sidebar__nav { flex: 1; overflow-y: auto; padding: 0.75rem 0.5rem; }
-.sidebar__section { margin-bottom: 1.25rem; }
+.sidebar__nav { flex: 1; overflow-y: auto; display: flex; flex-direction: column; padding: 0.75rem 0.5rem; }
+.sidebar__section { display: flex; flex-direction: column; gap: 0.125rem; margin-bottom: 1.25rem; }
 .sidebar__section-label { padding: 0 0.75rem 0.375rem; font-size: 0.625rem; font-weight: 600; letter-spacing: 0.06em; text-transform: uppercase; color: var(--text-faint); }
 .sidebar__link {
   display: flex; align-items: center; gap: 0.625rem; padding: 0 0.75rem; height: 2rem;
   border-radius: var(--radius-md); color: var(--text); font-weight: 500;
   text-decoration: none; transition: background-color .15s; width: 100%; border: 0; background: transparent; text-align: left;
 }
+/* #1237 — sidebar Lucide icons sit next to font-weight: 500 labels. Lucide
+   ships SVG with stroke-width="2", which visually outweighs medium-weight
+   text. CSS `stroke-width` overrides the SVG attribute, no JS change needed.
+   Scoped to `.sidebar__link svg` only — topbar / drawer / palette icons live
+   on denser surfaces and intentionally stay at the default 2.0 weight. */
+.sidebar__link svg { stroke-width: 1.5; }
 .sidebar__link:hover { background: var(--bg-muted); }
 .sidebar__link[aria-current="page"] { background: var(--zinc-900); color: white; }
 /* #1207 CC-4 — dark-theme active nav state. The original


### PR DESCRIPTION
## Summary

Three small fixes on the sidebar nav rail (`core/navbar.php` + `core/navbar.tpl` + `theme.css` sidebar rules):

- **#1233**: On `?p=admin&c=<sub>` URLs, the parent `Admin Panel` row no longer carries the active state — only the leaf sub-route does. Restores the single `aria-current="page"` contract that screen-readers expect.
- **#1234**:
  - Small parent gap (`gap: 0.125rem`) on `.sidebar__section` so the active state's rounded fill no longer butts up against sibling rows.
  - Username row drops the nested `font-semibold text-xs` overrides; it now inherits `.sidebar__link`'s typography (font-weight: 500) and matches every other nav row.
- **#1237**: `.sidebar__link svg { stroke-width: 1.5; }` — Lucide icons no longer visually outweigh the medium-weight labels. Scoped to sidebar only; topbar / drawer / palette stay at the default 2.0 weight intentionally.

Closes #1233
Closes #1234
Closes #1237

## Test plan

- [ ] Visit `?p=admin&c=groups` (or any admin sub-route) → only the leaf row carries `aria-current="page"` and the active CSS class.
- [ ] Visit `?p=admin` (no `c`) → `Admin Panel` is the leaf, gets the active state.
- [ ] Sidebar rows have visible breathing room between them; active fill doesn't touch siblings.
- [ ] Username row's typography matches Logout / Dashboard / etc.
- [ ] Sidebar icons read balanced against the labels.
- [ ] Active-pill contrast unchanged in light + dark.
- [ ] PHPStan + PHPUnit pass on CI.