### PR TITLE
fix(php82): clear strlen($null) deprecations across panel + add static + runtime gates (#1273)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -279,6 +279,49 @@ Playwright E2E specifics:
 - Pattern: `query` → `bind` → `execute` / `single` / `resultset`.
 - ADOdb was fully removed (commit `b9c812b2`). **Do not reintroduce it.**
 
+### Null-into-scalar discipline (PHP 8.2+)
+
+`web/composer.json` requires `php >= 8.2`, so PHP's
+"`Deprecated: <fn>(): Passing null to parameter #1 of type string`"
+surface is active. PHP 9 will turn it into a `TypeError`. Every
+`strlen` / `trim` / `substr` / `preg_match` / `mb_strlen` / etc.
+call against a value that can be `null` at runtime needs one of
+two idiomatic shapes (#1273):
+
+- **Coalesce** when null is semantically "absent" — e.g. a `$_POST`
+  / `$_GET` / `$_SESSION` / `$_SERVER` lookup the form may have
+  omitted:
+
+  ```php
+  if (strlen($_POST['password'] ?? '') < MIN_PASS_LENGTH) { … }
+  $name = trim((string) ($_POST['name'] ?? ''));
+  ```
+
+- **Cast** when the value should always be a string but the type
+  system can't see it (most often a nullable `:prefix_*` row column,
+  or a `mixed`-returning helper like `CUserManager::GetProperty`):
+
+  ```php
+  if (strlen((string) $row['ban_ip']) < 7) { … }
+  $steam = trim((string) $userbank->GetProperty('authid', $aid));
+  ```
+
+- Never `if (!is_null($x) && strlen($x) > 0)` — verbose and the
+  conditional reads worse than the coalesce.
+- `phpstan/phpstan-deprecation-rules` + `phpVersion: 80200` is the
+  static gate; `Php82DeprecationsTest` (PHPUnit) is the runtime gate
+  for the bits PHPStan doesn't see (excluded paths like
+  `includes/auth/openid.php`, runtime values that look non-null to
+  the type system but actually aren't).
+- `web/includes/auth/openid.php` is excluded from PHPStan and is
+  third-party-shaped: cast at function inputs (entry points) so the
+  diff stays bounded; never sprinkle `(string)` at every internal
+  call.
+- Replacing nullable `:prefix_*` columns with `NOT NULL DEFAULT ''`
+  would also clear the deprecation, but it's a paired schema
+  migration with a separate semantic change ("no IP" vs "empty IP")
+  — file separately, not as part of a deprecation sweep.
+
 ### Dev DB seeder (`./sbpp.sh db-seed`)
 
 `./sbpp.sh db-seed` populates the dev DB (`sourcebans`) with a deterministic,
@@ -828,6 +871,16 @@ audit (#1207) locked in. New CTAs:
   value is safe HTML; without a `{* nofilter: <why> *}` comment above
   it, future readers can't tell whether it's a real escape hatch or a
   copy-paste accident waiting to be exploited (#1113 audit).
+- `strlen($_POST['x'])` / `trim($_POST['x'])` / `substr($row['col'], …)`
+  on values that can be `null` at runtime → coalesce
+  (`strlen($_POST['x'] ?? '')`) when null is "absent", or cast
+  (`strlen((string) $row['col'])`) when the value should always be a
+  string. PHP 8.1 deprecated this implicit null-into-scalar coercion;
+  PHP 9 makes it a `TypeError` (#1273). The static gate is
+  `phpstan/phpstan-deprecation-rules` + `phpVersion: 80200`; the
+  runtime gate (for PHPStan-excluded files like `auth/openid.php`) is
+  `Php82DeprecationsTest`. See "Null-into-scalar discipline" in
+  Conventions for the per-shape idiom.
 - `setTimeout` / `waitForTimeout` waits in E2E specs → wait on
   terminal attributes (`[data-loading="false"]` settled, `[data-skeleton]`
   removed) per #1123's "Testability hooks" rule.
@@ -901,6 +954,7 @@ audit (#1207) locked in. New CTAs:
 | Populate the dev DB with realistic synthetic data (banlist > 1 page, drawer history, moderation queues, audit log) | `./sbpp.sh db-seed` → `web/tests/scripts/seed-dev-db.php` (CLI driver) → `web/tests/Synthesizer.php` (`Sbpp\Tests\Synthesizer`). Dev-only: refuses any `DB_NAME` other than `sourcebans` (so `sourcebans_test` / `sourcebans_e2e` stay untouched). Idempotent; deterministic given a fixed `--seed` (default `Synthesizer::DEFAULT_SEED`). Does NOT share plumbing with `Fixture::truncateAndReseed` — the e2e hot path stays minimal. |
 | API wire-format snapshots              | `web/tests/api/__snapshots__/<topic>/<scenario>.json`    |
 | Action -> permission lock              | `web/tests/api/PermissionMatrixTest.php`                 |
+| Trap PHP 8.1 null-into-scalar deprecations at runtime (the bits PHPStan can't see) | `web/tests/integration/Php82DeprecationsTest.php` (#1273) — process-isolated render harness with a stub Smarty + `set_error_handler` that promotes `E_DEPRECATED` / `E_USER_DEPRECATED` to `\ErrorException`. Mirrors the LostPasswordChromeTest stub-Smarty pattern; each test method runs in a separate process because the page handlers declare top-level helpers (`setPostKey()` etc.) that PHP can't redeclare in one process. Add a marquee route here whenever a new high-traffic page handler ships, especially if it reads nullable `:prefix_*` columns or `$_POST` / `$_GET` lookups. |
 | Add an E2E spec                        | `web/tests/e2e/specs/<smoke|flows|a11y|responsive>/...` + `web/tests/e2e/pages/...` |
 | Add a route to the screenshot gallery  | `web/tests/e2e/specs/_screenshots.spec.ts` (`ROUTES` array) |
 | Tweak mobile (<=768px) chrome layout   | `web/themes/default/css/theme.css` — see the `#1207` `@media (max-width: 768px)` blocks for the canonical shapes (icon-only topbar search, full-width drawer + scroll lock). Sub-paged admin routes (servers / mods / groups / settings) use the `<details open>` accordion in the `#1259` `@media (min-width: 1024px)` block (sidebar inline at `<1024px`, sticky 14rem rail at `>=1024px`); see "Sub-paged admin routes" in Conventions. |

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -736,6 +736,16 @@ removes an entry or when bumping the level.
 strings against the schema. Set `PHPSTAN_DBA_DISABLE=1` to skip it; CI
 sets `DBA_REQUIRE=1` so credential drift fails loudly.
 
+`phpstan/phpstan-deprecation-rules` (#1273) is wired in via
+`phpstan.neon` with `phpVersion: 80200` so the analyser flags the
+PHP 8.1 null-into-scalar deprecation surface (`strlen($null)`,
+`trim($null)`, `substr($null, ...)`, `preg_match($null, ...)`, …)
+before it bites us on the PHP 9 bump. `web/includes/auth/openid.php`
+is excluded from PHPStan, so the same surface there is gated by the
+runtime smoke test in `web/tests/integration/Php82DeprecationsTest.php`
+(per-process `set_error_handler` that promotes `E_DEPRECATED` to a
+thrown `ErrorException` while it requires each marquee page handler).
+
 ## Test architecture
 
 Tests live in `web/tests/`:

--- a/web/composer.json
+++ b/web/composer.json
@@ -40,6 +40,7 @@
     },
     "require-dev": {
         "phpstan/phpstan": "^2.1",
+        "phpstan/phpstan-deprecation-rules": "^2.0",
         "phpunit/phpunit": "^11",
         "staabm/phpstan-dba": "^0.4"
     },

--- a/web/composer.lock
+++ b/web/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c7c89714a50c75adc97dad3723a8dfa8",
+    "content-hash": "216890b7211751ba9ceef7fa10d497aa",
     "packages": [
         {
             "name": "dflydev/dot-access-data",
@@ -2366,6 +2366,56 @@
                 }
             ],
             "time": "2026-04-29T13:31:09+00:00"
+        },
+        {
+            "name": "phpstan/phpstan-deprecation-rules",
+            "version": "2.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/phpstan-deprecation-rules.git",
+                "reference": "6b5571001a7f04fa0422254c30a0017ec2f2cacc"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpstan-deprecation-rules/zipball/6b5571001a7f04fa0422254c30a0017ec2f2cacc",
+                "reference": "6b5571001a7f04fa0422254c30a0017ec2f2cacc",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4 || ^8.0",
+                "phpstan/phpstan": "^2.1.39"
+            },
+            "require-dev": {
+                "php-parallel-lint/php-parallel-lint": "^1.2",
+                "phpstan/phpstan-phpunit": "^2.0",
+                "phpunit/phpunit": "^9.6"
+            },
+            "type": "phpstan-extension",
+            "extra": {
+                "phpstan": {
+                    "includes": [
+                        "rules.neon"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PHPStan\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPStan rules for detecting usage of deprecated classes, methods, properties, constants and traits.",
+            "keywords": [
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/phpstan/phpstan-deprecation-rules/issues",
+                "source": "https://github.com/phpstan/phpstan-deprecation-rules/tree/2.0.4"
+            },
+            "time": "2026-02-09T13:21:14+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",

--- a/web/includes/CUserManager.php
+++ b/web/includes/CUserManager.php
@@ -124,9 +124,11 @@ class CUserManager
             return ((int)$this->admins[$aid]['extraflags'] & (int)$flags) != 0 ? true : false;
         }
 
-        for ($i=0; $i < strlen($this->admins[$aid]['srv_flags']); $i++) {
-            for ($a=0; $a < strlen($flags); $a++) {
-                if (strstr($this->admins[$aid]['srv_flags'][$i], $flags[$a])) {
+        $srvFlags = (string) ($this->admins[$aid]['srv_flags'] ?? '');
+        $flagsStr = (string) $flags;
+        for ($i=0; $i < strlen($srvFlags); $i++) {
+            for ($a=0; $a < strlen($flagsStr); $a++) {
+                if (strstr($srvFlags[$i], $flagsStr[$a])) {
                     return true;
                 }
             }
@@ -295,7 +297,7 @@ class CUserManager
      */
     public function AddAdmin($name, $steam, $password, $email, $web_group, $web_flags, $srv_group, $srv_flags, $immunity, $srv_password)
     {
-        if (!empty($password) && strlen($password) < MIN_PASS_LENGTH) {
+        if (!empty($password) && strlen((string) $password) < MIN_PASS_LENGTH) {
             throw new RuntimeException('Password must be at least ' . MIN_PASS_LENGTH . ' characters long.');
         }
         if (empty($password)) {

--- a/web/includes/PHPStan/SmartyTemplateRule.php
+++ b/web/includes/PHPStan/SmartyTemplateRule.php
@@ -75,7 +75,11 @@ final class SmartyTemplateRule implements Rule
             return [];
         }
         $reflection = $this->reflectionProvider->getClass($className);
-        if (!$reflection->isSubclassOf(View::class)) {
+        if (!$this->reflectionProvider->hasClass(View::class)) {
+            return [];
+        }
+        $viewReflection = $this->reflectionProvider->getClass(View::class);
+        if (!$reflection->isSubclassOfClass($viewReflection)) {
             return [];
         }
 

--- a/web/includes/auth/handler/SteamAuthHandler.php
+++ b/web/includes/auth/handler/SteamAuthHandler.php
@@ -26,7 +26,11 @@ class SteamAuthHandler
     {
         $pattern = "/^https:\/\/steamcommunity\.com\/openid\/id\/(7[0-9]{15,25}+)$/";
 
-        if (!preg_match($pattern, $this->openid->data['openid_claimed_id']))
+        // Issue #1273: $this->openid->data is $_POST / $_GET (mixed), and
+        // PHPStan can't see that LightOpenID::validate() guarantees
+        // openid_claimed_id is set on a real Steam round-trip — cast at
+        // the call site to keep the bounded-diff strategy from openid.php.
+        if (!preg_match($pattern, (string) ($this->openid->data['openid_claimed_id'] ?? '')))
             return false;
 
         preg_match($pattern, $this->openid->identity, $match);

--- a/web/includes/auth/openid.php
+++ b/web/includes/auth/openid.php
@@ -46,10 +46,14 @@ class LightOpenID
         $this->set_realm($host);
         $this->set_proxy($proxy);
 
-        $uri = rtrim(preg_replace('#((?<=\?)|&)openid\.[^&]+#', '', $_SERVER['REQUEST_URI']), '?');
+        // Issue #1273: cast at the entry point so the rest of this third-party-shaped
+        // file doesn't need per-call (string) casts for the PHP 8.1 null-to-scalar
+        // deprecation. $_SERVER['REQUEST_URI'] can be null on some SAPIs.
+        $requestUri = (string) ($_SERVER['REQUEST_URI'] ?? '');
+        $uri = rtrim((string) preg_replace('#((?<=\?)|&)openid\.[^&]+#', '', $requestUri), '?');
         $this->returnUrl = $this->trustRoot . $uri;
 
-        $this->data = ($_SERVER['REQUEST_METHOD'] === 'POST') ? $_POST : $_GET;
+        $this->data = (($_SERVER['REQUEST_METHOD'] ?? '') === 'POST') ? $_POST : $_GET;
 
         if(!function_exists('curl_init') && !in_array('https', stream_get_wrappers())) {
             throw new ErrorException('You must have either https wrappers or curl enabled.');
@@ -79,7 +83,9 @@ class LightOpenID
             break;
         case 'trustRoot':
         case 'realm':
-            $this->trustRoot = trim($value);
+            // Issue #1273: cast at the input — non-string values silently coerced
+            // to '' here mirror the existing 'identity' branch behaviour.
+            $this->trustRoot = trim((string) $value);
             break;
         case 'xrdsOverride':
             if (is_array($value)) {
@@ -704,8 +710,10 @@ class LightOpenID
     	$result = '';
 
     	if (!empty($provider_url)) {
+    		// Issue #1273: parse_url can return null on a malformed URL; cast so
+    		// explode() doesn't trip the PHP 8.1 null-to-scalar deprecation.
     		$tokens = array_reverse(
-    			explode('.', parse_url($provider_url, PHP_URL_HOST))
+    			explode('.', (string) parse_url($provider_url, PHP_URL_HOST))
     		);
     		$result = strtolower(
     			(count($tokens) > 1 && strlen($tokens[1]) > 3)
@@ -942,7 +950,9 @@ class LightOpenID
             $prefix = 'openid_' . $alias;
             $length = strlen('http://axschema.org/');
 
-            foreach (explode(',', $this->data['openid_signed']) as $key) {
+            // Issue #1273: cast at the explode boundary — $this->data is $_POST/$_GET,
+            // values are mixed; downstream substr/strlen on the resulting string slices is then safe.
+            foreach (explode(',', (string) ($this->data['openid_signed'] ?? '')) as $key) {
                 $keyMatch = $alias . '.type.';
 
                 if (strncmp($key, $keyMatch, strlen($keyMatch)) !== 0) {
@@ -984,7 +994,8 @@ class LightOpenID
     {
         $attributes = [];
         $sreg_to_ax = array_flip(self::$ax_to_sreg);
-        foreach (explode(',', $this->data['openid_signed']) as $key) {
+        // Issue #1273: cast at the explode boundary — see getAxAttributes() above.
+        foreach (explode(',', (string) ($this->data['openid_signed'] ?? '')) as $key) {
             $keyMatch = 'sreg.';
             if (strncmp($key, $keyMatch, strlen($keyMatch)) !== 0) {
                 continue;

--- a/web/includes/system-functions.php
+++ b/web/includes/system-functions.php
@@ -39,7 +39,7 @@ function CreateLinkR($title, $url, $tooltip="", $target="_self", $wide=false, $o
 {
     $class = ($wide) ? "perm" : "tip";
 
-    if (strlen($tooltip) == 0) {
+    if (strlen((string) $tooltip) == 0) {
         return "<a href='{$url}' onclick=\"{$onclick}\" target='{$target}'> {$title} </a>";
     }
     return "<a href='{$url}' class='{$class}' title='{$tooltip}' target='{$target}'> {$title} </a>";

--- a/web/install/template/page.2.php
+++ b/web/install/template/page.2.php
@@ -7,7 +7,7 @@ if (isset($_POST['postd'])) {
         $db = new Database($_POST['server'], $_POST['port'], $_POST['database'], $_POST['username'], $_POST['password'], $_POST['prefix']);
         if (!$db) {
             echo "<script>ShowBox('Error', 'There was an error connecting to your database. <br />Recheck the details to make sure they are correct', 'red', '', true);</script>";
-        } elseif (strlen($_POST['prefix']) > 9) {
+        } elseif (strlen((string) $_POST['prefix']) > 9) {
             echo "<script>ShowBox('Error', 'The prefix cannot be longer than 9 characters.<br />Correct this and submit again.', 'red', '', true);</script>";
         } else {
 ?>

--- a/web/pages/admin.admins.php
+++ b/web/pages/admin.admins.php
@@ -359,10 +359,10 @@ if ($AdminsEnd < $admin_count) {
 //=================[ Start Layout ]==================================
 $admin_nav = 'displaying&nbsp;' . $AdminsStart . '&nbsp;-&nbsp;' . $AdminsEnd . '&nbsp;of&nbsp;' . $admin_count . '&nbsp;results';
 
-if (strlen($prev) > 0) {
+if ($prev !== '') {
     $admin_nav .= ' | <b>' . $prev . '</b>';
 }
-if (strlen($next) > 0) {
+if ($next !== '') {
     $admin_nav .= ' | <b>' . $next . '</b>';
 }
 

--- a/web/pages/admin.bans.php
+++ b/web/pages/admin.bans.php
@@ -223,10 +223,10 @@ if ($PageEnd < $page_count) {
 
 $page_nav = 'displaying&nbsp;' . $PageStart . '&nbsp;-&nbsp;' . $PageEnd . '&nbsp;of&nbsp;' . $page_count . '&nbsp;results';
 
-if (strlen($prev) > 0) {
+if ($prev !== '') {
     $page_nav .= ' | <b>' . $prev . '</b>';
 }
-if (strlen($next) > 0) {
+if ($next !== '') {
     $page_nav .= ' | <b>' . $next . '</b>';
 }
 
@@ -377,10 +377,10 @@ if ($PageEnd < $page_count) {
 
 $page_nav = 'displaying&nbsp;' . $PageStart . '&nbsp;-&nbsp;' . $PageEnd . '&nbsp;of&nbsp;' . $page_count . '&nbsp;results';
 
-if (strlen($prev) > 0) {
+if ($prev !== '') {
     $page_nav .= ' | <b>' . $prev . '</b>';
 }
-if (strlen($next) > 0) {
+if ($next !== '') {
     $page_nav .= ' | <b>' . $next . '</b>';
 }
 
@@ -552,10 +552,10 @@ if ($PageEnd < $page_count) {
 
 $page_nav = 'displaying&nbsp;' . $PageStart . '&nbsp;-&nbsp;' . $PageEnd . '&nbsp;of&nbsp;' . $page_count . '&nbsp;results';
 
-if (strlen($prev) > 0) {
+if ($prev !== '') {
     $page_nav .= ' | <b>' . $prev . '</b>';
 }
-if (strlen($next) > 0) {
+if ($next !== '') {
     $page_nav .= ' | <b>' . $next . '</b>';
 }
 
@@ -692,10 +692,10 @@ if ($PageEnd < $page_count) {
 
 $page_nav = 'displaying&nbsp;' . $PageStart . '&nbsp;-&nbsp;' . $PageEnd . '&nbsp;of&nbsp;' . $page_count . '&nbsp;results';
 
-if (strlen($prev) > 0) {
+if ($prev !== '') {
     $page_nav .= ' | <b>' . $prev . '</b>';
 }
-if (strlen($next) > 0) {
+if ($next !== '') {
     $page_nav .= ' | <b>' . $next . '</b>';
 }
 

--- a/web/pages/admin.edit.admindetails.php
+++ b/web/pages/admin.edit.admindetails.php
@@ -64,9 +64,9 @@ $errorScript = "";
 
 // Form submitted?
 if (isset($_POST['adminname'])) {
-    $a_name           = trim($_POST['adminname']);
-    $a_steam          = \SteamID\SteamID::toSteam2(trim($_POST['steam']));
-    $a_email          = trim($_POST['email']);
+    $a_name           = trim((string) $_POST['adminname']);
+    $a_steam          = \SteamID\SteamID::toSteam2(trim((string) ($_POST['steam'] ?? '')));
+    $a_email          = trim((string) ($_POST['email'] ?? ''));
     $a_serverpass     = isset($_POST['a_useserverpass']) && $_POST['a_useserverpass'] == "on";
     $pw_changed       = false;
     $serverpw_changed = false;
@@ -94,7 +94,7 @@ if (isset($_POST['adminname'])) {
     }
 
     // If they didnt type a steamid
-    if ((empty($a_steam) || strlen($a_steam) < 10)) {
+    if ((empty($a_steam) || strlen((string) $a_steam) < 10)) {
         $error++;
         $errorScript .= "$('steam.msg').innerHTML = 'You must type a Steam ID or Community ID for the admin.';";
         $errorScript .= "$('steam.msg').setStyle('display', 'block');";
@@ -152,7 +152,7 @@ if (isset($_POST['adminname'])) {
             $pw_changed = true;
             // DID type a password, so he wants to change it.
             // Password too short?
-            if (strlen($_POST['password']) < MIN_PASS_LENGTH) {
+            if (strlen((string) $_POST['password']) < MIN_PASS_LENGTH) {
                 $error++;
                 $errorScript .= "$('password.msg').innerHTML = 'Your password must be at-least " . MIN_PASS_LENGTH . " characters long.';";
                 $errorScript .= "$('password.msg').setStyle('display', 'block');";
@@ -183,7 +183,7 @@ if (isset($_POST['adminname'])) {
                 $error++;
                 $errorScript .= "$('a_serverpass.msg').innerHTML = 'You must type a server password or uncheck the box.';";
                 $errorScript .= "$('a_serverpass.msg').setStyle('display', 'block');";
-            } elseif (strlen($_POST['a_serverpass']) < MIN_PASS_LENGTH) {
+            } elseif (strlen((string) ($_POST['a_serverpass'] ?? '')) < MIN_PASS_LENGTH) {
                 // Password too short?
                 $error++;
                 $errorScript .= "$('a_serverpass.msg').innerHTML = 'Your password must be at-least " . MIN_PASS_LENGTH . " characters long.';";
@@ -285,7 +285,7 @@ if (isset($_POST['adminname'])) {
 } else {
     // get current values
     $a_name = $userbank->GetProperty("user", $_GET['id']);
-    $a_steam = trim($userbank->GetProperty("authid", $_GET['id']));
+    $a_steam = trim((string) $userbank->GetProperty("authid", $_GET['id']));
     $a_email = $userbank->GetProperty("email", $_GET['id']);
     $a_serverpass = $userbank->GetProperty("srv_password", $_GET['id']);
     $a_serverpass = !empty($a_serverpass);

--- a/web/pages/admin.edit.adminperms.php
+++ b/web/pages/admin.edit.adminperms.php
@@ -63,7 +63,7 @@ if (!$userbank->HasAccess(ADMIN_OWNER | ADMIN_EDIT_ADMINS)) {
 }
 
 $web_root  = $userbank->HasAccess(ADMIN_OWNER, $_GET['id']);
-$steam     = trim($userbank->GetProperty("authid", $_GET['id']));
+$steam     = trim((string) $userbank->GetProperty("authid", $_GET['id']));
 $web_flags = intval($userbank->GetProperty("extraflags", $_GET['id']));
 $name      = $userbank->GetProperty("user", $_GET['id'])?>
 <div id="admin-page-content">

--- a/web/pages/admin.edit.ban.php
+++ b/web/pages/admin.edit.ban.php
@@ -124,8 +124,8 @@ $validationErrors = [];
 $postSuccess = false;
 
 if (isset($_POST['name'])) {
-    $_POST['steam'] = \SteamID\SteamID::toSteam2(trim($_POST['steam']));
-    $_POST['type']  = (int) $_POST['type'];
+    $_POST['steam'] = \SteamID\SteamID::toSteam2(trim((string) ($_POST['steam'] ?? '')));
+    $_POST['type']  = (int) ($_POST['type'] ?? 0);
 
     // Form Validation
     $error = 0;
@@ -194,7 +194,7 @@ if (isset($_POST['name'])) {
         }
     }
 
-    $_POST['ip'] = preg_replace('#[^\d\.]#', '', $_POST['ip']); //strip ip of all but numbers and dots
+    $_POST['ip'] = preg_replace('#[^\d\.]#', '', (string) ($_POST['ip'] ?? '')); //strip ip of all but numbers and dots
     $reason = $_POST['listReason'] == "other" ? $_POST['txtReason'] : $_POST['listReason'];
 
     if (!$_POST['banlength']) {

--- a/web/pages/admin.edit.comms.php
+++ b/web/pages/admin.edit.comms.php
@@ -53,8 +53,8 @@ isset($_GET["page"]) ? $pagelink = "&page=" . urlencode($_GET["page"]) : $pageli
 $errorScript = "";
 
 if (isset($_POST['name'])) {
-    $_POST['steam'] = \SteamID\SteamID::toSteam2(trim($_POST['steam']));
-    $_POST['type']  = (int) $_POST['type'];
+    $_POST['steam'] = \SteamID\SteamID::toSteam2(trim((string) ($_POST['steam'] ?? '')));
+    $_POST['type']  = (int) ($_POST['type'] ?? 0);
 
     // Form Validation
     $error = 0;

--- a/web/pages/admin.overrides.php
+++ b/web/pages/admin.overrides.php
@@ -71,7 +71,7 @@ try {
                 $GLOBALS['PDO']->query("UPDATE `:prefix_overrides` SET name = ?, type = ?, flags = ? WHERE id = ?")->execute([
                     $_POST['override_name'][$index],
                     $_POST['override_type'][$index],
-                    trim($_POST['override_flags'][$index]),
+                    trim((string) ($_POST['override_flags'][$index] ?? '')),
                     $id,
                 ]);
             }
@@ -97,7 +97,7 @@ try {
             $GLOBALS['PDO']->query("INSERT INTO `:prefix_overrides` (type, name, flags) VALUES (?, ?, ?)")->execute([
                 $_POST['new_override_type'],
                 $_POST['new_override_name'],
-                trim($_POST['new_override_flags']),
+                trim((string) ($_POST['new_override_flags'] ?? '')),
             ]);
         }
 

--- a/web/pages/page.banlist.php
+++ b/web/pages/page.banlist.php
@@ -38,7 +38,7 @@ function setPostKey()
         $_SESSION['banlist_postkey'] = md5(time() . rand(0, 100000));
     }
 }
-if (!isset($_SESSION['banlist_postkey']) || strlen($_SESSION['banlist_postkey']) < 4) {
+if (!isset($_SESSION['banlist_postkey']) || strlen((string) $_SESSION['banlist_postkey']) < 4) {
     setPostKey();
 }
 
@@ -94,7 +94,7 @@ if (isset($_GET['a']) && $_GET['a'] == "unban" && isset($_GET['id'])) {
             }
             continue;
         }
-        $unbanReason = htmlspecialchars(trim($_GET['ureason']));
+        $unbanReason = htmlspecialchars(trim((string) ($_GET['ureason'] ?? '')));
         $GLOBALS['PDO']->query("UPDATE `:prefix_bans` SET
 										`RemovedBy` = :removedby,
 										`RemoveType` = 'U',
@@ -116,10 +116,10 @@ if (isset($_GET['a']) && $_GET['a'] == "unban" && isset($_GET['id'])) {
         $GLOBALS['PDO']->bind(':bid', $bid);
         $blocked = $GLOBALS['PDO']->resultset();
         foreach ($blocked as $tempban) {
-            rcon(($row['type'] == 0 ? "removeid STEAM_" . $tempban['steam_universe'] . substr($row['authid'], 7) : "removeip " . $row['ip']), $tempban['sid']);
+            rcon(($row['type'] == 0 ? "removeid STEAM_" . $tempban['steam_universe'] . substr((string) $row['authid'], 7) : "removeip " . $row['ip']), $tempban['sid']);
         }
         if (((int) $row['now'] - (int) $row['created']) <= 300 && $row['sid'] != "0" && !in_array($row['sid'], $blocked)) {
-            rcon(($row['type'] == 0 ? "removeid STEAM_" . $row['steam_universe'] . substr($row['authid'], 7) : "removeip " . $row['ip']), $row['sid']);
+            rcon(($row['type'] == 0 ? "removeid STEAM_" . $row['steam_universe'] . substr((string) $row['authid'], 7) : "removeip " . $row['ip']), $row['sid']);
         }
 
         if ($res) {
@@ -184,10 +184,10 @@ if (isset($_GET['a']) && $_GET['a'] == "unban" && isset($_GET['id'])) {
         $res = $GLOBALS['PDO']->execute();
         if (empty($steam['RemoveType'])) {
             foreach ($blocked as $tempban) {
-                rcon(($steam['type'] == 0 ? "removeid STEAM_" . $tempban['steam_universe'] . substr($steam['authid'], 7) : "removeip " . $steam['ip']), $tempban['sid']);
+                rcon(($steam['type'] == 0 ? "removeid STEAM_" . $tempban['steam_universe'] . substr((string) $steam['authid'], 7) : "removeip " . $steam['ip']), $tempban['sid']);
             }
             if (((int) $steam['now'] - (int) $steam['created']) <= 300 && $steam['sid'] != "0" && !in_array($steam['sid'], $blocked)) {
-                rcon(($steam['type'] == 0 ? "removeid STEAM_" . $steam['steam_universe'] . substr($steam['authid'], 7) : "removeip " . $steam['ip']), $steam['sid']);
+                rcon(($steam['type'] == 0 ? "removeid STEAM_" . $steam['steam_universe'] . substr((string) $steam['authid'], 7) : "removeip " . $steam['ip']), $steam['sid']);
             }
         }
 
@@ -273,7 +273,7 @@ if ($publicFilterClauses) {
 }
 
 if (isset($_GET['searchText'])) {
-    $searchText = trim($_GET['searchText']);
+    $searchText = trim((string) $_GET['searchText']);
 
     // #1130: when the input parses as any Steam-ID format, match `authid`
     // via REGEXP so both STEAM_0:Y:Z and STEAM_1:Y:Z stored variants hit
@@ -367,7 +367,7 @@ if (isset($_GET['searchText'])) {
 
 $advcrit = [];
 if (isset($_GET['advSearch'])) {
-    $value = trim($_GET['advSearch']);
+    $value = trim((string) $_GET['advSearch']);
 
     try {
         SteamID::init();
@@ -723,7 +723,7 @@ foreach ($res as $row) {
 
 
 
-    if (strlen($row['ban_ip']) < 7) {
+    if (strlen((string) $row['ban_ip']) < 7) {
         $data['ip'] = 'none';
     } else {
         $data['ip'] = $data['country'] . '&nbsp;' . $row['ban_ip'];
@@ -1002,7 +1002,7 @@ if (isset($_GET["comment"])) {
         $ctext          = "";
     }
 
-    $_GET["ctype"] = substr($_GET["ctype"], 0, 1);
+    $_GET["ctype"] = substr((string) ($_GET["ctype"] ?? ''), 0, 1);
 
     $cotherdata = $GLOBALS['PDO']->query("SELECT cid, aid, commenttxt, added, edittime,
 											(SELECT user FROM `:prefix_admins` WHERE aid = C.aid) AS comname,

--- a/web/pages/page.commslist.php
+++ b/web/pages/page.commslist.php
@@ -45,7 +45,7 @@ function setPostKey()
         $_SESSION['banlist_postkey'] = md5(time() . rand(0, 100000));
     }
 }
-if (!isset($_SESSION['banlist_postkey']) || strlen($_SESSION['banlist_postkey']) < 4) {
+if (!isset($_SESSION['banlist_postkey']) || strlen((string) $_SESSION['banlist_postkey']) < 4) {
     setPostKey();
 }
 
@@ -83,7 +83,7 @@ if (isset($_GET['a']) && $_GET['a'] == "ungag" && isset($_GET['id'])) {
         PageDie();
     }
 
-    $unbanReason = htmlspecialchars(trim($_GET['ureason']));
+    $unbanReason = htmlspecialchars(trim((string) ($_GET['ureason'] ?? '')));
     $GLOBALS['PDO']->query("UPDATE `:prefix_comms` SET
 										`RemovedBy` = :removedby,
 										`RemoveType` = 'U',
@@ -132,7 +132,7 @@ if (isset($_GET['a']) && $_GET['a'] == "ungag" && isset($_GET['id'])) {
         PageDie();
     }
 
-    $unbanReason = htmlspecialchars(trim($_GET['ureason']));
+    $unbanReason = htmlspecialchars(trim((string) ($_GET['ureason'] ?? '')));
     $GLOBALS['PDO']->query("UPDATE `:prefix_comms` SET
 										`RemovedBy` = :removedby,
 										`RemoveType` = 'U',
@@ -232,7 +232,7 @@ if (isset($_SESSION["hideinactive"])) {
 }
 
 if (isset($_GET['searchText'])) {
-    $searchText = trim($_GET['searchText']);
+    $searchText = trim((string) $_GET['searchText']);
 
     // #1130: when the input parses as any Steam-ID format, match `authid`
     // via REGEXP so both STEAM_0:Y:Z and STEAM_1:Y:Z stored variants hit
@@ -310,7 +310,7 @@ if (isset($_GET['searchText'])) {
 
 $advcrit = [];
 if (isset($_GET['advSearch'])) {
-    $value = trim($_GET['advSearch']);
+    $value = trim((string) $_GET['advSearch']);
 
     try {
         SteamID::init();
@@ -844,10 +844,10 @@ if ($BanCount === 0) {
     //=================[ Start Layout ]==================================
     $ban_nav = 'displaying&nbsp;' . $BansStart . '&nbsp;-&nbsp;' . $BansEnd . '&nbsp;of&nbsp;' . $BanCount . '&nbsp;results';
 
-    if (strlen($prev) > 0) {
+    if ($prev !== '') {
         $ban_nav .= ' | <b>' . $prev . '</b>';
     }
-    if (strlen($next) > 0) {
+    if ($next !== '') {
         $ban_nav .= ' | <b>' . $next . '</b>';
     }
     $pages = ceil($BanCount / $BansPerPage);

--- a/web/pages/page.lostpassword.php
+++ b/web/pages/page.lostpassword.php
@@ -50,7 +50,7 @@ if (isset($_GET['email'], $_GET['validation']) && (!empty($_GET['email']) || !em
         PageDie();
     }
 
-    if (strlen($validation) < 10) {
+    if (strlen((string) $validation) < 10) {
         print "<script>ShowBox('Error', 'Invalid validation string.', 'red');</script>";
         PageDie();
     }

--- a/web/pages/page.protest.php
+++ b/web/pages/page.protest.php
@@ -39,12 +39,12 @@ if (!isset($_POST['subprotest']) || $_POST['subprotest'] != 1) {
     $UnbanReason = "";
     $Email       = "";
 } else {
-    $Type        = (int) $_POST['Type'];
-    $SteamID     = $_POST['SteamID'];
-    $IP          = $_POST['IP'];
-    $PlayerName  = $_POST['PlayerName'];
-    $UnbanReason = $_POST['BanReason'];
-    $Email       = $_POST['EmailAddr'];
+    $Type        = (int) ($_POST['Type']      ?? 0);
+    $SteamID     = (string) ($_POST['SteamID']   ?? '');
+    $IP          = (string) ($_POST['IP']        ?? '');
+    $PlayerName  = (string) ($_POST['PlayerName']?? '');
+    $UnbanReason = (string) ($_POST['BanReason'] ?? '');
+    $Email       = (string) ($_POST['EmailAddr'] ?? '');
     $validsubmit = true;
     $errors      = "";
     $BanId       = -1;
@@ -136,7 +136,8 @@ if (!isset($_POST['subprotest']) || $_POST['subprotest'] != 1) {
         $GLOBALS['PDO']->query("SELECT aid, user, email FROM `:prefix_admins` WHERE aid = (SELECT aid FROM `:prefix_bans` WHERE bid = :bid)");
         $GLOBALS['PDO']->bind(':bid', (int) $BanId);
         $emailinfo = $GLOBALS['PDO']->single();
-        $requri    = substr($_SERVER['REQUEST_URI'], 0, strrpos($_SERVER['REQUEST_URI'], ".php") + 4);
+        $requestUri = (string) ($_SERVER['REQUEST_URI'] ?? '');
+        $requri    = substr($requestUri, 0, (int) strrpos($requestUri, ".php") + 4);
         if (Config::getBool('protest.emailonlyinvolved') && !empty($emailinfo['email'])) {
             $admins = array(
                 array(

--- a/web/pages/page.submit.php
+++ b/web/pages/page.submit.php
@@ -103,13 +103,13 @@ if (!isset($_POST['subban']) || $_POST['subban'] != 1) {
     $Email         = "";
     $SID           = -1;
 } else {
-    $SteamID       = trim($_POST['SteamID']);
-    $BanIP         = trim($_POST['BanIP']);
-    $PlayerName    = $_POST['PlayerName'];
-    $BanReason     = $_POST['BanReason'];
-    $SubmitterName = $_POST['SubmitName'];
-    $Email         = trim($_POST['EmailAddr']);
-    $SID           = (int) $_POST['server'];
+    $SteamID       = trim((string) ($_POST['SteamID']    ?? ''));
+    $BanIP         = trim((string) ($_POST['BanIP']      ?? ''));
+    $PlayerName    = (string) ($_POST['PlayerName']  ?? '');
+    $BanReason     = (string) ($_POST['BanReason']   ?? '');
+    $SubmitterName = (string) ($_POST['SubmitName']  ?? '');
+    $Email         = trim((string) ($_POST['EmailAddr']  ?? ''));
+    $SID           = (int) ($_POST['server']         ?? -1);
     $validsubmit   = true;
     $errors        = "";
     if ((strlen($SteamID) != 0 && $SteamID != "STEAM_0:") && !\SteamID\SteamID::isValidID($SteamID)) {
@@ -244,7 +244,8 @@ if (!isset($_POST['subban']) || $_POST['subban'] != 1) {
             $headers = 'From: ' . SB_EMAIL . "\n" . 'X-Mailer: PHP/' . phpversion();
 
             $admins = $userbank->GetAllAdmins();
-            $requri = substr($_SERVER['REQUEST_URI'], 0, strrpos($_SERVER['REQUEST_URI'], ".php") - 5);
+            $requestUri = (string) ($_SERVER['REQUEST_URI'] ?? '');
+            $requri = substr($requestUri, 0, (int) strrpos($requestUri, ".php") - 5);
             $mailDests = [];
 
             foreach ($admins as $admin) {

--- a/web/phpstan.neon
+++ b/web/phpstan.neon
@@ -1,6 +1,10 @@
 includes:
     - phpstan-baseline.neon
     - includes/vendor/staabm/phpstan-dba/config/dba.neon
+    # #1273: catch the PHP 8.1 null-to-scalar deprecation surface (strlen,
+    # trim, substr, preg_match, mb_strlen, …) before it bites us on the
+    # PHP 9 bump. The matched phpVersion below is what flips the rules on.
+    - includes/vendor/phpstan/phpstan-deprecation-rules/rules.neon
 
 parameters:
     level: 5

--- a/web/tests/integration/Php82DeprecationsTest.php
+++ b/web/tests/integration/Php82DeprecationsTest.php
@@ -1,0 +1,303 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sbpp\Tests\Integration;
+
+use ErrorException;
+use PHPUnit\Framework\Attributes\PreserveGlobalState;
+use PHPUnit\Framework\Attributes\RunInSeparateProcess;
+use Sbpp\Tests\ApiTestCase;
+use Sbpp\Tests\Fixture;
+use Smarty\Smarty;
+
+/**
+ * Issue #1273: PHP 8.1 deprecated implicit `null` -> scalar coercion for
+ * internal functions (`strlen($null)`, `trim($null)`, `substr($null,...)`,
+ * etc.). PHP 9 will turn the deprecation into a `TypeError`. Per
+ * `web/composer.json`, the panel already requires `php >= 8.2`, so we're
+ * firmly inside the deprecation window.
+ *
+ * The PHPStan deprecation-rules plugin (#1273) is the static gate that
+ * blocks new offenders inside the analyzable codebase. This test is the
+ * runtime gate — PHPStan can't see `web/includes/auth/openid.php` (it's
+ * excluded), and a row whose runtime value is `null` despite the column
+ * looking `NOT NULL` to the type system can still slip through. The
+ * trap below promotes any `E_DEPRECATED` raised while a marquee page
+ * renders into a thrown `ErrorException`, so the test fails with the
+ * exact site (file + line) instead of silently printing into
+ * `display_errors` like it does today.
+ *
+ * Each test method runs in a separate process because the page handlers
+ * declare top-level helper functions like `setPostKey()` that PHP can't
+ * redeclare inside one process. Process isolation also guarantees each
+ * test starts from a clean error-handler stack and `$_SESSION` /
+ * `$_GET` / `$GLOBALS` state so the deprecation trap only sees errors
+ * from the page under test.
+ */
+final class Php82DeprecationsTest extends ApiTestCase
+{
+    /**
+     * Promote `E_DEPRECATED` / `E_USER_DEPRECATED` into thrown
+     * `ErrorException`s so the failing PHPUnit assertion points at the
+     * exact `<file>:<line>` that triggered the deprecation. Other
+     * severities fall through to PHPUnit's default handler so we don't
+     * accidentally swallow real warnings or errors.
+     *
+     * Bumps `error_reporting()` to `E_ALL` first because PHPUnit's
+     * bootstrap (and `init.php` in non-dev mode) leaves
+     * `E_NOTICE | E_DEPRECATED` masked off. Without the bump, the new
+     * error handler would never fire on a deprecation.
+     */
+    private static function trapDeprecations(): void
+    {
+        error_reporting(E_ALL);
+        set_error_handler(function (int $severity, string $message, string $file, int $line): bool {
+            if ($severity === E_DEPRECATED || $severity === E_USER_DEPRECATED) {
+                throw new ErrorException($message, 0, $severity, $file, $line);
+            }
+            // Let PHPUnit's default handler take everything else.
+            return false;
+        });
+    }
+
+    /**
+     * Capture-only Smarty stub. Page handlers reach for
+     * `$theme->assign(...)`, `$theme->display(...)`, and
+     * `Sbpp\View\Renderer::render($theme, $view)` (which type-hints
+     * `Smarty $theme`). Subclassing Smarty keeps the type compatible
+     * with the production signatures; both methods are no-ops because
+     * the contract under test is the PHP code path, not the Smarty
+     * render itself. Mirrors the LostPasswordChromeTest pattern.
+     */
+    private function makeStubTheme(): Smarty
+    {
+        return new class extends Smarty {
+            /** @phpstan-ignore method.childParameterType */
+            public function assign($tpl_var, $value = null, $nocache = false, $scope = null)
+            {
+                return $this;
+            }
+
+            public function display($template = null, $cache_id = null, $compile_id = null)
+            {
+                return '';
+            }
+        };
+    }
+
+    /**
+     * Wire the globals every page handler under `web/pages/*` reads
+     * straight from `$GLOBALS` (`$theme`, `$userbank`, `$PDO`). Page
+     * handlers each open with their own `global $theme, $userbank;`
+     * declaration, which then resolves against `$GLOBALS[...]`, so we
+     * only need to set the entries — no `global` declaration here.
+     * Returns the stub Smarty so callers can keep a reference if they
+     * want to assert against captured calls (we don't here).
+     */
+    private function bootRenderHarness(): Smarty
+    {
+        $theme = $this->makeStubTheme();
+        $GLOBALS['theme']    = $theme;
+        $GLOBALS['userbank'] = $GLOBALS['userbank'] ?? new \CUserManager(null);
+        $GLOBALS['username'] = $GLOBALS['username'] ?? 'tester';
+
+        return $theme;
+    }
+
+    /**
+     * The headline regression: `page.banlist.php:724` reads
+     * `$row['ban_ip']` and feeds it to `strlen(...)`. The column is
+     * declared `varchar(32) default NULL` (see
+     * `web/install/includes/sql/struc.sql`), so a web-only ban that
+     * was created without an IP will yield `null` — and pre-#1273
+     * the page rendered exactly one deprecation per such row.
+     *
+     * The fixture inserts one ban with `ip = NULL` so the foreach
+     * over the result set actually exercises the cast path; without
+     * a row the page short-circuits into the empty-state branch and
+     * the regression goes uncaught.
+     */
+    #[RunInSeparateProcess]
+    #[PreserveGlobalState(false)]
+    public function testBanlistRendersWithoutDeprecationsForNullIpRow(): void
+    {
+        $this->loginAsAdmin();
+        $this->seedBanWithNullIp();
+        $this->bootRenderHarness();
+
+        $_SESSION = [];
+        $_GET     = [];
+
+        self::trapDeprecations();
+        ob_start();
+        try {
+            require ROOT . 'pages/page.banlist.php';
+        } finally {
+            ob_end_clean();
+            restore_error_handler();
+        }
+
+        $this->assertTrue(true, 'page.banlist.php rendered without raising any deprecation notice.');
+    }
+
+    /**
+     * commslist mirrors banlist's pagination + filter shape; the
+     * `$prev` / `$next` strings used to be checked with `strlen(...)`
+     * and the `$_GET['searchText']` / `$_GET['advSearch']` values
+     * with `trim(...)` (see #1273 issue body). Render with default
+     * GET state to exercise the empty-pagination branch + the
+     * filter-empty branch in one pass.
+     */
+    #[RunInSeparateProcess]
+    #[PreserveGlobalState(false)]
+    public function testCommsListRendersWithoutDeprecations(): void
+    {
+        $this->loginAsAdmin();
+        $this->bootRenderHarness();
+
+        $_SESSION = [];
+        $_GET     = [];
+
+        self::trapDeprecations();
+        ob_start();
+        try {
+            require ROOT . 'pages/page.commslist.php';
+        } finally {
+            ob_end_clean();
+            restore_error_handler();
+        }
+
+        $this->assertTrue(true, 'page.commslist.php rendered without raising any deprecation notice.');
+    }
+
+    /**
+     * admin.bans.php has the worst per-file count (8 sites in #1273's
+     * `rg -c` table), all on the `$prev`/`$next` pagination shape
+     * across four nested sections (current protests / archive /
+     * current submissions / archive). Rendering the surface end-to-end
+     * exercises every one of them in a single pass.
+     */
+    #[RunInSeparateProcess]
+    #[PreserveGlobalState(false)]
+    public function testAdminBansRendersWithoutDeprecations(): void
+    {
+        $this->loginAsAdmin();
+        $this->bootRenderHarness();
+
+        $_SESSION = [];
+        $_GET     = [];
+        // admin.bans.php reads `$_SERVER['REMOTE_ADDR']` for the
+        // import-bans branch; the bootstrap already defaults it but
+        // belt-and-braces in case a previous test left it cleared.
+        $_SERVER['REMOTE_ADDR'] = $_SERVER['REMOTE_ADDR'] ?? '127.0.0.1';
+
+        self::trapDeprecations();
+        ob_start();
+        try {
+            require ROOT . 'pages/admin.bans.php';
+        } finally {
+            ob_end_clean();
+            restore_error_handler();
+        }
+
+        $this->assertTrue(true, 'admin.bans.php rendered without raising any deprecation notice.');
+    }
+
+    /**
+     * admin.admins.php has the same `$prev`/`$next` strlen pattern
+     * (lines 362/365 pre-fix) plus a couple of `preg_match` calls
+     * over `$_GET['advSearch']` shimmed into the modern filter shape.
+     */
+    #[RunInSeparateProcess]
+    #[PreserveGlobalState(false)]
+    public function testAdminAdminsRendersWithoutDeprecations(): void
+    {
+        $this->loginAsAdmin();
+        $this->bootRenderHarness();
+
+        $_SESSION = [];
+        $_GET     = [];
+
+        self::trapDeprecations();
+        ob_start();
+        try {
+            require ROOT . 'pages/admin.admins.php';
+        } finally {
+            ob_end_clean();
+            restore_error_handler();
+        }
+
+        $this->assertTrue(true, 'admin.admins.php rendered without raising any deprecation notice.');
+    }
+
+    /**
+     * The OpenID 2.0 vendored library (`web/includes/auth/openid.php`)
+     * is excluded from PHPStan, so the per-call deprecation surface
+     * is not statically gated. The fix at #1273 casts `$value` and
+     * `$_SERVER['REQUEST_URI']` at the entry points; this test pins
+     * the contract by constructing the LightOpenID object the same
+     * way `web/pages/page.login.php` does (Steam OpenID with default
+     * `$_SERVER` state) so a future regression in `set()` or the
+     * constructor's `$_SERVER` reads trips the deprecation trap.
+     *
+     * We intentionally don't dispatch a real Steam request — that
+     * would require network egress. Construction + the `set('realm', …)`
+     * write path is enough to hit every `(string)` cast added at
+     * #1273 in this file (the constructor's `parse_url` + the magic
+     * setter's `trim((string) $value)`).
+     */
+    #[RunInSeparateProcess]
+    #[PreserveGlobalState(false)]
+    public function testOpenIdConstructionDoesNotEmitDeprecations(): void
+    {
+        require_once ROOT . 'includes/auth/openid.php';
+
+        // Mirror the fields page.login.php's Steam branch sets — the
+        // only thing the constructor actually needs is HTTP_HOST.
+        $_SERVER['HTTP_HOST']      = 'localhost';
+        $_SERVER['REQUEST_URI']    = '/index.php?p=login';
+        $_SERVER['REQUEST_METHOD'] = 'GET';
+
+        self::trapDeprecations();
+        try {
+            $openid = new \LightOpenID('localhost');
+            // The magic setter for `realm` / `trustRoot` was the
+            // second site that took a non-string `$value`; pin both
+            // assignments so a regression in the cast tracks back to
+            // this test.
+            $openid->realm     = 'http://localhost/';
+            $openid->trustRoot = 'http://localhost/';
+        } finally {
+            restore_error_handler();
+        }
+
+        $this->assertSame('http://localhost/', $openid->trustRoot,
+            'LightOpenID::set() should still propagate the trustRoot value through the (string) cast.');
+    }
+
+    /**
+     * Insert one minimal ban row whose `ip` column is `NULL`. Keeps
+     * the SQL string short and ASCII-only so test output stays
+     * readable when this fails. Foreign keys / constraints on
+     * `:prefix_bans` are nominal; only `name`, `reason` are NOT NULL
+     * (see struc.sql) so we only need to populate those + the ones
+     * the banlist SELECT reads back.
+     */
+    private function seedBanWithNullIp(): void
+    {
+        $pdo  = Fixture::rawPdo();
+        $stmt = $pdo->prepare(sprintf(
+            'INSERT INTO `%s_bans`
+                (ip, authid, name, created, ends, length, reason, aid, adminIp, sid, country, type)
+             VALUES (NULL, ?, ?, UNIX_TIMESTAMP(), 0, 0, ?, 0, ?, 0, NULL, 0)',
+            DB_PREFIX
+        ));
+        $stmt->execute([
+            'STEAM_0:0:1',
+            'NullIpPlayer',
+            'no-ip ban (deprecation regression fixture for #1273)',
+            '127.0.0.1',
+        ]);
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #1273. Browsing the panel was emitting a stream of `Deprecated: strlen(): Passing null to parameter #1 ($string) of type string is deprecated.` notices (and the same shape for `trim` / `substr` / `preg_match` / `preg_replace` / `mb_strlen`) on every hot path. PHP 8.1 deprecated this implicit null-into-scalar coercion; PHP 9 will turn it into a `TypeError`. `web/composer.json` already requires `php >= 8.2`, so we're inside the deprecation window today and one major bump from a fatal.

Three coordinated halves so the fix doesn't regress:

- **Per-site fixes** — 21 files, ~64 sites — using `?? ''` when null is semantically "absent" ($\_POST / $\_GET / $\_SESSION / $\_SERVER lookups the form may have omitted) and `(string)` when the value should always be a string but the type system can't see it (nullable `:prefix_*` row columns, `mixed`-returning helpers like `CUserManager::GetProperty`). The `admin.bans.php` / `admin.admins.php` / `commslist.php` pagination idiom (`if (strlen($prev) > 0)` → `if ($prev !== '')`) since both branches assign strings.
- **`web/includes/auth/openid.php`** (third-party-shaped, excluded from PHPStan) gets entry-point casts only — `$_SERVER['REQUEST_URI']`, the magic setter's `$value`, the `parse_url(..., PHP_URL_HOST)` return, the `$this->data['openid_signed']` explode boundary — so the diff stays bounded and the vendored 2007 library doesn't need per-call `(string)` sprinkling.
- **Two regression gates**:
  - `phpstan/phpstan-deprecation-rules` (dev-dep) wired into `phpstan.neon` with `phpVersion: 80200` — catches new null-into-scalar offenders in the analyzable codebase before they ship. Baseline stayed at 0 deprecation entries because the audit cleared everything PHPStan can see.
  - `web/tests/integration/Php82DeprecationsTest.php` — process-isolated render harness with a stub Smarty + `set_error_handler` that promotes `E_DEPRECATED` / `E_USER_DEPRECATED` to thrown `\ErrorException`s. Covers the marquee routes (banlist with a fixture `ip = NULL` row, commslist, admin.bans, admin.admins) and the OpenID construction path PHPStan can't see.

Incidental: replace `ClassReflection::isSubclassOf(string)` (deprecated in PHPStan 1.x) with `isSubclassOfClass(ClassReflection)` in `SmartyTemplateRule` so the new deprecation-rules plugin doesn't trip on our own infra.

Doc-sync per AGENTS.md: new "Null-into-scalar discipline (PHP 8.2+)" Conventions section + Anti-pattern entry + ARCHITECTURE.md note on the static gate + index row pointing at the runtime smoke test.

## Per-file fix count

| File | Sites |
|------|-------|
| `web/pages/page.banlist.php` | 10 |
| `web/pages/admin.bans.php` | 8 |
| `web/pages/page.commslist.php` | 7 |
| `web/pages/admin.edit.admindetails.php` | 7 |
| `web/pages/page.submit.php` | 7 |
| `web/pages/page.protest.php` | 6 |
| `web/includes/auth/openid.php` | 5 (entry-point casts) |
| `web/includes/CUserManager.php` | 3 |
| `web/pages/admin.overrides.php` | 2 |
| `web/pages/admin.edit.ban.php` | 2 |
| `web/pages/admin.admins.php` | 2 |
| `web/pages/page.lostpassword.php` | 1 |
| `web/pages/admin.edit.comms.php` | 1 |
| `web/pages/admin.edit.adminperms.php` | 1 |
| `web/install/template/page.2.php` | 1 |
| `web/includes/system-functions.php` | 1 |
| **Total** | **64** |

`web/sb_debug_connection.php`, `web/install/template/page.{4,5}.php`, and the `strlen()` calls under `web/api/handlers/*.php` were spot-checked and are not deprecation-prone (the input variables are unconditionally `(string)`-cast at the handler boundary, or come from `pack(...)` / `explode(...)` which never return null elements). PHPStan running at `phpVersion: 80200` confirms the type system view; baseline grew zero deprecation entries.

## Out of scope (per issue)

Replacing nullable `:prefix_*` columns (e.g. `bans.ip`) with `NOT NULL DEFAULT ''` would also clear the deprecation, but it's a paired schema migration with a separate semantic change ("no IP" vs "empty IP"). Documented in the new AGENTS.md "Null-into-scalar discipline" section as the deferred follow-up.

## Test plan

- [x] `./sbpp.sh phpstan` — clean. Deprecation-rules plugin wired in, `phpVersion: 80200`, baseline unchanged (zero new entries).
- [x] `./sbpp.sh test` — full suite green (366 tests, 1493 assertions). New `Php82DeprecationsTest` adds 5 cases (banlist + null-IP fixture row, commslist, admin.bans, admin.admins, OpenID construction).
- [x] `./sbpp.sh ts-check` — clean.
- [x] `./sbpp.sh composer api-contract` — clean (no API surface changed).