### PR TITLE
fix(admin-admins): exact/partial match for Login and E-mail filters (#1231)

### DIFF
--- a/web/includes/View/AdminAdminsSearchView.php
+++ b/web/includes/View/AdminAdminsSearchView.php
@@ -22,11 +22,16 @@ namespace Sbpp\View;
  * `{load_template file="admin.admins.search"}` Smarty plugin.
  *
  * The form submits as a plain `GET` to `?p=admin&c=admins` with one
- * parameter per populated filter (`name`, `steamid`, `steam_match`,
- * `admemail`, `webgroup`, `srvadmgroup`, `srvgroup`, `admwebflag[]`,
- * `admsrvflag[]`, `server`). admin.admins.php AND-combines every
- * non-empty filter — see #1207 ADM-4. No CSRF field — search is
- * read-only.
+ * parameter per populated filter (`name`, `name_match`, `steamid`,
+ * `steam_match`, `admemail`, `admemail_match`, `webgroup`,
+ * `srvadmgroup`, `srvgroup`, `admwebflag[]`, `admsrvflag[]`,
+ * `server`). admin.admins.php AND-combines every non-empty filter —
+ * see #1207 ADM-4. No CSRF field — search is read-only.
+ *
+ * `name_match` / `admemail_match` were added in #1231 so Login and
+ * E-mail can be flipped between exact / partial mode the way SteamID
+ * already could; defaults are partial ('1') to preserve pre-#1231
+ * substring behaviour for legacy URLs.
  *
  * `$active_filter_*` mirror the corresponding $_GET keys so the
  * template can pre-fill the form without splattering
@@ -80,9 +85,11 @@ final class AdminAdminsSearchView extends View
         public readonly array $admwebflag_list,
         public readonly array $admsrvflag_list,
         public readonly string $active_filter_name = '',
+        public readonly string $active_filter_name_match = '1',
         public readonly string $active_filter_steamid = '',
         public readonly string $active_filter_steam_match = '0',
         public readonly string $active_filter_admemail = '',
+        public readonly string $active_filter_admemail_match = '1',
         public readonly string $active_filter_webgroup = '',
         public readonly string $active_filter_srvadmgroup = '',
         public readonly string $active_filter_srvgroup = '',

--- a/web/pages/admin.admins.php
+++ b/web/pages/admin.admins.php
@@ -98,11 +98,21 @@ if (isset($_GET['advType']) && isset($_GET['advSearch']) && $_GET['advSearch'] !
     }
 }
 
-// 1) Login name (substring against ADM.user).
+// 1) Login name (exact or partial against ADM.user).
+//    `name_match` was added in #1231; default is partial ('1') so
+//    pre-#1231 URLs (`?name=alice` with no name_match) keep their
+//    substring semantics. `0` flips to exact.
 if (!empty($_GET['name']) && is_string($_GET['name'])) {
-    $where                  .= " AND ADM.user LIKE ?";
-    $whereParams[]           = '%' . $_GET['name'] . '%';
-    $activeFilters['name']   = (string) $_GET['name'];
+    $partialName = !isset($_GET['name_match']) || (string) $_GET['name_match'] !== '0';
+    if ($partialName) {
+        $where        .= " AND ADM.user LIKE ?";
+        $whereParams[] = '%' . $_GET['name'] . '%';
+    } else {
+        $where        .= " AND ADM.user = ?";
+        $whereParams[] = $_GET['name'];
+    }
+    $activeFilters['name']       = (string) $_GET['name'];
+    $activeFilters['name_match'] = $partialName ? '1' : '0';
 }
 
 // 2) Steam ID (exact or partial against ADM.authid).
@@ -119,12 +129,21 @@ if (!empty($_GET['steamid']) && is_string($_GET['steamid'])) {
     $activeFilters['steam_match'] = $partial ? '1' : '0';
 }
 
-// 3) E-mail (substring, gated on the same flag the search box gates the
-// input field on so URL forgery can't bypass the visibility gate).
+// 3) E-mail (exact or partial; `admemail_match` was added in #1231,
+//    same default-partial shape as `name_match`). Gated on the same
+//    flag the search box gates the input field on so URL forgery
+//    can't bypass the visibility gate.
 if (!empty($_GET['admemail']) && is_string($_GET['admemail']) && $userbank->HasAccess(ADMIN_OWNER | ADMIN_EDIT_ADMINS)) {
-    $where                       .= " AND ADM.email LIKE ?";
-    $whereParams[]                = '%' . $_GET['admemail'] . '%';
-    $activeFilters['admemail']    = (string) $_GET['admemail'];
+    $partialEmail = !isset($_GET['admemail_match']) || (string) $_GET['admemail_match'] !== '0';
+    if ($partialEmail) {
+        $where        .= " AND ADM.email LIKE ?";
+        $whereParams[] = '%' . $_GET['admemail'] . '%';
+    } else {
+        $where        .= " AND ADM.email = ?";
+        $whereParams[] = $_GET['admemail'];
+    }
+    $activeFilters['admemail']       = (string) $_GET['admemail'];
+    $activeFilters['admemail_match'] = $partialEmail ? '1' : '0';
 }
 
 // 4) Web group (`:prefix_groups.gid` -> `:prefix_admins.gid`).

--- a/web/pages/admin.admins.search.php
+++ b/web/pages/admin.admins.search.php
@@ -187,14 +187,23 @@ if (is_array($rawSrvFlag)) {
     srvgroup_list:             $srvgroups,
     admwebflag_list:           $webflag,
     admsrvflag_list:           $serverflag,
-    active_filter_name:        is_string($_GET['name']        ?? null) ? (string) $_GET['name']        : '',
-    active_filter_steamid:     is_string($_GET['steamid']     ?? null) ? (string) $_GET['steamid']     : '',
-    active_filter_steam_match: is_scalar($_GET['steam_match'] ?? null) ? (string) $_GET['steam_match'] : '0',
-    active_filter_admemail:    is_string($_GET['admemail']    ?? null) ? (string) $_GET['admemail']    : '',
-    active_filter_webgroup:    is_scalar($_GET['webgroup']    ?? null) ? (string) $_GET['webgroup']    : '',
-    active_filter_srvadmgroup: is_string($_GET['srvadmgroup'] ?? null) ? (string) $_GET['srvadmgroup'] : '',
-    active_filter_srvgroup:    is_scalar($_GET['srvgroup']    ?? null) ? (string) $_GET['srvgroup']    : '',
-    active_filter_server:      is_scalar($_GET['server']      ?? null) ? (string) $_GET['server']      : '',
-    active_filter_admwebflag:  $activeWebFlags,
-    active_filter_admsrvflag:  $activeSrvFlags,
+    // Match-mode defaults differ per filter (#1231):
+    //   - steam_match defaults to '0' (exact) — typical SteamID
+    //     queries are "find this one admin by their full ID".
+    //   - name_match / admemail_match default to '1' (partial) so
+    //     pre-#1231 URLs (`?name=alice`) keep their substring
+    //     behaviour. Adding the toggle widens the UI without
+    //     regressing the default.
+    active_filter_name:           is_string($_GET['name']           ?? null) ? (string) $_GET['name']           : '',
+    active_filter_name_match:     is_scalar($_GET['name_match']     ?? null) ? (string) $_GET['name_match']     : '1',
+    active_filter_steamid:        is_string($_GET['steamid']        ?? null) ? (string) $_GET['steamid']        : '',
+    active_filter_steam_match:    is_scalar($_GET['steam_match']    ?? null) ? (string) $_GET['steam_match']    : '0',
+    active_filter_admemail:       is_string($_GET['admemail']       ?? null) ? (string) $_GET['admemail']       : '',
+    active_filter_admemail_match: is_scalar($_GET['admemail_match'] ?? null) ? (string) $_GET['admemail_match'] : '1',
+    active_filter_webgroup:       is_scalar($_GET['webgroup']       ?? null) ? (string) $_GET['webgroup']       : '',
+    active_filter_srvadmgroup:    is_string($_GET['srvadmgroup']    ?? null) ? (string) $_GET['srvadmgroup']    : '',
+    active_filter_srvgroup:       is_scalar($_GET['srvgroup']       ?? null) ? (string) $_GET['srvgroup']       : '',
+    active_filter_server:         is_scalar($_GET['server']         ?? null) ? (string) $_GET['server']         : '',
+    active_filter_admwebflag:     $activeWebFlags,
+    active_filter_admsrvflag:     $activeSrvFlags,
 ));

--- a/web/tests/integration/AdminAdminsSearchTest.php
+++ b/web/tests/integration/AdminAdminsSearchTest.php
@@ -218,6 +218,88 @@ final class AdminAdminsSearchTest extends ApiTestCase
     }
 
     /**
+     * Login-name and E-mail exact / partial split (#1231).
+     *
+     * Pre-#1231, only SteamID shipped a `<select>` to flip between
+     * exact and partial; Login and E-mail silently substring-matched
+     * with no way to ask for "give me the row whose login is
+     * literally `admin`". The fix mirrors the steam_match shape onto
+     * both filters as `name_match` and `admemail_match`.
+     *
+     * Match-mode default is `'1'` (partial) for both — i.e. when the
+     * URL omits the new param, the filter behaves the way it always
+     * did. That preserves every legacy bookmark and the
+     * `?advType=name&advSearch=…` shim's contract; the new feature is
+     * purely opt-in via `…_match=0`.
+     */
+    public function testLoginAndEmailExactMatchSplit(): void
+    {
+        // Login name: 'ali' is a substring of 'alice' but not exact.
+        // Partial → 1 row (alice). Exact → 0 rows. Then 'alice' exact
+        // → 1 row (the literal alice), proving exact mode resolves
+        // the "find me the single admin" contract.
+        $_GET = [
+            'p'          => 'admin',
+            'c'          => 'admins',
+            'name'       => 'ali',
+            'name_match' => '1',
+        ];
+        $partialName = $this->renderAdminsPage();
+        $this->assertSame(1, $this->extractAdminCount($partialName), 'partial name=ali matches alice');
+
+        $_GET = [
+            'p'          => 'admin',
+            'c'          => 'admins',
+            'name'       => 'ali',
+            'name_match' => '0',
+        ];
+        $exactNameMiss = $this->renderAdminsPage();
+        $this->assertSame(0, $this->extractAdminCount($exactNameMiss), 'exact name=ali matches no admin (none is literally ali)');
+
+        $_GET = [
+            'p'          => 'admin',
+            'c'          => 'admins',
+            'name'       => 'alice',
+            'name_match' => '0',
+        ];
+        $exactNameHit = $this->renderAdminsPage();
+        $this->assertSame(1, $this->extractAdminCount($exactNameHit), 'exact name=alice matches alice');
+        $this->assertStringContainsString('>alice<', $exactNameHit);
+
+        // E-mail: every seeded row (admin, alice, bob, charlie) shares
+        // '@example.test', so partial 'example.test' returns 4 and
+        // exact 'example.test' returns 0; exact 'alice@example.test'
+        // narrows back to alice.
+        $_GET = [
+            'p'              => 'admin',
+            'c'              => 'admins',
+            'admemail'       => 'example.test',
+            'admemail_match' => '1',
+        ];
+        $partialEmail = $this->renderAdminsPage();
+        $this->assertSame(4, $this->extractAdminCount($partialEmail), 'partial admemail=example.test matches all 4 admins');
+
+        $_GET = [
+            'p'              => 'admin',
+            'c'              => 'admins',
+            'admemail'       => 'example.test',
+            'admemail_match' => '0',
+        ];
+        $exactEmailMiss = $this->renderAdminsPage();
+        $this->assertSame(0, $this->extractAdminCount($exactEmailMiss), 'exact admemail=example.test matches no admin (none is literally that)');
+
+        $_GET = [
+            'p'              => 'admin',
+            'c'              => 'admins',
+            'admemail'       => 'alice@example.test',
+            'admemail_match' => '0',
+        ];
+        $exactEmailHit = $this->renderAdminsPage();
+        $this->assertSame(1, $this->extractAdminCount($exactEmailHit), 'exact admemail=alice@example.test matches alice');
+        $this->assertStringContainsString('>alice<', $exactEmailHit);
+    }
+
+    /**
      * Multi-select web flag filter accepts the modern `[]` array
      * shape (`?admwebflag[]=ADMIN_OWNER&admwebflag[]=ADMIN_ADD_BAN`).
      * The seed admin and one of our test admins have ADMIN_OWNER —

--- a/web/themes/default/box_admin_admins_search.tpl
+++ b/web/themes/default/box_admin_admins_search.tpl
@@ -9,17 +9,28 @@
     page_admin_admins_list.tpl. Submits as a plain `GET` to
     ?p=admin&c=admins with one parameter per populated filter.
 
-    Wire format (#1207 ADM-4 redesign — single submit, AND semantics):
-        name=<text>                login (substring)
+    Wire format (#1207 ADM-4 redesign — single submit, AND semantics;
+    extended in #1231 to give every text filter its own match-mode select):
+        name=<text>                login
+        name_match=0|1             0 = exact, 1 = partial (default 1)
         steamid=<text>             Steam ID
         steam_match=0|1            0 = exact, 1 = partial (default 0)
-        admemail=<text>            E-mail (substring, gated by can_edit_admins)
+        admemail=<text>            E-mail (gated by can_edit_admins)
+        admemail_match=0|1         0 = exact, 1 = partial (default 1)
         webgroup=<gid>             Panel group
         srvadmgroup=<group_name>   SourceMod admin group
         srvgroup=<gid>             Server group
         admwebflag[]=ADMIN_*       Web permission flags (multi)
         admsrvflag[]=SM_*          Server permission flags (multi)
         server=<sid>               Server access
+
+    Match-mode defaults are asymmetric on purpose:
+        - SteamID defaults to exact (0) — typical use is "find one
+          admin by their full Steam ID".
+        - Login / E-mail default to partial (1) — preserves the
+          pre-#1231 substring behaviour so existing bookmarks and
+          legacy `advType=…&advSearch=…` URLs keep narrowing the
+          way admins expect.
 
     Multiple non-empty filters are combined with AND on the server side
     (admin.admins.php). The legacy single-filter shape
@@ -50,9 +61,11 @@
     Testability hooks (per #1123 issue body, "search-<scope>-<…>"):
         data-testid="search-admins-form"           outer form
         data-testid="search-admins-name"           login <input>
+        data-testid="search-admins-name-match"     login exact / partial match (#1231)
         data-testid="search-admins-steamid"        SteamID <input>
-        data-testid="search-admins-steam-match"    exact / partial match
+        data-testid="search-admins-steam-match"    SteamID exact / partial match
         data-testid="search-admins-admemail"       email <input>      (gated)
+        data-testid="search-admins-admemail-match" email exact / partial match (#1231; gated)
         data-testid="search-admins-webgroup"       web-group <select>
         data-testid="search-admins-srvadmgroup"    SM admin-group <select>
         data-testid="search-admins-srvgroup"       server-group <select>
@@ -80,14 +93,26 @@
     <div class="card__body space-y-3">
         <div class="grid gap-3" style="grid-template-columns:12rem 1fr;align-items:end">
             <label class="label" for="search-admins-name" style="grid-column:1;align-self:end">Login name</label>
-            <input class="input"
-                   id="search-admins-name"
-                   name="name"
-                   type="text"
-                   placeholder="Substring match against the panel login&hellip;"
-                   data-testid="search-admins-name"
-                   value="{$active_filter_name|escape}"
-                   autocomplete="off">
+            <div class="flex gap-2" style="flex-wrap:wrap">
+                <input class="input"
+                       id="search-admins-name"
+                       name="name"
+                       type="text"
+                       placeholder="Match against the panel login&hellip;"
+                       data-testid="search-admins-name"
+                       value="{$active_filter_name|escape}"
+                       style="flex:1;min-width:14rem"
+                       autocomplete="off">
+                <select class="select"
+                        id="search-admins-name-match"
+                        name="name_match"
+                        data-testid="search-admins-name-match"
+                        aria-label="Login name match mode"
+                        style="width:9rem">
+                    <option value="0"{if $active_filter_name_match == '0'} selected{/if}>Exact match</option>
+                    <option value="1"{if $active_filter_name_match != '0'} selected{/if}>Partial match</option>
+                </select>
+            </div>
         </div>
 
         <div class="grid gap-3" style="grid-template-columns:12rem 1fr;align-items:end">
@@ -117,14 +142,26 @@
         {if $can_editadmin}
             <div class="grid gap-3" style="grid-template-columns:12rem 1fr;align-items:end">
                 <label class="label" for="search-admins-admemail" style="grid-column:1;align-self:end">E-mail</label>
-                <input class="input"
-                       id="search-admins-admemail"
-                       name="admemail"
-                       type="email"
-                       placeholder="Substring match against the panel e-mail&hellip;"
-                       data-testid="search-admins-admemail"
-                       value="{$active_filter_admemail|escape}"
-                       autocomplete="off">
+                <div class="flex gap-2" style="flex-wrap:wrap">
+                    <input class="input"
+                           id="search-admins-admemail"
+                           name="admemail"
+                           type="email"
+                           placeholder="Match against the panel e-mail&hellip;"
+                           data-testid="search-admins-admemail"
+                           value="{$active_filter_admemail|escape}"
+                           style="flex:1;min-width:14rem"
+                           autocomplete="off">
+                    <select class="select"
+                            id="search-admins-admemail-match"
+                            name="admemail_match"
+                            data-testid="search-admins-admemail-match"
+                            aria-label="E-mail match mode"
+                            style="width:9rem">
+                        <option value="0"{if $active_filter_admemail_match == '0'} selected{/if}>Exact match</option>
+                        <option value="1"{if $active_filter_admemail_match != '0'} selected{/if}>Partial match</option>
+                    </select>
+                </div>
             </div>
         {/if}
 


### PR DESCRIPTION
## Summary

Pre-fix the admin-admins advanced-search box only let you flip
**Steam ID** between Exact and Partial mode; Login name and E-mail
silently substring-matched with no way to ask for an exact match.
Issue #1231 lays out two options — A) lift the existing
`<select name="steam_match">` shape onto every text filter, or B)
absorb match-mode into the input itself via a quoted-string
convention.

**Shipped Option A.** It keeps the existing `steam_match=0|1` wire
format and just clones the proven shape onto `name_match` /
`admemail_match`. Option B (`"alice"` → exact, bare → partial) was
the lighter chrome but would have meant shipping a fresh
quoted-string parser, a helper-hint banner, a new URL-encoding
contract for SteamID values containing colons, *and* the same
`?steam_match=0|1` legacy shim — bigger PR for the same end-user
contract. Option A ships the feature with the smallest possible
footprint.

Defaults are asymmetric on purpose:

- **SteamID** stays exact-by-default (`steam_match` defaults to
  `'0'`) — typical SteamID queries are "find this one admin by
  their full ID".
- **Login / E-mail** default to partial (`name_match` /
  `admemail_match` default to `'1'`) so pre-#1231 URLs (`?name=alice`,
  the legacy `?advType=name&advSearch=alice` shim) keep their
  substring behaviour. The new toggle is purely opt-in via
  `…_match=0`.

- Touches: `web/themes/default/box_admin_admins_search.tpl`,
  `web/pages/admin.admins.search.php`,
  `web/includes/View/AdminAdminsSearchView.php`,
  `web/pages/admin.admins.php`,
  `web/tests/integration/AdminAdminsSearchTest.php`.
- Legacy URL shim preserved per AGENTS.md "Where to find what" →
  admin-admins. The existing `advType=name|admemail&advSearch=…`
  shim continues to translate into the modern `?name=…` /
  `?admemail=…` shape; because the new `_match` defaults are
  partial, those legacy URLs narrow exactly the way they always
  did.

Closes #1231

## Test plan

- [x] Login name `alice` with exact mode → only the row whose login
      is literally `alice` returns.
- [x] Login name `ali` with partial mode → matches `alice`.
- [x] Login name `ali` with exact mode → matches no admin.
- [x] Same for E-mail (`example.test` partial → 4, exact → 0;
      `alice@example.test` exact → 1).
- [x] Existing `?advType=name&advSearch=alice` URL still resolves
      to the alice row (covered by the pre-existing
      `testLegacyAdvTypeUrlStillWorks` case).
- [x] PHPStan + PHPUnit pass locally
      (`./sbpp.sh phpstan` clean against 217 files; the new
      `testLoginAndEmailExactMatchSplit` case is the 8th in
      `AdminAdminsSearchTest`, all 11 pass).
- [ ] Full CI quality gates (PHPStan, PHPUnit, ts-check,
      api-contract, Playwright E2E) pass on this PR.