### PR TITLE
fix(admin): add page padding to .page-toc-shell so admin-admins/admin-bans match (#1260)

### DIFF
--- a/web/themes/default/css/theme.css
+++ b/web/themes/default/css/theme.css
@@ -1264,6 +1264,20 @@ details.queue-row > summary > .row-actions {
   .page-toc__link    { transition: none; }
 }
 
+/* Page-padding inset for the cross-template ToC shell. Mirrors the
+   .page-section rule (1.5rem all-around, 1400px cap) so admin-admins
+   and admin-bans match the visual rhythm of every other admin page
+   #1240 wrapped — the sibling fix missed these two because they ride
+   `.page-toc-shell` instead of `.page-section`. Declared at the base
+   level (not inside the desktop @media below) so the inset applies
+   at every viewport, including the <1024px accordion shape. The
+   desktop media-query block adds `display: grid` etc. on top — both
+   sets of properties merge cleanly via the cascade. (#1260) */
+.page-toc-shell {
+  padding: 1.5rem;
+  max-width: 1400px;
+}
+
 /* Desktop layout — anchor sidebar floats next to the content column.
    The sidebar is `position: sticky`, scoped to the shell, so it stays
    pinned beneath the topbar (top: 4rem) while the user scrolls


### PR DESCRIPTION
## Summary

- #1240 added `.page-section { padding: 1.5rem; max-width: 1400px; }` and wrapped nine admin templates that had no outer container. The fix missed `admin-admins` and `admin-bans` because both pages ride a *different* wrapper — `.page-toc-shell`, introduced by #1207 ADM-3 / #1239 to host the page-level table of contents. That wrapper's only CSS rule was the desktop grid layout inside `@media (min-width: 1024px)`; it carried no padding (and no base-level declaration at all), so on `?p=admin&c=admins` the "Admins" heading slammed under the topbar and the table butted against the right edge of the column at every viewport.
- Add a base `.page-toc-shell { padding: 1.5rem; max-width: 1400px; }` rule **outside** the desktop media query so the inset applies at every viewport (including the `<1024px` accordion shape). The existing desktop block adds `display: grid` and friends on top — padding and max-width merge cleanly via the cascade with grid layout properties.
- Picked option (a) (the CSS rule edit) over option (b) (wrapping each shell in `<section class="page-section">`): single 14-line CSS edit vs touching three templates and one PHP echo, and `.page-toc-shell` is already the canonical "outermost content shell" identifier for these two pages — making it carry the inset directly mirrors how `.page-section` works for the rest of the admin tree. The cross-template open/close pairing is already brittle (closing `</div>` for admin-admins lives in `page_admin_overrides.tpl`, two templates away from where it opens); a second wrapper layered on top would compound that fragility.
- `admin-bans` inherits the fix via the same selector — `web/pages/admin.bans.php` echoes `<div class="page-toc-shell" data-testid="admin-bans-shell">` on the same wrapper class, so one CSS rule fixes both pages simultaneously.

## Test plan

- [x] PHPStan: `./sbpp.sh phpstan` — `[OK] No errors`.
- [x] ts-check: `./sbpp.sh ts-check` — clean.
- [x] E2E (admin/admins density rework): `./sbpp.sh e2e specs/flows/admin-admins-density.spec.ts` — 6 passed, 6 desktop-only specs skipped on mobile-chromium per design.
- [x] Confirmed the served stylesheet contains the new rule via `curl http://localhost:<port>/themes/default/css/theme.css`.
- [x] Static-checked `.page-toc-shell` has no other rule in `theme.css` that resets padding (only the desktop media-query block adds grid layout properties — no overrides).
- [ ] Visual smoke at `?p=admin&c=admins` and `?p=admin&c=bans`: heading sits a comfortable 1.5rem below the topbar; right edge of the table no longer butts the column edge; layout matches `?p=admin&c=settings`.
- [ ] Mobile (<1024px): accordion shape gets the same 1.5rem inset.
- Skipped `./sbpp.sh test` (pure CSS, no PHP behavior change) and `./sbpp.sh composer api-contract` (no handler/permission edits).

Closes #1260