### PR TITLE
fix(admin-settings): move page heading inside right column so sidebar sits flush (#1261)

### DIFF
--- a/web/themes/default/page_admin_settings_features.tpl
+++ b/web/themes/default/page_admin_settings_features.tpl
@@ -26,11 +26,6 @@
         - Save button: data-testid="settings-save".
 *}
 <div class="p-6">
-    <div class="mb-6">
-        <h1 style="font-size:var(--fs-2xl);font-weight:600;margin:0">Settings</h1>
-        <p class="text-sm text-muted m-0 mt-2">Optional features and integrations.</p>
-    </div>
-
     <div class="grid gap-4" style="grid-template-columns:14rem 1fr;align-items:start">
         <nav aria-label="Settings sections" role="tablist">
             <a class="sidebar__link" href="?p=admin&amp;c=settings&amp;section=settings"
@@ -60,6 +55,17 @@
         </nav>
 
         <div>
+            {*
+                #1261: page heading lives inside the right-column
+                <div> so the sidebar's first row sits flush with the
+                top of the section — see sibling
+                page_admin_settings_settings.tpl for the rationale.
+            *}
+            <div class="mb-6">
+                <h1 style="font-size:var(--fs-2xl);font-weight:600;margin:0">Settings</h1>
+                <p class="text-sm text-muted m-0 mt-2">Optional features and integrations.</p>
+            </div>
+
             {if NOT $can_web_settings}
                 <div class="card">
                     <div class="card__body">

--- a/web/themes/default/page_admin_settings_logs.tpl
+++ b/web/themes/default/page_admin_settings_logs.tpl
@@ -24,11 +24,6 @@
         - "Clear log" button: data-testid="logs-clear".
 *}
 <div class="p-6">
-    <div class="mb-6">
-        <h1 style="font-size:var(--fs-2xl);font-weight:600;margin:0">Settings</h1>
-        <p class="text-sm text-muted m-0 mt-2">System log of admin actions and warnings.</p>
-    </div>
-
     <div class="grid gap-4" style="grid-template-columns:14rem 1fr;align-items:start">
         <nav aria-label="Settings sections" role="tablist">
             <a class="sidebar__link" href="?p=admin&amp;c=settings&amp;section=settings"
@@ -58,6 +53,17 @@
         </nav>
 
         <div>
+            {*
+                #1261: page heading lives inside the right-column
+                <div> so the sidebar's first row sits flush with the
+                top of the section — see sibling
+                page_admin_settings_settings.tpl for the rationale.
+            *}
+            <div class="mb-6">
+                <h1 style="font-size:var(--fs-2xl);font-weight:600;margin:0">Settings</h1>
+                <p class="text-sm text-muted m-0 mt-2">System log of admin actions and warnings.</p>
+            </div>
+
             {if NOT $can_web_settings}
                 <div class="card">
                     <div class="card__body">

--- a/web/themes/default/page_admin_settings_settings.tpl
+++ b/web/themes/default/page_admin_settings_settings.tpl
@@ -56,11 +56,6 @@
     can discover the syntax without losing the safe-on-render contract.
 *}
 <div class="p-6">
-    <div class="mb-6">
-        <h1 style="font-size:var(--fs-2xl);font-weight:600;margin:0">Settings</h1>
-        <p class="text-sm text-muted m-0 mt-2">Site-wide configuration. Changes apply immediately.</p>
-    </div>
-
     <div class="grid gap-4" style="grid-template-columns:14rem 1fr;align-items:start">
         <nav aria-label="Settings sections" role="tablist">
             <a class="sidebar__link" href="?p=admin&amp;c=settings&amp;section=settings"
@@ -90,6 +85,20 @@
         </nav>
 
         <div>
+            {*
+                #1261: page heading lives inside the right-column
+                <div> so the sidebar's first row sits flush with the
+                top of the section. Moving the heading here keeps the
+                sidebar visually anchored to the page label rather
+                than floating below it (the previous shape rendered
+                ~3-4rem of empty space to the left of the heading
+                because the heading row sat *above* the grid).
+            *}
+            <div class="mb-6">
+                <h1 style="font-size:var(--fs-2xl);font-weight:600;margin:0">Settings</h1>
+                <p class="text-sm text-muted m-0 mt-2">Site-wide configuration. Changes apply immediately.</p>
+            </div>
+
             {if NOT $can_web_settings}
                 <div class="card">
                     <div class="card__body">

--- a/web/themes/default/page_admin_settings_themes.tpl
+++ b/web/themes/default/page_admin_settings_themes.tpl
@@ -46,11 +46,6 @@
         - "Use this theme" button: data-testid="theme-apply".
 *}
 <div class="p-6">
-    <div class="mb-6">
-        <h1 style="font-size:var(--fs-2xl);font-weight:600;margin:0">Settings</h1>
-        <p class="text-sm text-muted m-0 mt-2">Pick the theme that paints the panel chrome for every visitor.</p>
-    </div>
-
     <div class="grid gap-4" style="grid-template-columns:14rem 1fr;align-items:start">
         <nav aria-label="Settings sections" role="tablist">
             <a class="sidebar__link" href="?p=admin&amp;c=settings&amp;section=settings"
@@ -80,6 +75,17 @@
         </nav>
 
         <div>
+            {*
+                #1261: page heading lives inside the right-column
+                <div> so the sidebar's first row sits flush with the
+                top of the section — see sibling
+                page_admin_settings_settings.tpl for the rationale.
+            *}
+            <div class="mb-6">
+                <h1 style="font-size:var(--fs-2xl);font-weight:600;margin:0">Settings</h1>
+                <p class="text-sm text-muted m-0 mt-2">Pick the theme that paints the panel chrome for every visitor.</p>
+            </div>
+
             <div class="card">
                 <div class="card__header">
                     <div>


### PR DESCRIPTION
## Summary

- The four `page_admin_settings_*.tpl` templates each rendered the "Settings" heading + subtitle as a sibling block ABOVE the two-column sidebar grid. The grid's `align-items: start` then aligned the sidebar to the top of the form column — but that top was already ~3-4rem below the heading, so the sidebar's "Main" link visually floated in the middle of the section with empty space to the left of the heading. The active sub-page label was also y-misaligned with the global "Settings" label, forcing the eye to bounce between two unaligned hierarchy levels.
- Move the `<div class="mb-6">` heading block into the right-column `<div>` (the same column that holds the form/content cards) in all four settings templates. With the heading now inside the grid, the sidebar's first row sits flush with the section top and the active sub-page label lines up roughly with the global page label. No class or style changes; the move alone fixes it because `align-items: start` already does the right thing once the heading is inside the grid.
- Scope is intentionally tight to a heading-position fix. The four templates duplicate a fair amount of sidebar markup; consolidating that into a parameterized partial is being explored in #1259 (in flight in a parallel worktree) — keeping this PR decoupled lets it ship independently and avoids merge conflicts. If #1259 lands first this PR will need a small rebase to apply the move once into the consolidated partial.

Closes #1261

## Test plan

- [x] PHPStan (`./sbpp.sh phpstan`) — pass. The `SmartyTemplateRule` view↔template variable check is satisfied by the moved heading; no View DTO touched, no new variables introduced.
- [x] ts-check (`./sbpp.sh ts-check`) — pass. No JS edited.
- [x] PHPUnit (`./sbpp.sh test --filter=AdminSettings`) — no Settings-specific PHPUnit fixture exists; ran for completeness, nothing to assert.
- [x] Manual smoke on each sub-page (`?section=settings|features|logs|themes`) on a freshly seeded dev DB:
  - Each renders HTTP 200 with no Smarty / PHP warnings.
  - Each surfaces the active `aria-current="page"` on the matching `[data-testid="settings-tab-<slug>"]`.
  - DOM order asserts that the `<h1>Settings</h1>` now sits AFTER the `<nav>` (i.e. inside the right column), confirming the fix.
- [ ] API contract — skipped (no handler change, no `_register.php` edit).
- [ ] Playwright E2E — skipped. The two settings-touching specs (`smoke/admin/settings.spec.ts`, `flows/admin-settings-token-lifetimes.spec.ts`, `flows/empty-states.spec.ts` SET-1) all anchor on `data-testid` selectors that live inside the right-column form, none of which depend on heading position. CI will exercise them.

## Notes for reviewer

- **Relationship to #1259**: that issue parameterizes the duplicated sidebar markup. If it lands first, the four-file diff here collapses to a one-file edit on the new partial — trivial rebase. Decoupling was deliberate to keep PR scope tight per the issue plan.
- The `<div class="mb-6">` retains its bottom margin so the heading still gets the same gap to the first card; only its parent changed.
- The `align-items: start` on the grid already does the right thing once the heading is inside it — no CSS edits required.