### PR TITLE
fix(admin-chrome): unify Pattern B ToC chrome onto Pattern A sidebar + lift inset to .admin-sidebar-shell (#1266)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -512,22 +512,71 @@ so jumps clear the sticky topbar (3.5rem).
 The ToC chrome lives in the parameterized partial
 `web/themes/default/page_toc.tpl`; both adopters (admin-admins and
 admin-bans) `{include file="page_toc.tpl"}` it after assigning
-`$toc_id`, `$toc_label`, and `$toc_entries`. Per-page CSS is shared
-under generic `.page-toc-*` class names in `theme.css` (`.page-toc-shell`
-/ `.page-toc` / `.page-toc-content` / `.page-toc-section`).
+`$toc_id`, `$toc_label`, and `$toc_entries`.
+
+#1266 unified the visual chrome with Pattern A (`core/admin_sidebar.tpl`):
+both surfaces sit in the same 14rem rail at the same breakpoint,
+and end users perceive them as the same chrome element — the
+pre-#1266 divergence (Pattern A: iconed pill rows + active-state
+highlight; Pattern B: plain text rows, no icons, no highlight) read
+as broken. The unified contract:
+
+- The DOM emits **dual class names** on the aside / details / summary
+  / nav elements (`admin-sidebar page-toc`, `admin-sidebar__details
+  page-toc__details`, …). The bare CSS lives in `theme.css` under
+  grouped `.admin-sidebar*, .page-toc*` selectors so chrome edits
+  apply to both surfaces simultaneously and future drift is
+  impossible. The legacy `.page-toc*` selectors keep matching for
+  any third-party theme that styles by these names.
+- Each entry is rendered as `<a class="sidebar__link admin-sidebar__link
+  page-toc__link" data-toc-target="<slug>">` with a Lucide icon —
+  same shape as Pattern A links — so the active-state CSS
+  (`.sidebar__link[aria-current="page"]`) is single-source with the
+  main app shell. Pre-#1266 the partial wrapped each link in `<ul><li>`;
+  the new shape flattens to direct `<a>` children of `<nav>`.
+- Active state is JS-driven by an inline `IntersectionObserver` in
+  `page_toc.tpl` itself (vanilla `// @ts-check` JSDoc, no new deps).
+  The first link is server-rendered with `aria-current="page"` so
+  the page works without JS; the observer refines the active link
+  as the user scrolls. The observer's `rootMargin: '-4rem 0px -50%
+  0px'` matches the section `scroll-margin-top` so a section
+  becomes "the active one" the moment its heading clears the
+  sticky topbar.
+- The routing semantics stay different (Pattern A navigates between
+  sibling URLs; Pattern B scrolls within one page) but the visible
+  chrome no longer diverges.
+
+Per-page CSS that's still page-toc-specific (the cross-template
+content-column anchors, the `.page-toc-shell` page-padding inset)
+lives under `.page-toc-section` / `.page-toc-shell` / `.page-toc-content`
+in `theme.css`. Per-link styling comes from the shared
+`.sidebar__link.admin-sidebar__link` block.
+
+`$toc_entries` is `list<{slug: string, label: string, icon: string}>`
+— each entry **MUST** carry a Lucide `icon` name. Pre-#1266 the
+field didn't exist; #1266 added it as required so every row has
+matching visual weight. Pick icons consistent with the Pattern A
+vocabulary already in `admin.servers.php` / `admin.groups.php` /
+etc (`server`, `plus`, `users`, `puzzle`, `globe`, `package`,
+`cog`, `image`, `flag`, `clipboard-list`, `search`, `user-plus`,
+`shield`, `upload`). Entries fall back to `circle-dot` when the
+field is missing so a partial migration never paints with no
+icon, but new entries should always declare one.
 
 Reference shapes:
 
-- **admin-admins** (#1207 ADM-3) — three templates wrap the
+- **admin-admins** (#1207 ADM-3 / #1266) — three templates wrap the
   cross-template `.page-toc-shell`. `page_admin_admins_list.tpl`
   opens the shell + includes `page_toc.tpl` + opens
   `.page-toc-content`; `page_admin_overrides.tpl` (the last template)
   closes both. The ToC payload is carried by `AdminAdminsListView`
   (the FIRST View rendered) — `toc_id`, `toc_label`, `toc_entries`.
-- **admin-bans** (#1239) — five sections live inside the ToC shell;
-  the page handler (`web/pages/admin.bans.php`) opens the shell +
-  drives `page_toc.tpl` directly via `$theme->display(...)` then
-  emits `<section id="…">` wrappers around each existing
+  Each entry's `icon` is set in `web/pages/admin.admins.php`
+  alongside the permission-gating block.
+- **admin-bans** (#1239 / #1266) — five sections live inside the
+  ToC shell; the page handler (`web/pages/admin.bans.php`) opens
+  the shell + drives `page_toc.tpl` directly via `$theme->display(...)`
+  then emits `<section id="…">` wrappers around each existing
   `Renderer::render(...)` call. Closing tags live at the bottom of
   the same handler. This shape is the right call when sections are
   already structured as PHP echo chunks (e.g. when a section like
@@ -545,26 +594,30 @@ Conventions for both shapes:
   an `<h2 id="…-heading" class="page-toc-section__heading">` so
   screen-readers can navigate by landmark name. Reuse the
   `page-toc-section` class so all sections share the
-  `scroll-margin-top` rule.
+  `scroll-margin-top` rule. The `id` attribute MUST match the ToC
+  entry's `slug` — the `IntersectionObserver` looks up
+  `document.getElementById(slug)` to drive active state.
 - Permission gates on ToC entries mirror what the dispatcher would
   render anyway (e.g. `$can_add_admins` in `admin-admins`,
   `$canImport` / `$canGroupBan` in `admin-bans`); a ToC entry for a
   section the dispatcher wouldn't paint is a dead link.
 - Selectors for E2E specs are `[data-testid="<page>-toc"]` (outer
   aside), `[data-testid="<page>-toc-link-<slug>"]` (per anchor),
-  and `[data-testid="<page>-section-<slug>"]` (per section). Never
-  CSS class chains; never visible-text-as-primary. The desktop
-  contract is "scrolls to the right section" — assert via
-  `expect(section).toBeInViewport()` after the click, not against
-  a fixed `boundingBox.y` because the **last** section can never
-  reach the top of the viewport (no document below it).
+  and `[data-testid="<page>-section-<slug>"]` (per section). The
+  active link asserts via `[aria-current="page"]` — same selector
+  as Pattern A. Never CSS class chains; never visible-text-as-primary.
+  The desktop contract is "scrolls to the right section" — assert
+  via `expect(section).toBeInViewport()` after the click, not
+  against a fixed `boundingBox.y` because the **last** section can
+  never reach the top of the viewport (no document below it).
 
 When `myaccount` (or any other dense page) adopts this pattern,
 reuse `page_toc.tpl` directly — it already takes `toc_id`,
-`toc_label`, `toc_entries` parameters scoped per page. Add the new
-`data-testid="<page>-toc"` to the spec list above and follow either
-the View-driven (admin-admins) or page-handler-driven (admin-bans)
-shape depending on whether the page renders one View or many.
+`toc_label`, `toc_entries` (with icons) parameters scoped per page.
+Add the new `data-testid="<page>-toc"` to the spec list above and
+follow either the View-driven (admin-admins) or page-handler-driven
+(admin-bans) shape depending on whether the page renders one View
+or many.
 
 ### Sub-paged admin routes (`?section=…` routing)
 
@@ -829,7 +882,7 @@ audit (#1207) locked in. New CTAs:
 | Display a user's own permission flags grouped by category | `Sbpp\View\PermissionCatalog::groupedDisplayFromMask($mask)` (`web/includes/View/PermissionCatalog.php`). Adding a new flag to `web/configs/permissions/web.json` requires a paired entry in `WEB_CATEGORIES`; `PermissionCatalogTest` enforces it. |
 | Live-preview Markdown in a settings textarea | `system.preview_intro_text` JSON action + `web/themes/default/page_admin_settings_settings.tpl` (`.dash-intro-editor` / `.dash-intro-preview`) |
 | Build an empty-state surface (first-run vs filtered, primary/secondary CTAs) | `.empty-state` rules in `web/themes/default/css/theme.css` + reference shapes in `page_servers.tpl`, `page_dashboard.tpl`, `page_bans.tpl`, `page_comms.tpl`, `page_admin_audit.tpl`, `page_admin_bans_protests.tpl`, `page_admin_bans_submissions.tpl` |
-| Add a sticky page-level ToC to a dense admin route (anchor sidebar at desktop, accordion at mobile) | `web/themes/default/page_toc.tpl` is the parameterized shared partial (toc_id / toc_label / toc_entries). `.page-toc-shell` / `.page-toc` / `.page-toc-content` / `.page-toc-section` rules in `web/themes/default/css/theme.css` carry the responsive layout. Two reference shapes: `admin-admins` (View-driven — `AdminAdminsListView` carries the toc payload, `page_admin_admins_list.tpl` opens the shell, `page_admin_overrides.tpl` closes it) and `admin-bans` (page-handler-driven — `web/pages/admin.bans.php` opens the shell + drives the partial via `$theme->display(...)`, emits `<section id="…">` wrappers in PHP echo around each `Renderer::render(...)`). See the Conventions section "Page-level table of contents (dense admin pages)" (#1207 ADM-3, #1239). |
+| Add a sticky page-level ToC to a dense admin route (anchor sidebar at desktop, accordion at mobile) | `web/themes/default/page_toc.tpl` is the parameterized shared partial (toc_id / toc_label / toc_entries — each entry carries `slug` + `label` + `icon`). The chrome is unified with Pattern A (`core/admin_sidebar.tpl`) at #1266: dual class names (`admin-sidebar page-toc`, `admin-sidebar__details page-toc__details`, …) on the partial's elements + grouped `.admin-sidebar*, .page-toc*` selectors in `theme.css` so the bare CSS lives in one place. Per-link styling comes from `.sidebar__link.admin-sidebar__link`; active state is JS-driven via an inline `IntersectionObserver` in the partial that toggles `aria-current="page"` on the matching link as the user scrolls (first link is server-rendered active so the page works without JS). The `.page-toc-shell` / `.page-toc-content` / `.page-toc-section` rules carry the cross-template content-column layout. Two reference shapes: `admin-admins` (View-driven — `AdminAdminsListView` carries the toc payload, `page_admin_admins_list.tpl` opens the shell, `page_admin_overrides.tpl` closes it) and `admin-bans` (page-handler-driven — `web/pages/admin.bans.php` opens the shell + drives the partial via `$theme->display(...)`, emits `<section id="…">` wrappers in PHP echo around each `Renderer::render(...)`). See the Conventions section "Page-level table of contents (dense admin pages)" (#1207 ADM-3, #1239, #1266). |
 | Subdivide an admin route into `?section=<slug>` URLs (servers, mods, groups, comms, settings) | `web/pages/admin.settings.php` is the long-standing reference; #1239 brought servers / mods / groups / comms onto the same shape; #1259 unified the chrome on the Settings-style vertical sidebar. The shared partial is `web/themes/default/core/admin_sidebar.tpl` (parameterized on `tabs` / `active_tab` / `sidebar_id` / `sidebar_label`); `web/includes/AdminTabs.php` opens `<div class="admin-sidebar-shell">`, emits the `<aside>` + link list, opens `<div class="admin-sidebar-content">`, and the page handler closes both wrappers (`echo '</div></div>'`) AFTER `Renderer::render(...)`. Each `$sections` entry carries `slug` + `name` + `permission` + `url` + `icon` (Lucide name); the link emits `<a href="?p=admin&c=<page>&section=<slug>" data-testid="admin-tab-<slug>" aria-current="page">` — never `<button onclick="openTab(...)">` (the JS handler was deleted at #1123 D1). See "Sub-paged admin routes" in Conventions. |
 | Lay out a sub-paged admin route's chrome (the 14rem vertical sidebar at `>=1024px`, the `<details open>` accordion at `<1024px`) | `web/themes/default/core/admin_sidebar.tpl` (the partial) + the `.admin-sidebar-shell` / `.admin-sidebar` / `.admin-sidebar__details` / `.admin-sidebar__summary` / `.admin-sidebar__nav` / `.admin-sidebar__link` / `.admin-sidebar-content` rules in `web/themes/default/css/theme.css` (#1259). The active link reuses the shared `.sidebar__link[aria-current="page"]` rule from the main app shell so the dark-pill-in-light / brand-orange-in-dark treatment is single-source. |
 | Render the trailing "Back" link on edit-* admin pages (the only surface that calls `new AdminTabs([], …)`) | `web/themes/default/core/admin_tabs.tpl` is the back-link-only partial (it still has a defensive `{foreach}` for legacy themes, but `AdminTabs.php` only routes here when `$tabs === []`). Page handlers like `admin.edit.ban.php` / `admin.rcon.php` / `admin.email.php` call `new AdminTabs([], $userbank, $theme)` and the partial emits the right-aligned Back anchor (`.admin-tabs__back` in theme.css). |

--- a/web/includes/View/AdminAdminsListView.php
+++ b/web/includes/View/AdminAdminsListView.php
@@ -34,11 +34,13 @@ final class AdminAdminsListView extends View
      *     fields (`user`, `name`, `aid`, `bancount`, `nodemocount`,
      *     `web_group`, `server_group`, `web_flag_string`,
      *     `server_flag_string`, `immunity`, `lastvisit`).
-     * @param list<array{slug: string, label: string}> $toc_entries
+     * @param list<array{slug: string, label: string, icon: string}> $toc_entries
      *     Permission-filtered list of ToC anchors. Each entry's `slug`
      *     matches the `id="…"` on the `<section>` it points at; the
      *     handler must omit entries the dispatcher wouldn't paint so a
-     *     ToC click never targets a non-existent anchor.
+     *     ToC click never targets a non-existent anchor. The `icon`
+     *     is a Lucide glyph name (e.g. "users", "shield"); #1266
+     *     unified the chrome with Pattern A's iconed pill rows.
      */
     public function __construct(
         public readonly bool $can_list_admins,

--- a/web/pages/admin.admins.php
+++ b/web/pages/admin.admins.php
@@ -405,16 +405,24 @@ $canAddAdmins    = $userbank->HasAccess(ADMIN_OWNER | ADMIN_ADD_ADMINS);
 $canEditAdmins   = $userbank->HasAccess(ADMIN_OWNER | ADMIN_EDIT_ADMINS);
 $canDeleteAdmins = $userbank->HasAccess(ADMIN_OWNER | ADMIN_DELETE_ADMINS);
 
-/** @var list<array{slug: string, label: string}> $tocEntries */
+/*
+ * #1266 — each ToC entry carries a Lucide `icon` so the rendered
+ * link gets the same iconed-pill visual weight as the Pattern A
+ * sidebar (`core/admin_sidebar.tpl`). Icons follow the Pattern A
+ * vocabulary (see admin.servers.php / admin.groups.php / etc):
+ * `users` for the admin list, `user-plus` / `plus` for create,
+ * `shield` for permission overrides.
+ */
+/** @var list<array{slug: string, label: string, icon: string}> $tocEntries */
 $tocEntries = [];
 if ($canListAdmins) {
-    $tocEntries[] = ['slug' => 'search', 'label' => 'Search'];
-    $tocEntries[] = ['slug' => 'admins', 'label' => 'Admins list'];
+    $tocEntries[] = ['slug' => 'search', 'label' => 'Search',      'icon' => 'search'];
+    $tocEntries[] = ['slug' => 'admins', 'label' => 'Admins list', 'icon' => 'users'];
 }
 if ($canAddAdmins) {
-    $tocEntries[] = ['slug' => 'add-admin', 'label' => 'Add admin'];
-    $tocEntries[] = ['slug' => 'overrides', 'label' => 'Overrides'];
-    $tocEntries[] = ['slug' => 'add-override', 'label' => 'Add override'];
+    $tocEntries[] = ['slug' => 'add-admin',    'label' => 'Add admin',    'icon' => 'user-plus'];
+    $tocEntries[] = ['slug' => 'overrides',    'label' => 'Overrides',    'icon' => 'shield'];
+    $tocEntries[] = ['slug' => 'add-override', 'label' => 'Add override', 'icon' => 'plus'];
 }
 
 \Sbpp\View\Renderer::render($theme, new \Sbpp\View\AdminAdminsListView(

--- a/web/pages/admin.bans.php
+++ b/web/pages/admin.bans.php
@@ -50,13 +50,21 @@ $canImport       = $userbank->HasAccess(ADMIN_OWNER | ADMIN_BAN_IMPORT);
 $groupBanEnabled = Config::getBool('config.enablegroupbanning');
 $canGroupBan     = $canAddBan && $groupBanEnabled;
 
-/** @var list<array{slug: string, label: string}> $tocEntries */
+/*
+ * #1266 — each ToC entry carries a Lucide `icon` so the rendered
+ * link gets the same iconed-pill visual weight as the Pattern A
+ * sidebar (`core/admin_sidebar.tpl`). Icons follow the Pattern A
+ * vocabulary (see admin.servers.php / admin.groups.php / etc):
+ * `plus` for create, `users` for multi-user, `flag` for reports,
+ * `clipboard-list` for queues, `upload` for file imports.
+ */
+/** @var list<array{slug: string, label: string, icon: string}> $tocEntries */
 $tocEntries = [];
-if ($canAddBan)      { $tocEntries[] = ['slug' => 'add-ban',     'label' => 'Add a ban']; }
-if ($canProtests)    { $tocEntries[] = ['slug' => 'protests',    'label' => 'Ban protests']; }
-if ($canSubmissions) { $tocEntries[] = ['slug' => 'submissions', 'label' => 'Ban submissions']; }
-if ($canImport)      { $tocEntries[] = ['slug' => 'import',      'label' => 'Import bans']; }
-if ($canGroupBan)    { $tocEntries[] = ['slug' => 'group-ban',   'label' => 'Group ban']; }
+if ($canAddBan)      { $tocEntries[] = ['slug' => 'add-ban',     'label' => 'Add a ban',       'icon' => 'plus']; }
+if ($canProtests)    { $tocEntries[] = ['slug' => 'protests',    'label' => 'Ban protests',    'icon' => 'flag']; }
+if ($canSubmissions) { $tocEntries[] = ['slug' => 'submissions', 'label' => 'Ban submissions', 'icon' => 'clipboard-list']; }
+if ($canImport)      { $tocEntries[] = ['slug' => 'import',      'label' => 'Import bans',     'icon' => 'upload']; }
+if ($canGroupBan)    { $tocEntries[] = ['slug' => 'group-ban',   'label' => 'Group ban',       'icon' => 'users']; }
 
 if (isset($_GET['mode']) && $_GET['mode'] == "delete") {
     // sb.message (sb.js) replaces the v1.x ShowBox helper.

--- a/web/tests/e2e/specs/_screenshots.spec.ts
+++ b/web/tests/e2e/specs/_screenshots.spec.ts
@@ -219,6 +219,12 @@ const ROUTES_SMOKE_ADMIN: RouteSpec[] = [
     { name: 'admin-bans',     path: '/index.php?p=admin&c=bans',      auth: true },
     { name: 'admin-admins',   path: '/index.php?p=admin&c=admins',    auth: true },
     { name: 'admin-groups',   path: '/index.php?p=admin&c=groups',    auth: true },
+    // #1266 — Pattern A routes (servers / mods / comms) join the
+    // gallery so the unified-chrome fix shows up on every adopter,
+    // not just the three already covered (groups / settings / bans).
+    { name: 'admin-servers',  path: '/index.php?p=admin&c=servers',   auth: true },
+    { name: 'admin-mods',     path: '/index.php?p=admin&c=mods',      auth: true },
+    { name: 'admin-comms',    path: '/index.php?p=admin&c=comms',     auth: true },
     { name: 'admin-settings', path: '/index.php?p=admin&c=settings',  auth: true },
     { name: 'admin-audit',    path: '/index.php?p=admin&c=audit',     auth: true },
     { name: 'myaccount',      path: '/index.php?p=account',           auth: true },

--- a/web/themes/default/css/theme.css
+++ b/web/themes/default/css/theme.css
@@ -439,13 +439,16 @@ html.dark .admin-tabs > [aria-current="page"] { border-bottom-color: var(--brand
    The active link reuses `.sidebar__link[aria-current="page"]` from
    the main shell so the dark-pill / brand-orange treatment is
    single-source. */
-.admin-sidebar { font-size: var(--fs-sm); margin-bottom: 1rem; }
-.admin-sidebar__details {
+.admin-sidebar,
+.page-toc { font-size: var(--fs-sm); margin-bottom: 1rem; }
+.admin-sidebar__details,
+.page-toc__details {
   border: 1px solid var(--border);
   border-radius: var(--radius-md);
   background: var(--bg-surface);
 }
-.admin-sidebar__summary {
+.admin-sidebar__summary,
+.page-toc__summary {
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -456,21 +459,63 @@ html.dark .admin-tabs > [aria-current="page"] { border-bottom-color: var(--brand
   list-style: none;
   user-select: none;
 }
-.admin-sidebar__summary::-webkit-details-marker { display: none; }
-.admin-sidebar__summary-label { display: inline-flex; align-items: center; gap: 0.5rem; }
-.admin-sidebar__chevron {
+.admin-sidebar__summary::-webkit-details-marker,
+.page-toc__summary::-webkit-details-marker { display: none; }
+.admin-sidebar__summary-label,
+.page-toc__summary-label { display: inline-flex; align-items: center; gap: 0.5rem; }
+.admin-sidebar__chevron,
+.page-toc__chevron {
   transition: transform .15s ease;
   color: var(--text-muted);
 }
-.admin-sidebar__details[open] .admin-sidebar__chevron { transform: rotate(180deg); }
-.admin-sidebar__nav {
+.admin-sidebar__details[open] .admin-sidebar__chevron,
+.page-toc__details[open] .page-toc__chevron { transform: rotate(180deg); }
+.admin-sidebar__nav,
+.page-toc__nav {
   padding: 0.5rem 0.5rem 0.625rem;
   display: flex;
   flex-direction: column;
   gap: 0.125rem;
 }
 @media (prefers-reduced-motion: reduce) {
-  .admin-sidebar__chevron { transition: none; }
+  .admin-sidebar__chevron,
+  .page-toc__chevron { transition: none; }
+}
+
+/* Page-padding inset for the sidebar shell (#1266). Mirrors
+   `.page-toc-shell` / `.page-section` — 1.5rem all-around, 1400px
+   cap. Declared at the base level so the inset applies at every
+   viewport (including the <1024px accordion shape); the desktop
+   media-query block below adds `display: grid` etc. on top, both
+   sets of properties merge cleanly via the cascade.
+
+   Pre-#1266 only the desktop block existed, so the shell carried
+   no padding while the inner Pattern A content templates wrapped
+   their body in a `.p-6` (1.5rem). `align-items: start` aligns
+   grid cells, not visible content inside them — so the sidebar
+   floated 1.5rem above the content column's first paint. Lifting
+   the inset onto the shell (and dropping the inner `.p-6` from
+   each Pattern A content template in the same diff) makes both
+   columns share the same top y and matches the parallel fix
+   #1260 → #1263 landed on `.page-toc-shell`. */
+.admin-sidebar-shell {
+  padding: 1.5rem;
+  max-width: 1400px;
+}
+
+/* Pattern A content templates that wrap their body in `.page-section`
+   (servers/mods/edit-mod) would otherwise double up the 1.5rem
+   inset — the shell now carries that inset (#1266), so suppress the
+   nested `.page-section`'s own padding + max-width-cap when it sits
+   inside `.admin-sidebar-content`. Each template's own inline-style
+   max-width (e.g. `style="max-width:900px"` on `page_admin_servers_add.tpl`)
+   still wins by inline-style specificity, so per-template content
+   clamps for narrow forms keep working. The `.page-section`
+   semantic at the outer use site is preserved — the suppression is
+   strictly contextual. */
+.admin-sidebar-content .page-section {
+  padding: 0;
+  max-width: none;
 }
 
 /* Desktop layout — vertical sidebar floats next to the content
@@ -479,7 +524,7 @@ html.dark .admin-tabs > [aria-current="page"] { border-bottom-color: var(--brand
    scrolls through the active section. We force the <details>
    contents visible regardless of [open] so accidental "collapse"
    at desktop can't strand the user without navigation — same
-   contract as `.page-toc` (#1207 ADM-3 / #1239). */
+   contract as `.page-toc` (#1207 ADM-3 / #1239 / #1266). */
 @media (min-width: 1024px) {
   .admin-sidebar-shell {
     display: grid;
@@ -1272,7 +1317,7 @@ details.queue-row > summary > .row-actions {
 }
 
 /* ============================================================
-   #1207 ADM-3, #1239 — page-level table of contents (shared)
+   #1207 ADM-3, #1239, #1266 — page-level table of contents
    ============================================================
    Sticky anchor sidebar at >=1024px and an accordion ToC at <1024px,
    with each section anchored via `id="…"` + `scroll-margin-top` so
@@ -1282,26 +1327,47 @@ details.queue-row > summary > .row-actions {
    page-specific class names (`.admin-admins-*`); #1239 lifted the
    class names to a generic `page-toc-*` prefix so admin-bans and any
    future dense page can reuse the same shape via the parameterized
-   `page_toc.tpl` partial. data-testids stay scoped per page (e.g.
-   `admin-admins-toc`, `admin-bans-toc`) so E2E specs can target each
-   surface independently — see `page_toc.tpl` for the contract.
+   `page_toc.tpl` partial. #1266 unified the chrome with the Pattern
+   A `core/admin_sidebar.tpl` (same iconed pill rows + active-state
+   highlight via `aria-current="page"`); the partial now emits dual
+   class names (`admin-sidebar page-toc` / `admin-sidebar__details
+   page-toc__details` / …) so the bare CSS comes from the grouped
+   `.admin-sidebar*, .page-toc*` selectors above and `.page-toc*`
+   keeps matching for any third-party theme that targets them. Per-
+   link styling comes from `.sidebar__link.admin-sidebar__link`.
+
+   data-testids stay scoped per page (e.g. `admin-admins-toc`,
+   `admin-bans-toc`) so E2E specs can target each surface
+   independently — see `page_toc.tpl` for the contract.
+
+   This block carries only the rules that ARE page-toc-specific:
+   the cross-template content column's `<section>` anchors and per-
+   section heading style, plus the page-padding inset on the shell
+   (mirrors `.admin-sidebar-shell` from the Pattern A block above)
+   and the desktop grid layout. Everything else lives in the
+   `.admin-sidebar*, .page-toc*` grouped block.
 
    Markup contract (see page_toc.tpl + the page templates that
    include it — page_admin_admins_*.tpl, page_admin_bans_*.tpl):
      .page-toc-shell             outer wrapper (grid host on desktop)
-       .page-toc                 <aside> with the link list
-         .page-toc__details      <details open> on every viewport;
+       .admin-sidebar.page-toc   <aside> with the link list
+         .admin-sidebar__details.page-toc__details
+                                 <details open> on every viewport;
                                  the open/close toggle only does
                                  something at <1024px (mobile/
                                  narrow-tablet accordion). At
                                  >=1024px we force the contents
                                  visible regardless of [open]
                                  state — see the desktop block.
-         .page-toc__summary      mobile-only chrome (hidden on
+         .admin-sidebar__summary.page-toc__summary
+                                 mobile-only chrome (hidden on
                                  desktop)
-         .page-toc__nav          the link container
-         .page-toc__list         <ul>
-         .page-toc__link         each <a>
+         .admin-sidebar__nav.page-toc__nav
+                                 <nav> wrapping the links
+           .sidebar__link.admin-sidebar__link.page-toc__link
+                                 each <a> (iconed; active state
+                                 via the shared `.sidebar__link
+                                 [aria-current="page"]` rule)
        .page-toc-content         the cross-template content column
          .page-toc-section       the anchored <section>s
          .page-toc-section__heading  per-section <h2>
@@ -1314,60 +1380,6 @@ details.queue-row > summary > .row-actions {
   letter-spacing: 0.06em;
   color: var(--text-muted);
   margin: 0 0 0.75rem;
-}
-.page-toc {
-  font-size: var(--fs-sm);
-  margin-bottom: 1rem;
-}
-.page-toc__details {
-  border: 1px solid var(--border);
-  border-radius: var(--radius-md);
-  background: var(--bg-surface);
-}
-.page-toc__summary {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 0.5rem;
-  padding: 0.625rem 0.875rem;
-  font-weight: 600;
-  cursor: pointer;
-  list-style: none;
-  user-select: none;
-}
-.page-toc__summary::-webkit-details-marker { display: none; }
-.page-toc__summary-label { display: inline-flex; align-items: center; gap: 0.5rem; }
-.page-toc__chevron {
-  transition: transform .15s ease;
-  color: var(--text-muted);
-}
-.page-toc__details[open] .page-toc__chevron { transform: rotate(180deg); }
-.page-toc__nav { padding: 0 0.5rem 0.5rem; }
-.page-toc__list {
-  list-style: none;
-  padding: 0;
-  margin: 0;
-  display: flex;
-  flex-direction: column;
-  gap: 0.125rem;
-}
-.page-toc__link {
-  display: block;
-  padding: 0.4375rem 0.625rem;
-  border-radius: var(--radius-sm);
-  color: var(--text-muted);
-  text-decoration: none;
-  transition: background-color .12s, color .12s;
-}
-.page-toc__link:hover,
-.page-toc__link:focus-visible {
-  background: var(--bg-muted);
-  color: var(--text);
-  outline: none;
-}
-@media (prefers-reduced-motion: reduce) {
-  .page-toc__chevron { transition: none; }
-  .page-toc__link    { transition: none; }
 }
 
 /* Page-padding inset for the cross-template ToC shell. Mirrors the
@@ -1389,7 +1401,8 @@ details.queue-row > summary > .row-actions {
    pinned beneath the topbar (top: 4rem) while the user scrolls
    through the sections. We force the <details> contents visible
    regardless of [open] so accidental "collapse" at desktop can't
-   strand the user without navigation. */
+   strand the user without navigation — same contract as
+   `.admin-sidebar-shell` (Pattern A). */
 @media (min-width: 1024px) {
   .page-toc-shell {
     display: grid;
@@ -1397,22 +1410,5 @@ details.queue-row > summary > .row-actions {
     gap: 1.5rem;
     align-items: start;
   }
-  .page-toc {
-    position: sticky;
-    top: 4rem;
-    align-self: start;
-    margin-bottom: 0;
-  }
-  .page-toc__details {
-    border: none;
-    background: transparent;
-  }
-  .page-toc__summary { display: none; }
-  /* Keep the link list visible whether the user has toggled the
-     <details> closed or not — at desktop the sidebar is a permanent
-     navigation surface, the accordion gesture only matters at mobile. */
-  .page-toc__details .page-toc__nav { display: block !important; }
-  .page-toc__nav { padding: 0; }
-  .page-toc__link { font-size: var(--fs-sm); }
   .page-toc-content { min-width: 0; }
 }

--- a/web/themes/default/page_admin_comms_add.tpl
+++ b/web/themes/default/page_admin_comms_add.tpl
@@ -30,11 +30,14 @@
         </div>
     </div>
 {else}
-    {* #1266 — outer `.p-6` removed; the 1.5rem page inset now lives on
-       `.admin-sidebar-shell` (the AdminTabs grid host). The `max-width:
-       48rem` form clamp stays so the form column doesn't grow past a
-       readable line length on wide viewports. *}
-    <div style="max-width:48rem">
+    {* #1266 — outer `.p-6` keeps the 1.5rem page inset because
+       `admin.comms.php` is a *single-section* page (simplified at
+       #1239 — no `AdminTabs` call, no `.admin-sidebar-shell`
+       wrapper), so this template is rendered directly under the
+       chrome's `<main class="page">` which has no padding of its
+       own. The `max-width: 48rem` form clamp keeps the form column
+       from growing past a readable line length on wide viewports. *}
+    <div class="p-6" style="max-width:48rem">
         <div class="mb-6">
             <h1 style="font-size:1.5rem;font-weight:600;margin:0">Add a block</h1>
             <p class="text-sm text-muted m-0 mt-2">Mute, gag, or silence a player on every connected server.</p>

--- a/web/themes/default/page_admin_comms_add.tpl
+++ b/web/themes/default/page_admin_comms_add.tpl
@@ -30,7 +30,11 @@
         </div>
     </div>
 {else}
-    <div class="p-6" style="max-width:48rem">
+    {* #1266 — outer `.p-6` removed; the 1.5rem page inset now lives on
+       `.admin-sidebar-shell` (the AdminTabs grid host). The `max-width:
+       48rem` form clamp stays so the form column doesn't grow past a
+       readable line length on wide viewports. *}
+    <div style="max-width:48rem">
         <div class="mb-6">
             <h1 style="font-size:1.5rem;font-weight:600;margin:0">Add a block</h1>
             <p class="text-sm text-muted m-0 mt-2">Mute, gag, or silence a player on every connected server.</p>

--- a/web/themes/default/page_admin_groups_add.tpl
+++ b/web/themes/default/page_admin_groups_add.tpl
@@ -15,7 +15,11 @@
 {if NOT $permission_addgroup}
     <div class="card"><div class="card__body"><p class="text-muted m-0">Access denied.</p></div></div>
 {else}
-<div class="p-6" style="max-width:48rem">
+{* #1266 — outer `.p-6` removed; the 1.5rem page inset now lives on
+   `.admin-sidebar-shell` (the AdminTabs grid host). The `max-width:
+   48rem` form clamp stays so the form column doesn't grow past a
+   readable line length on wide viewports. *}
+<div style="max-width:48rem">
     <div class="mb-4">
         <h1 style="font-size:var(--fs-2xl);font-weight:600;margin:0">Create a group</h1>
         <p class="text-sm text-muted m-0 mt-2">Pick a name and a type. You can edit permission flags from the <strong>List groups</strong> tab once the group exists.</p>

--- a/web/themes/default/page_admin_groups_list.tpl
+++ b/web/themes/default/page_admin_groups_list.tpl
@@ -16,7 +16,12 @@
 {if NOT $permission_listgroups}
     <div class="card"><div class="card__body"><p class="text-muted m-0">Access denied.</p></div></div>
 {else}
-<div class="p-6 space-y-6" style="max-width:1400px">
+{* #1266 — outer `.p-6` removed; the 1.5rem page inset now lives on
+   `.admin-sidebar-shell` (the AdminTabs grid host). The `space-y-6`
+   stays so the per-section vertical rhythm holds; the `max-width`
+   cap is also unnecessary here because the outer shell already
+   clamps to 1400px. *}
+<div class="space-y-6">
 
     {* ------------------------------------------------------------ *}
     {* Master-detail: Web admin groups                              *}

--- a/web/themes/default/page_admin_settings_features.tpl
+++ b/web/themes/default/page_admin_settings_features.tpl
@@ -33,8 +33,11 @@
           servers / mods / groups).
         - Each toggle row: data-testid="setting-row" + data-key="<key>".
         - Save button: data-testid="settings-save".
+
+    #1266 — outer `.p-6` removed; the page inset lives on
+    `.admin-sidebar-shell` so both grid columns share the same top y.
 *}
-<div class="p-6">
+<div>
     <div class="mb-6">
         <h1 style="font-size:var(--fs-2xl);font-weight:600;margin:0">Settings</h1>
         <p class="text-sm text-muted m-0 mt-2">Optional features and integrations.</p>

--- a/web/themes/default/page_admin_settings_logs.tpl
+++ b/web/themes/default/page_admin_settings_logs.tpl
@@ -29,8 +29,11 @@
           shape across servers / mods / groups / settings).
         - Each summary row: data-testid="log-row" + data-id (lid).
         - "Clear log" button: data-testid="logs-clear".
+
+    #1266 — outer `.p-6` removed; the page inset lives on
+    `.admin-sidebar-shell` so both grid columns share the same top y.
 *}
-<div class="p-6">
+<div>
     <div class="mb-6">
         <h1 style="font-size:var(--fs-2xl);font-weight:600;margin:0">Settings</h1>
         <p class="text-sm text-muted m-0 mt-2">System log of admin actions and warnings.</p>

--- a/web/themes/default/page_admin_settings_settings.tpl
+++ b/web/themes/default/page_admin_settings_settings.tpl
@@ -68,8 +68,19 @@
     Documented in AGENTS.md "Anti-patterns" + "Admin-authored display
     text". The help icon links to the CommonMark cheat-sheet so admins
     can discover the syntax without losing the safe-on-render contract.
+
+    #1266 — outer `.p-6` removed
+    ----------------------------
+    The page padding now lives on the `.admin-sidebar-shell` (the grid
+    host opened by AdminTabs.php), so this template no longer wraps
+    its body in `<div class="p-6">`. Without that change the sidebar's
+    first row floated 1.5rem above the page heading because
+    `align-items: start` aligned grid cells, not visible content
+    inside them. The `.mb-6` heading wrapper inside this template is
+    intentionally kept so the heading still gets its bottom gap to
+    the first card.
 *}
-<div class="p-6">
+<div>
     <div class="mb-6">
         <h1 style="font-size:var(--fs-2xl);font-weight:600;margin:0">Settings</h1>
         <p class="text-sm text-muted m-0 mt-2">Site-wide configuration. Changes apply immediately.</p>

--- a/web/themes/default/page_admin_settings_themes.tpl
+++ b/web/themes/default/page_admin_settings_themes.tpl
@@ -51,8 +51,11 @@
         - Each card: data-testid="theme-card" + data-theme="<dir>".
         - Active card carries aria-current="true" (per the issue plan).
         - "Use this theme" button: data-testid="theme-apply".
+
+    #1266 — outer `.p-6` removed; the page inset lives on
+    `.admin-sidebar-shell` so both grid columns share the same top y.
 *}
-<div class="p-6">
+<div>
     <div class="mb-6">
         <h1 style="font-size:var(--fs-2xl);font-weight:600;margin:0">Settings</h1>
         <p class="text-sm text-muted m-0 mt-2">Pick the theme that paints the panel chrome for every visitor.</p>

--- a/web/themes/default/page_toc.tpl
+++ b/web/themes/default/page_toc.tpl
@@ -6,6 +6,37 @@
     `admin.admins.toc.tpl` (#1207 ADM-3) per AGENTS.md guidance, so a
     second dense page (admin-bans, #1239) can reuse the same shape.
 
+    #1266 — chrome unified with Pattern A (`core/admin_sidebar.tpl`)
+    ----------------------------------------------------------------
+    Pre-#1266 this partial rendered plain text rows with no icons and
+    no active-state highlight while the sibling Pattern A partial
+    (`core/admin_sidebar.tpl`, used by admin-settings / -servers /
+    -mods / -groups / -comms) rendered iconed pill rows with a
+    dark-pill / brand-orange `aria-current="page"` treatment. Both
+    surfaces sit in the same 14rem rail at the same breakpoint, so
+    end users perceived them as the same chrome element — the
+    divergence read as broken (#1266 Symptom 1).
+
+    The unified contract:
+
+      - The DOM uses BOTH class sets — `.admin-sidebar*` (the new
+        single-source chrome) AND `.page-toc*` (kept for backward
+        compatibility with any third-party theme that styles by these
+        names; the bare CSS rules now consolidate via grouped
+        selectors in `theme.css`).
+      - Each entry renders as `<a class="sidebar__link admin-sidebar__link page-toc__link">`
+        with a Lucide icon — same shape as the Pattern A links — so
+        the active-state CSS (`.sidebar__link[aria-current="page"]`)
+        is single-source with the main app shell.
+      - Active state is JS-driven: an `IntersectionObserver` on the
+        `<section class="page-toc-section">` siblings of the host
+        page toggles `aria-current="page"` on the matching link as
+        the user scrolls. The first link is rendered active by
+        default so the page works without JS too.
+      - The routing semantics stay different (Pattern A navigates
+        between sibling URLs; Pattern B scrolls within one page)
+        but the visible chrome no longer diverges.
+
     Parameters (assigned by the calling View; SmartyTemplateRule
     follows the {include} so both ends agree on the contract):
 
@@ -19,11 +50,15 @@
                       sections"). Screen readers announce the
                       navigation by this label.
 
-        $toc_entries  list<{slug: string, label: string}>. Permission
-                      filtering happens in the page handler — only
-                      entries the dispatcher would actually render get
-                      passed in, so a ToC click never targets a
-                      non-existent anchor.
+        $toc_entries  list<{slug: string, label: string, icon?: string}>.
+                      Permission filtering happens in the page
+                      handler — only entries the dispatcher would
+                      actually render get passed in, so a ToC click
+                      never targets a non-existent anchor. The
+                      optional `icon` is a Lucide glyph name (e.g.
+                      "list", "flag", "import"); falls back to
+                      `circle-dot` so every row has matching visual
+                      weight.
 
     Caller contract:
 
@@ -40,27 +75,122 @@
           `scroll-margin-top: 4rem` so anchor jumps clear the sticky
           topbar.
 *}
-<aside class="page-toc"
+<aside class="admin-sidebar page-toc"
        data-testid="{$toc_id}-toc"
        aria-label="{$toc_label}">
-    <details class="page-toc__details" open>
-        <summary class="page-toc__summary">
-            <span class="page-toc__summary-label">
+    <details class="admin-sidebar__details page-toc__details" open>
+        <summary class="admin-sidebar__summary page-toc__summary">
+            <span class="admin-sidebar__summary-label page-toc__summary-label">
                 <i data-lucide="list" style="width:14px;height:14px"></i>
                 On this page
             </span>
-            <i data-lucide="chevron-down" class="page-toc__chevron" style="width:14px;height:14px"></i>
+            <i data-lucide="chevron-down" class="admin-sidebar__chevron page-toc__chevron" style="width:14px;height:14px"></i>
         </summary>
-        <nav class="page-toc__nav">
-            <ul class="page-toc__list">
-                {foreach from=$toc_entries item=entry}
-                    <li>
-                        <a href="#{$entry.slug}"
-                           class="page-toc__link"
-                           data-testid="{$toc_id}-toc-link-{$entry.slug}">{$entry.label}</a>
-                    </li>
-                {/foreach}
-            </ul>
+        {*
+            #1266 — flatten the link list to direct <a> children of
+            <nav> (matches `core/admin_sidebar.tpl`). The pre-#1266
+            shape wrapped each link in `<ul><li>` which the CSS reset
+            then had to fight (`list-style: none; padding: 0`). Direct
+            children give every link the same gap/padding rhythm as
+            Pattern A links without per-template overrides.
+        *}
+        <nav class="admin-sidebar__nav page-toc__nav" aria-label="{$toc_label}">
+            {foreach from=$toc_entries item=entry name=tocLoop}
+                <a class="sidebar__link admin-sidebar__link page-toc__link"
+                   href="#{$entry.slug}"
+                   data-testid="{$toc_id}-toc-link-{$entry.slug}"
+                   data-toc-target="{$entry.slug}"
+                   {if $smarty.foreach.tocLoop.first}aria-current="page"{/if}>
+                    <i data-lucide="{if isset($entry.icon) && $entry.icon}{$entry.icon}{else}circle-dot{/if}"></i>
+                    <span>{$entry.label}</span>
+                </a>
+            {/foreach}
         </nav>
     </details>
 </aside>
+<script>
+{literal}
+// @ts-check
+//
+// #1266 — page-level ToC active-section observer.
+//
+// Drive `aria-current="page"` on the `[data-toc-target="<slug>"]`
+// link whose matching `<section id="<slug>">` is currently the most
+// prominently visible inside the viewport. Mirrors the Pattern A
+// active-link treatment so users see the same "this is where you
+// are" signal whether the chrome is a sub-page sidebar or a
+// page-level ToC.
+//
+// Idempotent: callable once per ToC instance via the
+// `data-toc-id` selector. The first link is server-rendered with
+// `aria-current="page"` so the page works without JS — this script
+// only refines the active link as the user scrolls. Honours
+// `prefers-reduced-motion` only by virtue of not animating
+// anything (it's a class/attr toggle).
+(function () {
+    'use strict';
+    /** @type {NodeListOf<HTMLElement>} */
+    var tocs = document.querySelectorAll('[data-testid$="-toc"]:not([data-toc-init])');
+    if (!tocs.length || typeof window.IntersectionObserver !== 'function') return;
+    tocs.forEach(function (toc) {
+        toc.setAttribute('data-toc-init', '1');
+        /** @type {NodeListOf<HTMLAnchorElement>} */
+        var links = toc.querySelectorAll('[data-toc-target]');
+        if (!links.length) return;
+        /** @type {Record<string, HTMLAnchorElement>} */
+        var linkBySlug = {};
+        /** @type {Element[]} */
+        var sections = [];
+        links.forEach(function (link) {
+            var slug = link.getAttribute('data-toc-target');
+            if (!slug) return;
+            linkBySlug[slug] = link;
+            var section = document.getElementById(slug);
+            if (section) sections.push(section);
+        });
+        if (!sections.length) return;
+        /** @type {Record<string, number>} */
+        var ratios = {};
+        function setActive(slug) {
+            links.forEach(function (link) {
+                if (link.getAttribute('data-toc-target') === slug) {
+                    link.setAttribute('aria-current', 'page');
+                } else {
+                    link.removeAttribute('aria-current');
+                }
+            });
+        }
+        var observer = new IntersectionObserver(function (entries) {
+            entries.forEach(function (entry) {
+                var id = entry.target.id;
+                if (!id) return;
+                ratios[id] = entry.isIntersecting ? entry.intersectionRatio : 0;
+            });
+            // Pick the section with the highest visible ratio; ties
+            // resolve to the earliest-in-DOM section (the iteration
+            // order over `sections`). When everything is below the
+            // viewport (e.g. the user scrolled past the last section)
+            // the active link sticks at whatever it last was, which
+            // matches the docs-site UX users expect from a ToC.
+            var bestSlug = null;
+            var bestRatio = 0;
+            sections.forEach(function (section) {
+                var r = ratios[section.id] || 0;
+                if (r > bestRatio) {
+                    bestRatio = r;
+                    bestSlug = section.id;
+                }
+            });
+            if (bestSlug) setActive(bestSlug);
+        }, {
+            // 4rem matches the `scroll-margin-top` on `.page-toc-section`
+            // (sticky topbar offset), so a section becomes "the active
+            // one" the moment its heading clears the topbar.
+            rootMargin: '-4rem 0px -50% 0px',
+            threshold: [0, 0.05, 0.25, 0.5, 0.75, 1],
+        });
+        sections.forEach(function (section) { observer.observe(section); });
+    });
+})();
+{/literal}
+</script>


### PR DESCRIPTION
## Summary

- **Symptom 1 (style divergence)** — Pattern B's `core/page_toc.tpl`
  ToC chrome is now visually unified with Pattern A's
  `core/admin_sidebar.tpl` (iconed pill rows + active-state
  highlight via `aria-current=\"page\"`); both surfaces share grouped
  `.admin-sidebar*, .page-toc*` selectors in `theme.css` so future
  drift is impossible. Routing semantics stay different (A navigates
  between sibling URLs, B scrolls within one page) but the visible
  chrome no longer diverges.
- **Symptom 2 (Pattern A offset bug)** — `.admin-sidebar-shell` now
  carries the 1.5rem page inset (mirroring the `.page-toc-shell`
  fix in #1260 → #1263); the redundant `.p-6` wrapper was dropped
  from the inner Pattern A content templates that still had it,
  and `.page-section` nested inside `.admin-sidebar-content` is
  contextually neutralised so the servers/mods templates don't
  double up.

Closes #1266.

## Symptom 2 — Pattern A offset fix

Mirrors #1260 → #1263 (`.page-toc-shell`). The shell now carries a
base 1.5rem inset (1400px max-width cap), so the sidebar's first
row and the content column's first heading both start at the same
top y. The `align-items: start` grid behaviour was always going to
align grid cells, never \"visible content inside cells\" — the fix is
to put the inset on the grid host itself.

CSS — base `.admin-sidebar-shell { padding: 1.5rem; max-width: 1400px }`
plus a contextual neutraliser for `.page-section` nested inside the
content column:

```css
.admin-sidebar-shell {
  padding: 1.5rem;
  max-width: 1400px;
}
.admin-sidebar-content .page-section {
  padding: 0;
  max-width: none;
}
```

The neutraliser keeps each template's own inline `style=\"max-width:Npx\"`
working (inline-style specificity wins over the CSS rule) so the
narrow form clamps on `page_admin_servers_add.tpl` /
`page_admin_groups_add.tpl` etc. are preserved.

Per-template `.p-6` removals (the inner wrappers that were causing
the bug pre-#1266):

- `web/themes/default/page_admin_settings_settings.tpl`
- `web/themes/default/page_admin_settings_features.tpl`
- `web/themes/default/page_admin_settings_logs.tpl`
- `web/themes/default/page_admin_settings_themes.tpl`
- `web/themes/default/page_admin_groups_add.tpl`
- `web/themes/default/page_admin_groups_list.tpl`
- `web/themes/default/page_admin_comms_add.tpl`

Each kept its inner `.mb-6` heading wrapper so the heading's bottom
gap to the first card holds. Pattern A templates that already use
`.page-section` (servers / mods / edit-mod) didn't need a template
edit — the neutraliser handles them.

## Symptom 1 — Pattern B chrome unified onto Pattern A

The page-toc partial now emits **dual class names** so the bare CSS
lives in one place:

```html
<aside class=\"admin-sidebar page-toc\" data-testid=\"…-toc\" aria-label=\"…\">
  <details class=\"admin-sidebar__details page-toc__details\" open>
    <summary class=\"admin-sidebar__summary page-toc__summary\">…</summary>
    <nav class=\"admin-sidebar__nav page-toc__nav\" aria-label=\"…\">
      <a class=\"sidebar__link admin-sidebar__link page-toc__link\"
         href=\"#<slug>\"
         data-testid=\"…-toc-link-<slug>\"
         data-toc-target=\"<slug>\"
         {if first}aria-current=\"page\"{/if}>
        <i data-lucide=\"<icon>\"></i>
        <span>{label}</span>
      </a>
      …
    </nav>
  </details>
</aside>
```

In `theme.css` the chrome rules merge via grouped selectors
(`.admin-sidebar, .page-toc` / `.admin-sidebar__details,
.page-toc__details` / …); the previously-duplicated `.page-toc__*`
block is now slimmed down to only the page-toc-specific rules
(content-column anchors, the `.page-toc-shell` page-padding inset,
the desktop grid layout). The legacy `.page-toc*` class names keep
matching for any third-party theme that styles by them — no
backward-compat break.

### Active state — `IntersectionObserver`

Vanilla JS, `// @ts-check`, no new deps. Lives inline at the bottom
of `page_toc.tpl` so it auto-registers on every page that includes
the partial:

- The first link is server-rendered with `aria-current=\"page\"` so
  the page works without JS.
- The observer watches each `<section id=\"<slug>\">` paired with the
  ToC's `[data-toc-target=\"<slug>\"]` link. Active link follows the
  section with the highest visible ratio; ties break in DOM order;
  past the last section, the active state sticks to where it last
  was (matches the docs-site UX users expect).
- `rootMargin: '-4rem 0px -50% 0px'` lines up with the
  `scroll-margin-top: 4rem` on `.page-toc-section` (the topbar
  offset), so a section becomes active the moment its heading
  clears the topbar.
- Idempotent — `[data-toc-init]` flag prevents double-binding.
- Honours `prefers-reduced-motion` by virtue of not animating
  anything (it's a class/attr toggle).

### Icons on every entry

`$toc_entries` gains a required `icon` field (Lucide name). Both
adopters and the View DTO updated:

- `web/pages/admin.bans.php` → `add-ban: plus`, `protests: flag`,
  `submissions: clipboard-list`, `import: upload`, `group-ban: users`.
- `web/pages/admin.admins.php` → `search: search`,
  `admins: users`, `add-admin: user-plus`, `overrides: shield`,
  `add-override: plus`.
- `web/includes/View/AdminAdminsListView.php` — `@param` shape
  upgraded to `list<array{slug: string, label: string, icon: string}>`.

Entries that don't carry an `icon` fall back to `circle-dot` (so a
partial future migration won't paint with no icon at all), but new
entries should always declare one — same convention as Pattern A.

### Docs

- `AGENTS.md` \"Page-level table of contents (dense admin pages)\"
  section rewritten: removed the implicit \"Pattern B uses different
  chrome by intent\" framing, documented the unified contract, the
  required `icon` field, the inline `IntersectionObserver`, and the
  E2E selector preservation (`[aria-current=\"page\"]` is the new
  active-link assertion — same as Pattern A).
- \"Where to find what\" row for `page_toc.tpl` extended with the
  unified-chrome pointers + the icon field.

## Quality gates

| Gate | Result |
| --- | --- |
| PHPStan | ✅ 0 errors over 218 paths |
| PHPUnit | ✅ 361 tests / 1488 assertions |
| ts-check | ✅ clean |
| composer api-contract | ✅ regen, no diff |
| Playwright E2E (workers=1) | ✅ 177 passed |

> **Re: parallel-worker E2E**: A first run with the dev runner's
> default 8 workers produced 9 failures clustered on
> banlist/comms/drawer/admin-ban-lifecycle specs (DB reset races
> between concurrent workers, the same hazard
> AGENTS.md \"Playwright E2E specifics\" calls out — \"Until each
> worker has its own DB, parallelism here is unsound. Don't bump
> `workers` back up\"). A re-run with `--workers=1` (matching CI's
> `workers: 1`) had zero failures.

## Screenshots

Gallery added the three Pattern A routes that #1259 introduced to
the unified chrome but `_screenshots.spec.ts` hadn't yet picked up
(`admin-servers`, `admin-mods`, `admin-comms`); the existing
`admin-bans`, `admin-admins`, `admin-groups`, `admin-settings` rows
already cover the rest of the affected surfaces. Markdown table will
be posted as a follow-up comment via
`web/tests/e2e/scripts/upload-screenshots.sh`.

## Test plan

- [ ] Pattern A routes (`admin-settings`, `admin-servers`,
  `admin-mods`, `admin-groups`, `admin-comms`): confirm the first
  sidebar row and the page heading start at the same top y at
  desktop, and the heading sits flush at the top of the content
  column at mobile (no 1.5rem dead band).
- [ ] Pattern B routes (`admin-bans`, `admin-admins`): confirm the
  ToC sidebar renders iconed pill rows; the link matching the
  current section carries the dark-pill / brand-orange
  `aria-current=\"page\"` treatment; scrolling the page transfers the
  active state to the right link.
- [ ] Mobile (≤1023px) on every adopter: `<details open>`
  accordion still expands/collapses; the iconed-link visual matches
  desktop.
- [ ] Dark mode on every adopter: active-link treatment paints the
  brand-orange hue (single-source rule from `.sidebar__link
  [aria-current=\"page\"]` block in `theme.css`).
- [ ] No-JS smoke test: load `?p=admin&c=bans`, disable JS in the
  browser, confirm the first ToC link is rendered with
  `aria-current=\"page\"` (server-rendered fallback).