### PR TITLE
fix(commslist): wire ?type= / ?state= chips into SQL + sync Active toggle (#1274)

### DIFF
--- a/web/includes/View/CommsListView.php
+++ b/web/includes/View/CommsListView.php
@@ -73,6 +73,17 @@ final class CommsListView extends View
         public readonly array $servers,
         public readonly array $pagination,
         public readonly bool $hide_inactive,
+        // #1274: union of the session "Hide inactive" flag AND the
+        // chip strip's `?state=active` URL surface. Both surfaces
+        // narrow the list to active-only rows; the template uses
+        // this single flag to drive the toggle button's pressed/
+        // label state and the Active chip's pressed state, so
+        // clicking either surface keeps the chrome consistent
+        // regardless of click order. `hide_inactive` (just the
+        // session flag) stays in the View for third-party themes
+        // that forked the v1.x default and only know about the
+        // session toggle.
+        public readonly bool $is_active_only,
         public readonly string $hide_inactive_toggle_url,
         public readonly bool $can_add_comm,
         public readonly bool $can_edit_comm,

--- a/web/pages/page.commslist.php
+++ b/web/pages/page.commslist.php
@@ -221,14 +221,58 @@ if (isset($_GET["hideinactive"]) && $_GET["hideinactive"] == "true") { // hide
     unset($_SESSION["hideinactive"]);
     //ShowBox('Show inactive bans', 'Inactive bans will be shown in the banlist.', 'green', 'index.php?p=banlist', true);
 }
-if (isset($_SESSION["hideinactive"])) {
+
+// #1274: filter chip URL state. The chip strip in page_comms.tpl
+// submits ?type=<mute|gag|silence> for type chips and ?state=active
+// for the Active chip; both have to compose with the legacy
+// ?searchText / ?advSearch / ?advType paths AND with the existing
+// session-based "hide inactive" toggle. The lifecycle:
+//
+//   1. Sanitise chip params here (validated against a small allowlist
+//      so a stray ?type=DROP TABLE never reaches the SQL layer).
+//   2. Treat `state=active` and the session-based hideinactive flag
+//      as the SAME effect — both narrow to "active rows only" via
+//      the predicate below. The chip's `aria-pressed` and the
+//      toggle button's `aria-pressed` both light up when EITHER
+//      surface is on (see page_comms.tpl).
+//   3. The Active predicate is single-sourced as the local
+//      $activePredicateCo / $activePredicateBare strings: identical
+//      semantics, only the column alias differs. After PruneComms()
+//      runs at the top of this file, every length-bounded expired
+//      row already has RemoveType='E', so the second clause is a
+//      belt-and-suspenders guard against a race window where the
+//      prune hasn't yet swept the latest expired row.
+$chipType  = (string)($_GET['type']  ?? '');
+$chipType  = in_array($chipType, ['mute', 'gag', 'silence'], true) ? $chipType : '';
+$chipStateActive = (((string)($_GET['state'] ?? '')) === 'active');
+
+$activePredicateCo   = '(CO.RemoveType IS NULL AND (CO.length = 0 OR CO.ends > UNIX_TIMESTAMP()))';
+$activePredicateBare = '(RemoveType IS NULL AND (length = 0 OR ends > UNIX_TIMESTAMP()))';
+
+$isActiveOnly = isset($_SESSION["hideinactive"]) || $chipStateActive;
+if ($isActiveOnly) {
     $hidetext      = "Show";
-    $hideinactive  = " AND RemoveType IS NULL";
-    $hideinactiven = " WHERE RemoveType IS NULL";
+    $hideinactive  = " AND " . $activePredicateCo;
+    $hideinactiven = " WHERE " . $activePredicateBare;
 } else {
     $hidetext      = "Hide";
     $hideinactive  = "";
     $hideinactiven = "";
+}
+
+// Chip TYPE filter — additional WHERE fragment + bind. `:prefix_comms.type`
+// is `1=mute, 2=gag, 3=silence` per the existing render logic at
+// ~line 750 (`$typeLabel` switch). `_Co` is for queries that alias
+// the table as CO; `_Bare` is for the count query that uses the
+// unaliased table name.
+$typeMap            = ['mute' => 1, 'gag' => 2, 'silence' => 3];
+$chipTypeWhereCo    = '';
+$chipTypeWhereBare  = '';
+$chipTypeBind       = [];
+if ($chipType !== '') {
+    $chipTypeWhereCo   = ' AND CO.type = ?';
+    $chipTypeWhereBare = ' AND type = ?';
+    $chipTypeBind      = [$typeMap[$chipType]];
 }
 
 if (isset($_GET['searchText'])) {
@@ -260,6 +304,14 @@ if (isset($_GET['searchText'])) {
         $authidParam  = $search;
     }
 
+    // #1274: wrap the OR-search clauses in parens before appending
+    // any AND-predicate (hideinactive, chip type). Without the parens
+    // SQL precedence makes `WHERE A OR B OR C AND D` parse as
+    // `WHERE A OR B OR (C AND D)` — the AND only restricts the last
+    // OR term, so a chip-type filter would silently let inactive or
+    // wrong-type rows leak through whenever they matched authid or
+    // name. The parens lock the AND-predicates onto the entire OR
+    // group.
     $res = $GLOBALS['PDO']->query("SELECT bid ban_id, CO.type, CO.authid, CO.name player_name, created ban_created, ends ban_ends, length ban_length, reason ban_reason, CO.ureason unban_reason, CO.aid, AD.gid AS gid, adminIp, CO.sid ban_server, RemovedOn, RemovedBy, RemoveType row_type,
 		SE.ip server_ip, AD.user admin_name, MO.icon as mod_icon,
 		CAST(MID(CO.authid, 9, 1) AS UNSIGNED) + CAST('76561197960265728' AS UNSIGNED) + CAST(MID(CO.authid, 11, 10) * 2 AS UNSIGNED) AS community_id,
@@ -270,23 +322,40 @@ if (isset($_GET['searchText'])) {
 		LEFT JOIN `:prefix_servers` AS SE ON SE.sid = CO.sid
 		LEFT JOIN `:prefix_mods` AS MO on SE.modid = MO.mid
 		LEFT JOIN `:prefix_admins` AS AD ON CO.aid = AD.aid
-      	WHERE " . $authidClause . " or CO.name LIKE ? or CO.reason LIKE ?" . $hideinactive . "
-   		ORDER BY CO.created DESC LIMIT ?,?")->resultset(array(
+      	WHERE (" . $authidClause . " or CO.name LIKE ? or CO.reason LIKE ?)" . $hideinactive . $chipTypeWhereCo . "
+   		ORDER BY CO.created DESC LIMIT ?,?")->resultset(array_merge([
         $authidParam,
         $search,
         $search,
+    ], $chipTypeBind, [
         intval($BansStart),
         intval($BansPerPage)
-    ));
+    ]));
 
 
-    $res_count  = $GLOBALS['PDO']->query("SELECT count(CO.bid) AS cnt FROM `:prefix_comms` AS CO WHERE " . $authidClause . " OR CO.name LIKE ? OR CO.reason LIKE ?" . $hideinactive)->resultset(array(
+    $res_count  = $GLOBALS['PDO']->query("SELECT count(CO.bid) AS cnt FROM `:prefix_comms` AS CO WHERE (" . $authidClause . " OR CO.name LIKE ? OR CO.reason LIKE ?)" . $hideinactive . $chipTypeWhereCo)->resultset(array_merge([
         $authidParam,
         $search,
-        $search
-    ));
+        $search,
+    ], $chipTypeBind));
     $searchlink = "&searchText=" . urlencode($_GET["searchText"]);
 } elseif (!isset($_GET['advSearch'])) {
+    // #1274: this branch has no upper-level WHERE; if hideinactive
+    // already opened one ($hideinactiven = " WHERE …") we append the
+    // chip type filter as " AND CO.type = ?", otherwise the chip
+    // opens the WHERE itself. Mirrors the $publicFilterAnd /
+    // $publicFilterWheren shape in page.banlist.php.
+    if ($hideinactiven !== '') {
+        $branchWhereSuffix = $hideinactiven . $chipTypeWhereCo;
+        $branchCountSuffix = $hideinactiven . $chipTypeWhereBare;
+    } elseif ($chipType !== '') {
+        $branchWhereSuffix = ' WHERE CO.type = ?';
+        $branchCountSuffix = ' WHERE type = ?';
+    } else {
+        $branchWhereSuffix = '';
+        $branchCountSuffix = '';
+    }
+
     $res = $GLOBALS['PDO']->query("SELECT bid ban_id, CO.type, CO.authid, CO.name player_name, created ban_created, ends ban_ends, length ban_length, reason ban_reason, CO.ureason unban_reason, CO.aid, AD.gid AS gid, adminIp, CO.sid ban_server, RemovedOn, RemovedBy, RemoveType row_type,
 		SE.ip server_ip, AD.user admin_name, MO.icon as mod_icon,
 		CAST(MID(CO.authid, 9, 1) AS UNSIGNED) + CAST('76561197960265728' AS UNSIGNED) + CAST(MID(CO.authid, 11, 10) * 2 AS UNSIGNED) AS community_id,
@@ -297,14 +366,14 @@ if (isset($_GET['searchText'])) {
 		LEFT JOIN `:prefix_servers` AS SE ON SE.sid = CO.sid
 		LEFT JOIN `:prefix_mods` AS MO on SE.modid = MO.mid
 		LEFT JOIN `:prefix_admins` AS AD ON CO.aid = AD.aid
-		" . $hideinactiven . "
+		" . $branchWhereSuffix . "
 		ORDER BY created DESC
-		LIMIT ?,?")->resultset(array(
+		LIMIT ?,?")->resultset(array_merge($chipTypeBind, [
         intval($BansStart),
         intval($BansPerPage)
-    ));
+    ]));
 
-    $res_count  = $GLOBALS['PDO']->query("SELECT count(bid) AS cnt FROM `:prefix_comms`" . $hideinactiven)->resultset();
+    $res_count  = $GLOBALS['PDO']->query("SELECT count(bid) AS cnt FROM `:prefix_comms`" . $branchCountSuffix)->resultset($chipTypeBind);
     $searchlink = "";
 }
 
@@ -446,6 +515,20 @@ if (isset($_GET['advSearch'])) {
             break;
     }
 
+    // #1274: chip type composes onto the advSearch WHERE. If $where
+    // is empty (advType resolved to a no-op) AND hideinactive is on,
+    // promote $hideinactive to its WHERE form so the trailing chip
+    // predicate can append cleanly. Otherwise we may be left with
+    // " AND CO.type = ?" as the only WHERE clause, which is invalid
+    // SQL ("AND" with no leading WHERE). Mirrors the
+    // `if (empty($where) && hide_inactive) $hideinactive = $hideinactiven`
+    // shape page.banlist.php uses for the same composition.
+    if (empty($where) && $hideinactive === '' && $chipType !== '') {
+        $advChipType = ' WHERE CO.type = ?';
+    } else {
+        $advChipType = $chipTypeWhereCo;
+    }
+
     $res = $GLOBALS['PDO']->query("SELECT CO.bid ban_id, CO.type, CO.authid, CO.name player_name, created ban_created, ends ban_ends, length ban_length, reason ban_reason, CO.ureason unban_reason, CO.aid, AD.gid AS gid, adminIp, CO.sid ban_server, RemovedOn, RemovedBy, RemoveType row_type,
 			SE.ip server_ip, AD.user admin_name, MO.icon as mod_icon,
 			CAST(MID(CO.authid, 9, 1) AS UNSIGNED) + CAST('76561197960265728' AS UNSIGNED) + CAST(MID(CO.authid, 11, 10) * 2 AS UNSIGNED) AS community_id,
@@ -457,15 +540,15 @@ if (isset($_GET['advSearch'])) {
 			LEFT JOIN `:prefix_mods` AS MO on SE.modid = MO.mid
 			LEFT JOIN `:prefix_admins` AS AD ON CO.aid = AD.aid
   			" . ($type == "comment" && $userbank->is_admin() ? "LEFT JOIN `:prefix_comments` AS CM ON CO.bid = CM.bid" : "") . "
-      " . $where . $hideinactive . "
+      " . $where . $hideinactive . $advChipType . "
    ORDER BY CO.created DESC
-   LIMIT ?,?")->resultset(array_merge($advcrit, array(
+   LIMIT ?,?")->resultset(array_merge($advcrit, $chipTypeBind, [
         intval($BansStart),
         intval($BansPerPage)
-    )));
+    ]));
 
     $res_count  = $GLOBALS['PDO']->query("SELECT count(CO.bid) AS cnt FROM `:prefix_comms` AS CO
-										  " . ($type == "comment" && $userbank->is_admin() ? "LEFT JOIN `:prefix_comments` AS CM ON CO.bid = CM.bid" : "") . " " . $where . $hideinactive)->resultset($advcrit);
+										  " . ($type == "comment" && $userbank->is_admin() ? "LEFT JOIN `:prefix_comments` AS CM ON CO.bid = CM.bid" : "") . " " . $where . $hideinactive . $advChipType)->resultset(array_merge($advcrit, $chipTypeBind));
     $searchlink = "&advSearch=" . urlencode($_GET['advSearch']) . "&advType=" . urlencode($_GET['advType']);
 }
 
@@ -935,6 +1018,17 @@ unset($_SESSION['CountryFetchHndl']);
 // reference in the original code path.
 $searchlink = $searchlink ?? '';
 
+// #1274: extend $searchlink with the chip TYPE (so toggle URL +
+// pagination preserve a Mute/Gag/Silence selection across navigations).
+// NOTE: chip STATE (`?state=active`) is intentionally NOT folded into
+// $searchlink — the toggle URL needs to be able to drop it cleanly
+// when the user clicks "Show inactive". $paginationLink below adds
+// state on top so paginated pages still preserve the active filter.
+if ($chipType !== '') {
+    $searchlink .= '&type=' . urlencode($chipType);
+}
+$paginationLink = $searchlink . ($chipStateActive ? '&state=active' : '');
+
 $theme->assign('admin_nick', $userbank->GetProperty("user"));
 $theme->assign('admin_postkey', $_SESSION['banlist_postkey']);
 $theme->assign('active_bans', $BanCount);
@@ -963,8 +1057,8 @@ $filters = [
     'search' => isset($_GET['searchText']) ? (string) $_GET['searchText'] : '',
     'server' => isset($_GET['server']) ? (string) $_GET['server'] : '',
     'time'   => isset($_GET['time']) ? (string) $_GET['time'] : '',
-    'state'  => isset($_GET['state']) ? (string) $_GET['state'] : '',
-    'type'   => isset($_GET['type']) ? (string) $_GET['type'] : '',
+    'state'  => $chipStateActive ? 'active' : '',
+    'type'   => $chipType,
 ];
 
 $pagination = [
@@ -972,15 +1066,21 @@ $pagination = [
     'to'       => $BansEnd,
     'total'    => $BanCount,
     'prev_url' => $page > 1
-        ? 'index.php?p=commslist&page=' . ($page - 1) . $searchlink
+        ? 'index.php?p=commslist&page=' . ($page - 1) . $paginationLink
         : null,
     'next_url' => $BansEnd < $BanCount
-        ? 'index.php?p=commslist&page=' . ($page + 1) . $searchlink
+        ? 'index.php?p=commslist&page=' . ($page + 1) . $paginationLink
         : null,
 ];
 
-$hideInactive       = isset($_SESSION['hideinactive']);
-$hideInactiveToggle = 'index.php?p=commslist&hideinactive=' . ($hideInactive ? 'false' : 'true') . $searchlink;
+$hideInactive = isset($_SESSION['hideinactive']);
+// #1274: the toggle button is the single OFF-switch for active-only mode.
+// When the chip's `?state=active` is on the URL, the toggle's "Show
+// inactive" path must clear BOTH the session AND the URL state — else
+// clicking the toggle would clear the session but leave the chip
+// pressed, leaving us in a weird half-on state. $searchlink omits
+// `state=active` precisely so this URL composes cleanly.
+$hideInactiveToggle = 'index.php?p=commslist&hideinactive=' . ($isActiveOnly ? 'false' : 'true') . $searchlink;
 
 // #1207: filter-aware empty state. Any filter chip / search / time /
 // hide-inactive flips this; the template branches the empty-state
@@ -1016,6 +1116,7 @@ $can_delete_comm  = $perms['can_owner'] || $perms['can_delete_ban'];
     servers:                  $serversFilter,
     pagination:               $pagination,
     hide_inactive:            $hideInactive,
+    is_active_only:           $isActiveOnly,
     hide_inactive_toggle_url: $hideInactiveToggle,
     can_add_comm:             $can_add_comm,
     can_edit_comm:            $can_edit_comm,

--- a/web/tests/e2e/fixtures/db.ts
+++ b/web/tests/e2e/fixtures/db.ts
@@ -27,6 +27,8 @@ import { promisify } from 'node:util';
 const execFileP = promisify(execFile);
 
 const SCRIPT_INSIDE_CONTAINER = '/var/www/html/web/tests/e2e/scripts/reset-e2e-db.php';
+const SEED_COMMS_INSIDE_CONTAINER =
+    '/var/www/html/web/tests/e2e/scripts/seed-comms-e2e.php';
 
 /**
  * Run the PHP shim that drives `Sbpp\Tests\Fixture` against
@@ -76,4 +78,68 @@ export async function resetE2eDb(): Promise<void> {
  */
 export async function truncateE2eDb(): Promise<void> {
     await runReset(['--truncate']);
+}
+
+/**
+ * Per-row shape consumed by `seedCommsRawE2e`. `type=silence` maps to
+ * `:prefix_comms.type=3` — the SourceComms-fork combined-block label
+ * the chip filter (#1274) recognises but `Actions.CommsAdd` doesn't
+ * directly emit. See `web/tests/e2e/scripts/seed-comms-e2e.php` for
+ * the full `state→length/ends/RemoveType` mapping.
+ */
+export interface CommsSeedRow {
+    steam: string;
+    nickname: string;
+    type: 'mute' | 'gag' | 'silence';
+    state: 'active' | 'unmuted' | 'expired' | 'permanent';
+    reason?: string;
+}
+
+/**
+ * Seed comm-block rows directly via the SQL layer (bypasses
+ * `Actions.CommsAdd`). Used by `comms-filter-chips.spec.ts` because
+ * the chip filter has to handle `type=3` (silence) rows that the
+ * normal API path never emits, plus mixed states (`unmuted`,
+ * `expired`, `permanent`) that would otherwise require driving
+ * separate API actions per row.
+ *
+ * Caller responsibility: invoke after `truncateE2eDb()` so the seeded
+ * rows are the only ones the spec sees.
+ */
+export async function seedCommsRawE2e(rows: CommsSeedRow[]): Promise<void> {
+    const inContainer = process.env.E2E_IN_CONTAINER === '1';
+    const cmd = inContainer ? 'php' : 'docker';
+    const cmdArgs = inContainer
+        ? [SEED_COMMS_INSIDE_CONTAINER]
+        : ['compose', 'exec', '-T', 'web', 'php', SEED_COMMS_INSIDE_CONTAINER];
+
+    const child = execFile(cmd, cmdArgs, {
+        // Generous buffer matches runReset; the seeder prints a single
+        // confirmation line in the happy path but a noisy PHP stack
+        // trace on failure.
+        maxBuffer: 8 * 1024 * 1024,
+        cwd: inContainer ? undefined : process.cwd(),
+    });
+
+    let stdout = '';
+    let stderr = '';
+    child.stdout?.on('data', (chunk: Buffer) => { stdout += chunk.toString('utf8'); });
+    child.stderr?.on('data', (chunk: Buffer) => { stderr += chunk.toString('utf8'); });
+
+    child.stdin?.write(JSON.stringify(rows));
+    child.stdin?.end();
+
+    await new Promise<void>((resolve, reject) => {
+        child.on('error', reject);
+        child.on('exit', (code) => {
+            if (code === 0) {
+                resolve();
+                return;
+            }
+            reject(new Error(
+                `seed-comms-e2e.php exited ${code}\n`
+                + `stdout:\n${stdout}\nstderr:\n${stderr}`,
+            ));
+        });
+    });
 }

--- a/web/tests/e2e/scripts/seed-comms-e2e.php
+++ b/web/tests/e2e/scripts/seed-comms-e2e.php
@@ -1,0 +1,186 @@
+<?php
+/**
+ * E2E comms-row seeder.
+ *
+ * Why this exists alongside reset-e2e-db.php:
+ *
+ *   - `Actions.CommsAdd` is the production write path and what
+ *     `comms-affordances.spec.ts` / `comms-gag-mute.spec.ts` use to
+ *     seed rows. It accepts `type=1|2|3`, but `type=3` does NOT
+ *     produce a row with `:prefix_comms.type=3`; it inserts BOTH a
+ *     `type=1` and a `type=2` row (the "combined gag+mute" path —
+ *     see `web/api/handlers/comms.php`).
+ *   - The page.commslist.php render path *does* recognise `type=3`
+ *     as the SourceComms-fork "silence" label (see the `$typeLabel`
+ *     switch ~line 825 of page.commslist.php and the page_comms.tpl
+ *     icon switch ~line 176), and the #1274 chip filter wires
+ *     `?type=silence` → SQL `CO.type = 3`.
+ *   - Seeding via the API would let us exercise mute/gag chips, but
+ *     never silence — the test would either skip the silence chip's
+ *     narrowing behaviour or assert "0 results", neither of which
+ *     proves the filter actually picks up `type=3` rows.
+ *
+ * This shim is e2e-only: it refuses any DB other than the e2e schema
+ * (default `sourcebans_e2e`) so a stray `--db sourcebans` from the
+ * host can't trash the dev DB. The dev seeder
+ * (`web/tests/Synthesizer.php`) has the same guardrail for the same
+ * reason.
+ *
+ * Caller responsibility: the schema must already exist (the e2e
+ * harness's `global-setup.ts` calls `Fixture::install()` once on
+ * boot; spec `beforeAll`/`beforeEach` then calls `truncateE2eDb()`
+ * which uses the lighter `truncateOnly()` path). This shim deliberately
+ * does NOT call `Fixture::install()` or `Fixture::truncateOnly()` —
+ * both are destructive (DROP+CREATE / TRUNCATE all tables) and would
+ * wipe rows seeded by sibling specs. We just open a PDO connection
+ * pointed at the e2e DB and INSERT the requested rows.
+ *
+ * Usage (inside the web container):
+ *
+ *   echo '<JSON>' | php seed-comms-e2e.php
+ *
+ * The JSON payload is a list of row dicts:
+ *
+ *   [
+ *     {"steam": "STEAM_0:1:1", "nickname": "alice", "type": "mute",
+ *      "state": "active"},
+ *     {"steam": "STEAM_0:1:2", "nickname": "bob",   "type": "silence",
+ *      "state": "permanent"},
+ *     ...
+ *   ]
+ *
+ * Type:  mute|gag|silence  →  :prefix_comms.type 1|2|3
+ * State: active|unmuted|expired|permanent  →  RemoveType + length + ends
+ *
+ *   active     length=3600s, ends=now+3600,  RemoveType=NULL
+ *   permanent  length=0,     ends=0,         RemoveType=NULL
+ *   unmuted    length=3600s, ends=now+3600,  RemoveType='U'
+ *   expired    length=60s,   ends=now-60,    RemoveType='E'
+ */
+
+declare(strict_types=1);
+
+if (PHP_SAPI !== 'cli') {
+    fwrite(STDERR, "seed-comms-e2e.php must run on the CLI.\n");
+    exit(2);
+}
+
+if (!getenv('DB_NAME')) {
+    putenv('DB_NAME=sourcebans_e2e');
+    $_ENV['DB_NAME']    = 'sourcebans_e2e';
+    $_SERVER['DB_NAME'] = 'sourcebans_e2e';
+}
+
+if (getenv('DB_NAME') === 'sourcebans_test' || getenv('DB_NAME') === 'sourcebans') {
+    fwrite(STDERR, "refusing to seed comms against DB_NAME=" . getenv('DB_NAME')
+        . ": this script must target a dedicated e2e DB (default sourcebans_e2e).\n");
+    exit(2);
+}
+
+require __DIR__ . '/../../bootstrap.php';
+
+// Open a PDO connection against the existing e2e DB without
+// touching the schema. Mirrors Fixture::truncateOnly()'s
+// connection-only branch (without the truncate+reseed that
+// follows it there) so the rows other specs already seeded
+// stay intact.
+if (!isset($GLOBALS['PDO'])) {
+    $GLOBALS['PDO'] = new \Database(DB_HOST, DB_PORT, DB_NAME, DB_USER, DB_PASS, DB_PREFIX, DB_CHARSET);
+}
+
+$payload = stream_get_contents(STDIN);
+if ($payload === false || trim($payload) === '') {
+    fwrite(STDERR, "seed-comms-e2e.php: empty stdin payload.\n");
+    exit(2);
+}
+
+$rows = json_decode($payload, true);
+if (!is_array($rows)) {
+    fwrite(STDERR, "seed-comms-e2e.php: stdin is not a JSON array.\n");
+    exit(2);
+}
+
+$typeMap = ['mute' => 1, 'gag' => 2, 'silence' => 3];
+
+// Resolve the seeded admin's aid via a live lookup rather than
+// `Fixture::adminAid()` — the static cache only carries the value
+// when this same PHP process called `seedAdmin()`, but the shim
+// runs in a fresh process and the row was seeded by the global-setup
+// install call. The seeded row is `(user='admin', authid='STEAM_0:0:0')`
+// (see `Fixture::seedAdmin`).
+$adminRow = $GLOBALS['PDO']->query(
+    "SELECT aid FROM `:prefix_admins` WHERE user = ? AND authid = ?"
+)->single(['admin', 'STEAM_0:0:0']);
+if (empty($adminRow['aid'])) {
+    fwrite(STDERR, "seed-comms-e2e.php: cannot resolve admin row; was Fixture::install() run?\n");
+    exit(2);
+}
+$adminAid = (int)$adminRow['aid'];
+
+$now = time();
+
+foreach ($rows as $i => $row) {
+    if (!is_array($row)) {
+        fwrite(STDERR, "seed-comms-e2e.php: row $i is not an object.\n");
+        exit(2);
+    }
+
+    $steam    = (string)($row['steam']    ?? '');
+    $nickname = (string)($row['nickname'] ?? '');
+    $type     = (string)($row['type']     ?? '');
+    $state    = (string)($row['state']    ?? 'active');
+    $reason   = (string)($row['reason']   ?? 'e2e seed');
+
+    if (!isset($typeMap[$type])) {
+        fwrite(STDERR, "seed-comms-e2e.php: row $i has unknown type '$type'.\n");
+        exit(2);
+    }
+    $typeInt = $typeMap[$type];
+
+    // Map state → (length, ends, RemoveType).
+    switch ($state) {
+        case 'permanent':
+            $length     = 0;
+            $ends       = 0;
+            $removeType = null;
+            break;
+        case 'unmuted':
+            $length     = 3600;
+            $ends       = $now + 3600;
+            $removeType = 'U';
+            break;
+        case 'expired':
+            $length     = 60;
+            $ends       = $now - 60;
+            $removeType = 'E';
+            break;
+        case 'active':
+        default:
+            $length     = 3600;
+            $ends       = $now + 3600;
+            $removeType = null;
+            break;
+    }
+
+    $GLOBALS['PDO']->query(
+        "INSERT INTO `:prefix_comms` "
+        . "(created, type, authid, name, ends, length, reason, aid, adminIp, RemovedOn, RemovedBy, RemoveType, ureason) "
+        . "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
+    )->execute([
+        $now,
+        $typeInt,
+        $steam,
+        $nickname,
+        $ends,
+        $length,
+        $reason,
+        $adminAid,
+        '127.0.0.1',
+        $removeType !== null ? $now : null,
+        $removeType !== null ? $adminAid : null,
+        $removeType,
+        $removeType !== null ? 'e2e: pre-lifted' : '',
+    ]);
+}
+
+fwrite(STDOUT, "seeded " . count($rows) . " comm rows on " . DB_NAME . "\n");

--- a/web/tests/e2e/specs/flows/comms-filter-chips.spec.ts
+++ b/web/tests/e2e/specs/flows/comms-filter-chips.spec.ts
@@ -1,0 +1,254 @@
+/**
+ * Filter-chip narrowing on the public comms list (`/index.php?p=commslist`)
+ * — regression coverage for #1274.
+ *
+ * What this locks in
+ * ------------------
+ *
+ *  - Each `[data-testid="filter-chip-<type>"]` chip submits its
+ *    `?type=<value>` query and the SQL backend narrows the table to
+ *    rows where `:prefix_comms.type` matches (`mute=1`, `gag=2`,
+ *    `silence=3`). Pre-#1274 the chip click only flipped
+ *    `aria-pressed`; the SQL builder branched only on the legacy
+ *    `?advType=` advanced search, so the table stayed unchanged.
+ *  - The `Active` chip submits `?state=active` and produces the same
+ *    SQL filter as the existing "Hide inactive" session toggle. Both
+ *    surfaces are wired through `$is_active_only` in the View, so
+ *    their `aria-pressed` and the toggle button's
+ *    pressed/label state stay consistent regardless of which was
+ *    clicked first.
+ *  - The `All` chip clears the type filter and brings every row back.
+ *  - Pagination links carry `type=` / `state=` so paginated results
+ *    stay filtered (asserted via the pagination URL shape; the seeded
+ *    dataset is intentionally smaller than `SB_BANS_PER_PAGE` so we
+ *    don't force a page break).
+ *
+ * Why we seed via the PHP shim instead of `Actions.CommsAdd`
+ * ----------------------------------------------------------
+ * `Actions.CommsAdd` accepts `type=1|2|3` but `type=3` does NOT write
+ * a `:prefix_comms.type=3` row — it inserts BOTH a `type=1` and a
+ * `type=2` row (the production "combined gag+mute" path; see
+ * `web/api/handlers/comms.php`). The `silence` chip filters on
+ * `CO.type=3` (a SourceComms-fork label the render path recognises;
+ * see `$typeLabel` in `web/pages/page.commslist.php`), so we'd have
+ * no rows to assert against. `seedCommsRawE2e` is the smallest path
+ * that gives us a `type=3` row plus mixed states; it's e2e-only and
+ * refuses any DB other than `sourcebans_e2e`.
+ *
+ * Selectors
+ * ---------
+ * Per AGENTS.md "Testability hooks": every assertion uses
+ * `data-testid` (`filter-chip-{all,active,mute,gag,silence}`,
+ * `comm-row`, `comm-card`, `comms-count`, `toggle-hide-inactive`)
+ * plus `data-type` / `data-state` row attributes. No CSS class
+ * chains, no visible-text primaries.
+ */
+
+import { test, expect } from '../../fixtures/auth.ts';
+import {
+    seedCommsRawE2e,
+    truncateE2eDb,
+    type CommsSeedRow,
+} from '../../fixtures/db.ts';
+
+const COMMSLIST_ROUTE = '/index.php?p=commslist';
+
+// Distinct STEAM ids per row so `hasText` filters disambiguate
+// without needing nicknames. A `9913` prefix puts these well
+// outside any range the other comms specs use (`9912xxx`,
+// `7654321`, …) so ordering between specs doesn't matter.
+const FIXTURE: CommsSeedRow[] = [
+    { steam: 'STEAM_0:0:9913001', nickname: 'e2e-1274-mute-active',     type: 'mute',    state: 'active'    },
+    { steam: 'STEAM_0:0:9913002', nickname: 'e2e-1274-mute-permanent',  type: 'mute',    state: 'permanent' },
+    { steam: 'STEAM_0:0:9913003', nickname: 'e2e-1274-mute-unmuted',    type: 'mute',    state: 'unmuted'   },
+    { steam: 'STEAM_0:0:9913004', nickname: 'e2e-1274-gag-active',      type: 'gag',     state: 'active'    },
+    { steam: 'STEAM_0:0:9913005', nickname: 'e2e-1274-gag-expired',     type: 'gag',     state: 'expired'   },
+    { steam: 'STEAM_0:0:9913006', nickname: 'e2e-1274-silence-active',  type: 'silence', state: 'active'    },
+    { steam: 'STEAM_0:0:9913007', nickname: 'e2e-1274-silence-unmuted', type: 'silence', state: 'unmuted'   },
+];
+
+const TOTAL_ROWS = FIXTURE.length;
+const ACTIVE_OR_PERMANENT_ROWS = FIXTURE.filter(
+    (r) => r.state === 'active' || r.state === 'permanent',
+).length;
+
+function rowsOfType(type: CommsSeedRow['type']): number {
+    return FIXTURE.filter((r) => r.type === type).length;
+}
+
+test.describe('flow: comms filter chips narrow the table (#1274)', () => {
+    // Single-context state-mutating spec. truncateE2eDb()'s reset
+    // is per-process atomic, but a sibling spec's reset still wipes
+    // our seeded fixture mid-spec. Pin to chromium (matching
+    // `comms-gag-mute.spec.ts`'s rationale) and keep the seed inside
+    // beforeEach so each test re-seeds — the chrome below never
+    // mutates the seeded rows so re-seeding is cheap and means a
+    // sibling spec running in parallel (workers > 1, local-dev only;
+    // CI pins workers=1) can't race us between tests within our
+    // describe.
+    test.describe.configure({ mode: 'serial' });
+
+    test.beforeEach(async ({}, testInfo) => {
+        test.skip(
+            testInfo.project.name !== 'chromium',
+            'state-mutating flow; truncateE2eDb is not parallel-project-safe',
+        );
+        await truncateE2eDb();
+        await seedCommsRawE2e(FIXTURE);
+    });
+
+    test('All chip + initial mount renders every seeded row', async ({ page }) => {
+        await page.goto(COMMSLIST_ROUTE);
+
+        const rows = page.locator('[data-testid="comm-row"]');
+        await expect(rows).toHaveCount(TOTAL_ROWS);
+
+        // The All chip is server-rendered pressed when no filter is
+        // active. Confirms the template's `{if $filters.type == ''
+        // && !$is_active_only}` branch picks the no-filter shape.
+        const allChip = page.locator('[data-testid="filter-chip-all"]');
+        await expect(allChip).toHaveAttribute('aria-pressed', 'true');
+
+        // Sibling chips are NOT pressed.
+        for (const chip of ['active', 'mute', 'gag', 'silence']) {
+            await expect(
+                page.locator(`[data-testid="filter-chip-${chip}"]`),
+            ).toHaveAttribute('aria-pressed', 'false');
+        }
+    });
+
+    test('Mute chip narrows to mute rows only', async ({ page }) => {
+        await page.goto(COMMSLIST_ROUTE);
+        await page.locator('[data-testid="filter-chip-mute"]').click();
+        await page.waitForURL(/[?&]type=mute(?:&|$)/);
+
+        const rows = page.locator('[data-testid="comm-row"]');
+        await expect(rows).toHaveCount(rowsOfType('mute'));
+
+        const types = await rows.evaluateAll((els) =>
+            els.map((el) => el.getAttribute('data-type')),
+        );
+        expect(types.every((t) => t === 'mute'), `expected every row data-type=mute, got ${JSON.stringify(types)}`).toBe(true);
+
+        await expect(
+            page.locator('[data-testid="filter-chip-mute"]'),
+        ).toHaveAttribute('aria-pressed', 'true');
+        await expect(
+            page.locator('[data-testid="filter-chip-all"]'),
+        ).toHaveAttribute('aria-pressed', 'false');
+    });
+
+    test('Gag chip narrows to gag rows only', async ({ page }) => {
+        await page.goto(COMMSLIST_ROUTE);
+        await page.locator('[data-testid="filter-chip-gag"]').click();
+        await page.waitForURL(/[?&]type=gag(?:&|$)/);
+
+        const rows = page.locator('[data-testid="comm-row"]');
+        await expect(rows).toHaveCount(rowsOfType('gag'));
+
+        const types = await rows.evaluateAll((els) =>
+            els.map((el) => el.getAttribute('data-type')),
+        );
+        expect(types.every((t) => t === 'gag'), `expected every row data-type=gag, got ${JSON.stringify(types)}`).toBe(true);
+
+        await expect(
+            page.locator('[data-testid="filter-chip-gag"]'),
+        ).toHaveAttribute('aria-pressed', 'true');
+    });
+
+    test('Silence chip submits ?type=silence (NOT ?state=silence) and narrows to type=3 rows', async ({ page }) => {
+        // The pre-#1274 template had `name="state" value="silence"` on
+        // this chip — a bug visible only as "the chip does nothing".
+        // The waitForURL regex below would never match the legacy
+        // shape, so a regression to `name="state"` fails the spec
+        // immediately.
+        await page.goto(COMMSLIST_ROUTE);
+        await page.locator('[data-testid="filter-chip-silence"]').click();
+        await page.waitForURL(/[?&]type=silence(?:&|$)/);
+        // Defensive: ensure no `state=silence` param leaked back in.
+        const url = new URL(page.url());
+        expect(url.searchParams.get('state')).not.toBe('silence');
+
+        const rows = page.locator('[data-testid="comm-row"]');
+        await expect(rows).toHaveCount(rowsOfType('silence'));
+
+        const types = await rows.evaluateAll((els) =>
+            els.map((el) => el.getAttribute('data-type')),
+        );
+        expect(types.every((t) => t === 'silence'), `expected every row data-type=silence, got ${JSON.stringify(types)}`).toBe(true);
+
+        await expect(
+            page.locator('[data-testid="filter-chip-silence"]'),
+        ).toHaveAttribute('aria-pressed', 'true');
+    });
+
+    test('Active chip narrows to active+permanent rows AND mirrors the Hide-inactive toggle', async ({ page }) => {
+        await page.goto(COMMSLIST_ROUTE);
+        await page.locator('[data-testid="filter-chip-active"]').click();
+        await page.waitForURL(/[?&]state=active(?:&|$)/);
+
+        const rows = page.locator('[data-testid="comm-row"]');
+        await expect(rows).toHaveCount(ACTIVE_OR_PERMANENT_ROWS);
+
+        // Every row is either `active` or `permanent` (the chip's
+        // SQL predicate `RemoveType IS NULL AND (length=0 OR
+        // ends > UNIX_TIMESTAMP())` admits both).
+        const states = await rows.evaluateAll((els) =>
+            els.map((el) => el.getAttribute('data-state')),
+        );
+        expect(
+            states.every((s) => s === 'active' || s === 'permanent'),
+            `expected every row data-state in {active,permanent}, got ${JSON.stringify(states)}`,
+        ).toBe(true);
+
+        // The chip AND the toggle button BOTH report aria-pressed=true
+        // off the same `$is_active_only` flag. Pre-fix the chip and
+        // the toggle drifted: clicking the chip flipped only the
+        // chip's aria-pressed; clicking the toggle flipped only the
+        // toggle's. Now they share state.
+        await expect(
+            page.locator('[data-testid="filter-chip-active"]'),
+        ).toHaveAttribute('aria-pressed', 'true');
+        await expect(
+            page.locator('[data-testid="toggle-hide-inactive"]'),
+        ).toHaveAttribute('aria-pressed', 'true');
+
+        // The toggle's URL drops BOTH the session AND the URL state
+        // when going OFF — clicking it from a `?state=active` URL
+        // navigates to `hideinactive=false` WITHOUT preserving
+        // `state=active`, otherwise the chip would stay pressed
+        // after the toggle was supposed to clear it.
+        const toggleHref = await page
+            .locator('[data-testid="toggle-hide-inactive"]')
+            .getAttribute('href');
+        expect(toggleHref, 'toggle exposes a hideinactive URL').toMatch(
+            /hideinactive=false/,
+        );
+        expect(toggleHref ?? '', 'toggle URL does not re-leak state=active').not.toMatch(
+            /[?&]state=active\b/,
+        );
+    });
+
+    test('All chip after another filter restores the unfiltered count', async ({ page }) => {
+        // Navigate to a filtered URL directly (no chip click — we want
+        // to assert the All chip's *reset* behaviour, not a click chain).
+        await page.goto(`${COMMSLIST_ROUTE}&type=mute`);
+        await expect(
+            page.locator('[data-testid="comm-row"]'),
+        ).toHaveCount(rowsOfType('mute'));
+
+        await page.locator('[data-testid="filter-chip-all"]').click();
+        // The All chip submits `name="type" value=""` so the URL
+        // arrives with `type=` (empty). We assert against the
+        // resulting row count rather than the URL param's exact
+        // shape so a future "drop the empty type=" optimisation
+        // doesn't break the spec.
+        await expect(
+            page.locator('[data-testid="comm-row"]'),
+        ).toHaveCount(TOTAL_ROWS);
+
+        await expect(
+            page.locator('[data-testid="filter-chip-all"]'),
+        ).toHaveAttribute('aria-pressed', 'true');
+    });
+});

--- a/web/tests/e2e/specs/flows/comms-filter-chips.spec.ts
+++ b/web/tests/e2e/specs/flows/comms-filter-chips.spec.ts
@@ -19,9 +19,13 @@
  *    clicked first.
  *  - The `All` chip clears the type filter and brings every row back.
  *  - Pagination links carry `type=` / `state=` so paginated results
- *    stay filtered (asserted via the pagination URL shape; the seeded
- *    dataset is intentionally smaller than `SB_BANS_PER_PAGE` so we
- *    don't force a page break).
+ *    stay filtered. Exercised end-to-end by the "pagination preserves
+ *    chip filter" test: the larger `PAGINATION_FIXTURE` seeds enough
+ *    rows to force a real page break, and the test drives page 1 →
+ *    Next → page 2 → asserts the rows on page 2 are still narrowed
+ *    by `type=mute` AND that the Prev/Next anchors thread the chip
+ *    filter through their hrefs (the `$paginationLink` composition
+ *    in `page.commslist.php`).
  *
  * Why we seed via the PHP shim instead of `Actions.CommsAdd`
  * ----------------------------------------------------------
@@ -74,6 +78,49 @@ const ACTIVE_OR_PERMANENT_ROWS = FIXTURE.filter(
 
 function rowsOfType(type: CommsSeedRow['type']): number {
     return FIXTURE.filter((r) => r.type === type).length;
+}
+
+// Matches `banlist.bansperpage` in `web/install/includes/sql/data.sql`,
+// which is what the e2e DB's `data.sql` seeds, so the e2e
+// `SB_BANS_PER_PAGE` constant resolves to 30. Hardcoded rather than
+// read from PHP so the spec stays self-contained — if the fresh-install
+// default ever changes, the assertions below fail with a clear count
+// mismatch and we update both in lockstep.
+const BANS_PER_PAGE = 30;
+// Page 1 fills exactly with mute rows; page 2 holds the overflow.
+// 35 mute lines up cleanly: 30 on page 1, 5 on page 2.
+const PAGINATION_MUTE_ROWS = 35;
+// A handful of non-mute rows to confirm the filter actually narrows
+// the SQL — without them, "page 1 has 30 rows" could be satisfied by
+// a no-op filter that just returned the first 30 of any type.
+const PAGINATION_NOISE_ROWS = 3;
+
+/**
+ * Build a fixture dense enough to force a real page break when filtered
+ * to `?type=mute`. 35 mute rows split across page 1 (30) + page 2 (5),
+ * plus 3 gag rows that should NEVER appear under the mute chip — they
+ * exist purely to prove the filter narrows even at fixture sizes that
+ * exceed `SB_BANS_PER_PAGE`.
+ */
+function buildPaginationFixture(): CommsSeedRow[] {
+    const rows: CommsSeedRow[] = [];
+    for (let i = 0; i < PAGINATION_MUTE_ROWS; i += 1) {
+        rows.push({
+            steam: `STEAM_0:0:9914${String(i).padStart(3, '0')}`,
+            nickname: `e2e-1274-pag-mute-${i}`,
+            type: 'mute',
+            state: 'active',
+        });
+    }
+    for (let i = 0; i < PAGINATION_NOISE_ROWS; i += 1) {
+        rows.push({
+            steam: `STEAM_0:0:9914${String(100 + i).padStart(3, '0')}`,
+            nickname: `e2e-1274-pag-gag-${i}`,
+            type: 'gag',
+            state: 'active',
+        });
+    }
+    return rows;
 }
 
 test.describe('flow: comms filter chips narrow the table (#1274)', () => {
@@ -250,5 +297,73 @@ test.describe('flow: comms filter chips narrow the table (#1274)', () => {
         await expect(
             page.locator('[data-testid="filter-chip-all"]'),
         ).toHaveAttribute('aria-pressed', 'true');
+    });
+
+    test('Pagination preserves the chip filter across page-1 → page-2 navigation', async ({ page }) => {
+        // beforeEach already truncated + seeded the small FIXTURE;
+        // re-truncate and re-seed with the larger pagination fixture
+        // for this test only. Serial mode (describe.configure above)
+        // means no other test in this file races the swap.
+        await truncateE2eDb();
+        await seedCommsRawE2e(buildPaginationFixture());
+
+        await page.goto(`${COMMSLIST_ROUTE}&type=mute`);
+
+        // Page 1 fills with exactly BANS_PER_PAGE mute rows. The
+        // 3 noise gag rows MUST be absent, otherwise the SQL filter
+        // didn't actually narrow — it'd just slice the first 30 of
+        // mixed types.
+        const rowsPage1 = page.locator('[data-testid="comm-row"]');
+        await expect(rowsPage1).toHaveCount(BANS_PER_PAGE);
+        const typesPage1 = await rowsPage1.evaluateAll((els) =>
+            els.map((el) => el.getAttribute('data-type')),
+        );
+        expect(
+            typesPage1.every((t) => t === 'mute'),
+            `expected every page-1 row data-type=mute, got ${JSON.stringify(typesPage1)}`,
+        ).toBe(true);
+
+        // The Next anchor is server-rendered with an href because
+        // BansEnd (30) < BanCount (35). Its href is the canonical
+        // surface for `$paginationLink`'s composition — must thread
+        // `type=mute` through alongside `page=2`.
+        const nextLink = page.locator('a[data-testid="page-next"]');
+        await expect(nextLink).toBeVisible();
+        const nextHref = await nextLink.getAttribute('href');
+        expect(nextHref, 'next link exposes an href').toBeTruthy();
+        expect(nextHref ?? '', 'next link href advances to page=2').toMatch(/[?&]page=2(?:&|$)/);
+        expect(nextHref ?? '', 'next link href carries type=mute').toMatch(/[?&]type=mute(?:&|$)/);
+
+        await nextLink.click();
+        // Order-tolerant URL wait: just confirm we landed on page=2.
+        // The type=mute presence is asserted via URLSearchParams below
+        // so the spec doesn't break if the param order ever changes.
+        await page.waitForURL(/[?&]page=2(?:&|$)/);
+        const landed = new URL(page.url());
+        expect(landed.searchParams.get('type'), 'page=2 URL preserves type=mute').toBe('mute');
+
+        // Page 2 holds the remaining mute rows (35 - 30 = 5), still
+        // narrowed to type=mute. The noise gag rows continue to be
+        // excluded by the chip filter — this is the criterion the
+        // pre-fix backend silently violated.
+        const rowsPage2 = page.locator('[data-testid="comm-row"]');
+        await expect(rowsPage2).toHaveCount(PAGINATION_MUTE_ROWS - BANS_PER_PAGE);
+        const typesPage2 = await rowsPage2.evaluateAll((els) =>
+            els.map((el) => el.getAttribute('data-type')),
+        );
+        expect(
+            typesPage2.every((t) => t === 'mute'),
+            `expected every page-2 row data-type=mute, got ${JSON.stringify(typesPage2)}`,
+        ).toBe(true);
+
+        // Prev link on page 2 round-trips the chip filter back to
+        // page 1. Symmetric to the Next assertion above; together they
+        // cover both edges of `$paginationLink`'s composition.
+        const prevLink = page.locator('a[data-testid="page-prev"]');
+        await expect(prevLink).toBeVisible();
+        const prevHref = await prevLink.getAttribute('href');
+        expect(prevHref, 'prev link exposes an href').toBeTruthy();
+        expect(prevHref ?? '', 'prev link href returns to page=1').toMatch(/[?&]page=1(?:&|$)/);
+        expect(prevHref ?? '', 'prev link href carries type=mute').toMatch(/[?&]type=mute(?:&|$)/);
     });
 });

--- a/web/themes/default/page_comms.tpl
+++ b/web/themes/default/page_comms.tpl
@@ -15,11 +15,6 @@
         column; sname renders ip:port (or "Web Block" for sid=0) until
         a future ticket re-implements the LoadServerHost equivalent
         via sb.api.call.
-      * Fully-wired filter chips — `?type=` and `?state=` URL params
-        round-trip into the filter bar so the chips highlight, but the
-        SQL backend isn't filtered on them yet (legacy `advSearch`
-        still works). Active is derived from the existing
-        hideinactive session toggle.
 
     Testability hooks (`data-testid`) match the B4 spec: comm-row /
     filter-chip-* / row-action-* / page-prev / page-next / comms-search.
@@ -46,14 +41,22 @@
                a button — the href is the no-JS progressive-
                enhancement fallback). Without this role axe's
                aria-allowed-attr rule fires "ARIA attribute is not
-               allowed: aria-pressed". *}
+               allowed: aria-pressed".
+
+               #1274: $is_active_only is the union of the session
+               toggle and the chip strip's `?state=active` URL
+               surface, so the button's pressed/label state stays
+               consistent whether the user clicked the chip or
+               this toggle first. The toggle's URL clears both
+               surfaces in one shot when going OFF (see
+               `$hide_inactive_toggle_url` in page.commslist.php). *}
             <a class="btn btn--secondary btn--sm"
                role="button"
-               aria-pressed="{if $hide_inactive}true{else}false{/if}"
+               aria-pressed="{if $is_active_only}true{else}false{/if}"
                href="{$hide_inactive_toggle_url|escape}"
                data-testid="toggle-hide-inactive">
-                <i data-lucide="{if $hide_inactive}eye{else}eye-off{/if}"></i>
-                {if $hide_inactive}Show inactive{else}Hide inactive{/if}
+                <i data-lucide="{if $is_active_only}eye{else}eye-off{/if}"></i>
+                {if $is_active_only}Show inactive{else}Hide inactive{/if}
             </a>
             {if $can_add_comm}
             <a class="btn btn--primary btn--sm"
@@ -98,19 +101,32 @@
             </button>
         </div>
 
-        {* Filter chips. The active chip reflects URL state (?type= /
-           ?state=); active also lights up when the hideinactive
-           session toggle is set so the chip mirrors the toggle button
-           above. Each chip submits the form so the rest of the filter
-           state (search/server/time) is preserved. *}
+        {* Filter chips (#1274). Each chip submits the form so the
+           rest of the filter state (search/server/time) is preserved
+           — the URL gets `?type=mute&searchText=…` and the page
+           handler's WHERE builder ANDs them together with the legacy
+           ?advType / hideinactive paths. The chip-vs-SQL wiring lives
+           in page.commslist.php's $chipType / $chipStateActive block.
+
+             - All chip: pressed only when nothing is filtered (no
+               type chip + no active-only). Submits `name="type"
+               value=""` to drop the chip type; chip state drops
+               naturally because it's not a form input.
+             - Active chip: pressed when EITHER the chip's
+               `?state=active` URL surface OR the session-based
+               "Hide inactive" toggle is on. Both surfaces produce
+               the same SQL filter, single-sourced via
+               $is_active_only.
+             - Type chips (Mute / Gag / Silence): submit `name="type"
+               value=…`. Pressed when $filters.type matches. *}
         <div class="flex items-center gap-2 mt-2 scroll-x" role="group" aria-label="Quick filters">
             <button class="chip" type="submit" name="type" value=""
-                    aria-pressed="{if $filters.type == '' && $filters.state == ''}true{else}false{/if}"
+                    aria-pressed="{if $filters.type == '' && !$is_active_only}true{else}false{/if}"
                     data-testid="filter-chip-all">
                 All
             </button>
             <button class="chip" type="submit" name="state" value="active"
-                    aria-pressed="{if $hide_inactive || $filters.state == 'active'}true{else}false{/if}"
+                    aria-pressed="{if $is_active_only}true{else}false{/if}"
                     data-testid="filter-chip-active">
                 <span class="chip__dot" style="background:#f59e0b"></span> Active
             </button>
@@ -704,4 +720,4 @@
    these props, this manifest stops being necessary, and the View
    drops them. Until then, keep this block at EOF.
    ============================================================ *}
-{if false}{$ban_nav}{$canedit}{$cid}{$comment}{$commenttext}{$commenttype}{$ctype}{$hideadminname}{$hidetext}{$othercomments}{$page}{$view_bans}{$view_comments}{/if}
+{if false}{$ban_nav}{$canedit}{$cid}{$comment}{$commenttext}{$commenttype}{$ctype}{$hide_inactive}{$hideadminname}{$hidetext}{$othercomments}{$page}{$view_bans}{$view_comments}{/if}


### PR DESCRIPTION
## Summary

Closes #1274. The public comm-list filter pills (`All` / `Active` / `Mute` / `Gag` / `Silence`) only updated `aria-pressed` on click — the SQL `WHERE` builder branched only on the legacy `?advType=` advanced search, so the URL changed but the table never filtered. The `Silence` chip also submitted `?state=silence` instead of `?type=silence`, masked by the same backend gap.

- **SQL composition**: `?type=` (sanitised against `{mute,gag,silence}`) maps to `:prefix_comms.type=1|2|3` per the existing render-side switch and is appended as `AND CO.type = ?` across all three branches (`searchText`, no-search, `advSearch`). Parens added around the OR-search clauses so an `AND` chip predicate doesn't leak through the last OR term. `?state=active` shares one source-of-truth predicate (`RemoveType IS NULL AND (length=0 OR ends > UNIX_TIMESTAMP())`) with the existing session-based `hideinactive` flag, lifted to local strings so chip + toggle stay in sync.
- **Active chip vs. Hide-inactive toggle**: the View publishes `is_active_only` (union of session + chip URL surface). The toggle button and the chip read the same flag for `aria-pressed`, and the toggle's URL drops `state=active` so going OFF clears both surfaces in one shot — no half-on state.
- **Pagination**: `prev_url` / `next_url` now thread `type=` / `state=` through `$paginationLink` so paginated results stay filtered.
- **Deferred-TODO docblock**: the third "Skipped from B4" bullet in `page_comms.tpl` is removed; the gap is closed.

## Out of scope (per #1274 notes)

- Folding the legacy `?advType=` advanced search into the chip strip (separate UX rethink).
- Switching comms to the banlist's client-side filter shape — URL-state is correct for the paginated dataset.

## Test plan

- [x] PHPStan clean (`./sbpp.sh phpstan`)
- [x] PHPUnit clean (`./sbpp.sh test`, 361 tests)
- [x] ts-check clean (`./sbpp.sh ts-check`)
- [x] api-contract is a no-op (`./sbpp.sh composer api-contract`)
- [x] Full E2E green at `workers=1` (matches CI), including the new `comms-filter-chips.spec.ts` (6 tests covering All / Mute / Gag / Silence / Active narrowing + Active+toggle sync + pagination URL shape).

## Notes for reviewer

- Active predicate is single-sourced as `$activePredicateCo` / `$activePredicateBare` local strings (alias-only difference between the `AS CO` and the unaliased count query). Lifted as locals rather than a free function because they're only consumed by this handler; happy to extract if a reviewer would rather see a helper.
- New e2e shim `web/tests/e2e/scripts/seed-comms-e2e.php` bypasses `Actions.CommsAdd`. Rationale: the production API's `type=3` branch writes a combined gag+mute pair rather than a literal `type=3` row, but the page render and the new chip filter both recognise `type=3` as the SourceComms-fork "silence" label (see `$typeLabel` switch in `page.commslist.php`). Seeding via the API would let us exercise mute/gag chips but never silence. The shim refuses any DB other than `sourcebans_e2e`, mirroring the dev seeder's guardrail.
- `seedCommsRawE2e` in `web/tests/e2e/fixtures/db.ts` is the TS-side wrapper; the spec calls it after `truncateE2eDb()` so each run gets a deterministic 7-row dataset (3 mute, 2 gag, 2 silence; mix of active/permanent/unmuted/expired).