### PR TITLE
fix(admin/bans): primary Ban + confirm-and-undo Remove on submissions (#1229)

### DIFF
--- a/web/themes/default/page_admin_bans_protests.tpl
+++ b/web/themes/default/page_admin_bans_protests.tpl
@@ -86,6 +86,13 @@
                             <div class="queue-row__date">
                                 {$protest.datesubmitted|escape}
                             </div>
+                            {* #1229 — Remove drops the inline danger color and
+                               is gated behind a click-again-to-confirm step
+                               (see the inline JS below) so a single misfire
+                               no longer silently archives the protest. The
+                               protest is recoverable from the archived
+                               protests page if the operator wants to restore
+                               it. *}
                             <div class="row-actions">
                                 {if $permission_editban}
                                     <button type="button"
@@ -94,9 +101,8 @@
                                             data-action="protest-archive"
                                             data-pid="{$protest.pid}"
                                             data-key="{if $protest.authid != ''}{$protest.authid|escape}{else}{$protest.ip|escape}{/if}"
-                                            data-archiv="1"
-                                            style="color:var(--danger)">
-                                        Remove
+                                            data-archiv="1">
+                                        <span data-confirm-label>Remove</span>
                                     </button>
                                 {/if}
                                 <a class="btn btn--ghost btn--sm"
@@ -201,40 +207,121 @@
     </section>
 {/if}
 {* Inline action wiring — Remove dispatches Actions.ProtestsRemove with
-   archiv=1. Both protest templates listen for `protest-archive` so the
-   handler is shared; the archive-template adds a `protest-archive-toggle`
-   variant for restore/delete to keep the two click handlers independent. *}
+   archiv=1. Only this template listens for `protest-archive`; the
+   archived-protests template uses `protest-archive-toggle` for
+   restore (archiv=2) and delete (archiv=0).
+
+   #1229 — `protest-archive` is gated behind a click-again-to-confirm
+   step instead of `window.confirm()`. The first click arms the button
+   (label flips to "Click to confirm", `data-pending="true"` flag set,
+   3s revert timer); the second click within that window actually
+   archives. This replaces the browser-native dialog (which the audit
+   flagged as both intrusive and easily dismissed) without expanding
+   the toast API.
+
+   No `// @ts-check` here because the file is rendered by Smarty;
+   ts-check only runs against `.js` sources in `web/scripts`. The
+   shape mirrors `page_admin_bans_submissions.tpl`. *}
 {literal}
 <script>
 (function () {
     'use strict';
-    function api() { return (window.sb && window.sb.api) || null; }
-    function actions() { return window.Actions || null; }
+
+    /** How long a click-armed Remove button waits for the second click. */
+    var PENDING_TIMEOUT_MS = 3000;
+
+    /** @returns {{call: (a:string,p?:object)=>Promise<any>}|null} */
+    function api()     { return (window.sb && window.sb.api) || null; }
+    /** @returns {Record<string,string>|null} */
+    function actions() { return /** @type {any} */ (window).Actions || null; }
     function toast(kind, title, body) {
         if (window.sb && window.sb.message && window.sb.message[kind]) {
             window.sb.message[kind](title, body || '');
         }
     }
+
+    /** @type {WeakMap<HTMLElement, number>} */
+    var pendingTimers = new WeakMap();
+
+    /**
+     * Is this Remove button currently armed (one click landed; waiting
+     * for the second within PENDING_TIMEOUT_MS).
+     * @param {HTMLElement} btn
+     * @returns {boolean}
+     */
+    function isPending(btn) {
+        return btn.getAttribute('data-pending') === 'true';
+    }
+
+    /**
+     * Move the button into the "click again to confirm" state. Caches
+     * the original label on the inner `[data-confirm-label]` span so
+     * disarm() can restore it byte-for-byte; falls back to the button
+     * itself if the span isn't present (defensive — the template ships
+     * the span).
+     * @param {HTMLElement} btn
+     * @returns {void}
+     */
+    function arm(btn) {
+        var labelEl = /** @type {HTMLElement} */ (btn.querySelector('[data-confirm-label]') || btn);
+        if (labelEl.getAttribute('data-original-label') === null) {
+            labelEl.setAttribute('data-original-label', labelEl.textContent || '');
+        }
+        labelEl.textContent = 'Click to confirm';
+        btn.setAttribute('data-pending', 'true');
+        btn.setAttribute('aria-label', 'Click again within 3 seconds to confirm removal');
+        var prev = pendingTimers.get(btn);
+        if (prev) window.clearTimeout(prev);
+        var t = window.setTimeout(function () { disarm(btn); }, PENDING_TIMEOUT_MS);
+        pendingTimers.set(btn, t);
+    }
+
+    /**
+     * Restore the original label and clear the pending state + revert
+     * timer.
+     * @param {HTMLElement} btn
+     * @returns {void}
+     */
+    function disarm(btn) {
+        var labelEl = /** @type {HTMLElement} */ (btn.querySelector('[data-confirm-label]') || btn);
+        var orig = labelEl.getAttribute('data-original-label');
+        if (orig !== null) labelEl.textContent = orig;
+        btn.removeAttribute('data-pending');
+        btn.removeAttribute('aria-label');
+        var t = pendingTimers.get(btn);
+        if (t !== undefined) {
+            window.clearTimeout(t);
+            pendingTimers.delete(btn);
+        }
+    }
+
     document.addEventListener('click', function (e) {
-        var t = e.target;
+        var t = /** @type {Element|null} */ (e.target);
         if (!t || !t.closest) return;
-        var btn = t.closest('[data-action="protest-archive"]');
+        var btn = /** @type {HTMLElement|null} */ (t.closest('[data-action="protest-archive"]'));
         if (!btn) return;
         e.preventDefault();
+        // First click on a non-armed button → arm it and bail. The
+        // archive call only fires on the second click within
+        // PENDING_TIMEOUT_MS; otherwise the revert timer disarms and
+        // the operator hasn't lost the protest.
+        if (!isPending(btn)) {
+            arm(btn);
+            return;
+        }
+        disarm(btn);
         var pid = Number(btn.dataset.pid);
-        var key = btn.dataset.key || ('protest #' + pid);
-        var archiv = btn.dataset.archiv || '1';
-        var msg;
-        if (archiv === '2') msg = 'Restore the ban protest for "' + key + '" from the archive?';
-        else if (archiv === '1') msg = 'Move the ban protest for "' + key + '" to the archive?';
-        else msg = 'Delete the ban protest for "' + key + '"?';
-        if (!window.confirm(msg)) return;
+        // This template only fires archiv=1 (archive a live protest).
+        // The archived-protests template uses a separate
+        // `protest-archive-toggle` action for restore (archiv=2) and
+        // delete (archiv=0), so the dead-code branches that handled
+        // those values here have been removed.
         var a = api(), A = actions();
         if (!a || !A || !Number.isFinite(pid)) return;
-        btn.disabled = true;
-        a.call(A.ProtestsRemove, { pid: pid, archiv: archiv }).then(function (r) {
+        /** @type {HTMLButtonElement} */ (btn).disabled = true;
+        a.call(A.ProtestsRemove, { pid: pid, archiv: '1' }).then(function (r) {
             if (!r || r.ok === false) {
-                btn.disabled = false;
+                /** @type {HTMLButtonElement} */ (btn).disabled = false;
                 toast('error', 'Action failed', (r && r.error && r.error.message) || 'Unknown error');
                 return;
             }
@@ -242,7 +329,7 @@
             if (node && node.parentNode) node.parentNode.removeChild(node);
             var counter = document.getElementById('protcount');
             if (counter) counter.textContent = String(Math.max(0, Number(counter.textContent) - 1));
-            toast('success', 'Done', 'Protest updated.');
+            toast('success', 'Protest archived', 'Restore from the archived protests page if needed.');
         });
     });
 })();

--- a/web/themes/default/page_admin_bans_submissions.tpl
+++ b/web/themes/default/page_admin_bans_submissions.tpl
@@ -86,9 +86,17 @@
                             <div class="queue-row__date">
                                 {$sub.submitted|escape}
                             </div>
+                            {* #1229 — Ban is the canonical approve path on this
+                               queue, so it carries the .btn--primary weight;
+                               Remove is a ghost button without the inline danger
+                               color so it stops competing visually with Ban.
+                               The Remove button is also gated behind a
+                               click-again-to-confirm step (see the inline JS
+                               below) — a single misfire no longer silently
+                               archives the submission. *}
                             <div class="row-actions">
                                 <button type="button"
-                                        class="btn btn--secondary btn--sm"
+                                        class="btn btn--primary btn--sm"
                                         data-testid="row-action-ban"
                                         data-action="submission-ban"
                                         data-subid="{$sub.subid}">
@@ -101,9 +109,8 @@
                                             data-action="submission-archive"
                                             data-subid="{$sub.subid}"
                                             data-name="{$sub.name|smarty_stripslashes|escape}"
-                                            data-archiv="1"
-                                            style="color:var(--danger)">
-                                        Remove
+                                            data-archiv="1">
+                                        <span data-confirm-label>Remove</span>
                                     </button>
                                 {/if}
                                 <a class="btn btn--ghost btn--sm"
@@ -212,22 +219,97 @@
 {* Inline action wiring — works in both themes, sb.api.call + Actions are
    loaded by both core/header.tpl variants. The legacy theme also exposes
    LoadSetupBan/RemoveSubmission via sourcebans.js; we prefer the inline
-   handler so the buttons behave identically in either chrome. *}
+   handler so the buttons behave identically in either chrome.
+
+   #1229 — `submission-archive` is gated behind a click-again-to-confirm
+   step instead of `window.confirm()`. The first click arms the button
+   (label flips to "Click to confirm", `data-pending="true"` flag set,
+   3s revert timer); the second click within that window actually
+   archives. This replaces the browser-native dialog (which the audit
+   flagged as both intrusive and easily dismissed) without expanding
+   the toast API. The submission is recoverable from the archived
+   submissions page if the operator wants to restore it.
+
+   No `// @ts-check` here because the file is rendered by Smarty;
+   ts-check only runs against `.js` sources in `web/scripts`. The
+   shape mirrors the inline handler in `page_comms.tpl`. *}
 {literal}
 <script>
 (function () {
     'use strict';
-    function api() { return (window.sb && window.sb.api) || null; }
-    function actions() { return window.Actions || null; }
+
+    /** How long a click-armed Remove button waits for the second click. */
+    var PENDING_TIMEOUT_MS = 3000;
+
+    /** @returns {{call: (a:string,p?:object)=>Promise<any>}|null} */
+    function api()     { return (window.sb && window.sb.api) || null; }
+    /** @returns {Record<string,string>|null} */
+    function actions() { return /** @type {any} */ (window).Actions || null; }
     function toast(kind, title, body) {
         if (window.sb && window.sb.message && window.sb.message[kind]) {
             window.sb.message[kind](title, body || '');
         }
     }
+
+    /** @type {WeakMap<HTMLElement, number>} */
+    var pendingTimers = new WeakMap();
+
+    /**
+     * Is this Remove button currently armed (one click landed; waiting
+     * for the second within PENDING_TIMEOUT_MS).
+     * @param {HTMLElement} btn
+     * @returns {boolean}
+     */
+    function isPending(btn) {
+        return btn.getAttribute('data-pending') === 'true';
+    }
+
+    /**
+     * Move the button into the "click again to confirm" state. Caches
+     * the original label on the inner `[data-confirm-label]` span so
+     * disarm() can restore it byte-for-byte; falls back to the button
+     * itself if the span isn't present (defensive — the template ships
+     * the span).
+     * @param {HTMLElement} btn
+     * @returns {void}
+     */
+    function arm(btn) {
+        var labelEl = /** @type {HTMLElement} */ (btn.querySelector('[data-confirm-label]') || btn);
+        if (labelEl.getAttribute('data-original-label') === null) {
+            labelEl.setAttribute('data-original-label', labelEl.textContent || '');
+        }
+        labelEl.textContent = 'Click to confirm';
+        btn.setAttribute('data-pending', 'true');
+        btn.setAttribute('aria-label', 'Click again within 3 seconds to confirm removal');
+        var prev = pendingTimers.get(btn);
+        if (prev) window.clearTimeout(prev);
+        var t = window.setTimeout(function () { disarm(btn); }, PENDING_TIMEOUT_MS);
+        pendingTimers.set(btn, t);
+    }
+
+    /**
+     * Restore the original label and clear the pending state + revert
+     * timer.
+     * @param {HTMLElement} btn
+     * @returns {void}
+     */
+    function disarm(btn) {
+        var labelEl = /** @type {HTMLElement} */ (btn.querySelector('[data-confirm-label]') || btn);
+        var orig = labelEl.getAttribute('data-original-label');
+        if (orig !== null) labelEl.textContent = orig;
+        btn.removeAttribute('data-pending');
+        btn.removeAttribute('aria-label');
+        var t = pendingTimers.get(btn);
+        if (t !== undefined) {
+            window.clearTimeout(t);
+            pendingTimers.delete(btn);
+        }
+    }
+
     document.addEventListener('click', function (e) {
-        var t = e.target;
+        var t = /** @type {Element|null} */ (e.target);
         if (!t || !t.closest) return;
-        var btn = t.closest('[data-action]');
+        var btn = /** @type {HTMLElement|null} */ (t.closest('[data-action]'));
         if (!btn) return;
         var act = btn.getAttribute('data-action');
         if (act === 'submission-ban') {
@@ -245,30 +327,39 @@
                 // silently breaking the entire "Ban a submission" UX.
                 // We keep the legacy name as a fallback so a third-party
                 // theme that still loads sourcebans.js keeps working.
-                var fill = (typeof window.__sbppApplyBanFields === 'function')
-                    ? window.__sbppApplyBanFields
-                    : (typeof window.applyBanFields === 'function' ? window.applyBanFields : null);
+                var w = /** @type {any} */ (window);
+                var fill = (typeof w.__sbppApplyBanFields === 'function')
+                    ? w.__sbppApplyBanFields
+                    : (typeof w.applyBanFields === 'function' ? w.applyBanFields : null);
                 if (fill) fill(r.data);
-                if (typeof window.swapTab === 'function') window.swapTab(0);
+                if (typeof w.swapTab === 'function') w.swapTab(0);
             });
             return;
         }
         if (act === 'submission-archive') {
             e.preventDefault();
+            // First click on a non-armed button → arm it and bail.
+            // The archive call only fires on the second click within
+            // PENDING_TIMEOUT_MS; otherwise the revert timer disarms
+            // and the operator hasn't lost the submission.
+            if (!isPending(btn)) {
+                arm(btn);
+                return;
+            }
+            disarm(btn);
             var sid = Number(btn.dataset.subid);
-            var name = btn.dataset.name || ('submission #' + sid);
-            var archiv = btn.dataset.archiv || '1';
-            var msg;
-            if (archiv === '2') msg = 'Restore the ban submission for "' + name + '" from the archive?';
-            else if (archiv === '1') msg = 'Move the ban submission for "' + name + '" to the archive?';
-            else msg = 'Delete the ban submission for "' + name + '"?';
-            if (!window.confirm(msg)) return;
+            // This template only fires archiv=1 (archive a live
+            // submission). The archived-submissions template uses a
+            // separate `submission-archive-toggle` action for restore
+            // (archiv=2) and delete (archiv=0), so the dead-code
+            // branches that handled those values here have been
+            // removed.
             var a2 = api(), A2 = actions();
             if (!a2 || !A2 || !Number.isFinite(sid)) return;
-            btn.disabled = true;
-            a2.call(A2.SubmissionsRemove, { sid: sid, archiv: archiv }).then(function (r) {
+            /** @type {HTMLButtonElement} */ (btn).disabled = true;
+            a2.call(A2.SubmissionsRemove, { sid: sid, archiv: '1' }).then(function (r) {
                 if (!r || r.ok === false) {
-                    btn.disabled = false;
+                    /** @type {HTMLButtonElement} */ (btn).disabled = false;
                     toast('error', 'Action failed', (r && r.error && r.error.message) || 'Unknown error');
                     return;
                 }
@@ -276,7 +367,7 @@
                 if (node && node.parentNode) node.parentNode.removeChild(node);
                 var counter = document.getElementById('subcount');
                 if (counter) counter.textContent = String(Math.max(0, Number(counter.textContent) - 1));
-                toast('success', 'Done', 'Submission updated.');
+                toast('success', 'Submission archived', 'Restore from the archived submissions page if needed.');
             });
         }
     });


### PR DESCRIPTION
## Summary

- Promote the per-row `Ban` button on the admin submissions queue from `.btn--secondary` to `.btn--primary` so the canonical approve path reads as the page's primary action.
- Reduce visual weight of `Remove` (drop inline `color: var(--danger)`) on both the submissions and protests queues so it stops competing with `Ban` for the operator's eye.
- The page-tail JS now gates `Remove` behind a click-again-to-confirm step (3s revert timer), so a single misfire no longer silently archives a submission/protest. The archived row is still recoverable from the corresponding archive view (`archiv=1`, not `archiv=0`).
- Same shape applied to the `Ban protests` rows in the same admin route since they share the row-action visual structure.

The "click again within ~3s" pattern is preferred over expanding `theme.js`'s `showToast` API to support `onUndo` (per AGENTS.md: don't widen the toast API in this PR; the current `showToast` is fire-and-forget with a close button only).

Closes #1229

## Test plan

- [ ] Submit a player report from the public page; queue shows `Ban` as `.btn--primary`, `Remove` as ghost without danger color.
- [ ] Click `Remove` once → button label flips to "Click to confirm" with `data-pending="true"` and an `aria-label` pointing at the 3s window. Wait 3s → label reverts, no archive call fires.
- [ ] Click `Remove` twice within 3s → archive fires, row removes, count decrements, success toast lands.
- [ ] Same flow on the Ban protests rows (single Remove button, no Ban button on that surface).
- [ ] PHPStan + ts-check + API contract + PHPUnit (Submissions / Protests / PermissionMatrix / Bans) all pass on CI.