### PR TITLE
fix(banlist+commslist): empty pagination, parity filter bar, pressed Hide-inactive (#1225, #1226, #1230)

### DIFF
--- a/web/includes/View/BanListView.php
+++ b/web/includes/View/BanListView.php
@@ -35,6 +35,8 @@ final class BanListView extends View
      * @param int|false                           $comment        Bid being commented on, or false when not in comment-edit mode.
      * @param int                                 $page           Active pagination page (or -1 when not paginated).
      * @param array<int, array<string,mixed>>|string $othercomments  Sibling comments shown beneath the editor; "None" string when the ban has no other comments.
+     * @param list<array{sid: int, name: string}> $server_list    Enabled servers for the public filter bar's `<select name="server">` (#1226).
+     * @param array{search: string, server: string, time: string} $filters Current filter state — drives the sticky filter bar's pre-fill + active selected `<option>` (#1226).
      */
     public function __construct(
         public readonly array $ban_list,
@@ -65,10 +67,19 @@ final class BanListView extends View
         // sees the body copy without the link). Splatted from
         // `Perms::for($userbank)` in `web/pages/page.banlist.php`.
         public readonly bool $can_add_ban,
-        // #1207: detects whether the current request applied any filter
-        // (search text / advSearch / hide-inactive). Drives the
-        // first-run-vs-filtered split in the empty-state shape.
+        // #1207 + #1226: detects whether the current request applied any
+        // filter (search text / advSearch / hide-inactive / server /
+        // time). Drives the first-run-vs-filtered split in the empty-
+        // state shape.
         public readonly bool $is_filtered,
+        // #1226: public filter parity with `CommsListView`. The
+        // server list mirrors `CommsListView::$servers`; it's named
+        // `server_list` here to match the existing
+        // `box_admin_bans_search.tpl` convention so a future
+        // consolidation between the inline filter bar and the
+        // advanced-search box doesn't have to rename the property.
+        public readonly array $server_list,
+        public readonly array $filters,
     ) {
     }
 }

--- a/web/pages/page.banlist.php
+++ b/web/pages/page.banlist.php
@@ -231,6 +231,46 @@ if (isset($_SESSION["hideinactive"])) {
     $hideinactiven = "";
 }
 
+// #1226: public ?server=<sid> + ?time=<1d|7d|30d> filter parity with
+// the commslist URL surface. Both are applied as additional AND
+// predicates on top of whichever upper branch (searchText / no
+// filter / advSearch) is active, so they compose with the existing
+// search box AND with the legacy ?advType=where_banned shim.
+//
+// Mirrors the $hideinactive / $hideinactiven pattern: build two
+// fragments — `$publicFilterAnd` (` AND a = ? AND b = ?`, appended
+// to a query that already opens a WHERE) and `$publicFilterWheren`
+// (` WHERE a = ? AND b = ?`, used when no other clause has opened
+// one yet).
+$serverFilter = isset($_GET['server']) ? trim((string) $_GET['server']) : '';
+$timeFilter   = isset($_GET['time'])   ? trim((string) $_GET['time'])   : '';
+$publicFilterTimeMap = [
+    '1d'  => 86400,
+    '7d'  => 7 * 86400,
+    '30d' => 30 * 86400,
+];
+
+$publicFilterClauses = [];
+$publicFilterArgs    = [];
+$publicFilterLink    = '';
+if ($serverFilter !== '' && ctype_digit($serverFilter)) {
+    $publicFilterClauses[] = 'BA.sid = ?';
+    $publicFilterArgs[]    = (int) $serverFilter;
+    $publicFilterLink     .= '&server=' . urlencode($serverFilter);
+}
+if ($timeFilter !== '' && isset($publicFilterTimeMap[$timeFilter])) {
+    $publicFilterClauses[] = 'BA.created >= ?';
+    $publicFilterArgs[]    = time() - $publicFilterTimeMap[$timeFilter];
+    $publicFilterLink     .= '&time=' . urlencode($timeFilter);
+}
+
+$publicFilterAnd     = '';
+$publicFilterWheren  = '';
+if ($publicFilterClauses) {
+    $joined             = implode(' AND ', $publicFilterClauses);
+    $publicFilterAnd    = ' AND ' . $joined;
+    $publicFilterWheren = ' WHERE ' . $joined;
+}
 
 if (isset($_GET['searchText'])) {
     $searchText = trim($_GET['searchText']);
@@ -280,24 +320,31 @@ if (isset($_GET['searchText'])) {
   LEFT JOIN `:prefix_servers` AS SE ON SE.sid = BA.sid
   LEFT JOIN `:prefix_mods` AS MO on SE.modid = MO.mid
   LEFT JOIN `:prefix_admins` AS AD ON BA.aid = AD.aid
-      WHERE " . $search_ips . $authidClause . " or BA.name LIKE ? or BA.reason LIKE ?" . $hideinactive . "
+      WHERE " . $search_ips . $authidClause . " or BA.name LIKE ? or BA.reason LIKE ?" . $hideinactive . $publicFilterAnd . "
    ORDER BY BA.created DESC
-   LIMIT ?,?")->resultset(array_merge($search_array, [
-        $authidParam,
-        $search,
-        $search,
-        intval($BansStart),
-        intval($BansPerPage),
-    ]));
+   LIMIT ?,?")->resultset(array_merge(
+        $search_array,
+        [$authidParam, $search, $search],
+        $publicFilterArgs,
+        [intval($BansStart), intval($BansPerPage)]
+    ));
 
 
-    $res_count  = $GLOBALS['PDO']->query("SELECT count(BA.bid) AS cnt FROM `:prefix_bans` AS BA WHERE " . $search_ips . $authidClause . " OR BA.name LIKE ? OR BA.reason LIKE ?" . $hideinactive)->resultset(array_merge($search_array, [
-        $authidParam,
-        $search,
-        $search,
-    ]));
-    $searchlink = "&searchText=" . urlencode($_GET["searchText"]);
+    $res_count  = $GLOBALS['PDO']->query("SELECT count(BA.bid) AS cnt FROM `:prefix_bans` AS BA WHERE " . $search_ips . $authidClause . " OR BA.name LIKE ? OR BA.reason LIKE ?" . $hideinactive . $publicFilterAnd)->resultset(array_merge(
+        $search_array,
+        [$authidParam, $search, $search],
+        $publicFilterArgs
+    ));
+    $searchlink = "&searchText=" . urlencode($_GET["searchText"]) . $publicFilterLink;
 } elseif (!isset($_GET['advSearch'])) {
+    // #1226: branch 2 has no upper-level WHERE; if hideinactive opened
+    // one (`$hideinactiven` = " WHERE RemoveType IS NULL") we append
+    // the public filters as " AND …", otherwise the public filters
+    // open the WHERE themselves via `$publicFilterWheren`.
+    $branch2WhereSuffix = $hideinactiven !== ''
+        ? $hideinactiven . $publicFilterAnd
+        : $publicFilterWheren;
+
     $res = $GLOBALS['PDO']->query("SELECT bid ban_id, BA.type, BA.ip ban_ip, BA.authid, BA.name player_name, created ban_created, ends ban_ends, length ban_length, reason ban_reason, BA.ureason unban_reason, BA.aid, AD.gid AS gid, adminIp, BA.sid ban_server, country ban_country, RemovedOn, RemovedBy, RemoveType row_type,
 			SE.ip server_ip, AD.user admin_name, AD.gid, MO.icon as mod_icon,
 			CAST(MID(BA.authid, 9, 1) AS UNSIGNED) + CAST('76561197960265728' AS UNSIGNED) + CAST(MID(BA.authid, 11, 10) * 2 AS UNSIGNED) AS community_id,
@@ -307,15 +354,15 @@ if (isset($_GET['searchText'])) {
   LEFT JOIN `:prefix_servers` AS SE ON SE.sid = BA.sid
   LEFT JOIN `:prefix_mods` AS MO on SE.modid = MO.mid
   LEFT JOIN `:prefix_admins` AS AD ON BA.aid = AD.aid
-  " . $hideinactiven . "
+  " . $branch2WhereSuffix . "
    ORDER BY created DESC
-   LIMIT ?,?")->resultset([
-        intval($BansStart),
-        intval($BansPerPage),
-    ]);
+   LIMIT ?,?")->resultset(array_merge(
+        $publicFilterArgs,
+        [intval($BansStart), intval($BansPerPage)]
+    ));
 
-    $res_count  = $GLOBALS['PDO']->query("SELECT count(bid) AS cnt FROM `:prefix_bans`" . $hideinactiven)->resultset();
-    $searchlink = "";
+    $res_count  = $GLOBALS['PDO']->query("SELECT count(bid) AS cnt FROM `:prefix_bans` AS BA" . $branch2WhereSuffix)->resultset($publicFilterArgs);
+    $searchlink = $publicFilterLink;
 }
 
 $advcrit = [];
@@ -482,6 +529,15 @@ if (isset($_GET['advSearch'])) {
         $hideinactive = $hideinactiven;
     }
 
+    // #1226: branch 3 may or may not have an upper-level WHERE. The
+    // existing $where is empty iff advType resolved to a no-op
+    // (default branch in the switch above) AND $hideinactive may
+    // have been promoted to $hideinactiven by the guard right above.
+    // Pick the right form of the public-filter SQL accordingly so
+    // the trailing WHERE-vs-AND boundary stays well-formed.
+    $branch3HasWhere     = ($where !== '') || (strpos($hideinactive, 'WHERE') !== false);
+    $publicFilterBranch3 = $branch3HasWhere ? $publicFilterAnd : $publicFilterWheren;
+
     $res = $GLOBALS['PDO']->query("SELECT BA.bid ban_id, BA.type, BA.ip ban_ip, BA.authid, BA.name player_name, created ban_created, ends ban_ends, length ban_length, reason ban_reason, BA.ureason unban_reason, BA.aid, AD.gid AS gid, adminIp, BA.sid ban_server, country ban_country, RemovedOn, RemovedBy, RemoveType row_type,
 			SE.ip server_ip, AD.user admin_name, AD.gid, MO.icon as mod_icon,
 			CAST(MID(BA.authid, 9, 1) AS UNSIGNED) + CAST('76561197960265728' AS UNSIGNED) + CAST(MID(BA.authid, 11, 10) * 2 AS UNSIGNED) AS community_id,
@@ -492,16 +548,17 @@ if (isset($_GET['advSearch'])) {
   LEFT JOIN `:prefix_mods` AS MO on SE.modid = MO.mid
   LEFT JOIN `:prefix_admins` AS AD ON BA.aid = AD.aid
   " . ($type == "comment" && $userbank->is_admin() ? "LEFT JOIN `:prefix_comments` AS CO ON BA.bid = CO.bid" : "") . "
-      " . $where . $hideinactive . "
+      " . $where . $hideinactive . $publicFilterBranch3 . "
    ORDER BY BA.created DESC
-   LIMIT ?,?")->resultset(array_merge($advcrit, [
-        intval($BansStart),
-        intval($BansPerPage),
-    ]));
+   LIMIT ?,?")->resultset(array_merge(
+        $advcrit,
+        $publicFilterArgs,
+        [intval($BansStart), intval($BansPerPage)]
+    ));
 
     $res_count  = $GLOBALS['PDO']->query("SELECT count(BA.bid) AS cnt FROM `:prefix_bans` AS BA
-										  " . ($type == "comment" && $userbank->is_admin() ? "LEFT JOIN `:prefix_comments` AS CO ON BA.bid = CO.bid" : "") . " " . $where . $hideinactive)->resultset($advcrit);
-    $searchlink = "&advSearch=" . urlencode($_GET['advSearch']) . "&advType=" . urlencode($_GET['advType']);
+										  " . ($type == "comment" && $userbank->is_admin() ? "LEFT JOIN `:prefix_comments` AS CO ON BA.bid = CO.bid" : "") . " " . $where . $hideinactive . $publicFilterBranch3)->resultset(array_merge($advcrit, $publicFilterArgs));
+    $searchlink = "&advSearch=" . urlencode($_GET['advSearch']) . "&advType=" . urlencode($_GET['advType']) . $publicFilterLink;
 }
 
 $BanCount = isset($res_count[0]['cnt']) ? (int) $res_count[0]['cnt'] : 0;
@@ -862,49 +919,61 @@ if (isset($_GET['advSearch'])) {
 //      this guards the JS-string-inside-HTML-attribute injection vector.
 //   4. Plain "Prev" / "Next" + Unicode arrows; the v2.0.0 default
 //      theme ships Lucide instead of FontAwesome.
+//   5. #1225: when the result count is zero we short-circuit to an
+//      empty string. The template's `{if !empty($ban_nav)}` guard
+//      then collapses the pagination card so the empty state owns
+//      the surface alone — otherwise a "displaying 0 - 0 of 0
+//      results" shell renders below the empty state on every fresh
+//      install.
 // ---------------------------------------------------------------------
 
-$searchTextParam = isset($_GET['searchText']) ? '&searchText=' . urlencode((string) $_GET['searchText']) : '';
-$pageQuerySuffix = $searchTextParam . $advSearchString;
+if ($BanCount === 0) {
+    $ban_nav = '';
+} else {
+    $searchTextParam = isset($_GET['searchText']) ? '&searchText=' . urlencode((string) $_GET['searchText']) : '';
+    // #1226: append the public ?server / ?time filter params so
+    // pagination links keep the active filter when navigating.
+    $pageQuerySuffix = $searchTextParam . $advSearchString . $publicFilterLink;
 
-$prev = '';
-if ($page > 1) {
-    $prevUrl = 'index.php?p=banlist&page=' . ($page - 1) . $pageQuerySuffix;
-    $prev = '<a href="' . htmlspecialchars($prevUrl, ENT_QUOTES, 'UTF-8')
-        . '" data-testid="page-prev" rel="prev" aria-label="Previous page">&laquo; prev</a>';
-}
-
-$next = '';
-if ($BansEnd < $BanCount) {
-    $nextUrl = 'index.php?p=banlist&page=' . ($page + 1) . $pageQuerySuffix;
-    $next = '<a href="' . htmlspecialchars($nextUrl, ENT_QUOTES, 'UTF-8')
-        . '" data-testid="page-next" rel="next" aria-label="Next page">next &raquo;</a>';
-}
-
-$ban_nav = 'displaying&nbsp;' . $BansStart . '&nbsp;-&nbsp;' . $BansEnd . '&nbsp;of&nbsp;' . $BanCount . '&nbsp;results';
-
-if ($prev !== '') {
-    $ban_nav .= ' | <b>' . $prev . '</b>';
-}
-if ($next !== '') {
-    $ban_nav .= ' | <b>' . $next . '</b>';
-}
-
-$pages = (int) ceil($BanCount / $BansPerPage);
-if ($pages > 1) {
-    // Page-jump select: vanilla inline navigation, no JS dependency.
-    // The query-suffix template (`pageQuerySuffix`) is double-escaped
-    // for the JS-string-inside-HTML-attribute boundary: addslashes
-    // for the JS string layer, htmlspecialchars(ENT_QUOTES) for the
-    // HTML attribute layer. Same defence-in-depth pattern as #1113.
-    $pageQueryJs = htmlspecialchars(addslashes($pageQuerySuffix), ENT_QUOTES, 'UTF-8');
-    $jumpHandler = "if(this.value!=='0')window.location.href='index.php?p=banlist&page='+this.value+'" . $pageQueryJs . "';";
-    $ban_nav .= '&nbsp;<select aria-label="Jump to page" onchange="' . $jumpHandler . '">';
-    for ($i = 1; $i <= $pages; $i++) {
-        $selected = (isset($_GET['page']) && (int) $_GET['page'] === $i) ? ' selected="selected"' : '';
-        $ban_nav .= '<option value="' . $i . '"' . $selected . '>' . $i . '</option>';
+    $prev = '';
+    if ($page > 1) {
+        $prevUrl = 'index.php?p=banlist&page=' . ($page - 1) . $pageQuerySuffix;
+        $prev = '<a href="' . htmlspecialchars($prevUrl, ENT_QUOTES, 'UTF-8')
+            . '" data-testid="page-prev" rel="prev" aria-label="Previous page">&laquo; prev</a>';
     }
-    $ban_nav .= '</select>';
+
+    $next = '';
+    if ($BansEnd < $BanCount) {
+        $nextUrl = 'index.php?p=banlist&page=' . ($page + 1) . $pageQuerySuffix;
+        $next = '<a href="' . htmlspecialchars($nextUrl, ENT_QUOTES, 'UTF-8')
+            . '" data-testid="page-next" rel="next" aria-label="Next page">next &raquo;</a>';
+    }
+
+    $ban_nav = 'displaying&nbsp;' . $BansStart . '&nbsp;-&nbsp;' . $BansEnd . '&nbsp;of&nbsp;' . $BanCount . '&nbsp;results';
+
+    if ($prev !== '') {
+        $ban_nav .= ' | <b>' . $prev . '</b>';
+    }
+    if ($next !== '') {
+        $ban_nav .= ' | <b>' . $next . '</b>';
+    }
+
+    $pages = (int) ceil($BanCount / $BansPerPage);
+    if ($pages > 1) {
+        // Page-jump select: vanilla inline navigation, no JS dependency.
+        // The query-suffix template (`pageQuerySuffix`) is double-escaped
+        // for the JS-string-inside-HTML-attribute boundary: addslashes
+        // for the JS string layer, htmlspecialchars(ENT_QUOTES) for the
+        // HTML attribute layer. Same defence-in-depth pattern as #1113.
+        $pageQueryJs = htmlspecialchars(addslashes($pageQuerySuffix), ENT_QUOTES, 'UTF-8');
+        $jumpHandler = "if(this.value!=='0')window.location.href='index.php?p=banlist&page='+this.value+'" . $pageQueryJs . "';";
+        $ban_nav .= '&nbsp;<select aria-label="Jump to page" onchange="' . $jumpHandler . '">';
+        for ($i = 1; $i <= $pages; $i++) {
+            $selected = (isset($_GET['page']) && (int) $_GET['page'] === $i) ? ' selected="selected"' : '';
+            $ban_nav .= '<option value="' . $i . '"' . $selected . '>' . $i . '</option>';
+        }
+        $ban_nav .= '</select>';
+    }
 }
 
 //COMMENT STUFF
@@ -974,16 +1043,41 @@ if (isset($_GET["comment"])) {
 
 unset($_SESSION['CountryFetchHndl']);
 
-// #1207: detect whether the current request is filtered (search box,
-// advanced search, hide-inactive toggle). Drives the
-// first-run-vs-filtered split in the empty-state shape — when zero
+// #1207 + #1226: detect whether the current request is filtered (search
+// box, advanced search, hide-inactive toggle, ?server, ?time). Drives
+// the first-run-vs-filtered split in the empty-state shape — when zero
 // rows AND no filter, the empty state shows "no bans recorded yet"
 // with an "Add a ban" CTA gated on can_add_ban; with a filter
 // active, it stays "No bans match those filters" + "Clear filters".
 $banlistIsFiltered =
     (isset($_GET['searchText']) && (string) $_GET['searchText'] !== '')
     || (isset($_GET['advSearch']) && (string) $_GET['advSearch'] !== '')
-    || isset($_SESSION['hideinactive']);
+    || isset($_SESSION['hideinactive'])
+    || $publicFilterClauses !== [];
+
+// #1226: server filter dropdown — public banlist parity with the
+// commslist URL surface. Mirrors the data shape page.commslist.php
+// builds in $serversFilter + the box_admin_bans_search.tpl pattern;
+// hostnames could be resolved asynchronously via
+// sb.api.call(Actions.ServersHostPlayers) in a follow-up. The
+// pre-resolution display is `ip:port`, which is what most public
+// visitors recognise the server by anyway.
+$serverRows = $GLOBALS['PDO']->query(
+    "SELECT sid, ip, port FROM `:prefix_servers` WHERE enabled = 1 ORDER BY ip"
+)->resultset();
+$banlistServerList = [];
+foreach ($serverRows as $sr) {
+    $banlistServerList[] = [
+        'sid'  => (int) $sr['sid'],
+        'name' => (string) $sr['ip'] . ':' . (int) $sr['port'],
+    ];
+}
+
+$banlistFilters = [
+    'search' => isset($_GET['searchText']) ? (string) $_GET['searchText'] : '',
+    'server' => $serverFilter,
+    'time'   => (isset($publicFilterTimeMap[$timeFilter]) ? $timeFilter : ''),
+];
 
 Renderer::render($theme, new BanListView(
     ban_list:        $bans,
@@ -1011,4 +1105,6 @@ Renderer::render($theme, new BanListView(
     admin_postkey:   $_SESSION['banlist_postkey'],
     can_add_ban:     (bool) $userbank->HasAccess(ADMIN_OWNER | ADMIN_ADD_BAN),
     is_filtered:     $banlistIsFiltered,
+    server_list:     $banlistServerList,
+    filters:         $banlistFilters,
 ));

--- a/web/pages/page.commslist.php
+++ b/web/pages/page.commslist.php
@@ -809,51 +809,62 @@ if (isset($_GET['advSearch'])) {
     $advSearchString = '';
 }
 
-if ($page > 1) {
-    if (isset($_GET['c']) && $_GET['c'] == "comms") {
-        $prev = CreateLinkR('<i class="fas fa-arrow-left fa-lg"></i> prev', "javascript:void(0);", "", "_self", false, $prev);
-    } else {
-        $prev = CreateLinkR('<i class="fas fa-arrow-left fa-lg"></i> prev', "index.php?p=commslist&page=" . ($page - 1) . (isset($_GET['searchText']) > 0 ? "&searchText=" . urlencode($_GET['searchText']) : '' . $advSearchString));
-    }
+// #1225: when the result count is zero we short-circuit to an empty
+// string. Mirrors page.banlist.php — the legacy theme reads $ban_nav
+// inside its `{if !empty($ban_nav)}` guard, and the new theme reads
+// $pagination separately (page_comms.tpl gates that block on
+// `$pagination.total > 0`). With no rows AND no filter, the empty
+// state owns the surface alone instead of being shadowed by a
+// "displaying 0 - 0 of 0 results" pagination shell.
+if ($BanCount === 0) {
+    $ban_nav = '';
 } else {
-    $prev = "";
-}
-if ($BansEnd < $BanCount) {
-    if (isset($_GET['c']) && $_GET['c'] == "comms") {
-        if (!isset($nxt)) {
-            $nxt = "";
+    if ($page > 1) {
+        if (isset($_GET['c']) && $_GET['c'] == "comms") {
+            $prev = CreateLinkR('<i class="fas fa-arrow-left fa-lg"></i> prev', "javascript:void(0);", "", "_self", false, $prev);
+        } else {
+            $prev = CreateLinkR('<i class="fas fa-arrow-left fa-lg"></i> prev', "index.php?p=commslist&page=" . ($page - 1) . (isset($_GET['searchText']) > 0 ? "&searchText=" . urlencode($_GET['searchText']) : '' . $advSearchString));
         }
-        $next = CreateLinkR('next <i class="fas fa-arrow-right fa-lg"></i>', "javascript:void(0);", "", "_self", false, $nxt);
     } else {
-        $next = CreateLinkR('next <i class="fas fa-arrow-right fa-lg"></i>', "index.php?p=commslist&page=" . ($page + 1) . (isset($_GET['searchText']) ? "&searchText=" . urlencode($_GET['searchText']) : '' . $advSearchString));
+        $prev = "";
     }
-} else {
-    $next = "";
-}
-
-//=================[ Start Layout ]==================================
-$ban_nav = 'displaying&nbsp;' . $BansStart . '&nbsp;-&nbsp;' . $BansEnd . '&nbsp;of&nbsp;' . $BanCount . '&nbsp;results';
-
-if (strlen($prev) > 0) {
-    $ban_nav .= ' | <b>' . $prev . '</b>';
-}
-if (strlen($next) > 0) {
-    $ban_nav .= ' | <b>' . $next . '</b>';
-}
-$pages = ceil($BanCount / $BansPerPage);
-if ($pages > 1) {
-    // Issue #1113: see page.banlist.php for the layered-escape rationale.
-    $advSearchJs = htmlspecialchars(addslashes((string)($_GET['advSearch'] ?? '')), ENT_QUOTES, 'UTF-8');
-    $advTypeJs   = htmlspecialchars(addslashes((string)($_GET['advType']   ?? '')), ENT_QUOTES, 'UTF-8');
-    $ban_nav .= '&nbsp;<select onchange="changePage(this,\'C\',\'' . $advSearchJs . '\',\'' . $advTypeJs . '\');">';
-    for ($i = 1; $i <= $pages; $i++) {
-        if (isset($_GET["page"]) && $i == $_GET["page"]) {
-            $ban_nav .= '<option value="' . $i . '" selected="selected">' . $i . '</option>';
-            continue;
+    if ($BansEnd < $BanCount) {
+        if (isset($_GET['c']) && $_GET['c'] == "comms") {
+            if (!isset($nxt)) {
+                $nxt = "";
+            }
+            $next = CreateLinkR('next <i class="fas fa-arrow-right fa-lg"></i>', "javascript:void(0);", "", "_self", false, $nxt);
+        } else {
+            $next = CreateLinkR('next <i class="fas fa-arrow-right fa-lg"></i>', "index.php?p=commslist&page=" . ($page + 1) . (isset($_GET['searchText']) ? "&searchText=" . urlencode($_GET['searchText']) : '' . $advSearchString));
         }
-        $ban_nav .= '<option value="' . $i . '">' . $i . '</option>';
+    } else {
+        $next = "";
     }
-    $ban_nav .= '</select>';
+
+    //=================[ Start Layout ]==================================
+    $ban_nav = 'displaying&nbsp;' . $BansStart . '&nbsp;-&nbsp;' . $BansEnd . '&nbsp;of&nbsp;' . $BanCount . '&nbsp;results';
+
+    if (strlen($prev) > 0) {
+        $ban_nav .= ' | <b>' . $prev . '</b>';
+    }
+    if (strlen($next) > 0) {
+        $ban_nav .= ' | <b>' . $next . '</b>';
+    }
+    $pages = ceil($BanCount / $BansPerPage);
+    if ($pages > 1) {
+        // Issue #1113: see page.banlist.php for the layered-escape rationale.
+        $advSearchJs = htmlspecialchars(addslashes((string)($_GET['advSearch'] ?? '')), ENT_QUOTES, 'UTF-8');
+        $advTypeJs   = htmlspecialchars(addslashes((string)($_GET['advType']   ?? '')), ENT_QUOTES, 'UTF-8');
+        $ban_nav .= '&nbsp;<select onchange="changePage(this,\'C\',\'' . $advSearchJs . '\',\'' . $advTypeJs . '\');">';
+        for ($i = 1; $i <= $pages; $i++) {
+            if (isset($_GET["page"]) && $i == $_GET["page"]) {
+                $ban_nav .= '<option value="' . $i . '" selected="selected">' . $i . '</option>';
+                continue;
+            }
+            $ban_nav .= '<option value="' . $i . '">' . $i . '</option>';
+        }
+        $ban_nav .= '</select>';
+    }
 }
 
 //COMMENT STUFF

--- a/web/themes/default/css/theme.css
+++ b/web/themes/default/css/theme.css
@@ -251,6 +251,30 @@ html.dark .theme-toggle__moon { display: inline-block; }
   --btn-border: var(--border);
   --btn-bg-hover: var(--bg-muted);
 }
+/* #1230: stateful pressed treatment for binary toggles rendered as
+   secondary buttons — currently the public banlist + commslist
+   "Hide / Show inactive" toggle. Without this rule the icon swap
+   (eye ↔ eye-off) is the only visual cue that the list is currently
+   filtered, which reads as a one-shot action rather than a
+   sticky state. The active fill mirrors the sidebar nav's
+   `aria-current="page"` treatment (dark pill on light, brand orange
+   on dark, see CC-4 above) so binary toggles read consistently
+   across the app. The selector intentionally lands on any
+   `.btn--secondary[aria-pressed="true"]` so future toggles
+   (e.g. group-by switches, density toggles) inherit the chrome
+   without re-styling. */
+.btn--secondary[aria-pressed="true"] {
+  --btn-bg: var(--zinc-900);
+  --btn-color: white;
+  --btn-border: var(--zinc-900);
+  --btn-bg-hover: var(--zinc-800);
+}
+html.dark .btn--secondary[aria-pressed="true"] {
+  --btn-bg: var(--brand-700);
+  --btn-color: var(--on-accent, #fff);
+  --btn-border: var(--brand-700);
+  --btn-bg-hover: var(--brand-600);
+}
 /* --btn-border self-reset keeps .btn--ghost transparent even when a
    sibling modifier (.btn--secondary, etc.) had set --btn-border earlier
    in the cascade — see #1183 (icon-only ghost should never show a

--- a/web/themes/default/page_bans.tpl
+++ b/web/themes/default/page_bans.tpl
@@ -71,7 +71,14 @@
       <a class="btn btn--secondary btn--sm" href="exportbans.php?type=steam" title="Export permanent SteamID bans">Export Steam</a>
       <a class="btn btn--secondary btn--sm" href="exportbans.php?type=ip" title="Export permanent IP bans">Export IP</a>
       {/if}
-      <a class="btn btn--secondary btn--sm" href="index.php?p=banlist&hideinactive={if $hidetext == 'Hide'}true{else}false{/if}{$searchlink}">{$hidetext} inactive</a>
+      {* #1230: aria-pressed mirrors whether inactive bans are
+         currently being hidden ($hidetext == 'Show' means the
+         session toggle is set, i.e. the list is filtered).
+         Pair: .btn--secondary[aria-pressed="true"] in theme.css. *}
+      <a class="btn btn--secondary btn--sm"
+         aria-pressed="{if $hidetext == 'Show'}true{else}false{/if}"
+         href="index.php?p=banlist&hideinactive={if $hidetext == 'Hide'}true{else}false{/if}{$searchlink}"
+         data-testid="toggle-hide-inactive">{$hidetext} inactive</a>
       {has_access flag=$smarty.const.ADMIN_ADD_BAN}
       <a class="btn btn--primary btn--sm" href="index.php?p=admin&c=bans">Add ban</a>
       {/has_access}
@@ -83,16 +90,40 @@
        ids). The form's `method=get action=index.php` mirrors the
        legacy advanced search wiring, so a no-JS browser still gets a
        working server-rendered search; banlist.js layers chip-state
-       URL sync on top of it. *}
+       URL sync on top of it.
+
+       #1226: parity with the public commslist filter bar — server +
+       time selects + Apply button alongside the existing search
+       field. The server `<option value="<sid>">` round-trips into
+       page.banlist.php's $publicFilterClauses (BA.sid = ?) and
+       composes with both the search box and the legacy advSearch
+       URL shim. The time options map to "Last N days" via the
+       BA.created >= ? predicate (mirrors page.commslist.php's
+       intent; the legacy advType=date shim stays the kitchen-sink
+       power-user tool in box_admin_bans_search.tpl). *}
   <form method="get" action="index.php" id="banlist-filters" style="position:sticky;top:3.5rem;z-index:20;background:var(--bg-page);padding:0.75rem 0;border-bottom:1px solid var(--border)">
     <input type="hidden" name="p" value="banlist">
     <div class="flex gap-3" style="flex-wrap:wrap">
       <div style="flex:1;min-width:14rem;max-width:24rem;position:relative">
         <input class="input" type="search" name="searchText" data-testid="bans-search"
-          value="{if isset($smarty.get.searchText)}{$smarty.get.searchText|escape}{/if}"
+          value="{$filters.search|escape}"
           placeholder="Player, SteamID, or IP&hellip;" aria-label="Search bans">
       </div>
-      <button class="btn btn--secondary btn--sm" type="submit">Search</button>
+      <select class="select" name="server" style="width:auto;min-width:11rem" data-testid="bans-server-filter" aria-label="Filter by server">
+        <option value="">All servers</option>
+        {foreach $server_list as $s}
+          <option value="{$s.sid}" {if $filters.server == $s.sid}selected{/if}>{$s.name|escape}</option>
+        {/foreach}
+      </select>
+      <select class="select" name="time" style="width:auto" data-testid="bans-time-filter" aria-label="Filter by time range">
+        <option value="">All time</option>
+        <option value="1d"  {if $filters.time == '1d'}selected{/if}>Today</option>
+        <option value="7d"  {if $filters.time == '7d'}selected{/if}>Last 7 days</option>
+        <option value="30d" {if $filters.time == '30d'}selected{/if}>Last 30 days</option>
+      </select>
+      <button class="btn btn--secondary btn--sm" type="submit" data-testid="bans-filter-apply">
+        <i data-lucide="filter"></i> Apply
+      </button>
     </div>
 
     <div class="flex items-center gap-2 mt-2 scroll-x" role="group" aria-label="Filter by status">

--- a/web/themes/default/page_bans.tpl
+++ b/web/themes/default/page_bans.tpl
@@ -74,8 +74,17 @@
       {* #1230: aria-pressed mirrors whether inactive bans are
          currently being hidden ($hidetext == 'Show' means the
          session toggle is set, i.e. the list is filtered).
-         Pair: .btn--secondary[aria-pressed="true"] in theme.css. *}
+         Pair: .btn--secondary[aria-pressed="true"] in theme.css.
+
+         role="button" makes aria-pressed a valid attribute on the
+         <a> per WAI-ARIA (the toggle is functionally a button —
+         the href is the no-JS progressive-enhancement fallback,
+         not a navigation in the breadcrumb sense). Without this
+         role axe's aria-allowed-attr rule fires "ARIA attribute
+         is not allowed: aria-pressed" — see the same shape on
+         page_comms.tpl. *}
       <a class="btn btn--secondary btn--sm"
+         role="button"
          aria-pressed="{if $hidetext == 'Show'}true{else}false{/if}"
          href="index.php?p=banlist&hideinactive={if $hidetext == 'Hide'}true{else}false{/if}{$searchlink}"
          data-testid="toggle-hide-inactive">{$hidetext} inactive</a>

--- a/web/themes/default/page_comms.tpl
+++ b/web/themes/default/page_comms.tpl
@@ -36,7 +36,12 @@
             </p>
         </div>
         <div class="flex gap-2">
+            {* #1230: aria-pressed reflects whether inactive blocks
+               are currently being hidden (binary state, not a
+               one-shot action). Pair: .btn--secondary[aria-pressed="true"]
+               in theme.css. *}
             <a class="btn btn--secondary btn--sm"
+               aria-pressed="{if $hide_inactive}true{else}false{/if}"
                href="{$hide_inactive_toggle_url|escape}"
                data-testid="toggle-hide-inactive">
                 <i data-lucide="{if $hide_inactive}eye{else}eye-off{/if}"></i>
@@ -421,7 +426,14 @@
         </div>
     </div>
 
-    {* -- Pagination --------------------------------------------------- *}
+    {* -- Pagination ---------------------------------------------------
+         #1225: short-circuit on a zero result count so the
+         "Showing 0–0 of 0" shell doesn't render below the empty
+         state on a fresh install. The empty state already owns the
+         "this list is empty" message; the pagination card is dead
+         chrome at total=0. Pair: page.commslist.php sets
+         $ban_nav = '' for the legacy theme contract. *}
+    {if $pagination.total > 0}
     <div class="flex items-center justify-between text-xs text-muted" data-testid="comms-pagination">
         <div>
             Showing
@@ -460,6 +472,7 @@
             {/if}
         </div>
     </div>
+    {/if}
 
     {* `searchlink` is the URL fragment (e.g. `&searchText=foo`) the
        handler builds to preserve the active query across navigation.

--- a/web/themes/default/page_comms.tpl
+++ b/web/themes/default/page_comms.tpl
@@ -39,8 +39,16 @@
             {* #1230: aria-pressed reflects whether inactive blocks
                are currently being hidden (binary state, not a
                one-shot action). Pair: .btn--secondary[aria-pressed="true"]
-               in theme.css. *}
+               in theme.css.
+
+               role="button" makes aria-pressed a valid attribute
+               on the <a> per WAI-ARIA (the toggle is functionally
+               a button — the href is the no-JS progressive-
+               enhancement fallback). Without this role axe's
+               aria-allowed-attr rule fires "ARIA attribute is not
+               allowed: aria-pressed". *}
             <a class="btn btn--secondary btn--sm"
+               role="button"
                aria-pressed="{if $hide_inactive}true{else}false{/if}"
                href="{$hide_inactive_toggle_url|escape}"
                data-testid="toggle-hide-inactive">


### PR DESCRIPTION
## Summary

Three fixes on the public banlist + commslist surfaces:

- **#1225**: Drop the empty pagination shell on first-run. `page.banlist.php` and `page.commslist.php` now short-circuit `$ban_nav` / `$comm_nav` to `''` when the count is 0, so the template's existing `{if !empty(...)}` guard collapses the card.
- **#1226**: Public banlist filter bar gains the `server` + `time` selects + `Apply` button the public commslist already had. Wires `BanListView` with `server_list` + `filters.{server,time}` props mirroring `CommsListView`. Existing `?advType=where_banned&advSearch=<sid>` URLs still resolve via the legacy shim.
- **#1230**: `Hide / Show inactive` button on both surfaces now sets `aria-pressed`, and a single `.btn--secondary[aria-pressed="true"]` rule in `theme.css` paints the chip when active.

Closes #1225
Closes #1226
Closes #1230

## Test plan

- [ ] Fresh-install banlist (no bans) → empty state alone, no pagination card.
- [ ] Fresh-install commslist (no comms) → same.
- [ ] Public banlist: pick a server in the new select, hit Apply → list filtered, URL preserves the filter, paging links keep the filter.
- [ ] Public banlist: pick "Last 7 days" → date-filtered correctly.
- [ ] Hide-inactive button reads as filled/pressed when filtering, outline when not, in both light and dark.
- [ ] PHPStan + PHPUnit pass on CI (esp. SmartyTemplateRule on the new BanListView props).