### PR TITLE
feat(admin-settings): humanize auth token lifetimes with live echo (#1232)

### DIFF
--- a/web/includes/Util/Duration.php
+++ b/web/includes/Util/Duration.php
@@ -1,0 +1,111 @@
+<?php
+
+/*************************************************************************
+This file is part of SourceBans++
+
+SourceBans++ (c) 2014-2024 by SourceBans++ Dev Team
+
+The SourceBans++ Web panel is licensed under a
+Creative Commons Attribution-NonCommercial-ShareAlike 3.0 Unported License.
+
+You should have received a copy of the license along with this
+work.  If not, see <http://creativecommons.org/licenses/by-nc-sa/3.0/>.
+ *************************************************************************/
+
+declare(strict_types=1);
+
+namespace Sbpp\Util;
+
+/**
+ * Helpers for presenting durations stored in minutes.
+ *
+ * Issue #1232: the admin Settings → Authentication fieldset stores token
+ * lifetimes (`auth.maxlife`, `auth.maxlife.remember`, `auth.maxlife.steam`)
+ * as raw minute counts because that's also the on-the-wire shape the
+ * SourceMod plugin reads. The defaults shipped in `data.sql` are `1440` /
+ * `10080` / `10080` — operator-readable only after a `/ 60 / 24` in their
+ * head. This helper converts those minute counts into a short echo
+ * (`"1 minute"` / `"≈ 12 hours"` / `"7 days"`) for the muted span next to
+ * each input. The wire format is unchanged; this is presentation only.
+ *
+ * The format follows two rules:
+ *   - Unit-aligned values render exactly: `60` → `"1 hour"`,
+ *     `1440` → `"1 day"`, `10080` → `"7 days"`.
+ *   - Non-aligned values render with a leading `≈` and one decimal of
+ *     precision in the most useful unit: `90` → `"≈ 1.5 hours"`,
+ *     `1500` → `"≈ 1 day"` (1500 / 1440 ≈ 1.04, rounded to 1 d.p.).
+ *   - `0` returns the literal `"disabled"` so the echo matches the
+ *     legend hint ("Set a value to 0 to disable a sign-in path").
+ *   - Negative values are defensively normalised to `"disabled"` so a
+ *     malformed `sb_settings` row never blows up the page handler.
+ *
+ * The browser-side mirror lives inline in
+ * `web/themes/default/page_admin_settings_settings.tpl` (the page-tail
+ * `<script>` near the bottom) and re-implements the same formula so the
+ * echo updates as the operator types. If you change the format here,
+ * change it there too — the unit test pins both ends.
+ */
+final class Duration
+{
+    /**
+     * Number of minutes per hour. Defined as a constant so the two
+     * branches below (the "exactly 60" guard and the rounding rule)
+     * can't drift out of sync via a literal typo.
+     */
+    private const MINUTES_PER_HOUR = 60;
+
+    /**
+     * Number of minutes per day. 24 * 60.
+     */
+    private const MINUTES_PER_DAY = 1440;
+
+    /**
+     * Convert a minute count into a short, human-readable string for
+     * display next to a minute-typed input.
+     *
+     * @param int $minutes Minute count from `sb_settings` (already cast
+     *                     via `(int) Config::get(...)` upstream). Zero
+     *                     and negative values both render as the
+     *                     "disabled" sentinel.
+     */
+    public static function humanizeMinutes(int $minutes): string
+    {
+        if ($minutes <= 0) {
+            return 'disabled';
+        }
+
+        if ($minutes < self::MINUTES_PER_HOUR) {
+            return $minutes === 1 ? '1 minute' : $minutes . ' minutes';
+        }
+
+        if ($minutes < self::MINUTES_PER_DAY) {
+            if ($minutes % self::MINUTES_PER_HOUR === 0) {
+                $hours = intdiv($minutes, self::MINUTES_PER_HOUR);
+                return $hours === 1 ? '1 hour' : $hours . ' hours';
+            }
+            $hoursStr = self::trimZero($minutes / self::MINUTES_PER_HOUR);
+            return '≈ ' . $hoursStr . ' ' . ($hoursStr === '1' ? 'hour' : 'hours');
+        }
+
+        if ($minutes % self::MINUTES_PER_DAY === 0) {
+            $days = intdiv($minutes, self::MINUTES_PER_DAY);
+            return $days === 1 ? '1 day' : $days . ' days';
+        }
+        $daysStr = self::trimZero($minutes / self::MINUTES_PER_DAY);
+        return '≈ ' . $daysStr . ' ' . ($daysStr === '1' ? 'day' : 'days');
+    }
+
+    /**
+     * Format a float to one decimal and strip a trailing `.0` so values
+     * that round to a whole number render without a redundant decimal
+     * (e.g. `1500 / 1440 ≈ 1.04` rounds to `"1"`, not `"1.0"`). Pure
+     * helper — the rounding mode is `round()`'s default (half-up).
+     */
+    private static function trimZero(float $value): string
+    {
+        $formatted = number_format($value, 1, '.', '');
+        return str_ends_with($formatted, '.0')
+            ? substr($formatted, 0, -2)
+            : $formatted;
+    }
+}

--- a/web/includes/View/AdminSettingsView.php
+++ b/web/includes/View/AdminSettingsView.php
@@ -50,6 +50,16 @@ final class AdminSettingsView extends View
         public readonly int $auth_maxlife,
         public readonly int $auth_maxlife_remember,
         public readonly int $auth_maxlife_steam,
+        // #1232: human-readable echoes for the three minute-typed
+        // auth lifetime fields. The wire format stays minutes (these
+        // are display-only spans next to each `<input type="number">`);
+        // the strings come from `Sbpp\Util\Duration::humanizeMinutes()`
+        // and are mirrored client-side by the page-tail JS so the echo
+        // updates as the operator types. First paint is server-rendered
+        // so the page works without JS.
+        public readonly string $auth_maxlife_human,
+        public readonly string $auth_maxlife_remember_human,
+        public readonly string $auth_maxlife_steam_human,
         public readonly int $config_bans_per_page,
         public readonly array $config_smtp,
         public readonly string $config_mail_from_email,

--- a/web/pages/admin.settings.php
+++ b/web/pages/admin.settings.php
@@ -394,38 +394,56 @@ if ($section === 'themes') {
     ];
 
     $dashText = (string) Config::get('dash.intro.text');
+    /*
+     * #1232: server-rendered first paint for the per-input duration
+     * echo on the Authentication fieldset. The minute-typed integers
+     * stay as the wire-format source of truth (the SourceMod plugin
+     * reads `auth.maxlife*` in minutes too); these `_human` props are
+     * the operator-readable strings ("≈ 7 days" / "1 hour" / etc.)
+     * the template emits in muted spans next to each input. The
+     * page-tail JS re-implements the same formula so the echo stays
+     * live as the operator types — see the matching `humanizeMinutes`
+     * in `page_admin_settings_settings.tpl`.
+     */
+    $authMaxlife         = (int) Config::get('auth.maxlife');
+    $authMaxlifeRemember = (int) Config::get('auth.maxlife.remember');
+    $authMaxlifeSteam    = (int) Config::get('auth.maxlife.steam');
+
     Renderer::render($theme, new AdminSettingsView(
-        can_web_settings:          $perms['can_web_settings'],
-        can_owner:                 $perms['can_owner'],
-        active_section:            $section,
-        config_title:              (string) Config::get('template.title'),
-        config_logo:               (string) Config::get('template.logo'),
-        config_min_password:       (int) MIN_PASS_LENGTH,
-        config_dateformat:         (string) Config::get('config.dateformat'),
-        config_dash_title:         (string) Config::get('dash.intro.title'),
-        config_dash_text:          $dashText,
+        can_web_settings:            $perms['can_web_settings'],
+        can_owner:                   $perms['can_owner'],
+        active_section:              $section,
+        config_title:                (string) Config::get('template.title'),
+        config_logo:                 (string) Config::get('template.logo'),
+        config_min_password:         (int) MIN_PASS_LENGTH,
+        config_dateformat:           (string) Config::get('config.dateformat'),
+        config_dash_title:           (string) Config::get('dash.intro.title'),
+        config_dash_text:            $dashText,
         // #1207 SET-1: server-rendered first paint for the live preview.
         // JS-side updates call system.preview_intro_text on input.
-        config_dash_text_preview:  \Sbpp\Markup\IntroRenderer::renderIntroText($dashText),
-        auth_maxlife:              (int) Config::get('auth.maxlife'),
-        auth_maxlife_remember:     (int) Config::get('auth.maxlife.remember'),
-        auth_maxlife_steam:        (int) Config::get('auth.maxlife.steam'),
-        config_debug:              Config::getBool('config.debug'),
-        enable_submit:             Config::getBool('config.enablesubmit'),
-        enable_protest:            Config::getBool('config.enableprotest'),
-        enable_commslist:          Config::getBool('config.enablecomms'),
-        protest_emailonlyinvolved: Config::getBool('protest.emailonlyinvolved'),
-        dash_lognopopup:           Config::getBool('dash.lognopopup'),
-        config_default_page:       (int) Config::get('config.defaultpage'),
-        config_bans_per_page:      (int) SB_BANS_PER_PAGE,
-        banlist_hideadmname:       Config::getBool('banlist.hideadminname'),
-        banlist_nocountryfetch:    Config::getBool('banlist.nocountryfetch'),
-        banlist_hideplayerips:     Config::getBool('banlist.hideplayerips'),
-        bans_customreason:         $customReasons,
-        config_smtp:               $smtpTuple,
-        config_smtp_verify_peer:   Config::getBool('smtp.verify_peer'),
-        config_mail_from_email:    (string) Config::get('config.mail.from_email'),
-        config_mail_from_name:     (string) Config::get('config.mail.from_name'),
+        config_dash_text_preview:    \Sbpp\Markup\IntroRenderer::renderIntroText($dashText),
+        auth_maxlife:                $authMaxlife,
+        auth_maxlife_remember:       $authMaxlifeRemember,
+        auth_maxlife_steam:          $authMaxlifeSteam,
+        auth_maxlife_human:          \Sbpp\Util\Duration::humanizeMinutes($authMaxlife),
+        auth_maxlife_remember_human: \Sbpp\Util\Duration::humanizeMinutes($authMaxlifeRemember),
+        auth_maxlife_steam_human:    \Sbpp\Util\Duration::humanizeMinutes($authMaxlifeSteam),
+        config_debug:                Config::getBool('config.debug'),
+        enable_submit:               Config::getBool('config.enablesubmit'),
+        enable_protest:              Config::getBool('config.enableprotest'),
+        enable_commslist:            Config::getBool('config.enablecomms'),
+        protest_emailonlyinvolved:   Config::getBool('protest.emailonlyinvolved'),
+        dash_lognopopup:             Config::getBool('dash.lognopopup'),
+        config_default_page:         (int) Config::get('config.defaultpage'),
+        config_bans_per_page:        (int) SB_BANS_PER_PAGE,
+        banlist_hideadmname:         Config::getBool('banlist.hideadminname'),
+        banlist_nocountryfetch:      Config::getBool('banlist.nocountryfetch'),
+        banlist_hideplayerips:       Config::getBool('banlist.hideplayerips'),
+        bans_customreason:           $customReasons,
+        config_smtp:                 $smtpTuple,
+        config_smtp_verify_peer:     Config::getBool('smtp.verify_peer'),
+        config_mail_from_email:      (string) Config::get('config.mail.from_email'),
+        config_mail_from_name:       (string) Config::get('config.mail.from_name'),
     ));
 }
 

--- a/web/tests/unit/Util/DurationTest.php
+++ b/web/tests/unit/Util/DurationTest.php
@@ -1,0 +1,149 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sbpp\Tests\Unit\Util;
+
+use PHPUnit\Framework\TestCase;
+use Sbpp\Util\Duration;
+
+/**
+ * Issue #1232 regression suite for `\Sbpp\Util\Duration::humanizeMinutes()`.
+ *
+ * The helper backs the muted echo span next to each minute-typed input
+ * on the admin Settings → Authentication fieldset. Two contracts the
+ * tests pin:
+ *
+ *   1. **Format**: unit-aligned values render *exactly* (no `≈`); only
+ *      non-aligned values get the approximation glyph + one-decimal
+ *      precision. The echo must read the same for the same input on
+ *      both sides (PHP for the server-rendered first paint, vanilla
+ *      JS for the live-on-input update). Drift between the two surfaces
+ *      would mean the echo flickers on first keystroke even when the
+ *      value didn't change.
+ *
+ *   2. **Edge cases**: `0` and negative values are normalised to the
+ *      `"disabled"` sentinel so the echo matches the legend hint
+ *      ("Set a value to 0 to disable a sign-in path") and so a
+ *      malformed `sb_settings` row never lands as a runtime error
+ *      mid-render.
+ *
+ * The JS mirror lives inline at the bottom of
+ * `web/themes/default/page_admin_settings_settings.tpl`. If you change
+ * the format here, change it there in the same PR.
+ */
+final class DurationTest extends TestCase
+{
+    /**
+     * `0` is the legend's "disable a sign-in path" sentinel; the echo
+     * span has to read the same so an operator setting `auth.maxlife`
+     * to `0` sees the disable confirmed live, not "0 minutes".
+     */
+    public function testZeroRendersAsDisabledSentinel(): void
+    {
+        $this->assertSame('disabled', Duration::humanizeMinutes(0));
+    }
+
+    /**
+     * Defensive — a hand-edited or otherwise malformed `sb_settings`
+     * row can land here as a negative integer; the helper must not
+     * regress to "−5 minutes" (or worse, divide-by-zero / fatal).
+     * Pin the same sentinel `0` returns so the echo reads as the
+     * non-functional state the value actually represents.
+     */
+    public function testNegativeMinutesRenderAsDisabledSentinel(): void
+    {
+        $this->assertSame('disabled', Duration::humanizeMinutes(-5));
+    }
+
+    /**
+     * Single-minute case — pinned for the singular "minute" (no `s`).
+     * Pluralisation matters because the echo is read out by screen
+     * readers (`aria-live="polite"`); "1 minutes" jars.
+     */
+    public function testSingleMinute(): void
+    {
+        $this->assertSame('1 minute', Duration::humanizeMinutes(1));
+    }
+
+    /**
+     * Sub-hour values render as plain "{n} minutes" — the smallest unit
+     * is the minute itself so there's no `≈` and no fractional part.
+     */
+    public function testFortyFiveMinutes(): void
+    {
+        $this->assertSame('45 minutes', Duration::humanizeMinutes(45));
+    }
+
+    /**
+     * Exactly one hour — the canonical "round value collapses to the
+     * larger unit, no `≈`" case. `60` is hour-aligned, so the echo
+     * drops the leading `≈` and the singular "1 hour" reads naturally.
+     */
+    public function testExactlyOneHour(): void
+    {
+        $this->assertSame('1 hour', Duration::humanizeMinutes(60));
+    }
+
+    /**
+     * 90 minutes is hour-aligned to a half-hour, not whole hours, so
+     * it crosses the `≈` threshold. The one-decimal precision is what
+     * keeps "≈ 1.5 hours" readable instead of, say, "≈ 1.50 hours" or
+     * "≈ 1 hour".
+     */
+    public function testNinetyMinutesUsesApproxHours(): void
+    {
+        $this->assertSame('≈ 1.5 hours', Duration::humanizeMinutes(90));
+    }
+
+    /**
+     * Plural-hours regression — two hours is hour-aligned (no `≈`)
+     * and uses the plural "hours". Same rule that gives "1 hour"
+     * back at 60.
+     */
+    public function testTwoHoursExact(): void
+    {
+        $this->assertSame('2 hours', Duration::humanizeMinutes(120));
+    }
+
+    /**
+     * The default value of `auth.maxlife` (= 24h). Day-aligned, so the
+     * echo collapses to the larger "day" unit and drops the `≈`.
+     */
+    public function testOneDay(): void
+    {
+        $this->assertSame('1 day', Duration::humanizeMinutes(1440));
+    }
+
+    /**
+     * The default value of `auth.maxlife.remember` and
+     * `auth.maxlife.steam` (= 7 days). Day-aligned (10080 = 7 × 1440)
+     * so the echo reads as the canonical "7 days" with no `≈`.
+     */
+    public function testSevenDays(): void
+    {
+        $this->assertSame('7 days', Duration::humanizeMinutes(10080));
+    }
+
+    /**
+     * Above one day, non-aligned. 1500 / 1440 ≈ 1.0417, which rounds
+     * to one decimal as `1.0` and then collapses to `"1"` — the echo
+     * reads "≈ 1 day", not "≈ 1.0 day". The leading `≈` carries the
+     * "this is a rounded approximation" signal.
+     */
+    public function testJustAboveOneDayRoundsToApproxOne(): void
+    {
+        $this->assertSame('≈ 1 day', Duration::humanizeMinutes(1500));
+    }
+
+    /**
+     * Above one day, non-aligned to a half-day. 2160 / 1440 = 1.5
+     * exactly, so the echo reads "≈ 1.5 days" — `≈` because the
+     * underlying value isn't day-aligned (2160 % 1440 ≠ 0), even
+     * though the division produces a clean half.
+     */
+    public function testTwoThousandOneHundredSixtyMinutesIsApproxOneAndAHalfDays(): void
+    {
+        $this->assertSame('≈ 1.5 days', Duration::humanizeMinutes(2160));
+    }
+}

--- a/web/themes/default/page_admin_settings_settings.tpl
+++ b/web/themes/default/page_admin_settings_settings.tpl
@@ -21,6 +21,11 @@
             $config_min_password, $config_dateformat,
             $config_dash_title, $config_dash_text, $auth_maxlife,
             $auth_maxlife_remember, $auth_maxlife_steam,
+            $auth_maxlife_human, $auth_maxlife_remember_human,
+            $auth_maxlife_steam_human (#1232 — server-rendered first
+            paint for the per-input duration echoes; the page-tail JS
+            mirrors `Sbpp\Util\Duration::humanizeMinutes()` so the
+            spans update live as the operator types),
             $config_debug, $enable_submit, $enable_protest,
             $enable_commslist, $protest_emailonlyinvolved,
             $dash_lognopopup, $config_default_page,
@@ -179,6 +184,37 @@
                                 <span class="settings-fieldset__hint">Session token lifetimes, measured in minutes. Set a value to <code>0</code> to disable a sign-in path.</span>
                             </legend>
                             <div class="settings-fieldset__body space-y-5">
+                                {*
+                                    #1232: per-input duration echo.
+
+                                    Each input gets a `data-duration-input`
+                                    marker attribute and an adjacent muted
+                                    span keyed by `data-duration-echo-for=
+                                    "<input-id>"`. The span carries
+                                    `aria-live="polite"` so screen-reader
+                                    users hear the conversion as they edit.
+
+                                    The span is server-rendered with the
+                                    `*_human` props from `AdminSettingsView`
+                                    (populated by
+                                    `Sbpp\Util\Duration::humanizeMinutes()`
+                                    in admin.settings.php) so the page works
+                                    without JS. The page-tail
+                                    `<script>` re-implements the same
+                                    formula and updates the span on every
+                                    `input` event — see the IIFE near the
+                                    bottom of this template.
+
+                                    The span sits between the input and the
+                                    `.settings-fieldset__help` paragraph.
+                                    On desktop the input is clamped at
+                                    18rem (`.settings-fieldset__input`)
+                                    so the inline span flows next to it
+                                    on the same line; on mobile (<=768px)
+                                    the input expands to 100% and the
+                                    span wraps below — both shapes are
+                                    fine because the span is short.
+                                *}
                                 <div data-testid="setting-row" data-key="auth.maxlife">
                                     <label class="label" for="auth_maxlife">Default sign-in</label>
                                     <input class="input settings-fieldset__input"
@@ -186,7 +222,11 @@
                                            id="auth_maxlife"
                                            name="auth_maxlife"
                                            value="{$auth_maxlife}"
+                                           data-duration-input
                                            aria-describedby="auth_maxlife_help">
+                                    <span class="text-muted text-xs"
+                                          data-duration-echo-for="auth_maxlife"
+                                          aria-live="polite">{$auth_maxlife_human}</span>
                                     <p class="settings-fieldset__help"
                                        id="auth_maxlife_help"
                                        data-testid="setting-help-auth.maxlife">
@@ -200,7 +240,11 @@
                                            id="auth_maxlife_remember"
                                            name="auth_maxlife_remember"
                                            value="{$auth_maxlife_remember}"
+                                           data-duration-input
                                            aria-describedby="auth_maxlife_remember_help">
+                                    <span class="text-muted text-xs"
+                                          data-duration-echo-for="auth_maxlife_remember"
+                                          aria-live="polite">{$auth_maxlife_remember_human}</span>
                                     <p class="settings-fieldset__help"
                                        id="auth_maxlife_remember_help"
                                        data-testid="setting-help-auth.maxlife.remember">
@@ -214,7 +258,11 @@
                                            id="auth_maxlife_steam"
                                            name="auth_maxlife_steam"
                                            value="{$auth_maxlife_steam}"
+                                           data-duration-input
                                            aria-describedby="auth_maxlife_steam_help">
+                                    <span class="text-muted text-xs"
+                                          data-duration-echo-for="auth_maxlife_steam"
+                                          aria-live="polite">{$auth_maxlife_steam_human}</span>
                                     <p class="settings-fieldset__help"
                                        id="auth_maxlife_steam_help"
                                        data-testid="setting-help-auth.maxlife.steam">
@@ -567,6 +615,70 @@
             }, 200);
         });
     }
+
+    /**
+     * #1232: live "minutes -> human" echo for the Authentication
+     * fieldset. Mirrors `Sbpp\Util\Duration::humanizeMinutes()` (PHP)
+     * so the muted span next to each `[data-duration-input]` updates
+     * as the operator types. The first paint is server-rendered (see
+     * `$auth_maxlife_human` etc. in the template), so this block only
+     * runs when the user actually edits a value.
+     *
+     * @param {number} minutes
+     * @returns {string}
+     */
+    function humanizeMinutes(minutes) {
+        if (!Number.isFinite(minutes) || minutes <= 0) return 'disabled';
+        var n = Math.floor(minutes);
+        if (n < 60) return n === 1 ? '1 minute' : n + ' minutes';
+        if (n < 1440) {
+            if (n % 60 === 0) {
+                var h = n / 60;
+                return h === 1 ? '1 hour' : h + ' hours';
+            }
+            var hStr = trimZero(n / 60);
+            return '\u2248 ' + hStr + ' ' + (hStr === '1' ? 'hour' : 'hours');
+        }
+        if (n % 1440 === 0) {
+            var d = n / 1440;
+            return d === 1 ? '1 day' : d + ' days';
+        }
+        var dStr = trimZero(n / 1440);
+        return '\u2248 ' + dStr + ' ' + (dStr === '1' ? 'day' : 'days');
+    }
+
+    /**
+     * Format a number to one decimal and drop a trailing `.0` so values
+     * that round to a whole number render without a redundant decimal.
+     * Mirrors the PHP helper's `trimZero()`.
+     *
+     * @param {number} value
+     * @returns {string}
+     */
+    function trimZero(value) {
+        var s = (Math.round(value * 10) / 10).toFixed(1);
+        return s.charAt(s.length - 1) === '0' && s.charAt(s.length - 2) === '.'
+            ? s.slice(0, -2)
+            : s;
+    }
+
+    var durationInputs = /** @type {NodeListOf<HTMLInputElement>} */ (
+        document.querySelectorAll('[data-duration-input]')
+    );
+    durationInputs.forEach(function (input) {
+        var echo = /** @type {HTMLElement|null} */ (
+            document.querySelector('[data-duration-echo-for="' + input.id + '"]')
+        );
+        if (!echo) return;
+        input.addEventListener('input', function () {
+            // Empty input -> treat as 0 (matches the "disabled" sentinel
+            // the PHP helper returns; the `<input type=number>` clears
+            // to "" rather than "0" on backspace).
+            var raw = input.value.trim();
+            var n = raw === '' ? 0 : parseInt(raw, 10);
+            echo.textContent = humanizeMinutes(Number.isNaN(n) ? 0 : n);
+        });
+    });
 })();
 {/literal}
 </script>


### PR DESCRIPTION
## Summary

- New: `Sbpp\Util\Duration::humanizeMinutes(int)` (with unit test) — "1 minute" / "≈ 12 hours" / "≈ 7 days".
- `AdminSettingsView` gains three `*_human` string props, populated by the page handler.
- `page_admin_settings_settings.tpl` renders an aria-live echo span next to each `auth_maxlife*` input via `data-duration-echo-for=…`.
- A small vanilla-JS module mirrors the same formula on `input` so the echo stays live as the operator types. First paint is server-rendered (works without JS).
- Wire format unchanged — DB stays in minutes, the SourceMod plugin stays in minutes.

Closes #1232

## Test plan

- [ ] Visit `?p=admin&c=settings&section=settings` → each Authentication field shows `≈ 7 days` / `≈ 24 hours` etc.
- [ ] Type a new value → echo updates live.
- [ ] Set a value to `0` → echo reads "disabled" (matches the legend hint).
- [ ] PHPStan passes, including the SmartyTemplateRule cross-check.
- [ ] PHPUnit covers the helper edge cases.
- [ ] ts-check passes.