### PR TITLE
fix(admin-settings/features): align row anatomy with Settings → Main + global checkbox paint (#1256)

### DIFF
--- a/web/tests/e2e/specs/_screenshots.spec.ts
+++ b/web/tests/e2e/specs/_screenshots.spec.ts
@@ -226,6 +226,15 @@ const ROUTES_SMOKE_ADMIN: RouteSpec[] = [
     { name: 'admin-mods',     path: '/index.php?p=admin&c=mods',      auth: true },
     { name: 'admin-comms',    path: '/index.php?p=admin&c=comms',     auth: true },
     { name: 'admin-settings', path: '/index.php?p=admin&c=settings',  auth: true },
+    // #1256: lock the Features sub-tab now that its row anatomy
+    // is unified with Settings → Main. Re-baselining
+    // `admin-settings` in the same PR is intentional — the
+    // global `input[type="checkbox"]` paint reshapes its two
+    // existing checkboxes (`config.debug`, plus the auth/token
+    // section) and any flow spec that asserts on those rows
+    // continues to use the same `data-testid="setting-row"`
+    // hooks (only the visual changes).
+    { name: 'admin-features', path: '/index.php?p=admin&c=settings&section=features', auth: true },
     { name: 'admin-audit',    path: '/index.php?p=admin&c=audit',     auth: true },
     { name: 'myaccount',      path: '/index.php?p=account',           auth: true },
 ];

--- a/web/themes/default/css/theme.css
+++ b/web/themes/default/css/theme.css
@@ -564,6 +564,67 @@ html.dark .admin-tabs > [aria-current="page"] { border-bottom-color: var(--brand
 .textarea { height: auto; padding: 0.625rem 0.75rem; resize: vertical; min-height: 5rem; }
 .input--with-icon { padding-left: 2rem; }
 
+/* Global checkbox paint (#1256).
+
+   Style the native checkbox so it reads at the same scale as
+   `.text-sm` row labels (~14–16px). The browser default is ~13px
+   square in Chromium, which reads as undersized against the
+   1.5rem (24px) row padding on Settings → Features and the
+   `text-sm font-medium` label-pair on Settings → Main; on a
+   settings page where the checkbox IS the action, the
+   affordance disappears at the right edge of the row.
+
+   The native `<input type="checkbox">` is retained — only the
+   paint is custom. Keyboard semantics, screen-reader announcement
+   ("checked"/"unchecked"), and the label-pair click target are
+   unchanged. The rule is global on purpose: the same paint
+   applies to Settings → Main's existing checkboxes
+   (`config.debug`), the login form's "Remember me", and any
+   future check-style affordance, so the panel converges on one
+   visual treatment.
+
+   The check glyph is an inline SVG data URL (white stroke, brand
+   background when `:checked`) so we don't ship a separate asset
+   and the rule stays self-contained. The same glyph paints in
+   both themes; the brand colour token (`--brand-600`) is themed
+   via the root variables. */
+input[type="checkbox"] {
+  appearance: none;
+  -webkit-appearance: none;
+  width: 1.125rem;
+  height: 1.125rem;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: var(--bg-surface);
+  cursor: pointer;
+  flex-shrink: 0;
+  position: relative;
+  transition: background-color .15s, border-color .15s;
+}
+input[type="checkbox"]:hover { border-color: var(--brand-600); }
+input[type="checkbox"]:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+input[type="checkbox"]:checked {
+  background: var(--brand-600);
+  border-color: var(--brand-600);
+}
+input[type="checkbox"]:checked::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  display: block;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='none' stroke='white' stroke-width='2.5' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='3 8 7 12 13 4'/%3E%3C/svg%3E");
+  background-size: 75% 75%;
+  background-repeat: no-repeat;
+  background-position: center;
+}
+input[type="checkbox"]:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
 /* File-input wrapper (#1189). The native button is hidden via `hidden`
    on the <input>; the styled <label class="btn btn--secondary"> is the
    click target, and the sibling span mirrors the chosen filename. */

--- a/web/themes/default/css/theme.css
+++ b/web/themes/default/css/theme.css
@@ -620,6 +620,30 @@ input[type="checkbox"]:checked::after {
   background-repeat: no-repeat;
   background-position: center;
 }
+/* Defensive paint for the indeterminate state (review nit on #1276):
+   `appearance: none` strips the OS-native paint, so a checkbox with
+   `el.indeterminate = true` would otherwise fall back to the
+   unchecked look. No panel surface sets `.indeterminate` today —
+   only the bundled tinymce skin references the keyword — but the
+   gap is real, so paint a centered horizontal-bar glyph (mirroring
+   the `:checked` SVG approach) at the brand colour so the state
+   reads like the OS-native indeterminate. `:indeterminate` wins
+   over `:checked` on the cascade because both selectors share
+   the same specificity and this rule comes later. */
+input[type="checkbox"]:indeterminate {
+  background: var(--brand-600);
+  border-color: var(--brand-600);
+}
+input[type="checkbox"]:indeterminate::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  display: block;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='none' stroke='white' stroke-width='2.5' stroke-linecap='round'%3E%3Cline x1='3' y1='8' x2='13' y2='8'/%3E%3C/svg%3E");
+  background-size: 75% 75%;
+  background-repeat: no-repeat;
+  background-position: center;
+}
 input[type="checkbox"]:disabled {
   opacity: 0.5;
   cursor: not-allowed;

--- a/web/themes/default/page_admin_settings_features.tpl
+++ b/web/themes/default/page_admin_settings_features.tpl
@@ -13,6 +13,29 @@
     page handler (admin.settings.php) opens the shell BEFORE this
     template renders. See AGENTS.md "Sub-paged admin routes".
 
+    #1256 — row anatomy aligned with Settings → Main
+    (page_admin_settings_settings.tpl). Each toggle row is now
+    `<div data-testid="setting-row" data-key="…"> <label
+    class="flex items-center gap-2"><input><span class="text-sm
+    font-medium"></span></label> <p
+    class="settings-fieldset__help" id="…_help"
+    data-testid="setting-help-…">…</p> </div>` — the label-pair
+    shape Settings → Main uses for its inline checkboxes (e.g.
+    `config.debug`), with the description copy promoted to a
+    sibling `<p>` paragraph wired via `aria-describedby` so screen
+    readers announce it as the input's description (the same wiring
+    Settings → Main's auth/token-lifetime block — #1207 ADM-7 —
+    uses for its number inputs). The pre-#1256 inline
+    `style="border:…;border-radius:…"` was dropped: the outer
+    `.card` is the only chrome now, and the per-row borders that
+    painted the card-in-card double-bordered look are gone. Card
+    body rhythm bumped from `space-y-3` to `space-y-4` to match
+    Settings → Main's card-body spacing now that the rows have a
+    sibling paragraph beneath the label-pair. The native checkbox
+    paint is unified panel-wide via the global
+    `input[type="checkbox"]` rule in
+    `web/themes/default/css/theme.css` (also #1256).
+
     Variable contract (kept in sync by SmartyTemplateRule):
         Permission gates:
             $can_web_settings — gates the entire body.
@@ -32,6 +55,7 @@
           `admin-tab-<slug>` shape now that the chrome is shared with
           servers / mods / groups).
         - Each toggle row: data-testid="setting-row" + data-key="<key>".
+        - Each help paragraph: data-testid="setting-help-<key>" (#1256).
         - Save button: data-testid="settings-save".
 
     #1266 — outer `.p-6` removed; the page inset lives on
@@ -56,86 +80,98 @@
 
                     <div class="card">
                         <div class="card__header"><div><h3>Bans</h3><p>Public exports, KickIt, group / friend banning.</p></div></div>
-                        <div class="card__body space-y-3">
-                            <label class="flex items-center justify-between gap-3 p-3" style="border:1px solid var(--border);border-radius:var(--radius-md)" data-testid="setting-row" data-key="config.exportpublic">
-                                <span class="text-sm">
-                                    <span class="font-medium">Public ban export</span>
-                                    <span class="block text-xs text-muted mt-2">Lets unauthenticated visitors download the full ban list.</span>
-                                </span>
-                                <input type="checkbox" name="export_public" id="export_public"{if $export_public} checked{/if}>
-                            </label>
+                        <div class="card__body space-y-4">
+                            <div data-testid="setting-row" data-key="config.exportpublic">
+                                <label class="flex items-center gap-2">
+                                    <input type="checkbox" id="export_public" name="export_public"{if $export_public} checked{/if} aria-describedby="export_public_help">
+                                    <span class="text-sm font-medium">Public ban export</span>
+                                </label>
+                                <p class="settings-fieldset__help" id="export_public_help" data-testid="setting-help-config.exportpublic">
+                                    Lets unauthenticated visitors download the full ban list.
+                                </p>
+                            </div>
 
-                            <label class="flex items-center justify-between gap-3 p-3" style="border:1px solid var(--border);border-radius:var(--radius-md)" data-testid="setting-row" data-key="config.enablekickit">
-                                <span class="text-sm">
-                                    <span class="font-medium">KickIt</span>
-                                    <span class="block text-xs text-muted mt-2">Auto-kick a player when their ban lands.</span>
-                                </span>
-                                <input type="checkbox" name="enable_kickit" id="enable_kickit"{if $enable_kickit} checked{/if}>
-                            </label>
+                            <div data-testid="setting-row" data-key="config.enablekickit">
+                                <label class="flex items-center gap-2">
+                                    <input type="checkbox" id="enable_kickit" name="enable_kickit"{if $enable_kickit} checked{/if} aria-describedby="enable_kickit_help">
+                                    <span class="text-sm font-medium">KickIt</span>
+                                </label>
+                                <p class="settings-fieldset__help" id="enable_kickit_help" data-testid="setting-help-config.enablekickit">
+                                    Auto-kick a player when their ban lands.
+                                </p>
+                            </div>
 
-                            <label class="flex items-center justify-between gap-3 p-3" style="border:1px solid var(--border);border-radius:var(--radius-md)" data-testid="setting-row" data-key="config.enablegroupbanning">
-                                <span class="text-sm">
-                                    <span class="font-medium">Steam group banning</span>
-                                    <span class="block text-xs text-muted mt-2">
-                                        Ban every member of a Steam community group.
-                                        {if NOT $steamapi}<br><span style="color:var(--warning)">Requires a Steam Web API key in <code>config.php</code>.</span>{/if}
-                                    </span>
-                                </span>
-                                <input type="checkbox" name="enable_groupbanning" id="enable_groupbanning"{if $enable_groupbanning} checked{/if}{if NOT $steamapi} disabled{/if}>
-                            </label>
+                            <div data-testid="setting-row" data-key="config.enablegroupbanning">
+                                <label class="flex items-center gap-2">
+                                    <input type="checkbox" id="enable_groupbanning" name="enable_groupbanning"{if $enable_groupbanning} checked{/if}{if NOT $steamapi} disabled{/if} aria-describedby="enable_groupbanning_help">
+                                    <span class="text-sm font-medium">Steam group banning</span>
+                                </label>
+                                <p class="settings-fieldset__help" id="enable_groupbanning_help" data-testid="setting-help-config.enablegroupbanning">
+                                    Ban every member of a Steam community group.
+                                    {if NOT $steamapi}<br><span style="color:var(--warning)">Requires a Steam Web API key in <code>config.php</code>.</span>{/if}
+                                </p>
+                            </div>
 
-                            <label class="flex items-center justify-between gap-3 p-3" style="border:1px solid var(--border);border-radius:var(--radius-md)" data-testid="setting-row" data-key="config.enablefriendsbanning">
-                                <span class="text-sm">
-                                    <span class="font-medium">Steam friends banning</span>
-                                    <span class="block text-xs text-muted mt-2">
-                                        Ban every Steam friend of a player.
-                                        {if NOT $steamapi}<br><span style="color:var(--warning)">Requires a Steam Web API key in <code>config.php</code>.</span>{/if}
-                                    </span>
-                                </span>
-                                <input type="checkbox" name="enable_friendsbanning" id="enable_friendsbanning"{if $enable_friendsbanning} checked{/if}{if NOT $steamapi} disabled{/if}>
-                            </label>
+                            <div data-testid="setting-row" data-key="config.enablefriendsbanning">
+                                <label class="flex items-center gap-2">
+                                    <input type="checkbox" id="enable_friendsbanning" name="enable_friendsbanning"{if $enable_friendsbanning} checked{/if}{if NOT $steamapi} disabled{/if} aria-describedby="enable_friendsbanning_help">
+                                    <span class="text-sm font-medium">Steam friends banning</span>
+                                </label>
+                                <p class="settings-fieldset__help" id="enable_friendsbanning_help" data-testid="setting-help-config.enablefriendsbanning">
+                                    Ban every Steam friend of a player.
+                                    {if NOT $steamapi}<br><span style="color:var(--warning)">Requires a Steam Web API key in <code>config.php</code>.</span>{/if}
+                                </p>
+                            </div>
 
-                            <label class="flex items-center justify-between gap-3 p-3" style="border:1px solid var(--border);border-radius:var(--radius-md)" data-testid="setting-row" data-key="config.enableadminrehashing">
-                                <span class="text-sm">
-                                    <span class="font-medium">Auto admin rehash</span>
-                                    <span class="block text-xs text-muted mt-2">Push admin/group changes to servers immediately.</span>
-                                </span>
-                                <input type="checkbox" name="enable_adminrehashing" id="enable_adminrehashing"{if $enable_adminrehashing} checked{/if}>
-                            </label>
+                            <div data-testid="setting-row" data-key="config.enableadminrehashing">
+                                <label class="flex items-center gap-2">
+                                    <input type="checkbox" id="enable_adminrehashing" name="enable_adminrehashing"{if $enable_adminrehashing} checked{/if} aria-describedby="enable_adminrehashing_help">
+                                    <span class="text-sm font-medium">Auto admin rehash</span>
+                                </label>
+                                <p class="settings-fieldset__help" id="enable_adminrehashing_help" data-testid="setting-help-config.enableadminrehashing">
+                                    Push admin/group changes to servers immediately.
+                                </p>
+                            </div>
                         </div>
                     </div>
 
                     <div class="card">
                         <div class="card__header"><div><h3>Login</h3><p>Sign-in surfaces exposed to admins.</p></div></div>
-                        <div class="card__body space-y-3">
-                            <label class="flex items-center justify-between gap-3 p-3" style="border:1px solid var(--border);border-radius:var(--radius-md)" data-testid="setting-row" data-key="config.enablesteamlogin">
-                                <span class="text-sm">
-                                    <span class="font-medium">Steam OpenID login</span>
-                                    <span class="block text-xs text-muted mt-2">Show "Sign in through Steam" on the login page.</span>
-                                </span>
-                                <input type="checkbox" name="enable_steamlogin" id="enable_steamlogin"{if $enable_steamlogin} checked{/if}>
-                            </label>
+                        <div class="card__body space-y-4">
+                            <div data-testid="setting-row" data-key="config.enablesteamlogin">
+                                <label class="flex items-center gap-2">
+                                    <input type="checkbox" id="enable_steamlogin" name="enable_steamlogin"{if $enable_steamlogin} checked{/if} aria-describedby="enable_steamlogin_help">
+                                    <span class="text-sm font-medium">Steam OpenID login</span>
+                                </label>
+                                <p class="settings-fieldset__help" id="enable_steamlogin_help" data-testid="setting-help-config.enablesteamlogin">
+                                    Show "Sign in through Steam" on the login page.
+                                </p>
+                            </div>
 
-                            <label class="flex items-center justify-between gap-3 p-3" style="border:1px solid var(--border);border-radius:var(--radius-md)" data-testid="setting-row" data-key="config.enablenormallogin">
-                                <span class="text-sm">
-                                    <span class="font-medium">Username/password login</span>
-                                    <span class="block text-xs text-muted mt-2">Disable to require Steam login for all admins.</span>
-                                </span>
-                                <input type="checkbox" name="enable_normallogin" id="enable_normallogin"{if $enable_normallogin} checked{/if}>
-                            </label>
+                            <div data-testid="setting-row" data-key="config.enablenormallogin">
+                                <label class="flex items-center gap-2">
+                                    <input type="checkbox" id="enable_normallogin" name="enable_normallogin"{if $enable_normallogin} checked{/if} aria-describedby="enable_normallogin_help">
+                                    <span class="text-sm font-medium">Username/password login</span>
+                                </label>
+                                <p class="settings-fieldset__help" id="enable_normallogin_help" data-testid="setting-help-config.enablenormallogin">
+                                    Disable to require Steam login for all admins.
+                                </p>
+                            </div>
                         </div>
                     </div>
 
                     <div class="card">
                         <div class="card__header"><div><h3>Comments</h3><p>Visibility of admin commentary on bans / submissions.</p></div></div>
-                        <div class="card__body space-y-3">
-                            <label class="flex items-center justify-between gap-3 p-3" style="border:1px solid var(--border);border-radius:var(--radius-md)" data-testid="setting-row" data-key="config.enablepubliccomments">
-                                <span class="text-sm">
-                                    <span class="font-medium">Public admin comments</span>
-                                    <span class="block text-xs text-muted mt-2">Show admin comments on a ban to anonymous visitors.</span>
-                                </span>
-                                <input type="checkbox" name="enable_publiccomments" id="enable_publiccomments"{if $enable_publiccomments} checked{/if}>
-                            </label>
+                        <div class="card__body space-y-4">
+                            <div data-testid="setting-row" data-key="config.enablepubliccomments">
+                                <label class="flex items-center gap-2">
+                                    <input type="checkbox" id="enable_publiccomments" name="enable_publiccomments"{if $enable_publiccomments} checked{/if} aria-describedby="enable_publiccomments_help">
+                                    <span class="text-sm font-medium">Public admin comments</span>
+                                </label>
+                                <p class="settings-fieldset__help" id="enable_publiccomments_help" data-testid="setting-help-config.enablepubliccomments">
+                                    Show admin comments on a ban to anonymous visitors.
+                                </p>
+                            </div>
                         </div>
                     </div>
 


### PR DESCRIPTION
## Summary

- Restructure each of the 8 toggle rows in `page_admin_settings_features.tpl` to the canonical Settings → Main shape (`<div data-testid="setting-row" data-key="…"><label class="flex items-center gap-2"><input><span class="text-sm font-medium"></span></label><p class="settings-fieldset__help" id="…_help" data-testid="setting-help-…">…</p></div>`). Drop the inline `style="border:…;border-radius:…"` so the outer `.card` is the only chrome and the card-in-card double-bordered look is gone. Wire `aria-describedby` on every input → help paragraph (mirrors the auth/token-lifetime block from #1207 ADM-7), and bump the per-card body rhythm from `space-y-3` to `space-y-4` to match Main now that rows have a sibling paragraph beneath the label-pair.
- Add a global `input[type="checkbox"]` paint rule in `theme.css`. The checkbox is now 18px (1.125rem), brand-orange when `:checked`, with a white inline-SVG check glyph and a focus ring matching the rest of the panel. Native `<input type="checkbox">` is retained — only the paint is custom — so keyboard semantics, screen-reader announcement, and the label-pair click target are unchanged. The rule is global on purpose (per the issue body): Settings → Main's two existing checkboxes (`config.debug` + the auth/token surfaces) pick up the same paint, the login form's "Remember me" gets it for free, and any future check-style affordance converges on one visual treatment.
- Lock the new shape in the screenshot harness: append `admin-features` to `_screenshots.spec.ts`'s `ROUTES_SMOKE_ADMIN`. Re-baselining `admin-settings` in the same PR is intentional — the global checkbox rule reshapes its existing checkboxes and the visual drift is the point.

## Changes

- `web/themes/default/page_admin_settings_features.tpl` — all 8 rows rewritten (5× Bans, 2× Login, 1× Comments) to the canonical setting-row shape; inline border style removed; `space-y-3` → `space-y-4` on each `.card__body`. Steam group/friends banning rows keep their inline warning span (`Requires a Steam Web API key…`) inside the new help paragraph rather than the old description span. Header docblock updated to point future readers at the new conventions.
- `web/themes/default/css/theme.css` — new global `input[type="checkbox"]` block in the "Inputs" section (between `.input--with-icon` and the `.file-input` wrapper). Hover, focus-visible, checked, and disabled states all themed via existing tokens (`--brand-600`, `--accent`, `--border`, `--bg-surface`, `--radius-sm`).
- `web/tests/e2e/specs/_screenshots.spec.ts` — `admin-features` appended to `ROUTES_SMOKE_ADMIN` with a comment explaining the intentional `admin-settings` re-baseline.

## Screenshots

Captured under `web/tests/e2e/screenshots/{light,dark}/desktop/admin-features.png` and `…/admin-settings.png` via `SCREENSHOTS=1 ./sbpp.sh e2e --grep "admin-features|admin-settings" --project chromium` (all 11 specs pass; 0 critical axe violations on admin-settings).

**Visual delta** — Settings → Features (after):

- Outer `.card` is the only chrome on each section ("Bans", "Login", "Comments"). The 8 sub-rows no longer paint individual borders.
- Every row reads as `<bold label> <checkbox>` + a muted explainer paragraph below. Identical typography to Settings → Main.
- Checkboxes are 18px brand-orange when checked, with a white check glyph; unchecked boxes have a 1px `--border` outline on the page background, matching `.input` chrome.
- The two API-gated rows (Steam group/friends banning) keep their disabled state + inline warning span.

**Side effect on Settings → Main**: the existing checkboxes (`Enable debug mode`, the four `Public pages` toggles, the three `Ban list` privacy toggles, `Verify TLS peer certificate`) all pick up the same brand-orange paint. Same testability hooks; only the visual treatment changes.

## Test plan

- [x] `./sbpp.sh phpstan` — clean (no errors).
- [x] `./sbpp.sh test` — 361 tests / 1488 assertions green.
- [x] `./sbpp.sh ts-check` — clean.
- [x] `./sbpp.sh composer api-contract` — no diff (no API surface touched).
- [x] `SCREENSHOTS=1 ./sbpp.sh e2e --grep "admin-features|admin-settings" --project chromium` — 11/11 pass:
  - `admin-features` (light + dark) screenshots captured.
  - `admin-settings` (light + dark) re-baseline screenshots captured.
  - `smoke /admin/settings` console-error + axe gate green.
  - `flow: admin settings token-lifetime inputs (#1207 ADM-7)` 4 specs green (vertical stack, help paragraphs, label-input width, axe).
  - `a11y axe scan (0 critical) › admin-settings` light + dark green.
- [x] Manually verified the screenshots: chrome unified, checkboxes legible at the row scale, focus ring visible, disabled state visibly muted, dark theme reads correctly.

## Out of scope (deferred follow-ups, called out in the issue body)

- Replacing the checkbox visual with a slider/switch element panel-wide. The labels here read like switches, but that's a separate visual decision that should land for every check-style affordance, not Features-only.
- Converting Settings → Features into a typed View DTO with a shared `{include file="settings/feature_row.tpl"}` partial driven by `(key, title, help, value, disabled)` tuples. The current page is hand-rolled; lifting it into a partial would simplify future additions but is structural refactor work better landed standalone.
- Auditing every other `<input type="checkbox">` site outside Settings (My Account "Remember me", any inline form-field checkbox). The global rule styles them automatically — a visual review pass to confirm each surface still reads correctly is its own issue.

Closes #1256