### PR TITLE
feat(admin-chrome): unify sub-paged admin routes on Settings-style sidebar (#1259)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -577,7 +577,8 @@ exactly one View per request.
 
 Reference: `web/pages/admin.settings.php` is the long-standing
 canonical shape; #1239 brought servers / mods / groups / comms onto
-the same convention.
+the same convention; #1259 unified the chrome on the Settings-style
+vertical sidebar partial `core/admin_sidebar.tpl`.
 
 Page-handler shape:
 
@@ -585,10 +586,10 @@ Page-handler shape:
 $canList = $userbank->HasAccess(ADMIN_OWNER | ADMIN_LIST_SERVERS);
 $canAdd  = $userbank->HasAccess(ADMIN_OWNER | ADMIN_ADD_SERVER);
 
-/** @var list<array{slug: string, name: string, permission: int, url: string}> $sections */
+/** @var list<array{slug: string, name: string, permission: int, url: string, icon: string}> $sections */
 $sections = [
-    ['slug' => 'list', 'name' => 'List servers', 'permission' => …, 'url' => '?p=admin&c=servers&section=list'],
-    ['slug' => 'add',  'name' => 'Add new server', 'permission' => …, 'url' => '?p=admin&c=servers&section=add'],
+    ['slug' => 'list', 'name' => 'List servers',   'permission' => …, 'url' => '?p=admin&c=servers&section=list', 'icon' => 'server'],
+    ['slug' => 'add',  'name' => 'Add new server', 'permission' => …, 'url' => '?p=admin&c=servers&section=add',  'icon' => 'plus'],
 ];
 
 $validSlugs = ['list', 'add'];
@@ -597,31 +598,62 @@ if (!in_array($section, $validSlugs, true)) {
     $section = $canList ? 'list' : ($canAdd ? 'add' : 'list');
 }
 
-new AdminTabs($sections, $userbank, $theme, $section);
+// AdminTabs opens the sidebar shell + emits the <aside> + opens the
+// content column. The page handler is responsible for closing both
+// wrappers AFTER the View renders — see the docblock on AdminTabs.php.
+new AdminTabs($sections, $userbank, $theme, $section, 'Server sections');
 
 if ($section === 'add') {
     Renderer::render($theme, new AdminServersAddView(...));
+    echo '</div></div><!-- /.admin-sidebar-content + /.admin-sidebar-shell -->';
     return;
 }
 Renderer::render($theme, new AdminServersListView(...));
+echo '</div></div><!-- /.admin-sidebar-content + /.admin-sidebar-shell -->';
 ```
 
 Conventions:
 
 - Default to the FIRST accessible section when `?section=` is
   missing or unknown — never render a blank body.
-- The `core/admin_tabs.tpl` strip is now anchor links
-  (`<a href="?p=admin&c=…&section=…" data-testid="admin-tab-<slug>"
-  aria-current="page">`), not buttons. Pre-#1239 the strip emitted
-  `<button onclick="openTab(...)">` which dispatched to a JS
-  function in `sourcebans.js` (deleted at #1123 D1) — clicks did
-  nothing and every pane stacked together. Don't reintroduce the
-  button shape.
-- Each section's tab `slug` matches `?section=<slug>` AND the
+- Chrome is the parameterized vertical sidebar `core/admin_sidebar.tpl`
+  (#1259). `AdminTabs.php` opens `<div class="admin-sidebar-shell">`,
+  emits the `<aside>` + link list, then opens
+  `<div class="admin-sidebar-content">` for the page View; the page
+  handler **must** close both wrappers (`echo '</div></div>'`) AFTER
+  the `Renderer::render(...)` call so each section nests correctly.
+  Mirror the `page-toc-shell` pairing from Pattern B (#1239).
+- Each link is an anchor (`<a href="?p=admin&c=…&section=…"
+  data-testid="admin-tab-<slug>" aria-current="page">`), not a button.
+  Pre-#1239 the strip emitted `<button onclick="openTab(...)">` which
+  dispatched to a JS function in `sourcebans.js` (deleted at #1123
+  D1) — clicks did nothing and every pane stacked together. Don't
+  reintroduce the button shape.
+- Each `$sections` entry carries an `icon` (Lucide name — `server`,
+  `plus`, `users`, `puzzle`, `globe`, `package`, `cog`, `image`,
+  `flag`, `clipboard-list`, …). When omitted, the partial renders a
+  generic `circle-dot` so every row has matching visual weight.
+  Pick icons that match the visual vocabulary already in the
+  Settings sidebar (`page_admin_settings_*.tpl`).
+- Each section's `slug` matches `?section=<slug>` AND the
   `data-testid="admin-tab-<slug>"` hook on the rendered link.
   E2E specs anchor on the testid + the active link's
   `aria-current="page"` attribute (see
-  `web/tests/e2e/specs/responsive/admin-tabs.spec.ts`).
+  `web/tests/e2e/specs/responsive/admin-tabs.spec.ts` for the
+  mobile accordion contract; the sidebar sits at the top of the
+  content column at `<1024px` and floats next to it as a sticky
+  14rem rail at `>=1024px`).
+- Pass an aria-label as the fifth `AdminTabs` argument
+  (`'Server sections'`, `'MOD sections'`, …); screen readers
+  announce the navigation by this label. Defaults to "Page
+  sections" when omitted.
+- The `core/admin_tabs.tpl` partial still exists but is now
+  exclusively the **back-link-only** shape for edit-* pages
+  (`admin.edit.ban.php`, `admin.rcon.php`, …) which call
+  `new AdminTabs([], $userbank, $theme)`. AdminTabs.php routes
+  empty `$tabs` to that partial and non-empty `$tabs` to
+  `core/admin_sidebar.tpl`. Don't reach for `core/admin_tabs.tpl`
+  directly from new code.
 - Use Pattern A (this section) when sub-tasks are unrelated and a
   small two-or-three-section split is enough. Use Pattern B
   (page-level ToC, above) when sub-tasks are *context for each
@@ -693,6 +725,22 @@ audit (#1207) locked in. New CTAs:
   / settings) or Pattern B (page-level ToC — admin-admins, admin-bans);
   see "Sub-paged admin routes" and "Page-level table of contents"
   conventions above.
+- The horizontal `core/admin_tabs.tpl` pill strip for Pattern A
+  routes → #1259 unified the chrome on the Settings-style vertical
+  sidebar (`core/admin_sidebar.tpl`). New Pattern A routes (or
+  changes to existing ones) build a `$sections` array with a
+  Lucide `icon` per entry, pass an aria-label as the fifth
+  `AdminTabs` argument, and close the sidebar shell + content
+  column with `echo '</div></div>'` AFTER `Renderer::render(...)`.
+  `core/admin_tabs.tpl` is now exclusively the back-link-only
+  partial for edit-* pages — don't reach for it from new code.
+- Inlining settings-style sidebar markup inside templates (the
+  pre-#1259 shape: `<div class="grid" style="grid-template-columns:14rem 1fr">`
+  followed by an inline `<nav><a class="sidebar__link">…</a></nav>`
+  block in every `page_admin_settings_*.tpl`) → the sidebar is
+  now single-source in `core/admin_sidebar.tpl` and mounted by
+  `AdminTabs.php`. Page templates render their content column
+  body and nothing else.
 - New `install/` flow → DB is seeded out-of-band in dev.
 - String literals for action names → `Actions.PascalName`.
 - Inlining the table prefix → use `:prefix_` and let `Database` rewrite.
@@ -782,7 +830,9 @@ audit (#1207) locked in. New CTAs:
 | Live-preview Markdown in a settings textarea | `system.preview_intro_text` JSON action + `web/themes/default/page_admin_settings_settings.tpl` (`.dash-intro-editor` / `.dash-intro-preview`) |
 | Build an empty-state surface (first-run vs filtered, primary/secondary CTAs) | `.empty-state` rules in `web/themes/default/css/theme.css` + reference shapes in `page_servers.tpl`, `page_dashboard.tpl`, `page_bans.tpl`, `page_comms.tpl`, `page_admin_audit.tpl`, `page_admin_bans_protests.tpl`, `page_admin_bans_submissions.tpl` |
 | Add a sticky page-level ToC to a dense admin route (anchor sidebar at desktop, accordion at mobile) | `web/themes/default/page_toc.tpl` is the parameterized shared partial (toc_id / toc_label / toc_entries). `.page-toc-shell` / `.page-toc` / `.page-toc-content` / `.page-toc-section` rules in `web/themes/default/css/theme.css` carry the responsive layout. Two reference shapes: `admin-admins` (View-driven — `AdminAdminsListView` carries the toc payload, `page_admin_admins_list.tpl` opens the shell, `page_admin_overrides.tpl` closes it) and `admin-bans` (page-handler-driven — `web/pages/admin.bans.php` opens the shell + drives the partial via `$theme->display(...)`, emits `<section id="…">` wrappers in PHP echo around each `Renderer::render(...)`). See the Conventions section "Page-level table of contents (dense admin pages)" (#1207 ADM-3, #1239). |
-| Subdivide an admin route into `?section=<slug>` URLs (servers, mods, groups, comms, settings) | `web/pages/admin.settings.php` is the long-standing reference; #1239 brought servers / mods / groups / comms onto the same shape. Read `?section=…`, default to the first accessible section, render exactly one View per request. The chrome (`core/admin_tabs.tpl` + `web/includes/AdminTabs.php`) emits `<a href="?p=admin&c=<page>&section=<slug>" data-testid="admin-tab-<slug>">` anchor links — never `<button onclick="openTab(...)">` (the JS handler was deleted at #1123 D1; #1239 repaired the chrome). See "Sub-paged admin routes" in Conventions. |
+| Subdivide an admin route into `?section=<slug>` URLs (servers, mods, groups, comms, settings) | `web/pages/admin.settings.php` is the long-standing reference; #1239 brought servers / mods / groups / comms onto the same shape; #1259 unified the chrome on the Settings-style vertical sidebar. The shared partial is `web/themes/default/core/admin_sidebar.tpl` (parameterized on `tabs` / `active_tab` / `sidebar_id` / `sidebar_label`); `web/includes/AdminTabs.php` opens `<div class="admin-sidebar-shell">`, emits the `<aside>` + link list, opens `<div class="admin-sidebar-content">`, and the page handler closes both wrappers (`echo '</div></div>'`) AFTER `Renderer::render(...)`. Each `$sections` entry carries `slug` + `name` + `permission` + `url` + `icon` (Lucide name); the link emits `<a href="?p=admin&c=<page>&section=<slug>" data-testid="admin-tab-<slug>" aria-current="page">` — never `<button onclick="openTab(...)">` (the JS handler was deleted at #1123 D1). See "Sub-paged admin routes" in Conventions. |
+| Lay out a sub-paged admin route's chrome (the 14rem vertical sidebar at `>=1024px`, the `<details open>` accordion at `<1024px`) | `web/themes/default/core/admin_sidebar.tpl` (the partial) + the `.admin-sidebar-shell` / `.admin-sidebar` / `.admin-sidebar__details` / `.admin-sidebar__summary` / `.admin-sidebar__nav` / `.admin-sidebar__link` / `.admin-sidebar-content` rules in `web/themes/default/css/theme.css` (#1259). The active link reuses the shared `.sidebar__link[aria-current="page"]` rule from the main app shell so the dark-pill-in-light / brand-orange-in-dark treatment is single-source. |
+| Render the trailing "Back" link on edit-* admin pages (the only surface that calls `new AdminTabs([], …)`) | `web/themes/default/core/admin_tabs.tpl` is the back-link-only partial (it still has a defensive `{foreach}` for legacy themes, but `AdminTabs.php` only routes here when `$tabs === []`). Page handlers like `admin.edit.ban.php` / `admin.rcon.php` / `admin.email.php` call `new AdminTabs([], $userbank, $theme)` and the partial emits the right-aligned Back anchor (`.admin-tabs__back` in theme.css). |
 | Add or rename an admin-admins advanced-search filter | `web/pages/admin.admins.php` (filter-building loop + active-filter map for pagination) + `web/pages/admin.admins.search.php` (DTO population) + `web/includes/View/AdminAdminsSearchView.php` (`active_filter_*` properties) + `web/themes/default/box_admin_admins_search.tpl` (input + pre-fill). The form is single-submit AND-semantics with a backward-compat shim for legacy `advType=…&advSearch=…` URLs (#1207 ADM-4); cover new filters in `web/tests/integration/AdminAdminsSearchTest.php`. |
 | Add a shared "1 of these required" badge for an either/or input pair | `web/themes/default/page_submitban.tpl` (`data-required-group="…"` + the inline guard script — vanilla JS `// @ts-check`, blocks submit when both are empty) |
 | Bootstrap (paths, autoload, theme)     | `web/init.php`                                           |
@@ -799,7 +849,7 @@ audit (#1207) locked in. New CTAs:
 | Action -> permission lock              | `web/tests/api/PermissionMatrixTest.php`                 |
 | Add an E2E spec                        | `web/tests/e2e/specs/<smoke|flows|a11y|responsive>/...` + `web/tests/e2e/pages/...` |
 | Add a route to the screenshot gallery  | `web/tests/e2e/specs/_screenshots.spec.ts` (`ROUTES` array) |
-| Tweak mobile (<=768px) chrome layout   | `web/themes/default/css/theme.css` — see the `#1207` `@media (max-width: 768px)` blocks for the canonical shapes (icon-only topbar search, full-width drawer + scroll lock, scrollable admin tab strip with chip-style active state) |
+| Tweak mobile (<=768px) chrome layout   | `web/themes/default/css/theme.css` — see the `#1207` `@media (max-width: 768px)` blocks for the canonical shapes (icon-only topbar search, full-width drawer + scroll lock). Sub-paged admin routes (servers / mods / groups / settings) use the `<details open>` accordion in the `#1259` `@media (min-width: 1024px)` block (sidebar inline at `<1024px`, sticky 14rem rail at `>=1024px`); see "Sub-paged admin routes" in Conventions. |
 | Stop mobile browsers auto-linking SteamIDs / IPs as phone numbers | `web/themes/default/core/header.tpl` (`<meta name="format-detection" content="telephone=no…">` + `<meta name="x-apple-data-detectors">`) and the defensive `.drawer a[href^="tel:"]` reset in `theme.css` |
 | Lock page scroll while a modal-style chrome is open | `web/themes/default/css/theme.css` (`html:has(#drawer-root[data-drawer-open="true"]) { overflow: hidden; }` — pure-CSS, gates on the same `data-drawer-open` mirror theme.js sets, applies at every viewport so the drawer-open contract is symmetric desktop/mobile per the Linear/Vercel/Notion modal idiom) |
 | Disable the chrome's slide-in / fade animations for `prefers-reduced-motion` users | `web/themes/default/css/theme.css` (`@media (prefers-reduced-motion: reduce)` global block — see the matching note in "Playwright E2E specifics" / Conventions) |

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -83,7 +83,7 @@ web/
 │   ├── Log.php               Audit + error log (writes to sb_log)
 │   ├── Api.php / ApiError.php  JSON dispatcher + structured errors
 │   ├── CUserManager.php      Current admin + permission checks
-│   ├── AdminTabs.php         Render admin sub-tab bar
+│   ├── AdminTabs.php         Render Pattern A admin sub-section nav (vertical sidebar via core/admin_sidebar.tpl, or back-link strip via core/admin_tabs.tpl when $tabs is empty)
 │   ├── page-builder.php      route() + build() (the page router)
 │   ├── system-functions.php  Legacy helpers shared across pages
 │   ├── SmartyCustomFunctions.php  {help_icon} / {csrf_field} / {load_template}

--- a/web/includes/AdminTabs.php
+++ b/web/includes/AdminTabs.php
@@ -3,16 +3,58 @@
 /**
  * Class AdminTabs
  *
- * Renders the intra-page section nav (`core/admin_tabs.tpl`) used by
- * admin routes that subdivide their chrome into sections (servers,
- * mods, groups, …) plus the edit.* pages that pass an empty `$tabs`
- * array so only the trailing "Back" link renders.
+ * Drives the intra-page section nav for Pattern A admin routes — the
+ * routes that subdivide via `?section=<slug>` URLs (servers, mods,
+ * groups, settings; see AGENTS.md "Sub-paged admin routes").
  *
+ * #1259 unified the chrome
+ * ------------------------
+ * Pre-#1259 there were two visuals:
+ *   - settings rendered a vertical 14rem sidebar inline in every
+ *     `page_admin_settings_*.tpl`,
+ *   - servers / mods / groups rendered a horizontal pill strip via
+ *     `core/admin_tabs.tpl`.
+ * The horizontal strip read as "tabs into one document" rather than
+ * "navigation between sibling pages" even after #1239 routed each
+ * section to its own URL, and stacked badly on dense routes (mods has
+ * a 3-section strip already; admins family hits 4+). #1259 lifted the
+ * settings sidebar into the parameterized `core/admin_sidebar.tpl`
+ * partial and pointed every Pattern A handler at it via this class.
+ *
+ * #1239 — anchor links, no JS toggle
+ * ----------------------------------
  * Pre-#1239 the partial emitted `<button onclick="openTab(this, …)">`
  * elements that called a JS function from the v1.x sourcebans.js bulk
  * file (removed at #1123 D1). Clicks were silent no-ops — every pane
  * was visible permanently — until the broken chrome was repaired in
  * #1239 by routing each section through its own `?section=<slug>` URL.
+ *
+ * Two render shapes
+ * -----------------
+ * 1. `$tabs === []` (edit-* pages: admin.edit.ban.php, admin.rcon.php,
+ *    admin.email.php, …):
+ *      Emits `core/admin_tabs.tpl` which renders just the trailing
+ *      "Back" anchor — there's no sub-section nav for these surfaces,
+ *      only the affordance to leave. This shape is unchanged by #1259.
+ *
+ * 2. `$tabs !== []` (Pattern A pages: admin.servers, admin.mods,
+ *    admin.groups, admin.settings):
+ *      Opens the sidebar shell (`<div class="admin-sidebar-shell">`),
+ *      emits `core/admin_sidebar.tpl` (the <aside> + link list), then
+ *      opens the content column (`<div class="admin-sidebar-content">`).
+ *      The page handler is responsible for closing both wrappers AFTER
+ *      `Renderer::render(...)` runs:
+ *
+ *      ```php
+ *      new AdminTabs($sections, $userbank, $theme, $section, 'Settings sections');
+ *      Renderer::render($theme, new AdminSettingsView(...));
+ *      echo '</div></div><!-- /.admin-sidebar-content + /.admin-sidebar-shell -->';
+ *      ```
+ *
+ *      The two-end shape mirrors admin.bans.php's `page-toc-shell`
+ *      handling (#1239 Pattern B): the wrapper opens before the View
+ *      and closes after, so each `Renderer::render` call slots into
+ *      the content column without per-View structural changes.
  *
  * Each tab in the `$tabs` array carries:
  *   - `name`        Display label rendered as the link text.
@@ -25,17 +67,19 @@
  *                   so the partial doesn't need to know about routing.
  *   - `slug`        (required for non-empty tabs) Short identifier used
  *                   for the `data-testid` and active-tab matching.
+ *   - `icon`        (optional) Lucide icon name (e.g. `server`,
+ *                   `puzzle`). When omitted the partial falls back to
+ *                   a generic `circle-dot` so every row has matching
+ *                   visual weight.
  *   - `config`      (optional) Feature-toggle gate; the tab is omitted
  *                   when `config` is set and falsy.
- *
- * Edit-* pages still pass `[]` (empty `$tabs`) so the chrome renders
- * just the "Back" anchor — that path is unchanged.
  *
  * @phpstan-type TabSpec array{
  *     name: string,
  *     permission: int|string,
  *     url?: string,
  *     slug?: string,
+ *     icon?: string,
  *     config?: bool,
  * }
  */
@@ -48,15 +92,25 @@ class AdminTabs
      * @param list<TabSpec> $tabs
      * @param CUserManager  $userbank
      * @param Smarty        $theme
-     * @param string|null   $activeSlug Slug of the section to mark with
+     * @param string|null   $activeSlug    Slug of the section to mark with
      *     `aria-current="page"`. When null, the first accessible tab's
      *     slug wins. When the value doesn't match any visible tab no
-     *     tab is marked active (and the strip falls back to its
-     *     inactive look — still better than every tab looking
+     *     tab is marked active (and the sidebar falls back to its
+     *     all-inactive look — still better than every entry looking
      *     identical).
+     * @param string|null   $sidebarLabel  aria-label for the sidebar
+     *     <aside>. Screen readers announce the navigation by this
+     *     label ("Settings sections" / "Server sections" / …). Only
+     *     consumed when `$tabs` is non-empty (the empty-tabs Back-link
+     *     shape has no sidebar).
      */
-    public function __construct(array $tabs, $userbank, $theme, ?string $activeSlug = null)
-    {
+    public function __construct(
+        array $tabs,
+        $userbank,
+        $theme,
+        ?string $activeSlug = null,
+        ?string $sidebarLabel = null,
+    ) {
         foreach ($tabs as $tab) {
             if ($userbank->HasAccess($tab['permission'])) {
                 if (!isset($tab['config']) || $tab['config']) {
@@ -72,8 +126,30 @@ class AdminTabs
             $resolvedActive = (string) $this->tabs[0]['slug'];
         }
 
+        if ($this->tabs === []) {
+            // Edit-* shape: just the trailing Back anchor. The legacy
+            // partial still owns this surface — there's no sidebar to
+            // unify, only the "leave this page" affordance.
+            $theme->assign('tabs', $this->tabs);
+            $theme->assign('active_tab', $resolvedActive);
+            $theme->display('core/admin_tabs.tpl');
+            return;
+        }
+
+        // Sidebar shape (#1259). Open the shell + render the <aside> +
+        // open the content column. Closing tags live in the calling
+        // page handler — see the class docblock for the contract.
+        $sidebarId    = 'admin-sidebar';
+        $sidebarLabel = $sidebarLabel !== null && $sidebarLabel !== ''
+            ? $sidebarLabel
+            : 'Page sections';
+
+        echo '<div class="admin-sidebar-shell" data-testid="admin-sidebar-shell">';
         $theme->assign('tabs', $this->tabs);
         $theme->assign('active_tab', $resolvedActive);
-        $theme->display('core/admin_tabs.tpl');
+        $theme->assign('sidebar_id', $sidebarId);
+        $theme->assign('sidebar_label', $sidebarLabel);
+        $theme->display('core/admin_sidebar.tpl');
+        echo '<div class="admin-sidebar-content">';
     }
 }

--- a/web/includes/View/AdminFeaturesView.php
+++ b/web/includes/View/AdminFeaturesView.php
@@ -24,7 +24,6 @@ final class AdminFeaturesView extends View
         public readonly bool $steamapi,
         public readonly bool $can_web_settings,
         public readonly bool $can_owner,
-        public readonly string $active_section,
         public readonly bool $export_public,
         public readonly bool $enable_kickit,
         public readonly bool $enable_groupbanning,

--- a/web/includes/View/AdminLogsView.php
+++ b/web/includes/View/AdminLogsView.php
@@ -26,7 +26,6 @@ final class AdminLogsView extends View
         public readonly array $log_items,
         public readonly bool $can_web_settings,
         public readonly bool $can_owner,
-        public readonly string $active_section,
     ) {
     }
 }

--- a/web/includes/View/AdminSettingsView.php
+++ b/web/includes/View/AdminSettingsView.php
@@ -67,7 +67,6 @@ final class AdminSettingsView extends View
         public readonly array $bans_customreason,
         public readonly bool $can_web_settings,
         public readonly bool $can_owner,
-        public readonly string $active_section,
         public readonly bool $config_debug,
         public readonly bool $enable_submit,
         public readonly bool $enable_protest,

--- a/web/includes/View/AdminThemesView.php
+++ b/web/includes/View/AdminThemesView.php
@@ -14,14 +14,19 @@ namespace Sbpp\View;
  * success the JSON envelope's `reload: true` flag triggers a full
  * page reload so the new chrome paints with the right CSS bundle.
  *
+ * #1259 dropped `$active_section` from this View. Section navigation
+ * (the Settings sidebar) lives in `core/admin_sidebar.tpl` driven by
+ * `web/includes/AdminTabs.php`; the active link is resolved from the
+ * partial's `$active_tab` variable, not from a per-View property the
+ * template re-reads. AGENTS.md "Sub-paged admin routes" carries the
+ * convention.
+ *
  * Variable shape:
  *
  *   - `$theme_list` is the structural variable. Each row carries
  *     `dir`, `name`, `author`, `version`, `link`, `screenshot`, and
  *     `active`; the card grid uses every field.
- *   - `$can_*`, `$active_section`, `$current_theme_dir` drive
- *     section navigation + per-card affordances on the redesigned
- *     template.
+ *   - `$can_*`, `$current_theme_dir` drive per-card affordances.
  *   - `$theme_name`, `$theme_author`, `$theme_version`, `$theme_link`,
  *     `$theme_screenshot` describe the currently-selected theme as
  *     standalone scalars. They are preserved here for any third-party
@@ -55,7 +60,6 @@ final class AdminThemesView extends View
         public readonly string $theme_screenshot,
         public readonly bool $can_web_settings,
         public readonly bool $can_owner,
-        public readonly string $active_section,
         public readonly string $current_theme_dir,
     ) {
     }

--- a/web/pages/admin.groups.php
+++ b/web/pages/admin.groups.php
@@ -27,9 +27,8 @@ global $userbank, $theme;
  * Section routing (#1239 — Pattern A, settings-page shape).
  *
  * Mirrors `admin.servers.php`: read `?section=list|add`, render one
- * View per request, the AdminTabs strip is now anchor links instead
- * of the broken `<button onclick="openTab(...)">` chrome (sourcebans.js
- * was dropped at #1123 D1 and the click handler with it).
+ * View per request. #1259 unified the chrome on the Settings-style
+ * vertical sidebar (`core/admin_sidebar.tpl`).
  *
  * Note: legacy callers reach this page with `?gid=<n>` to focus the
  * master-detail editor on a specific group; that's a *list* concern,
@@ -38,19 +37,21 @@ global $userbank, $theme;
 $canList = $userbank->HasAccess(ADMIN_OWNER | ADMIN_LIST_GROUPS);
 $canAdd  = $userbank->HasAccess(ADMIN_OWNER | ADMIN_ADD_GROUP);
 
-/** @var list<array{slug: string, name: string, permission: int, url: string}> $sections */
+/** @var list<array{slug: string, name: string, permission: int, url: string, icon: string}> $sections */
 $sections = [
     [
         'slug'       => 'list',
         'name'       => 'List groups',
         'permission' => ADMIN_OWNER | ADMIN_LIST_GROUPS,
         'url'        => 'index.php?p=admin&c=groups&section=list',
+        'icon'       => 'users',
     ],
     [
         'slug'       => 'add',
         'name'       => 'Add a group',
         'permission' => ADMIN_OWNER | ADMIN_ADD_GROUP,
         'url'        => 'index.php?p=admin&c=groups&section=add',
+        'icon'       => 'plus',
     ],
 ];
 
@@ -66,12 +67,18 @@ if (!in_array($section, $validSlugs, true)) {
     }
 }
 
-new AdminTabs($sections, $userbank, $theme, $section);
+// AdminTabs opens the sidebar shell + emits the <aside> + opens the
+// content column. Closing tags live at the bottom of this file. The
+// PHP block here is followed by a `<script>` HTML island in the
+// default theme — the closing divs are emitted via PHP `echo` BEFORE
+// the file's closing PHP delimiter so the markup nests correctly.
+new AdminTabs($sections, $userbank, $theme, $section, 'Group sections');
 
 if ($section === 'add') {
     \Sbpp\View\Renderer::render($theme, new \Sbpp\View\AdminGroupsAddView(
         permission_addgroup: $canAdd,
     ));
+    echo '</div></div><!-- /.admin-sidebar-content + /.admin-sidebar-shell — opened by new AdminTabs(...) above -->';
     return;
 }
 
@@ -252,6 +259,8 @@ if (!empty($web_group_list)) {
     all_flags:                $all_flags,
     selected_group:           $selected_group,
 ));
+
+echo '</div></div><!-- /.admin-sidebar-content + /.admin-sidebar-shell — opened by new AdminTabs(...) above -->';
 ?>
 <script>
 // sb.accordion (sb.js) is the actual implementation, so call it directly.

--- a/web/pages/admin.mods.php
+++ b/web/pages/admin.mods.php
@@ -27,26 +27,30 @@ global $userbank, $theme;
  * Section routing (#1239 — Pattern A, settings-page shape).
  *
  * Mirrors `admin.servers.php`: read `?section=list|add`, render one
- * View per request, the AdminTabs strip is now anchor links instead
- * of the broken `<button onclick="openTab(...)">` chrome (sourcebans.js
- * was dropped at #1123 D1 and the click handler with it).
+ * View per request. #1259 unified the chrome on the Settings-style
+ * vertical sidebar (`core/admin_sidebar.tpl`), so the page handler
+ * just builds `$sections` (with an `icon` per row for the Lucide
+ * glyph) and lets `AdminTabs.php` open the shell + render the
+ * <aside> + open the content column.
  */
 $canList = $userbank->HasAccess(ADMIN_OWNER | ADMIN_LIST_MODS);
 $canAdd  = $userbank->HasAccess(ADMIN_OWNER | ADMIN_ADD_MODS);
 
-/** @var list<array{slug: string, name: string, permission: int, url: string}> $sections */
+/** @var list<array{slug: string, name: string, permission: int, url: string, icon: string}> $sections */
 $sections = [
     [
         'slug'       => 'list',
         'name'       => 'List MODs',
         'permission' => ADMIN_OWNER | ADMIN_LIST_MODS,
         'url'        => 'index.php?p=admin&c=mods&section=list',
+        'icon'       => 'puzzle',
     ],
     [
         'slug'       => 'add',
         'name'       => 'Add new MOD',
         'permission' => ADMIN_OWNER | ADMIN_ADD_MODS,
         'url'        => 'index.php?p=admin&c=mods&section=add',
+        'icon'       => 'plus',
     ],
 ];
 
@@ -62,12 +66,15 @@ if (!in_array($section, $validSlugs, true)) {
     }
 }
 
-new AdminTabs($sections, $userbank, $theme, $section);
+// AdminTabs opens the sidebar shell + emits the <aside> + opens the
+// content column. Closing tags live at the bottom of this file.
+new AdminTabs($sections, $userbank, $theme, $section, 'MOD sections');
 
 if ($section === 'add') {
     \Sbpp\View\Renderer::render($theme, new \Sbpp\View\AdminModsAddView(
         permission_add: $canAdd,
     ));
+    echo '</div></div><!-- /.admin-sidebar-content + /.admin-sidebar-shell — opened by new AdminTabs(...) above -->';
     return;
 }
 
@@ -81,3 +88,5 @@ $mod_count = (int) $GLOBALS['PDO']->query("SELECT COUNT(mid) AS cnt FROM `:prefi
     mod_count:             $mod_count,
     mod_list:              $mod_list,
 ));
+
+echo '</div></div><!-- /.admin-sidebar-content + /.admin-sidebar-shell — opened by new AdminTabs(...) above -->';

--- a/web/pages/admin.servers.php
+++ b/web/pages/admin.servers.php
@@ -9,30 +9,37 @@ global $userbank, $theme;
  * Section routing (#1239 — Pattern A, settings-page shape).
  *
  * Each section is its own page request keyed on `?section=list|add`;
- * the sub-nav at the top carries `aria-current="page"` on the active
- * link. Pre-#1239 the page emitted a broken `<button onclick="openTab(...)">`
- * strip (the JS handler was deleted with sourcebans.js at #1123 D1)
- * and rendered BOTH panes back-to-back below it, so the tab strip
- * lied about being a tab control. The fix follows the long-standing
- * `admin.settings.php` convention: read `?section=…`, render one View
- * per request, list every section pill as an anchor link.
+ * the sub-nav (vertical sidebar since #1259 — see AGENTS.md
+ * "Sub-paged admin routes") carries `aria-current="page"` on the
+ * active link. Pre-#1239 the page emitted a broken
+ * `<button onclick="openTab(...)">` strip (the JS handler was deleted
+ * with sourcebans.js at #1123 D1) and rendered BOTH panes back-to-back
+ * below it, so the tab strip lied about being a tab control. #1239
+ * routed each section to its own URL and #1259 unified the chrome on
+ * the Settings-style vertical sidebar.
+ *
+ * `icon` keys feed the Lucide glyph in `core/admin_sidebar.tpl`; the
+ * vocabulary mirrors `page_admin_settings_*.tpl` ("server" for the
+ * list, "plus" for the add form).
  */
 $canList = $userbank->HasAccess(ADMIN_OWNER | ADMIN_LIST_SERVERS);
 $canAdd  = $userbank->HasAccess(ADMIN_OWNER | ADMIN_ADD_SERVER);
 
-/** @var list<array{slug: string, name: string, permission: int, url: string}> $sections */
+/** @var list<array{slug: string, name: string, permission: int, url: string, icon: string}> $sections */
 $sections = [
     [
         'slug'       => 'list',
         'name'       => 'List servers',
         'permission' => ADMIN_OWNER | ADMIN_LIST_SERVERS,
         'url'        => 'index.php?p=admin&c=servers&section=list',
+        'icon'       => 'server',
     ],
     [
         'slug'       => 'add',
         'name'       => 'Add new server',
         'permission' => ADMIN_OWNER | ADMIN_ADD_SERVER,
         'url'        => 'index.php?p=admin&c=servers&section=add',
+        'icon'       => 'plus',
     ],
 ];
 
@@ -52,7 +59,10 @@ if (!in_array($section, $validSlugs, true)) {
     }
 }
 
-new AdminTabs($sections, $userbank, $theme, $section);
+// AdminTabs opens the sidebar shell + emits the <aside> + opens the
+// content column. Closing tags live at the bottom of this file —
+// document the pairing so future edits don't strand an open <div>.
+new AdminTabs($sections, $userbank, $theme, $section, 'Server sections');
 
 if ($section === 'add') {
     // List mods (drives the mod <select> in the add form).
@@ -71,6 +81,7 @@ if ($section === 'add') {
         grouplist: $grouplist,
         submit_text: 'Add Server',
     ));
+    echo '</div></div><!-- /.admin-sidebar-content + /.admin-sidebar-shell — opened by new AdminTabs(...) above -->';
     return;
 }
 
@@ -117,3 +128,5 @@ foreach ($servers as &$server) {
     server_count: (int) $server_count['cnt'],
     server_list: $servers,
 ));
+
+echo '</div></div><!-- /.admin-sidebar-content + /.admin-sidebar-shell — opened by new AdminTabs(...) above -->';

--- a/web/pages/admin.settings.php
+++ b/web/pages/admin.settings.php
@@ -34,20 +34,67 @@ use Sbpp\View\Renderer;
  * Section routing (B18 redesign).
  *
  * Each section is its own page request keyed on
- * `?section=settings|features|logs|themes`; the sub-nav at the top of
- * each template carries `aria-current="page"` on the active tab. CSRF
- * is enforced globally by `route()` in includes/page-builder.php.
+ * `?section=settings|features|logs|themes`; the sub-nav (vertical
+ * sidebar since #1259 — see AGENTS.md "Sub-paged admin routes")
+ * carries `aria-current="page"` on the active link. CSRF is enforced
+ * globally by `route()` in includes/page-builder.php.
  *
  * #1239 brought the rest of the admin family onto this same shape —
- * servers / mods / groups / comms now route via `?section=…` too.
- * See AGENTS.md "Sub-paged admin routes" for the convention; this
- * file remains the long-standing reference.
+ * servers / mods / groups now route via `?section=…` too.
+ * #1259 unified the chrome on the Settings-style vertical sidebar
+ * (`core/admin_sidebar.tpl` driven by `web/includes/AdminTabs.php`),
+ * replacing the Settings-only inline `<nav>` block that lived in
+ * every page_admin_settings_*.tpl. See AGENTS.md "Sub-paged admin
+ * routes" for the convention; this file remains the long-standing
+ * reference.
  */
 $validSections = ['settings', 'features', 'logs', 'themes'];
 $section = (string)($_GET['section'] ?? 'settings');
 if (!in_array($section, $validSections, true)) {
     $section = 'settings';
 }
+
+/*
+ * Sidebar sections.
+ *
+ * Every entry is gated behind ADMIN_OWNER|ADMIN_WEB_SETTINGS — the
+ * Settings page itself requires the flag, so the gate per row mirrors
+ * what the dispatcher would render anyway. `icon` keys feed the
+ * Lucide glyph in `core/admin_sidebar.tpl`; the vocabulary mirrors
+ * what the inline pre-#1259 templates declared (settings / toggle-
+ * right / scroll-text / palette).
+ */
+/** @var list<array{slug: string, name: string, permission: int, url: string, icon: string}> $sections */
+$sections = [
+    [
+        'slug'       => 'settings',
+        'name'       => 'Main',
+        'permission' => ADMIN_OWNER | ADMIN_WEB_SETTINGS,
+        'url'        => 'index.php?p=admin&c=settings&section=settings',
+        'icon'       => 'settings',
+    ],
+    [
+        'slug'       => 'features',
+        'name'       => 'Features',
+        'permission' => ADMIN_OWNER | ADMIN_WEB_SETTINGS,
+        'url'        => 'index.php?p=admin&c=settings&section=features',
+        'icon'       => 'toggle-right',
+    ],
+    [
+        'slug'       => 'logs',
+        'name'       => 'System Log',
+        'permission' => ADMIN_OWNER | ADMIN_WEB_SETTINGS,
+        'url'        => 'index.php?p=admin&c=settings&section=logs',
+        'icon'       => 'scroll-text',
+    ],
+    [
+        'slug'       => 'themes',
+        'name'       => 'Themes',
+        'permission' => ADMIN_OWNER | ADMIN_WEB_SETTINGS,
+        'url'        => 'index.php?p=admin&c=settings&section=themes',
+        'icon'       => 'palette',
+    ],
+];
 
 if (isset($_GET['log_clear']) && $_GET['log_clear'] === 'true') {
     if ($userbank->HasAccess(ADMIN_OWNER)) {
@@ -286,11 +333,18 @@ $currentScreenshotImg = '<img width="250px" height="170px" src="' . htmlspecialc
  */
 $perms = Perms::for($userbank);
 
+/*
+ * Open the sidebar shell (#1259). AdminTabs emits the outer
+ * `<div class="admin-sidebar-shell">` + the <aside> + the opening
+ * `<div class="admin-sidebar-content">`. Closing tags live near the
+ * bottom of this file — search for "/.admin-sidebar-shell".
+ */
+new AdminTabs($sections, $userbank, $theme, $section, 'Settings sections');
+
 if ($section === 'themes') {
     Renderer::render($theme, new AdminThemesView(
         can_web_settings:  $perms['can_web_settings'],
         can_owner:         $perms['can_owner'],
-        active_section:    $section,
         current_theme_dir: SB_THEME,
         theme_list:        $validThemes,
         theme_name:        strip_tags((string) constant('theme_name')),
@@ -353,7 +407,6 @@ if ($section === 'themes') {
     Renderer::render($theme, new AdminLogsView(
         can_web_settings: $perms['can_web_settings'],
         can_owner:        $perms['can_owner'],
-        active_section:   $section,
         clear_logs:       $userbank->HasAccess(ADMIN_OWNER) ? "( <a href='javascript:ClearLogs();'>Clear Log</a> )" : '',
         page_numbers:     $pageNumbers,
         log_items:        $logList,
@@ -362,7 +415,6 @@ if ($section === 'themes') {
     Renderer::render($theme, new AdminFeaturesView(
         can_web_settings:      $perms['can_web_settings'],
         can_owner:             $perms['can_owner'],
-        active_section:        $section,
         steamapi:              adminSettingsHasSteamApiKey(),
         export_public:         Config::getBool('config.exportpublic'),
         enable_kickit:         Config::getBool('config.enablekickit'),
@@ -411,7 +463,6 @@ if ($section === 'themes') {
     Renderer::render($theme, new AdminSettingsView(
         can_web_settings:            $perms['can_web_settings'],
         can_owner:                   $perms['can_owner'],
-        active_section:              $section,
         config_title:                (string) Config::get('template.title'),
         config_logo:                 (string) Config::get('template.logo'),
         config_min_password:         (int) MIN_PASS_LENGTH,
@@ -445,6 +496,15 @@ if ($section === 'themes') {
         config_mail_from_name:       (string) Config::get('config.mail.from_name'),
     ));
 }
+
+/*
+ * Close the sidebar shell (#1259) — paired with the `new AdminTabs(...)`
+ * call above. The `<div class="admin-sidebar-content">` and outer
+ * `<div class="admin-sidebar-shell">` were both opened by AdminTabs;
+ * the post-save flash <script> below sits OUTSIDE the shell so it
+ * never lands inside the content column.
+ */
+echo '</div></div><!-- /.admin-sidebar-content + /.admin-sidebar-shell — opened by new AdminTabs(...) above -->';
 
 /*
  * Post-save flash + bounce.

--- a/web/phpstan-baseline.neon
+++ b/web/phpstan-baseline.neon
@@ -15,13 +15,13 @@ parameters:
 		-
 			message: '#^Call to method assign\(\) on an unknown class Smarty\.$#'
 			identifier: class.notFound
-			count: 2
+			count: 6
 			path: includes/AdminTabs.php
 
 		-
 			message: '#^Call to method display\(\) on an unknown class Smarty\.$#'
 			identifier: class.notFound
-			count: 1
+			count: 2
 			path: includes/AdminTabs.php
 
 		-

--- a/web/tests/e2e/pages/admin/AdminSettings.ts
+++ b/web/tests/e2e/pages/admin/AdminSettings.ts
@@ -7,10 +7,11 @@ import { BasePage } from '../_base.ts';
  *
  * Pair: `web/pages/admin.settings.php` -> Sbpp\View\AdminSettingsView
  * + `page_admin_settings_settings.tpl` (default `?section=settings`).
- * The sub-nav at the top of every settings page renders the
- * `[data-testid="settings-tab-settings"]` link unconditionally; the
- * sub-nav itself sits outside the `$can_web_settings` gate, so this
- * selector remains valid even on the access-denied fallback.
+ * #1259 unified the sidebar chrome on `core/admin_sidebar.tpl` so the
+ * Settings page now exposes its sub-nav under the same testid shape
+ * every Pattern A admin route uses (`admin-tab-<slug>`); the sidebar
+ * itself sits outside the `$can_web_settings` gate, so this selector
+ * remains valid even on the access-denied fallback.
  */
 export class AdminSettingsPage extends BasePage {
     constructor(page: Page) {
@@ -20,7 +21,7 @@ export class AdminSettingsPage extends BasePage {
     readonly path = '/index.php?p=admin&c=settings';
 
     get pageMounted(): Locator {
-        return this.page.locator('[data-testid="settings-tab-settings"]');
+        return this.page.locator('[data-testid="admin-tab-settings"]');
     }
 
     async goto(): Promise<void> {

--- a/web/tests/e2e/specs/responsive/admin-tabs.spec.ts
+++ b/web/tests/e2e/specs/responsive/admin-tabs.spec.ts
@@ -1,51 +1,71 @@
 /**
- * Responsive: admin sub-section nav strip (#1207 ADM-8, #1239).
+ * Responsive: admin sub-section sidebar (#1259, replacing the
+ * horizontal strip contract from #1207 ADM-8 / #1239).
  *
  * iPhone-13 viewport contract for the Pattern A admin pages
- * (servers / mods / groups / settings — every page that still
- * subdivides its chrome via `?section=…` URLs and the
- * `core/admin_tabs.tpl` strip):
+ * (servers / mods / groups / settings — every page that subdivides
+ * its chrome via `?section=…` URLs):
  *
- *   - The intra-page admin tab strip ("List servers · Add new server"
- *     on `?p=admin&c=servers`, the equivalent on `&c=mods` /
- *     `&c=groups` / `&c=settings`) renders on a SINGLE
- *     horizontally-scrollable line at <=768px instead of wrapping
- *     onto multiple lines — wrapping was the source of the audit's
- *     "active-tab orange underline sits under the wrapped second
- *     line" complaint.
- *   - The active link gets a chip-style background (orange in light,
- *     brand-500 in dark) so the active state is visible at a glance
- *     even while the underline is partly out of view.
- *   - Every link is reachable via `scrollIntoViewIfNeeded` once the
- *     strip is the focused scrollable surface.
+ *   - Pre-#1259 these routes rendered a horizontal `core/admin_tabs.tpl`
+ *     pill strip (servers / mods / groups) AND a separate inline
+ *     14rem `<nav>` block for settings. Two patterns, same routing
+ *     shape, completely different chrome. #1259 unifies them on the
+ *     Settings-style vertical sidebar partial `core/admin_sidebar.tpl`,
+ *     mounted by `AdminTabs.php` whenever `$tabs` is non-empty.
+ *   - At <=1024px the sidebar collapses to a `<details open>`
+ *     accordion (matches `page_toc.tpl`'s mobile shape). The
+ *     summary chrome carries a chevron that rotates 180° on toggle.
+ *   - At >=1024px the sidebar floats next to the content column as
+ *     a sticky 14rem rail (`grid-template-columns: 14rem 1fr`).
+ *     This file's project-gating is mobile-only — the desktop
+ *     shape is exercised by the screenshot gallery and ad-hoc
+ *     `chromium` runs of these specs.
+ *   - The active link still carries `aria-current="page"` and
+ *     reuses the shared `.sidebar__link[aria-current="page"]` rule
+ *     — dark-pill in light theme, brand-orange in dark — so the
+ *     highlight is single-source with the main app shell.
  *
- * Markup contract: `core/admin_tabs.tpl` renders
- *   <div class="admin-tabs flex gap-2 mb-4 items-center">
- *     <a href="?p=admin&c=…&section=…"
- *        data-testid="admin-tab-<slug>"
- *        [aria-current="page" if active]>…</a>
- *     …
- *     <a class="admin-tabs__back" data-testid="admin-tab-back">…</a>
+ * Markup contract (`core/admin_sidebar.tpl`, mounted by
+ * `AdminTabs.php` when `$tabs !== []`):
+ *
+ *   <div class="admin-sidebar-shell" data-testid="admin-sidebar-shell">
+ *     <aside class="admin-sidebar"
+ *            data-testid="admin-sidebar"
+ *            aria-label="<sidebar label>">
+ *       <details class="admin-sidebar__details" open>
+ *         <summary class="admin-sidebar__summary">…</summary>
+ *         <nav class="admin-sidebar__nav">
+ *           <a class="sidebar__link admin-sidebar__link"
+ *              href="?p=admin&c=…&section=…"
+ *              data-testid="admin-tab-<slug>"
+ *              [aria-current="page" if active]>…</a>
+ *           …
+ *         </nav>
+ *       </details>
+ *     </aside>
+ *     <div class="admin-sidebar-content">
+ *       <!-- page View(s) render here -->
+ *     </div>
  *   </div>
- * The CSS at theme.css's #1207 block flips `flex-wrap: nowrap` +
- * `overflow-x: auto` and gives the active link the chip background.
+ *
+ * The per-link `data-testid="admin-tab-<slug>"` matches the legacy
+ * `core/admin_tabs.tpl` strip's hook so any spec that anchored on
+ * `admin-tab-<slug>` keeps working.
  *
  * #1239 — admin-bans is Pattern B
  * --------------------------------
- * `?p=admin&c=bans` no longer renders this strip at all. Pre-#1239 it
- * carried the broken `<button onclick="openTab(...)">` chrome that
- * stacked every pane below the strip; #1239 repaired it by riding the
- * sticky page-level ToC pattern (admin-admins family). The bans
- * responsive contract is locked elsewhere (`responsive/admin-queue.spec.ts`
- * for the moderation queue, the screenshot gallery for the ToC
- * sidebar / accordion). Don't add bans assertions to this file.
+ * `?p=admin&c=bans` does not render this sidebar — it rides the
+ * page-level ToC pattern (admin-admins family) per #1239. Don't add
+ * bans assertions here; the bans responsive contract is locked in
+ * `responsive/admin-queue.spec.ts` for the moderation queue and the
+ * screenshot gallery for the sticky ToC sidebar / accordion.
  *
  * Project gating: mobile-chromium only.
  */
 
 import { expect, test } from '../../fixtures/auth.ts';
 
-test.describe('responsive: admin tab strip', () => {
+test.describe('responsive: admin sub-section sidebar', () => {
     test.beforeEach(({}, testInfo) => {
         test.skip(
             testInfo.project.name !== 'mobile-chromium',
@@ -53,85 +73,120 @@ test.describe('responsive: admin tab strip', () => {
         );
     });
 
-    test('admin-servers tabs render on a single scrollable line at iPhone-13 width', async ({ page }) => {
+    test('admin-servers sidebar renders as an accordion at iPhone-13 width', async ({ page }) => {
         // `?p=admin&c=servers` is the canonical Pattern A page after
-        // #1239 — two sections ("List servers", "Add new server")
-        // wired through `?section=list|add`. Same chrome (`admin_tabs.tpl`),
-        // just anchor links instead of broken `<button onclick>`s.
+        // #1239 (#1259 lifted the strip onto the sidebar partial) —
+        // two sections ("List servers", "Add new server") wired
+        // through `?section=list|add`.
         await page.goto('/index.php?p=admin&c=servers');
 
-        // `data-testid="admin-tabs"` is the primary hook on the
-        // wrapper (#1123 contract); the `.first()` is defensive
-        // because edit-* pages render an empty-tabs strip alongside
-        // a populated one in some flows. See admin_tabs.tpl for the
-        // markup.
-        const strip = page.locator('[data-testid="admin-tabs"]').first();
-        await expect(strip).toBeVisible();
+        // The shell is the grid host; at <1024px it collapses to a
+        // single column so the sidebar paints inline above the
+        // content column.
+        const shell = page.locator('[data-testid="admin-sidebar-shell"]');
+        await expect(shell).toBeVisible();
+
+        const sidebar = page.locator('[data-testid="admin-sidebar"]');
+        await expect(sidebar).toBeVisible();
 
         // Sections rendered for an OWNER user (the seeded admin/admin
         // holds OWNER, so every permission-gated section is visible).
-        // Bare `?p=admin&c=servers` defaults to the `list` section per
-        // admin.servers.php's "first accessible section" fallback.
         const tabSlugs = ['list', 'add'];
-        const firstTab = strip.locator(`[data-testid="admin-tab-${tabSlugs[0]}"]`);
-        const firstBox = await firstTab.boundingBox();
-        expect(firstBox, `${tabSlugs[0]} tab must render a bounding box`).not.toBeNull();
-
-        for (const slug of tabSlugs.slice(1)) {
-            const tab = strip.locator(`[data-testid="admin-tab-${slug}"]`);
+        for (const slug of tabSlugs) {
+            const tab = sidebar.locator(`[data-testid="admin-tab-${slug}"]`);
             await expect(tab).toBeAttached();
-            const box = await tab.boundingBox();
-            expect(box, `${slug} tab must render a bounding box`).not.toBeNull();
-            // All tabs share the same y-axis position — i.e. on a
-            // single line. The pre-fix shape wrapped after ~2 tabs
-            // and the second line was 30+ px lower. Allow a 2px
-            // tolerance for sub-pixel layout differences.
-            expect(Math.abs(box!.y - firstBox!.y)).toBeLessThanOrEqual(2);
+            await expect(tab).toBeVisible();
         }
 
-        // The strip itself fits the viewport (the inner content
-        // CAN exceed it — that's what the horizontal scroll is for —
-        // but the wrapper element still respects the viewport bounds).
-        const vw = page.viewportSize()?.width ?? 0;
-        const stripBox = await strip.boundingBox();
-        expect(stripBox, 'admin-tabs wrapper must render a bounding box').not.toBeNull();
-        expect(stripBox!.x).toBeGreaterThanOrEqual(-1);
-        expect(stripBox!.x + stripBox!.width).toBeLessThanOrEqual(vw + 1);
+        // The accordion summary is mobile-only chrome — visible at
+        // <1024px, hidden at desktop.
+        const summary = sidebar.locator('.admin-sidebar__summary');
+        await expect(summary).toBeVisible();
 
-        // Every visible link is reachable inside the viewport. With
-        // only 2 sections the strip doesn't actually overflow at
-        // iPhone-13 width, but the call still verifies that the
-        // last tab paints fully on-screen — same invariant a future
-        // 3+ section page on this strip would exercise.
-        const lastTab = strip.locator(`[data-testid="admin-tab-${tabSlugs[tabSlugs.length - 1]}"]`);
-        await lastTab.scrollIntoViewIfNeeded();
-        const lastBox = await lastTab.boundingBox();
-        expect(lastBox, 'last tab must render a bounding box once scrolled into view').not.toBeNull();
-        expect(lastBox!.x).toBeGreaterThanOrEqual(-1);
-        expect(lastBox!.x + lastBox!.width).toBeLessThanOrEqual(vw + 1);
+        // The link list paints as a vertical stack — the second link
+        // sits below the first by at least one row's worth of pixels.
+        // The pre-#1259 shape was a horizontal strip where every link
+        // shared the same y-axis (the failure mode this assertion
+        // guards against).
+        const firstTab = sidebar.locator(`[data-testid="admin-tab-${tabSlugs[0]}"]`);
+        const secondTab = sidebar.locator(`[data-testid="admin-tab-${tabSlugs[1]}"]`);
+        const firstBox = await firstTab.boundingBox();
+        const secondBox = await secondTab.boundingBox();
+        expect(firstBox, `${tabSlugs[0]} tab must render a bounding box`).not.toBeNull();
+        expect(secondBox, `${tabSlugs[1]} tab must render a bounding box`).not.toBeNull();
+        // The second link is below the first by at least 16px (one
+        // padded row) and shares the same x-coordinate (vertical
+        // stack). Allow 2px tolerance on x for sub-pixel layout.
+        expect(secondBox!.y).toBeGreaterThan(firstBox!.y + 16);
+        expect(Math.abs(secondBox!.x - firstBox!.x)).toBeLessThanOrEqual(2);
+
+        // The shell stays inside the viewport — the accordion is a
+        // single column at this width, no horizontal scroll.
+        const vw = page.viewportSize()?.width ?? 0;
+        const shellBox = await shell.boundingBox();
+        expect(shellBox, 'admin-sidebar-shell wrapper must render a bounding box').not.toBeNull();
+        expect(shellBox!.x).toBeGreaterThanOrEqual(-1);
+        expect(shellBox!.x + shellBox!.width).toBeLessThanOrEqual(vw + 1);
+    });
+
+    test('admin-servers accordion can be toggled closed at iPhone-13 width', async ({ page }) => {
+        // The mobile shape is `<details open>` — the link list is
+        // visible by default and the user can collapse it via the
+        // chevron summary. Verify the toggle closes the link list
+        // without breaking the rest of the page.
+        await page.goto('/index.php?p=admin&c=servers');
+
+        const sidebar = page.locator('[data-testid="admin-sidebar"]');
+        const details = sidebar.locator('.admin-sidebar__details');
+        const summary = sidebar.locator('.admin-sidebar__summary');
+        const firstLink = sidebar.locator('[data-testid="admin-tab-list"]');
+
+        await expect(details).toHaveAttribute('open', '');
+        await expect(firstLink).toBeVisible();
+
+        await summary.click();
+
+        // After collapsing, the `open` attribute is removed. The link
+        // list is technically still in the DOM but `<details>` hides
+        // its children so Playwright's visibility check returns false.
+        await expect(details).not.toHaveAttribute('open', /.*/);
+        await expect(firstLink).toBeHidden();
+
+        // Toggle back open so any subsequent debugging artefacts
+        // (screenshots / traces) capture the default state.
+        await summary.click();
+        await expect(details).toHaveAttribute('open', '');
+        await expect(firstLink).toBeVisible();
     });
 
     /**
-     * Assert the active admin-tab carries the chip-style brand-orange
-     * background at the iPhone-13 viewport. Shared between the light
-     * and dark theme tests — both variants resolve to the brand orange
-     * family (`--brand-600` in light = rgb(234, 88, 12); `--brand-500`
-     * in dark = rgb(249, 115, 22)). The R/G/B heuristic below tolerates
-     * both, which is the actual contract: "active tab is orange-ish
-     * regardless of theme", not "active tab is exactly hex X".
+     * Assert the active sidebar link carries the brand-orange highlight
+     * at the iPhone-13 viewport. Shared between the light and dark
+     * theme tests — the active token differs by theme:
+     *   - light: `var(--zinc-900)` (dark pill on light background)
+     *   - dark:  `var(--brand-700)` (orange pill on dark background)
+     * The R/G/B heuristic below tolerates either: "active link is
+     * highlighted with a saturated colour, not the surrounding text
+     * colour", which is what users see.
      * @param {import('@playwright/test').Page} page
+     * @param {'light' | 'dark'} theme
      */
-    async function assertActiveTabIsBrandOrange(
+    async function assertActiveLinkIsHighlighted(
         page: import('@playwright/test').Page,
+        theme: 'light' | 'dark',
     ): Promise<void> {
-        // Scope by `[data-testid="admin-tabs"]` (the wrapper hook
-        // added in #1123 testability-hooks pass), then pivot on the
-        // ARIA `[aria-current="page"]` attribute — that's the
-        // load-bearing identifier for "active tab" on this strip.
-        const activeTab = page.locator('[data-testid="admin-tabs"] > [aria-current="page"]').first();
-        await expect(activeTab).toBeVisible();
+        // Scope by `[data-testid="admin-sidebar"]` (the new wrapper
+        // hook for #1259), then pivot on the ARIA `[aria-current="page"]`
+        // attribute — that's the load-bearing identifier for the
+        // active section. Use `.first()` because the parent app
+        // shell carries its own sidebar with active links too; we
+        // want the admin sub-section sidebar.
+        const activeLink = page.locator(
+            '[data-testid="admin-sidebar"] [aria-current="page"]',
+        ).first();
+        await expect(activeLink).toBeVisible();
 
-        const bgColor = await activeTab.evaluate((el) =>
+        const bgColor = await activeLink.evaluate((el) =>
             getComputedStyle(el).backgroundColor,
         );
         const match = bgColor.match(/rgba?\((\d+),\s*(\d+),\s*(\d+)/);
@@ -140,40 +195,49 @@ test.describe('responsive: admin tab strip', () => {
         const r = parseInt(rStr, 10);
         const g = parseInt(gStr, 10);
         const b = parseInt(bStr, 10);
-        // Brand orange family: red dominates, blue is small.
-        expect(r).toBeGreaterThan(180);
-        expect(r).toBeGreaterThan(g);
-        expect(r).toBeGreaterThan(b);
-        expect(b).toBeLessThan(60);
+
+        if (theme === 'dark') {
+            // Brand orange family in dark: red dominates, blue is small.
+            expect(r).toBeGreaterThan(180);
+            expect(r).toBeGreaterThan(g);
+            expect(r).toBeGreaterThan(b);
+            expect(b).toBeLessThan(60);
+        } else {
+            // Zinc-900 in light: very dark, all three channels < 60.
+            // The contrast contract is "active is dark on light" — any
+            // saturated dark colour passes. Specifically rgb(24, 24, 27)
+            // for `--zinc-900`, but tolerating drift up to ~60.
+            expect(r).toBeLessThan(60);
+            expect(g).toBeLessThan(60);
+            expect(b).toBeLessThan(60);
+        }
     }
 
-    test('active tab carries the chip-style background at iPhone-13 width (light)', async ({ page }) => {
+    test('active link carries the highlighted background at iPhone-13 width (light)', async ({ page }) => {
         // The first section ("List servers", slug "list") is the
         // default-active one when the page lands on
         // `?p=admin&c=servers` without an explicit `&section=…` —
         // see admin.servers.php's "first accessible section is
         // active" fallback. It carries `aria-current="page"` per
-        // admin_tabs.tpl + AdminTabs.php's `$resolvedActive` path.
-        // The chip-style background at <=768px maps to `var(--brand-600)`
-        // in light theme — that's the orange CTA token (#ea580c).
+        // admin_sidebar.tpl + AdminTabs.php's `$resolvedActive` path.
         await page.goto('/index.php?p=admin&c=servers');
-        await assertActiveTabIsBrandOrange(page);
+        await assertActiveLinkIsHighlighted(page, 'light');
     });
 
-    test('active tab keeps the chip-style background under html.dark', async ({ page }) => {
-        // Slice 1 review finding 3: the dark-theme override
-        // (`html.dark .admin-tabs > [aria-current="page"] { background: var(--brand-500); … }`
-        // in theme.css) was previously unlocked — a token rename
-        // would silently regress the dark variant. Seed the theme
-        // preference into localStorage before the first navigation
-        // so theme.js's init-time `applyTheme(currentTheme())`
-        // resolves to `html.dark` on first paint (no toggle click
-        // needed, no race with the post-paint click handler).
+    test('active link keeps the highlighted background under html.dark', async ({ page }) => {
+        // The dark-theme override
+        // (`html.dark .sidebar__link[aria-current="page"] { background:
+        // var(--brand-700); … }` in theme.css) is the brand-orange
+        // family. Seed the theme preference into localStorage before
+        // the first navigation so theme.js's init-time
+        // `applyTheme(currentTheme())` resolves to `html.dark` on
+        // first paint (no toggle click needed, no race with the
+        // post-paint click handler).
         await page.addInitScript(() => {
             try { localStorage.setItem('sbpp-theme', 'dark'); } catch (e) { /* ignore */ }
         });
         await page.goto('/index.php?p=admin&c=servers');
         await expect(page.locator('html')).toHaveClass(/(^|\s)dark(\s|$)/);
-        await assertActiveTabIsBrandOrange(page);
+        await assertActiveLinkIsHighlighted(page, 'dark');
     });
 });

--- a/web/themes/default/core/admin_sidebar.tpl
+++ b/web/themes/default/core/admin_sidebar.tpl
@@ -1,0 +1,105 @@
+{*
+    SourceBans++ 2026 — chrome / admin_sidebar.tpl
+
+    Sub-paged admin sidebar nav (#1259). Renders the vertical-sidebar
+    chrome used by Pattern A admin routes — settings / servers / mods /
+    groups — that subdivide via `?section=<slug>` URLs. Pre-#1259 each
+    of these routes drew its own chrome:
+
+      - Settings inlined a full `<nav><a class="sidebar__link">…</a></nav>`
+        block inside every settings template (page_admin_settings_*.tpl),
+        each declaring its own `grid-template-columns:14rem 1fr`.
+      - Servers / Mods / Groups rode the horizontal `core/admin_tabs.tpl`
+        pill strip (the Back-link partial in disguise — same wrapper,
+        different visual).
+
+    Two patterns, same routing shape, completely different chrome. #1259
+    unifies them on the Settings-style vertical sidebar so dense routes
+    with 3+ sections (mods/groups/admins) don't read as a chip cluster.
+
+    Caller contract (mirrors page_toc.tpl):
+
+      - Open `<div class="admin-sidebar-shell">` BEFORE this partial. The
+        shell is the grid host at >=1024px (14rem + 1fr) and a single
+        column at <1024px.
+      - {include this partial} — emits the <aside> + the link list.
+      - Open `<div class="admin-sidebar-content">` AFTER this partial.
+        That's the content column the sticky sidebar pairs with at
+        desktop.
+      - Close both wrappers AFTER the View(s) render. Document the
+        open/close pairing with a comment at each end so edits don't
+        silently break the layout.
+
+    AdminTabs.php drives all three open/close emissions when $tabs is
+    non-empty so individual page handlers stay terse — see the docblock
+    there for the contract + the close-tag echo at the bottom of each
+    Pattern A page handler (admin.servers.php, admin.mods.php,
+    admin.groups.php, admin.settings.php).
+
+    Parameters (assigned by AdminTabs.php):
+
+        $tabs           list<TabSpec>. Already filtered by AdminTabs to
+                        the entries the current user can reach +
+                        feature-toggle gates (config:false drops the
+                        entry). Each tab carries:
+                          - name  (string)         link label
+                          - slug  (string)         URL slug + testid
+                          - url   (string)         href target
+                          - icon  (string|null)    optional Lucide name
+                                                   (e.g. "server",
+                                                   "puzzle"). Falls
+                                                   back to a generic
+                                                   "circle-dot" if
+                                                   omitted so every
+                                                   row has matching
+                                                   visual weight.
+
+        $active_tab     string. Slug of the section currently rendered;
+                        the matching <a> carries `aria-current="page"`.
+                        Empty string = no link is marked active (the
+                        sidebar still renders).
+
+        $sidebar_id     string. Testid prefix for the surface (e.g.
+                        "admin-servers-sidebar"). Drives
+                        `data-testid="{$sidebar_id}"` on the <aside>
+                        and `data-testid="admin-tab-<slug>"` on each
+                        link (the per-link hook is shared with the
+                        legacy admin_tabs.tpl strip — E2E specs that
+                        anchor on `admin-tab-<slug>` keep working).
+
+        $sidebar_label  string. aria-label on the <aside>. Screen
+                        readers announce the navigation by this label
+                        ("Settings sections" / "Server sections" / …).
+
+    Mobile (<1024px) shape:
+        The aside collapses to a `<details open>` accordion — the
+        section name above the link list, chevron rotates 180° on
+        toggle. Identical pattern to page_toc.tpl so both surfaces
+        feel consistent. The link list paints inline at desktop;
+        the summary chrome is hidden via `.admin-sidebar__summary
+        { display: none }` in the desktop media query.
+*}
+<aside class="admin-sidebar"
+       data-testid="{$sidebar_id}"
+       aria-label="{$sidebar_label}">
+    <details class="admin-sidebar__details" open>
+        <summary class="admin-sidebar__summary">
+            <span class="admin-sidebar__summary-label">
+                <i data-lucide="menu" style="width:14px;height:14px"></i>
+                {$sidebar_label}
+            </span>
+            <i data-lucide="chevron-down" class="admin-sidebar__chevron" style="width:14px;height:14px"></i>
+        </summary>
+        <nav class="admin-sidebar__nav" aria-label="{$sidebar_label}">
+            {foreach from=$tabs item=tab}
+                <a class="sidebar__link admin-sidebar__link"
+                   href="{$tab.url}"
+                   data-testid="admin-tab-{$tab.slug}"
+                   {if $tab.slug == $active_tab}aria-current="page"{/if}>
+                    <i data-lucide="{if $tab.icon}{$tab.icon}{else}circle-dot{/if}"></i>
+                    <span>{$tab.name}</span>
+                </a>
+            {/foreach}
+        </nav>
+    </details>
+</aside>

--- a/web/themes/default/core/admin_tabs.tpl
+++ b/web/themes/default/core/admin_tabs.tpl
@@ -1,12 +1,26 @@
 {*
     SourceBans++ 2026 — chrome / admin_tabs.tpl
 
-    Admin sub-section nav. Pair: includes/AdminTabs.php (assigns $tabs +
-    $active_tab). Rendered with the theme's button primitives —
-    inactive sections use `btn--ghost`; the section whose `slug`
-    matches `$active_tab` carries `aria-current="page"` and gets the
-    active treatment via `.admin-tabs > [aria-current="page"]` in
-    theme.css (#1186).
+    Trailing "Back" anchor strip for admin edit-* pages. Pair:
+    includes/AdminTabs.php (assigns $tabs + $active_tab; only routes
+    to this partial when $tabs === [], i.e. the edit-* shape that
+    only needs the Back affordance).
+
+    #1259 — sidebar split
+    --------------------
+    Pre-#1259 this partial drew BOTH the section-nav strip (when $tabs
+    was non-empty) AND the trailing Back link. Pattern A admin routes
+    (servers / mods / groups / settings) have since been moved onto
+    the parameterized `core/admin_sidebar.tpl` partial — see #1259's
+    notes in includes/AdminTabs.php — so this template's only job
+    today is the Back link emitted by edit-* pages that pass `$tabs
+    === []`.
+
+    The `{foreach}` branch below survives for defence in depth: any
+    third-party theme that calls `$theme->display('core/admin_tabs.tpl')`
+    with a populated `$tabs` array still gets a working horizontal
+    strip. AdminTabs.php's #1259 router never sends a populated array
+    here.
 
     #1239 — anchor links, no JS toggle
     ----------------------------------
@@ -14,33 +28,22 @@
     elements that called a JS function from the v1.x sourcebans.js
     bulk file (removed at #1123 D1, AGENTS.md "Anti-patterns"). The
     handler was silently dead, so every pane stacked together below
-    the strip with no way to switch. The chrome now emits anchor
-    `<a href="{$tab.url}">` links — each section is its own URL
-    (`?p=admin&c=<page>&section=<slug>`), linkable, back-button-
-    friendly, and works with JS off. The page handler is responsible
-    for building each tab's `url` + `slug` and for routing the
-    request to render exactly the matching section. See
-    `web/pages/admin.servers.php` / `admin.mods.php` /
-    `admin.groups.php` / `admin.comms.php` for the canonical Pattern A
-    shape, and `admin.settings.php` for the long-standing reference
-    that #1239 is aligning the rest of the admin family with.
+    the strip with no way to switch. Since #1259 the section-nav
+    surface lives in `core/admin_sidebar.tpl`; the foreach below is
+    the legacy fallback shape only.
 
-    "Back" is rendered outside the tab cluster (right-aligned via the
-    `.admin-tabs__back` rule) so it no longer reads as a peer tab
-    (#1186). Edit-* pages that pass an empty `$tabs` array still
-    render the Back link standalone — the right-aligned positioning
-    is harmless when no siblings precede it.
+    "Back" is right-aligned via the `.admin-tabs__back` rule
+    (#1186) so it visibly separates from the (now legacy-fallback)
+    tab cluster.
 
     A11y note (#1124 Slice 2): the wrapper used to declare
     role="tablist" with role="tab" children. The full ARIA tabs
     pattern is NOT implemented (the surface is now a plain anchor
     list — semantically a navigation toolbar, not a JS tab control),
     so the roles described an interaction model the DOM didn't
-    honour. axe-core's `aria-required-children` rule additionally
-    flags the trailing "Back" anchor as an unallowed [tabindex]
-    child of role="tablist". Both reasons argue for the same fix:
-    drop the partial ARIA roles, label the wrapper as a plain
-    "Admin sections" toolbar so SR users hear the links as links.
+    honour. Both reasons argue for the same fix: drop the partial
+    ARIA roles, label the wrapper as a plain "Admin sections"
+    toolbar so SR users hear the links as links.
 *}
 <div class="admin-tabs flex gap-2 mb-4 items-center" data-testid="admin-tabs" aria-label="Admin sections">
     {foreach from=$tabs item=tab}

--- a/web/themes/default/css/theme.css
+++ b/web/themes/default/css/theme.css
@@ -400,6 +400,112 @@ html.dark .admin-tabs > [aria-current="page"] { border-bottom-color: var(--brand
   .admin-tabs__back { margin-left: 0; }
 }
 
+/* ---- Admin sidebar (Pattern A `?section=…` routes) ----
+   #1259 unified the chrome for sub-paged admin routes (servers / mods
+   / groups / settings) onto a single vertical sidebar partial
+   (`core/admin_sidebar.tpl` driven by `web/includes/AdminTabs.php`).
+   Pre-#1259 settings had its own inline sidebar markup with a
+   hardcoded `grid-template-columns:14rem 1fr` while servers/mods/
+   groups rendered the horizontal `core/admin_tabs.tpl` pill strip;
+   the layout below replaces both shapes.
+
+   Markup contract (see core/admin_sidebar.tpl + the page handlers
+   that call `new AdminTabs(...)` with a non-empty $sections):
+     .admin-sidebar-shell           outer wrapper (grid host on desktop,
+                                    single column at <1024px). Opened
+                                    by AdminTabs.php; closed by the
+                                    page handler after Renderer::render.
+       .admin-sidebar               <aside> with the link list
+         .admin-sidebar__details    <details open> on every viewport;
+                                    the open/close toggle only does
+                                    something at <1024px (mobile/
+                                    narrow-tablet accordion). At
+                                    >=1024px we force the contents
+                                    visible regardless of [open]
+                                    state so a stray click on the
+                                    summary can't strand the user
+                                    without navigation.
+         .admin-sidebar__summary    mobile-only chrome (hidden on
+                                    desktop)
+         .admin-sidebar__nav        <nav> wrapping the links
+         .admin-sidebar__link       per-link rule overlay on the
+                                    shared `.sidebar__link` from the
+                                    main app shell — keeps icon+label
+                                    spacing consistent with the
+                                    primary sidebar.
+       .admin-sidebar-content       the content column the sticky
+                                    sidebar pairs with at >=1024px
+
+   The active link reuses `.sidebar__link[aria-current="page"]` from
+   the main shell so the dark-pill / brand-orange treatment is
+   single-source. */
+.admin-sidebar { font-size: var(--fs-sm); margin-bottom: 1rem; }
+.admin-sidebar__details {
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  background: var(--bg-surface);
+}
+.admin-sidebar__summary {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  padding: 0.625rem 0.875rem;
+  font-weight: 600;
+  cursor: pointer;
+  list-style: none;
+  user-select: none;
+}
+.admin-sidebar__summary::-webkit-details-marker { display: none; }
+.admin-sidebar__summary-label { display: inline-flex; align-items: center; gap: 0.5rem; }
+.admin-sidebar__chevron {
+  transition: transform .15s ease;
+  color: var(--text-muted);
+}
+.admin-sidebar__details[open] .admin-sidebar__chevron { transform: rotate(180deg); }
+.admin-sidebar__nav {
+  padding: 0.5rem 0.5rem 0.625rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.125rem;
+}
+@media (prefers-reduced-motion: reduce) {
+  .admin-sidebar__chevron { transition: none; }
+}
+
+/* Desktop layout — vertical sidebar floats next to the content
+   column. The aside is `position: sticky`, scoped to the shell, so
+   it stays pinned beneath the topbar (top: 4rem) while the user
+   scrolls through the active section. We force the <details>
+   contents visible regardless of [open] so accidental "collapse"
+   at desktop can't strand the user without navigation — same
+   contract as `.page-toc` (#1207 ADM-3 / #1239). */
+@media (min-width: 1024px) {
+  .admin-sidebar-shell {
+    display: grid;
+    grid-template-columns: 14rem minmax(0, 1fr);
+    gap: 1.5rem;
+    align-items: start;
+  }
+  .admin-sidebar {
+    position: sticky;
+    top: 4rem;
+    align-self: start;
+    margin-bottom: 0;
+  }
+  .admin-sidebar__details {
+    border: none;
+    background: transparent;
+  }
+  .admin-sidebar__summary { display: none; }
+  /* Keep the link list visible whether the user has toggled the
+     <details> closed or not — at desktop the sidebar is a permanent
+     navigation surface, the accordion gesture only matters at mobile. */
+  .admin-sidebar__details .admin-sidebar__nav { display: flex !important; }
+  .admin-sidebar__nav { padding: 0; }
+  .admin-sidebar-content { min-width: 0; }
+}
+
 /* ---- Inputs ---- */
 .input, .select, .textarea {
   width: 100%; height: 2.25rem; padding: 0 0.75rem;

--- a/web/themes/default/page_admin_settings_features.tpl
+++ b/web/themes/default/page_admin_settings_features.tpl
@@ -6,12 +6,18 @@
     routes by ?section= and renders one View per request — see
     sibling page_admin_settings_settings.tpl for the rationale).
 
+    #1259 — sidebar lifted into a shared partial: the inline
+    `<nav>` block + `grid-template-columns:14rem 1fr` shell that
+    used to wrap this template's content is now driven by
+    `core/admin_sidebar.tpl` via `web/includes/AdminTabs.php`. The
+    page handler (admin.settings.php) opens the shell BEFORE this
+    template renders. See AGENTS.md "Sub-paged admin routes".
+
     Variable contract (kept in sync by SmartyTemplateRule):
         Permission gates:
             $can_web_settings — gates the entire body.
             $can_owner — currently unused in this section but kept
                 across all settings views for parity.
-        Section nav: $active_section.
         Toggles: $export_public, $enable_kickit,
             $enable_groupbanning, $enable_friendsbanning,
             $enable_adminrehashing, $enable_steamlogin,
@@ -21,7 +27,10 @@
             inputs the same way the legacy theme did).
 
     Testability hooks:
-        - Sub-nav links: data-testid="settings-tab-<key>".
+        - Sidebar links: data-testid="admin-tab-<slug>" (#1259 — the
+          legacy `settings-tab-<slug>` was renamed to the cross-page
+          `admin-tab-<slug>` shape now that the chrome is shared with
+          servers / mods / groups).
         - Each toggle row: data-testid="setting-row" + data-key="<key>".
         - Save button: data-testid="settings-save".
 *}
@@ -31,42 +40,13 @@
         <p class="text-sm text-muted m-0 mt-2">Optional features and integrations.</p>
     </div>
 
-    <div class="grid gap-4" style="grid-template-columns:14rem 1fr;align-items:start">
-        <nav aria-label="Settings sections" role="tablist">
-            <a class="sidebar__link" href="?p=admin&amp;c=settings&amp;section=settings"
-               role="tab"
-               data-testid="settings-tab-settings"
-               {if $active_section == 'settings'}aria-current="page"{/if}>
-                <i data-lucide="settings"></i> Main
-            </a>
-            <a class="sidebar__link" href="?p=admin&amp;c=settings&amp;section=features"
-               role="tab"
-               data-testid="settings-tab-features"
-               {if $active_section == 'features'}aria-current="page"{/if}>
-                <i data-lucide="toggle-right"></i> Features
-            </a>
-            <a class="sidebar__link" href="?p=admin&amp;c=settings&amp;section=logs"
-               role="tab"
-               data-testid="settings-tab-logs"
-               {if $active_section == 'logs'}aria-current="page"{/if}>
-                <i data-lucide="scroll-text"></i> System Log
-            </a>
-            <a class="sidebar__link" href="?p=admin&amp;c=settings&amp;section=themes"
-               role="tab"
-               data-testid="settings-tab-themes"
-               {if $active_section == 'themes'}aria-current="page"{/if}>
-                <i data-lucide="palette"></i> Themes
-            </a>
-        </nav>
-
-        <div>
-            {if NOT $can_web_settings}
-                <div class="card">
-                    <div class="card__body">
-                        <p class="text-muted">Access denied. <code>ADMIN_WEB_SETTINGS</code> required.</p>
-                    </div>
-                </div>
-            {else}
+    {if NOT $can_web_settings}
+        <div class="card">
+            <div class="card__body">
+                <p class="text-muted">Access denied. <code>ADMIN_WEB_SETTINGS</code> required.</p>
+            </div>
+        </div>
+    {else}
                 <form action="?p=admin&amp;c=settings&amp;section=features" method="post" class="space-y-4">
                     {csrf_field}
                     <input type="hidden" name="settingsGroup" value="features">
@@ -162,7 +142,5 @@
                         </button>
                     </div>
                 </form>
-            {/if}
-        </div>
-    </div>
+    {/if}
 </div>

--- a/web/themes/default/page_admin_settings_logs.tpl
+++ b/web/themes/default/page_admin_settings_logs.tpl
@@ -6,6 +6,13 @@
     routes by ?section= and renders one View per request — see
     sibling page_admin_settings_settings.tpl for the rationale).
 
+    #1259 — sidebar lifted into a shared partial: the inline
+    `<nav>` block + `grid-template-columns:14rem 1fr` shell that
+    used to wrap this template's content is now driven by
+    `core/admin_sidebar.tpl` via `web/includes/AdminTabs.php`. The
+    page handler (admin.settings.php) opens the shell BEFORE this
+    template renders. See AGENTS.md "Sub-paged admin routes".
+
     Variable contract (kept in sync by SmartyTemplateRule):
         Permission gates:
             $can_web_settings — required to see the table; mirrors
@@ -13,13 +20,13 @@
             $can_owner — required to truncate the log table; gates
                 the "Clear log" button. Mirrors legacy
                 CheckAccess(ADMIN_OWNER) before TRUNCATE.
-        Section nav: $active_section.
         Pagination: $page_numbers (server-built nav HTML emitted via
             nofilter; see annotation below).
         Rows: $log_items — list of legacy-shaped log dicts.
 
     Testability hooks:
-        - Sub-nav links: data-testid="settings-tab-<key>".
+        - Sidebar links: data-testid="admin-tab-<slug>" (#1259 unified
+          shape across servers / mods / groups / settings).
         - Each summary row: data-testid="log-row" + data-id (lid).
         - "Clear log" button: data-testid="logs-clear".
 *}
@@ -29,42 +36,13 @@
         <p class="text-sm text-muted m-0 mt-2">System log of admin actions and warnings.</p>
     </div>
 
-    <div class="grid gap-4" style="grid-template-columns:14rem 1fr;align-items:start">
-        <nav aria-label="Settings sections" role="tablist">
-            <a class="sidebar__link" href="?p=admin&amp;c=settings&amp;section=settings"
-               role="tab"
-               data-testid="settings-tab-settings"
-               {if $active_section == 'settings'}aria-current="page"{/if}>
-                <i data-lucide="settings"></i> Main
-            </a>
-            <a class="sidebar__link" href="?p=admin&amp;c=settings&amp;section=features"
-               role="tab"
-               data-testid="settings-tab-features"
-               {if $active_section == 'features'}aria-current="page"{/if}>
-                <i data-lucide="toggle-right"></i> Features
-            </a>
-            <a class="sidebar__link" href="?p=admin&amp;c=settings&amp;section=logs"
-               role="tab"
-               data-testid="settings-tab-logs"
-               {if $active_section == 'logs'}aria-current="page"{/if}>
-                <i data-lucide="scroll-text"></i> System Log
-            </a>
-            <a class="sidebar__link" href="?p=admin&amp;c=settings&amp;section=themes"
-               role="tab"
-               data-testid="settings-tab-themes"
-               {if $active_section == 'themes'}aria-current="page"{/if}>
-                <i data-lucide="palette"></i> Themes
-            </a>
-        </nav>
-
-        <div>
-            {if NOT $can_web_settings}
-                <div class="card">
-                    <div class="card__body">
-                        <p class="text-muted">Access denied. <code>ADMIN_WEB_SETTINGS</code> required.</p>
-                    </div>
-                </div>
-            {else}
+    {if NOT $can_web_settings}
+        <div class="card">
+            <div class="card__body">
+                <p class="text-muted">Access denied. <code>ADMIN_WEB_SETTINGS</code> required.</p>
+            </div>
+        </div>
+    {else}
                 {* nofilter: $clear_logs is the legacy default-theme "( <a href='javascript:ClearLogs();'>Clear Log</a> )" link string built in admin.settings.php (static literal gated by ADMIN_OWNER, no user input). The sbpp2026 layout renders its own <button> below via $can_owner, so the legacy link string is captured-and-discarded — keeps the SmartyTemplateRule view↔template parity green without rendering the link twice. Drop this capture and the View property when D1 retires the default theme. *}
                 {capture name="legacy_clear_logs"}{$clear_logs nofilter}{/capture}
                 <div class="card">
@@ -139,9 +117,7 @@
                         {/if}
                     </div>
                 </div>
-            {/if}
-        </div>
-    </div>
+    {/if}
 </div>
 
 <script>

--- a/web/themes/default/page_admin_settings_settings.tpl
+++ b/web/themes/default/page_admin_settings_settings.tpl
@@ -5,8 +5,20 @@
     Sbpp\View\AdminSettingsView + web/pages/admin.settings.php (which
     routes by ?section=settings|features|logs|themes and renders one
     View per request — no AdminTabs JS tab-switching, no .tabcontent
-    wrapper divs). The active section is reflected in the sub-nav at
-    the top of every settings template via aria-current="page".
+    wrapper divs).
+
+    #1259 — sidebar lifted into a shared partial
+    --------------------------------------------
+    Pre-#1259 every page_admin_settings_*.tpl carried its own inline
+    `<nav>` block declaring four `<a class="sidebar__link">` rows and
+    a hardcoded `grid-template-columns:14rem 1fr` layout. The chrome
+    is now driven by `core/admin_sidebar.tpl` (parameterized partial)
+    via `web/includes/AdminTabs.php`; the page handler
+    (admin.settings.php) opens the shell + sidebar + content column
+    BEFORE this template renders. This template's outer wrapper is
+    just the page-level padding + heading + form content — no grid,
+    no sidebar markup. See AGENTS.md "Sub-paged admin routes" for
+    the convention.
 
     Variable contract (kept in sync by SmartyTemplateRule):
         Permission gates:
@@ -16,7 +28,6 @@
             $can_owner — kept for parity with sibling settings views;
                 this template doesn't gate any UI on it directly but
                 the View constructor requires it for cross-tab parity.
-        Section nav: $active_section.
         Settings values: $config_title, $config_logo,
             $config_min_password, $config_dateformat,
             $config_dash_title, $config_dash_text, $auth_maxlife,
@@ -36,8 +47,11 @@
             $config_mail_from_email, $config_mail_from_name.
 
     Testability hooks:
-        - Sub-nav <a> elements: data-testid="settings-tab-<key>"
-          + aria-current="page" on the active tab.
+        - Sidebar <a> elements: data-testid="admin-tab-<slug>" (#1259
+          unified hook on `core/admin_sidebar.tpl`; the legacy
+          `settings-tab-<slug>` hook is gone — the chrome is now
+          shared with servers / mods / groups so the testid uses the
+          common `admin-tab-<slug>` shape).
         - Each <label>/<input> row: data-testid="setting-row" +
           data-key="<setting.key>" so end-to-end tests can target
           a setting by its persisted name (e.g. "template.title")
@@ -61,42 +75,13 @@
         <p class="text-sm text-muted m-0 mt-2">Site-wide configuration. Changes apply immediately.</p>
     </div>
 
-    <div class="grid gap-4" style="grid-template-columns:14rem 1fr;align-items:start">
-        <nav aria-label="Settings sections" role="tablist">
-            <a class="sidebar__link" href="?p=admin&amp;c=settings&amp;section=settings"
-               role="tab"
-               data-testid="settings-tab-settings"
-               {if $active_section == 'settings'}aria-current="page"{/if}>
-                <i data-lucide="settings"></i> Main
-            </a>
-            <a class="sidebar__link" href="?p=admin&amp;c=settings&amp;section=features"
-               role="tab"
-               data-testid="settings-tab-features"
-               {if $active_section == 'features'}aria-current="page"{/if}>
-                <i data-lucide="toggle-right"></i> Features
-            </a>
-            <a class="sidebar__link" href="?p=admin&amp;c=settings&amp;section=logs"
-               role="tab"
-               data-testid="settings-tab-logs"
-               {if $active_section == 'logs'}aria-current="page"{/if}>
-                <i data-lucide="scroll-text"></i> System Log
-            </a>
-            <a class="sidebar__link" href="?p=admin&amp;c=settings&amp;section=themes"
-               role="tab"
-               data-testid="settings-tab-themes"
-               {if $active_section == 'themes'}aria-current="page"{/if}>
-                <i data-lucide="palette"></i> Themes
-            </a>
-        </nav>
-
-        <div>
-            {if NOT $can_web_settings}
-                <div class="card">
-                    <div class="card__body">
-                        <p class="text-muted">Access denied. <code>ADMIN_WEB_SETTINGS</code> required.</p>
-                    </div>
-                </div>
-            {else}
+    {if NOT $can_web_settings}
+        <div class="card">
+            <div class="card__body">
+                <p class="text-muted">Access denied. <code>ADMIN_WEB_SETTINGS</code> required.</p>
+            </div>
+        </div>
+    {else}
                 <form action="?p=admin&amp;c=settings&amp;section=settings" method="post" class="space-y-4" id="form-settings-main">
                     {csrf_field}
                     <input type="hidden" name="settingsGroup" value="mainsettings">
@@ -505,9 +490,7 @@
                         </button>
                     </div>
                 </form>
-            {/if}
-        </div>
-    </div>
+    {/if}
 </div>
 
 <script>

--- a/web/themes/default/page_admin_settings_themes.tpl
+++ b/web/themes/default/page_admin_settings_themes.tpl
@@ -6,6 +6,13 @@
     routes by ?section= and renders one View per request — see
     sibling page_admin_settings_settings.tpl for the rationale).
 
+    #1259 — sidebar lifted into a shared partial: the inline
+    `<nav>` block + `grid-template-columns:14rem 1fr` shell that
+    used to wrap this template's content is now driven by
+    `core/admin_sidebar.tpl` via `web/includes/AdminTabs.php`. The
+    page handler (admin.settings.php) opens the shell BEFORE this
+    template renders. See AGENTS.md "Sub-paged admin routes".
+
     Variable contract (kept in sync by SmartyTemplateRule):
         Permission gates:
             $can_web_settings — required to enable the "Use this
@@ -13,7 +20,6 @@
                 way so admins without write access still get a
                 useful preview of what's installed.
             $can_owner — kept for parity with sibling settings views.
-        Section nav: $active_section.
         Active selection: $current_theme_dir (matches the running
             SB_THEME constant).
         Theme list: $theme_list — list of dicts with keys dir, name,
@@ -40,7 +46,8 @@
         tickets cannot touch web/api/handlers/.
 
     Testability hooks:
-        - Sub-nav links: data-testid="settings-tab-<key>".
+        - Sidebar links: data-testid="admin-tab-<slug>" (#1259 unified
+          shape across servers / mods / groups / settings).
         - Each card: data-testid="theme-card" + data-theme="<dir>".
         - Active card carries aria-current="true" (per the issue plan).
         - "Use this theme" button: data-testid="theme-apply".
@@ -50,36 +57,6 @@
         <h1 style="font-size:var(--fs-2xl);font-weight:600;margin:0">Settings</h1>
         <p class="text-sm text-muted m-0 mt-2">Pick the theme that paints the panel chrome for every visitor.</p>
     </div>
-
-    <div class="grid gap-4" style="grid-template-columns:14rem 1fr;align-items:start">
-        <nav aria-label="Settings sections" role="tablist">
-            <a class="sidebar__link" href="?p=admin&amp;c=settings&amp;section=settings"
-               role="tab"
-               data-testid="settings-tab-settings"
-               {if $active_section == 'settings'}aria-current="page"{/if}>
-                <i data-lucide="settings"></i> Main
-            </a>
-            <a class="sidebar__link" href="?p=admin&amp;c=settings&amp;section=features"
-               role="tab"
-               data-testid="settings-tab-features"
-               {if $active_section == 'features'}aria-current="page"{/if}>
-                <i data-lucide="toggle-right"></i> Features
-            </a>
-            <a class="sidebar__link" href="?p=admin&amp;c=settings&amp;section=logs"
-               role="tab"
-               data-testid="settings-tab-logs"
-               {if $active_section == 'logs'}aria-current="page"{/if}>
-                <i data-lucide="scroll-text"></i> System Log
-            </a>
-            <a class="sidebar__link" href="?p=admin&amp;c=settings&amp;section=themes"
-               role="tab"
-               data-testid="settings-tab-themes"
-               {if $active_section == 'themes'}aria-current="page"{/if}>
-                <i data-lucide="palette"></i> Themes
-            </a>
-        </nav>
-
-        <div>
             <div class="card">
                 <div class="card__header">
                     <div>
@@ -152,8 +129,6 @@
                     </div>
                 </div>
             </div>
-        </div>
-    </div>
 </div>
 
 <script>


### PR DESCRIPTION
## Summary

Closes #1259.

Pre-#1259 the Pattern A admin routes (servers / mods / groups /
settings) carried two different chromes for the same `?section=…`
routing shape — Settings rendered an inline 14rem vertical sidebar
in every `page_admin_settings_*.tpl`, while servers / mods / groups
rendered the horizontal `core/admin_tabs.tpl` pill strip. The strip
read as "tabs into one document" rather than "navigation between
sibling pages" even after #1239 routed each section to its own URL,
and stacked badly on dense routes.

This PR lifts the Settings sidebar markup into a parameterized
partial (`core/admin_sidebar.tpl`) and points every Pattern A
handler at it via `AdminTabs.php`. The horizontal strip lives on
exclusively as the trailing "Back" affordance for edit-* pages
(the `$tabs === []` branch of `AdminTabs.php`).

### Changed

- New parameterized partial `web/themes/default/core/admin_sidebar.tpl`
  keyed on `tabs` / `active_tab` / `sidebar_id` / `sidebar_label`.
  Each entry carries `name` / `slug` / `url` + an optional `icon`
  (Lucide name; falls back to `circle-dot` so every row has matching
  visual weight).
- `web/includes/AdminTabs.php` now branches on `$tabs`: empty →
  emits `core/admin_tabs.tpl` for the trailing Back link (edit-*
  pages); non-empty → opens `<div class="admin-sidebar-shell">`,
  emits the `<aside>` + link list, opens `<div class="admin-sidebar-content">`.
  Page handlers close both wrappers (`echo '</div></div>'`) AFTER
  `Renderer::render(...)` — mirrors `admin.bans.php`'s
  `page-toc-shell` pairing.
- `admin.servers.php`, `admin.mods.php`, `admin.groups.php`,
  `admin.settings.php` add an `icon` per `$sections` entry (server,
  plus, users, puzzle, globe, package, cog, image, flag,
  clipboard-list, …) and emit the closing `echo` after each
  `Renderer::render(...)`. `admin.settings.php` was restructured
  to build `$sections` once + render exactly one View per
  `?section=…`, dropping the per-template inline sidebar markup.
- The four `page_admin_settings_*.tpl` templates lose their inline
  `<nav>` blocks (and the `settings-tab-*` testids). The
  `active_section` property is removed from `AdminFeaturesView` /
  `AdminSettingsView` / `AdminLogsView` / `AdminThemesView` so
  PHPStan's `SmartyTemplateRule` stays clean.
- `web/themes/default/css/theme.css` gains the `.admin-sidebar-shell`
  / `.admin-sidebar` / `.admin-sidebar__details` / `.admin-sidebar__summary`
  / `.admin-sidebar__nav` / `.admin-sidebar__link` /
  `.admin-sidebar-content` rules. Mobile (<1024px) collapses the
  sidebar into a `<details open>` accordion with a chevron summary
  (mirrors `page_toc.tpl`'s mobile shape); desktop (>=1024px) floats
  it as a sticky 14rem rail next to the content column. The active
  link reuses the shared `.sidebar__link[aria-current="page"]` rule
  so the dark-pill-in-light / brand-orange-in-dark treatment is
  single-source with the main app shell.

### Edit-* pages and the Back-link decision

Edit-* pages (`admin.edit.ban.php`, `admin.rcon.php`,
`admin.email.php`, …) still call `new AdminTabs([], $userbank, $theme)`;
that branch lands on `core/admin_tabs.tpl` which is now exclusively
the back-link-only partial. The Back affordance has nowhere natural
to live in a vertical sidebar (it's the "leave this page" CTA, not a
sub-section), so the simplest path was to keep it in the existing
horizontal partial gated on `$tabs === []`.

`core/admin_tabs.tpl` retains a defensive `{foreach}` loop for
third-party themes that still call it with a populated `$tabs`
array — the docblock explains it's the legacy fallback shape only;
`AdminTabs.php`'s #1259 router never sends a populated array there.

### Docs

- `AGENTS.md` "Sub-paged admin routes" rewrites the page-handler
  template + conventions around the new sidebar contract,
  documents the icon vocabulary and the open/close pairing rule,
  and notes that `core/admin_tabs.tpl` is now the back-link-only
  partial. Anti-patterns gain a new entry against reintroducing
  the horizontal pill strip on Pattern A routes or inlining
  settings-style sidebar markup.
- `AGENTS.md` "Where to find what" gains rows for the new sidebar
  partial + chrome layout and the back-link partial; the existing
  "Subdivide an admin route into ?section=…" row was rewritten
  end-to-end.
- `ARCHITECTURE.md` updates the `AdminTabs.php` description in
  the directory tree to call out both render shapes.

### Out of scope

- The page-level ToC pattern (admin-admins, admin-bans). Those use
  Pattern B by design.
- Edit-* pages that render no tabs (only the trailing Back link).
  The Back affordance shape is unchanged.
- `admin.comms.php` was already simplified to a single-section
  page in #1239 (no `AdminTabs` call), so it doesn't need updates.

### Notes for the reviewer

- #1261 (parallel work on the Settings page heading-to-content
  positioning) likely touches the same `page_admin_settings_*.tpl`
  templates. Merge-conflict expected; flag for a clean resolution.

## Test plan

- [x] `./sbpp.sh phpstan` — passes (baseline updated for the
      additional `Smarty` `assign()` / `display()` calls in the
      new `AdminTabs.php` branch).
- [x] `./sbpp.sh test` — 361 tests pass (1488 assertions).
- [x] `./sbpp.sh ts-check` — passes.
- [x] `./sbpp.sh composer api-contract` — no diff.
- [x] `CI=1 ./sbpp.sh e2e` — 177 / 177 pass (workers=1; locally
      the suite races against the shared `sourcebans_e2e` DB at
      higher worker counts, see `playwright.config.ts`).
- [x] Smoke-checked admin-servers, admin-mods, admin-groups,
      admin-settings (each section), admin-edit-ban manually in
      the dev panel; sidebar paints correctly at desktop +
      mobile, accordion toggles, active link highlights match
      both themes, edit-page Back link still right-floats.