### PR TITLE
fix(chrome): land the structural half of #1271 — footer inside .app so the sidebar stays sticky-pinned to the document bottom

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -980,6 +980,32 @@ per spec, not the shared `sourcebans_e2e`. Wrapper:
   the sibling theme-toggle's chrome. The `.topbar__search-label` /
   `.topbar__search-kbd` spans stay in the DOM for SR users + the
   Mac glyph swap, but `display: none` everywhere — don't unhide them.
+- Moving `<footer class="app-footer">` back outside `<div class="app">`
+  (the body-level sibling shape from before #1271's structural fix) →
+  `.sidebar` is `position: sticky; top: 0; height: 100vh` and its
+  sticky containing block is `.app`. Pulling the footer out leaves
+  `.app` `footerHeight` short of the document, so on tall pages the
+  sidebar releases at the bottom (brand cuts off) and on barely-tall
+  pages where `docHeight - viewport ≤ footerHeight` (the bare-e2e
+  `?p=admin&c=audit` shape) the entire scroll range falls inside the
+  release phase and the sidebar appears to track the scroll — exactly
+  the symptom rumblefrog reported in #1271. The footer must stay as
+  the last flex column item of `<div class="main">`. The
+  `align-self: flex-start` on `.sidebar` (added by #1278) is
+  defensive parity with `.admin-sidebar`, NOT the load-bearing fix —
+  a future refactor that puts the footer back outside `.app` will
+  silently regress even with `align-self` in place. The regression
+  guard is `web/tests/e2e/specs/responsive/sidebar-sticky.spec.ts`'s
+  strict `top===0` assertion at scroll=`document.scrollHeight`.
+- Pinning `<aside id="drawer-root">` or `<dialog id="palette-root">`
+  inside `<div class="app">` "to be consistent with the footer" → the
+  drawer is `position: fixed; inset: 0` and `<dialog>` promotes itself
+  to the top layer when `showModal()`-ed; both are floating overlays
+  whose containing block is irrelevant to layout. Nesting the drawer
+  inside `.app` would extend `.app`'s flex cross-axis to the drawer's
+  `100vh` (and break the sticky containing-block math the same way
+  the pre-#1271 footer did, just from the opposite direction). Keep
+  them as direct children of `<body>`, after `</div>` closing `.app`.
 
 ## Where to find what
 
@@ -1026,6 +1052,7 @@ per spec, not the shared `sourcebans_e2e`. Wrapper:
 | Tweak mobile (<=768px) chrome layout   | `web/themes/default/css/theme.css` — see the `#1207` `@media (max-width: 768px)` blocks for the canonical shapes (icon-only topbar search, full-width drawer + scroll lock). Sub-paged admin routes (servers / mods / groups / settings) use the `<details open>` accordion in the `#1259` `@media (min-width: 1024px)` block (sidebar inline at `<1024px`, sticky 14rem rail at `>=1024px`); see "Sub-paged admin routes" in Conventions. |
 | Stop mobile browsers auto-linking SteamIDs / IPs as phone numbers | `web/themes/default/core/header.tpl` (`<meta name="format-detection" content="telephone=no…">` + `<meta name="x-apple-data-detectors">`) and the defensive `.drawer a[href^="tel:"]` reset in `theme.css` |
 | Lock page scroll while a modal-style chrome is open | `web/themes/default/css/theme.css` (`html:has(#drawer-root[data-drawer-open="true"]) { overflow: hidden; }` — pure-CSS, gates on the same `data-drawer-open` mirror theme.js sets, applies at every viewport so the drawer-open contract is symmetric desktop/mobile per the Linear/Vercel/Notion modal idiom) |
+| Keep the main sidebar sticky-pinned across the full document scroll (`<aside class="sidebar">`) | The structural half of #1271 lives in `web/themes/default/core/footer.tpl`: `<footer class="app-footer">` is rendered as the LAST flex column item of `<div class="main">`, INSIDE `<div class="app">`. `.sidebar`'s sticky containing block is `.app`; if the footer were a body-level sibling of `.app` (the pre-fix shape), `.app`'s height would fall short of the document by `footerHeight` and the sidebar would release at the bottom — brand cut off, on barely-tall pages (`docHeight - viewport ≤ footerHeight`, e.g. `?p=admin&c=audit` on the bare e2e seed) the entire scroll range would be in the release phase and the sidebar would track the scroll. Keeping the footer inside `.app` makes the sticky CB extend to the full document. The CSS half (`.sidebar { align-self: flex-start; }` from #1278) is defensive parity with `.admin-sidebar` and is RETAINED but not load-bearing on its own. The footer's `margin-top: auto` (`.app-footer` rule in `theme.css`) is the classic "sticky footer" pattern — pushes the footer to the bottom of `.main`'s flex column on short pages so the credit doesn't float halfway up the viewport. Regression guard: `web/tests/e2e/specs/responsive/sidebar-sticky.spec.ts` asserts strict `top===0` at scroll=`document.scrollHeight` on `?p=admin&c=bans` (the canonical tall page) AND on `?p=admin&c=audit` (the barely-tall page that historically presented the bug most visibly). |
 | Disable the chrome's slide-in / fade animations for `prefers-reduced-motion` users | `web/themes/default/css/theme.css` (`@media (prefers-reduced-motion: reduce)` global block — see the matching note in "Playwright E2E specifics" / Conventions) |
 | Run a stack in parallel with another worktree | Worktree-local `docker-compose.override.yml` (see "Parallel stacks") |
 | Local dev stack details                | `docker/README.md`                                       |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -999,13 +999,25 @@ per spec, not the shared `sourcebans_e2e`. Wrapper:
   strict `top===0` assertion at scroll=`document.scrollHeight`.
 - Pinning `<aside id="drawer-root">` or `<dialog id="palette-root">`
   inside `<div class="app">` "to be consistent with the footer" → the
-  drawer is `position: fixed; inset: 0` and `<dialog>` promotes itself
-  to the top layer when `showModal()`-ed; both are floating overlays
-  whose containing block is irrelevant to layout. Nesting the drawer
-  inside `.app` would extend `.app`'s flex cross-axis to the drawer's
-  `100vh` (and break the sticky containing-block math the same way
-  the pre-#1271 footer did, just from the opposite direction). Keep
-  them as direct children of `<body>`, after `</div>` closing `.app`.
+  drawer is `position: fixed; right: 0; top: 0; height: 100%`
+  (right-pinned panel, NOT full-bleed — `inset: 0` is on the
+  separate `.drawer-backdrop`); `<dialog>` promotes itself to the
+  top layer when `showModal()`-ed. Both are conceptually top-layer
+  overlays — they're not part of the app shell's layout, so they
+  belong outside `.app` for the same reason a Linear/Notion modal
+  isn't nested inside the page header. The defensiveness reason is
+  CSS containing-block scoping: a future refactor that declares
+  `transform`, `filter`, `perspective`, `contain: layout`, or
+  `will-change: transform` on `.app` (or any descendant in the
+  drawer's would-be ancestry) RE-ESTABLISHES THE CONTAINING BLOCK
+  for `position: fixed` descendants per CSS Position Module §3.2 —
+  the drawer would suddenly be positioned relative to that
+  ancestor instead of the viewport, painting at the wrong size /
+  in the wrong place. Keeping the drawer as a direct `<body>`
+  child sidesteps that landmine. The structural-fix concern that
+  motivated #1271 (sidebar's sticky CB short of the document)
+  doesn't apply — `position: fixed` removes the drawer from flow,
+  so it cannot grow `.app`'s height.
 
 ## Where to find what
 

--- a/web/tests/e2e/specs/responsive/sidebar-sticky.spec.ts
+++ b/web/tests/e2e/specs/responsive/sidebar-sticky.spec.ts
@@ -160,16 +160,17 @@ test.describe('responsive: sidebar sticky at desktop', () => {
             `sidebar must remain pinned at viewport y=0 at scroll=document.scrollHeight (got ${bottomTop})`,
         ).toBeLessThanOrEqual(1);
 
-        // Belt-and-suspenders: the brand area (`.sidebar__brand` —
-        // the "S SourceBans++" header at the top of the sidebar) is
-        // the user-visible canary for the pre-fix regression. If
-        // sticky drifts up by `footerHeight`, the brand is the first
-        // thing to scroll off the top. Assert the brand is in the
-        // viewport at scroll=BOTTOM. (`toBeInViewport()` requires
-        // ≥0% intersection — together with the strict `top` check
-        // above, this catches both "sidebar fully off-screen" and
-        // "sidebar pinned but brand cut off" failure modes.)
-        await expect(page.locator('.sidebar__brand')).toBeInViewport();
+        // Belt-and-suspenders: the brand area
+        // (`[data-testid="sidebar-brand"]` — the "S SourceBans++"
+        // header at the top of the sidebar) is the user-visible
+        // canary for the pre-fix regression. If sticky drifts up by
+        // `footerHeight`, the brand is the first thing to scroll off
+        // the top. Assert the brand is in the viewport at
+        // scroll=BOTTOM. (`toBeInViewport()` requires ≥0%
+        // intersection — together with the strict `top` check above,
+        // this catches both "sidebar fully off-screen" and "sidebar
+        // pinned but brand cut off" failure modes.)
+        await expect(page.locator('[data-testid="sidebar-brand"]')).toBeInViewport();
 
         // First nav link is `[data-testid="nav-home"]` (always
         // rendered for any logged-in user — the navbar's "Public"
@@ -190,24 +191,38 @@ test.describe('responsive: sidebar sticky at desktop', () => {
         // Post-fix, `.app`'s `min-height: 100vh` + the footer-as-
         // last-flex-item layout collapses `docHeight` to exactly
         // `viewport` on this seed (no scroll at all). The
-        // assertion below is the conjunctive guard:
-        //   1. If a future refactor shaves `min-height: 100vh` off
-        //      `.app` and `docHeight` shrinks below `viewport`,
-        //      the sticky behaviour is still intact (sticky
-        //      degenerates to `static` on a non-scrolling page,
-        //      sidebar still at top=0).
-        //   2. If a future refactor re-introduces a small
-        //      `docHeight - viewport` gap (e.g. the audit page
-        //      grows a hero banner that's outside `.app`), this
-        //      page becomes scrollable AND the sidebar must
-        //      remain at top=0 throughout — exactly the
-        //      pre-fix bug we shipped this PR to close.
+        // bottom-walk assertion is therefore CONDITIONAL: it only
+        // fires when the page is scrollable. This catches a narrow
+        // band of regressions:
+        //   - Future refactor moves the footer back outside `.app`
+        //     while leaving `min-height: 100vh` in place →
+        //     `docHeight = viewport + footerHeight`, scroll fires,
+        //     strict `top === 0` at bottom fails.
+        //   - Future refactor adds a hero banner / docked alert /
+        //     anything that lives outside `.app` and pushes
+        //     `docHeight` above `viewport` → same shape.
+        //
+        // It does NOT catch a regression where the footer goes back
+        // outside AND `min-height: 100vh` is also shaved off so
+        // `.app` collapses to its content height (which on the
+        // bare-seed audit page can fit in 720px). That joint
+        // regression presents as `docHeight === viewport` and the
+        // bottom-walk silently no-ops here. The admin-bans guard
+        // above is the load-bearing tall-page invariant — it fires
+        // regardless of footer placement, because admin-bans is
+        // structurally taller than the viewport on its own. Treat
+        // this audit-page test as the surface-level memorial of
+        // rumblefrog's original report, not as a complete
+        // regression suite. If a future contributor wants the
+        // joint-regression case covered, they should seed a row
+        // into `:prefix_log` from the e2e `Fixture` so the audit
+        // page is reliably scrollable.
         await page.goto('/index.php?p=admin&c=audit');
         // Brand visibility is the load anchor: the Audit Log page
         // chrome carries no testid we can wait on without coupling
         // to its content, but the navbar brand is rendered on every
         // logged-in route by `core/navbar.tpl`.
-        await expect(page.locator('.sidebar__brand')).toBeVisible();
+        await expect(page.locator('[data-testid="sidebar-brand"]')).toBeVisible();
 
         const { docHeight, viewport } = await page.evaluate(() => ({
             docHeight: document.documentElement.scrollHeight,
@@ -224,10 +239,6 @@ test.describe('responsive: sidebar sticky at desktop', () => {
         });
         expect(topAtZero, `sidebar must be at viewport y=0 at scroll=0 (got ${topAtZero})`).toBe(0);
 
-        // The conditional half: if the page IS scrollable, walk to
-        // the bottom and assert sticky still holds. The pre-fix bug
-        // tripped here whenever `0 < docHeight - viewport <=
-        // footerHeight`.
         if (docHeight > viewport) {
             await page.evaluate(() => window.scrollTo(0, document.documentElement.scrollHeight));
             await page.evaluate(() => new Promise((resolve) => requestAnimationFrame(() => resolve(undefined))));
@@ -240,7 +251,7 @@ test.describe('responsive: sidebar sticky at desktop', () => {
                 `sidebar must remain pinned at viewport y=0 at scroll=document.scrollHeight on the audit page (docHeight=${docHeight}, viewport=${viewport}); pre-#1271 this scroll range was entirely in the sticky-release phase (got ${topAtBottom})`,
             ).toBeGreaterThanOrEqual(-1);
             expect(topAtBottom).toBeLessThanOrEqual(1);
-            await expect(page.locator('.sidebar__brand')).toBeInViewport();
+            await expect(page.locator('[data-testid="sidebar-brand"]')).toBeInViewport();
         }
     });
 });

--- a/web/tests/e2e/specs/responsive/sidebar-sticky.spec.ts
+++ b/web/tests/e2e/specs/responsive/sidebar-sticky.spec.ts
@@ -6,28 +6,57 @@
  * `web/themes/default/core/navbar.tpl`):
  *
  *   - The sidebar declares `position: sticky; top: 0; height: 100vh;
- *     align-self: flex-start;` inside `.app` (`display: flex`). The
- *     explicit `height: 100vh` keeps the sidebar's cross-axis size at
- *     the viewport so sticky has room to operate; `align-self:
- *     flex-start` is defensive parity with the Pattern A inner rail
- *     (`.admin-sidebar`, which has `align-self: start` for the same
- *     reason — see #1259). #1271 added the parity so a future refactor
- *     that drops the explicit height (or wraps `.app` in a transformed
- *     / overflow-hidden ancestor that breaks the sticky containing
- *     block) cannot regress the chrome silently.
+ *     align-self: flex-start;` inside `.app` (`display: flex`).
+ *     `position: sticky` works only when the sticky containing block
+ *     (`.app`) is taller than the sticky element (`.sidebar` =
+ *     100vh). To keep the sidebar pinned at viewport y=0 across the
+ *     ENTIRE scroll range — including scroll=document.scrollHeight —
+ *     `.app` must extend to the full document height. The structural
+ *     half of #1271's fix lives in `core/footer.tpl`:
+ *     `<footer class="app-footer">` is rendered as the last flex
+ *     column item of `<div class="main">`, INSIDE `.app`. Pre-fix
+ *     the footer was a body-level sibling of `.app`, leaving the
+ *     sticky containing block `footerHeight` short of the document
+ *     and forcing the sidebar to release at the bottom — brand cut
+ *     off, on barely-tall pages the entire scroll range was in the
+ *     release phase and the sidebar appeared to track the scroll.
+ *     The CSS half (`align-self: flex-start` on the sidebar) is
+ *     defensive parity with the Pattern A inner rail (#1259) and is
+ *     RETAINED but not load-bearing on its own; see the comment
+ *     above `.sidebar` in `theme.css` for the full archaeology.
  *   - The contract is desktop-only. At <=1024px the sidebar swaps to
  *     `position: fixed` drawer mode (`responsive/sidebar.spec.ts`
  *     covers that shape on iPhone-13).
  *
- * Choice of test page: `?p=admin&c=bans` rides the multi-section
- * page-level ToC layout (Add a ban form + Ban protests + Ban
- * submissions + Import bans + Group ban) and is reliably taller than
- * the 720px desktop viewport even on the bare e2e seed (the forms
- * and section chrome are structural, not row-count-driven). The issue
- * also calls out `?p=admin&c=audit`, but the audit log on
- * `sourcebans_e2e` is empty by default and would not necessarily
- * exceed the viewport without extra seeding — the bans route is the
- * deterministic-tall surface for this assertion.
+ * Choice of test pages: two surfaces exercise complementary parts of
+ * the contract.
+ *
+ *   - **`?p=admin&c=bans`** (the canonical tall page) rides the
+ *     multi-section page-level ToC layout (Add a ban form + Ban
+ *     protests + Ban submissions + Import bans + Group ban) and is
+ *     reliably taller than the 720px desktop viewport even on the
+ *     bare e2e seed (the forms and section chrome are structural,
+ *     not row-count-driven). On a tall page the strict assertion is
+ *     "sidebar.top === 0 at scroll = document.scrollHeight" — the
+ *     pre-fix bug presented here as the brand area shifting up by
+ *     `footerHeight` (~75px) at the very bottom; the post-fix
+ *     contract is that sticky never releases.
+ *   - **`?p=admin&c=audit`** with an empty audit log (the bare e2e
+ *     seed) is the BARELY-tall surface where the pre-fix bug was
+ *     most visually obvious. With the footer outside `.app`,
+ *     `docHeight - viewport` was ≈ `footerHeight`, putting the
+ *     entire scroll range in the sticky-release phase — the sidebar
+ *     would visibly track the scroll from any non-zero scrollY. On
+ *     the post-fix layout, `.app`'s `min-height: 100vh` with the
+ *     footer pushed to the bottom by `margin-top: auto` collapses
+ *     the doc to exactly viewport height, so there's no scroll at
+ *     all and the assertion degrades to "sidebar.top === 0 at
+ *     scroll = 0". The probe still has value because it's the
+ *     surface that pre-fix drove rumblefrog to file the issue —
+ *     keeping it under test means a future refactor that
+ *     re-introduces a small `docHeight - viewport` gap (e.g.
+ *     ships a tall hero banner that's outside `.app`) would fail
+ *     here even though admin-bans would still pass.
  *
  * Project gating: this whole describe runs only on `chromium`
  * (Desktop Chrome at 1280x720). The `mobile-chromium` project
@@ -46,7 +75,7 @@ test.describe('responsive: sidebar sticky at desktop', () => {
         );
     });
 
-    test('sidebar stays pinned to the viewport top after scrolling to the bottom of admin-bans', async ({ page }) => {
+    test('sidebar stays pinned at viewport y=0 across the entire scroll range of admin-bans', async ({ page }) => {
         const p = new AdminBansPage(page);
         await p.goto();
         await expect(p.pageMounted).toBeVisible();
@@ -76,55 +105,142 @@ test.describe('responsive: sidebar sticky at desktop', () => {
         await expect(sidebarNav).toBeVisible();
         await expect(sidebarNav).toBeInViewport();
 
-        // Mid-scroll, well clear of the page top, the sticky contract
-        // says the sidebar's bounding-box top must be at viewport y=0
-        // (sticky-pinned to the viewport, not scrolling with the
-        // document). The `aside.sidebar` chrome is the sticky element;
-        // measure its top directly via the live DOM rect. This is the
-        // tight regression guard — `toBeInViewport()` only requires
-        // partial overlap and would tolerate a sidebar drifting tens
-        // of pixels off-screen, but a fully-broken sticky layout
-        // (sidebar scrolls with the page) drives the rect's top to
-        // -scrollY which is unmistakable.
-        await page.evaluate(() => window.scrollTo(0, 500));
-        const midScrollTop = await page.evaluate(() => {
-            const el = document.getElementById('sidebar');
-            return el ? el.getBoundingClientRect().top : null;
-        });
-        expect(
-            midScrollTop,
-            'sidebar must report a bounding-box top once mounted',
-        ).not.toBeNull();
-        expect(
-            Math.round(midScrollTop ?? -1),
-            `sidebar must be sticky-pinned at viewport y=0 mid-scroll (got ${midScrollTop})`,
-        ).toBe(0);
+        // Helper: read the sticky `<aside class="sidebar">` chrome's
+        // bounding box and round to whole pixels. The aside is the
+        // sticky element; the nav inside it inherits sticky pinning
+        // when the aside is pinned. We measure the aside directly
+        // because the strict assertion is on its `top` (the contract
+        // is "sidebar at viewport y=0", not "nav at viewport y=N").
+        const sidebarTopAt = async (scrollY: number) => {
+            await page.evaluate((sy) => window.scrollTo(0, sy), scrollY);
+            // One frame for sticky to resolve in Chromium.
+            await page.evaluate(() => new Promise((resolve) => requestAnimationFrame(() => resolve(undefined))));
+            return await page.evaluate(() => {
+                const el = document.getElementById('sidebar');
+                return el ? Math.round(el.getBoundingClientRect().top) : null;
+            });
+        };
 
-        // Scroll to the bottom of the page. A regression that
-        // breaks the sticky contract entirely (sidebar scrolls with
-        // the document) drives the rect's top to -scrollY, so by the
-        // time the user reaches the bottom of admin-bans the sidebar
-        // is far below the viewport. At the very bottom of `.app`
-        // sticky correctly releases as the containing block runs out
-        // of "room" — the sidebar follows `.app`'s bottom edge upward
-        // — so the strict y=0 assertion above lives at mid-scroll,
-        // while the bottom-of-page check below stays on
-        // `inViewport()`: the sidebar must stay reachable, even if its
-        // top drifts a few pixels above the viewport edge.
-        await page.evaluate(() => window.scrollTo(0, document.documentElement.scrollHeight));
+        // Mid-scroll: tightest historical guard — pre-#1278's purely
+        // CSS-side `align-self: flex-start` was already enough for
+        // sticky to pin at viewport y=0 in the middle of the scroll
+        // range (the pre-fix bug only manifested at the very bottom
+        // and on barely-tall pages). Keep the assertion at scroll=500
+        // as a regression guard against gross sticky breakage —
+        // e.g. a future ancestor that sets `transform` / `filter` /
+        // `overflow: hidden` and silently kills the sticky containing
+        // block.
+        const midTop = await sidebarTopAt(500);
+        expect(midTop, 'sidebar must report a bounding-box top once mounted').not.toBeNull();
+        expect(midTop, `sidebar must be sticky-pinned at viewport y=0 mid-scroll (got ${midTop})`).toBe(0);
 
-        // Post-scroll: the sidebar must remain in the viewport. The
-        // `<nav role="navigation" aria-label="Primary">` element is
-        // inside the `<aside class="sidebar">` chrome; if the aside
-        // is sticky-pinned at the top of the viewport, the nav inside
-        // is in the viewport too.
-        await expect(sidebarNav).toBeInViewport();
+        // Bottom-of-page: the actual #1271 regression guard. Pre-fix
+        // the footer was a body-level sibling of `.app`, so `.app`'s
+        // height fell short of the document by `footerHeight` (~75px
+        // on the dev seed). Sticky correctly released as `.app`'s
+        // bottom edge entered the viewport, sliding the sidebar up
+        // and chopping the brand area off the top. Post-fix the
+        // footer lives inside `.main`/`.app`, `.app`'s height matches
+        // the document, and sticky never releases — sidebar.top must
+        // remain exactly 0 at scroll = document.scrollHeight.
+        //
+        // Sub-pixel tolerance: Chromium reports sub-pixel coordinates
+        // for sticky elements when the scroll position lands on a
+        // fractional `.app` end (e.g. `appHeight = 2120.5`). The
+        // tolerance of ±1 swallows the rounding without admitting
+        // the pre-fix `~-75` regression.
+        const docHeightLive = await page.evaluate(() => document.documentElement.scrollHeight);
+        const bottomTop = await sidebarTopAt(docHeightLive);
+        expect(
+            bottomTop,
+            `sidebar must remain pinned at viewport y=0 at scroll=document.scrollHeight (${docHeightLive}px); pre-#1271 the footer-outside-.app layout drove this to roughly -footerHeight (got ${bottomTop})`,
+        ).toBeGreaterThanOrEqual(-1);
+        expect(
+            bottomTop,
+            `sidebar must remain pinned at viewport y=0 at scroll=document.scrollHeight (got ${bottomTop})`,
+        ).toBeLessThanOrEqual(1);
+
+        // Belt-and-suspenders: the brand area (`.sidebar__brand` —
+        // the "S SourceBans++" header at the top of the sidebar) is
+        // the user-visible canary for the pre-fix regression. If
+        // sticky drifts up by `footerHeight`, the brand is the first
+        // thing to scroll off the top. Assert the brand is in the
+        // viewport at scroll=BOTTOM. (`toBeInViewport()` requires
+        // ≥0% intersection — together with the strict `top` check
+        // above, this catches both "sidebar fully off-screen" and
+        // "sidebar pinned but brand cut off" failure modes.)
+        await expect(page.locator('.sidebar__brand')).toBeInViewport();
 
         // First nav link is `[data-testid="nav-home"]` (always
         // rendered for any logged-in user — the navbar's "Public"
-        // section emits Home unconditionally). It sits at the top of
-        // the sidebar; pre-#1271 it would scroll off the top of the
-        // viewport and `toBeInViewport()` would fail.
+        // section emits Home unconditionally). It sits at the top
+        // of the nav (just below the brand); a regression that
+        // pinned the sidebar but pushed the nav off-screen would
+        // be caught here.
         await expect(page.locator('[data-testid="nav-home"]')).toBeInViewport();
+    });
+
+    test('barely-tall page (audit log on the bare e2e seed) does not regress to "sidebar tracks scroll"', async ({ page }) => {
+        // The audit-log surface is the one rumblefrog originally
+        // flagged: with the footer outside `.app`, the bare e2e
+        // seed produced `docHeight = viewport + footerHeight`, so
+        // the entire scroll range was in the sticky-release phase
+        // and the sidebar visibly drifted with the scroll.
+        //
+        // Post-fix, `.app`'s `min-height: 100vh` + the footer-as-
+        // last-flex-item layout collapses `docHeight` to exactly
+        // `viewport` on this seed (no scroll at all). The
+        // assertion below is the conjunctive guard:
+        //   1. If a future refactor shaves `min-height: 100vh` off
+        //      `.app` and `docHeight` shrinks below `viewport`,
+        //      the sticky behaviour is still intact (sticky
+        //      degenerates to `static` on a non-scrolling page,
+        //      sidebar still at top=0).
+        //   2. If a future refactor re-introduces a small
+        //      `docHeight - viewport` gap (e.g. the audit page
+        //      grows a hero banner that's outside `.app`), this
+        //      page becomes scrollable AND the sidebar must
+        //      remain at top=0 throughout — exactly the
+        //      pre-fix bug we shipped this PR to close.
+        await page.goto('/index.php?p=admin&c=audit');
+        // Brand visibility is the load anchor: the Audit Log page
+        // chrome carries no testid we can wait on without coupling
+        // to its content, but the navbar brand is rendered on every
+        // logged-in route by `core/navbar.tpl`.
+        await expect(page.locator('.sidebar__brand')).toBeVisible();
+
+        const { docHeight, viewport } = await page.evaluate(() => ({
+            docHeight: document.documentElement.scrollHeight,
+            viewport: window.innerHeight,
+        }));
+
+        // Always assert at scroll=0 — sticky and static both pin the
+        // sidebar at viewport y=0 here, so this is the "still
+        // mounted" smoke check.
+        await page.evaluate(() => window.scrollTo(0, 0));
+        const topAtZero = await page.evaluate(() => {
+            const el = document.getElementById('sidebar');
+            return el ? Math.round(el.getBoundingClientRect().top) : null;
+        });
+        expect(topAtZero, `sidebar must be at viewport y=0 at scroll=0 (got ${topAtZero})`).toBe(0);
+
+        // The conditional half: if the page IS scrollable, walk to
+        // the bottom and assert sticky still holds. The pre-fix bug
+        // tripped here whenever `0 < docHeight - viewport <=
+        // footerHeight`.
+        if (docHeight > viewport) {
+            await page.evaluate(() => window.scrollTo(0, document.documentElement.scrollHeight));
+            await page.evaluate(() => new Promise((resolve) => requestAnimationFrame(() => resolve(undefined))));
+            const topAtBottom = await page.evaluate(() => {
+                const el = document.getElementById('sidebar');
+                return el ? Math.round(el.getBoundingClientRect().top) : null;
+            });
+            expect(
+                topAtBottom,
+                `sidebar must remain pinned at viewport y=0 at scroll=document.scrollHeight on the audit page (docHeight=${docHeight}, viewport=${viewport}); pre-#1271 this scroll range was entirely in the sticky-release phase (got ${topAtBottom})`,
+            ).toBeGreaterThanOrEqual(-1);
+            expect(topAtBottom).toBeLessThanOrEqual(1);
+            await expect(page.locator('.sidebar__brand')).toBeInViewport();
+        }
     });
 });

--- a/web/themes/default/core/footer.tpl
+++ b/web/themes/default/core/footer.tpl
@@ -31,12 +31,21 @@
     attribute mirrors the dialog's open/closed state for tests +
     CSS so selectors don't have to probe the `hidden` property.
     Both are intentionally siblings of `.app` (not nested inside)
-    because they're floating overlays — the drawer is positioned via
-    `inset:0` against the viewport and `<dialog>` already promotes to
-    the top layer when `showModal()`-ed, so their containing block is
-    irrelevant to layout. Keeping them outside `.app` also avoids the
-    drawer's `position: fixed; height: 100vh` accidentally extending
-    `.app`'s flex cross-axis.
+    because they're conceptually top-layer overlays — the drawer is
+    `position: fixed; right: 0; top: 0; height: 100%` (right-pinned
+    panel, not full-bleed; `inset: 0` is on the separate
+    `.drawer-backdrop`) and `<dialog>` promotes to the top layer
+    when `showModal()`-ed. Keeping them outside `.app` is
+    defensiveness against the CSS containing-block scoping rules:
+    a future refactor that declares `transform` / `filter` /
+    `contain: layout` on `.app` (or any descendant in the drawer's
+    would-be ancestry) would re-establish the containing block for
+    `position: fixed` descendants, suddenly positioning the drawer
+    relative to that ancestor instead of the viewport. The
+    structural-fix concern that motivated #1271 (sidebar's sticky
+    CB short of the document) does NOT apply to the drawer —
+    `position: fixed` removes the element from flow, so the drawer
+    cannot grow `.app`'s height regardless of where it nests.
 
     Legacy hooks intentionally NOT carried over from
     web/themes/default/core/footer.tpl:

--- a/web/themes/default/core/footer.tpl
+++ b/web/themes/default/core/footer.tpl
@@ -1,10 +1,25 @@
 {*
     SourceBans++ 2026 — chrome / footer.tpl
 
-    Closes <main>, .main, .app, then mounts the drawer + palette
-    scaffolds and loads vendored Lucide + theme.js. Pair:
-    web/pages/core/footer.php (assigns $version, $git, $query — same
-    contract as web/themes/default/core/footer.tpl).
+    Closes <main> + the page footer + .main + .app, then mounts the
+    drawer + palette scaffolds and loads vendored Lucide + theme.js.
+    Pair: web/pages/core/footer.php (assigns $version, $git, $query —
+    same contract as web/themes/default/core/footer.tpl).
+
+    Layout note (#1271 — actual fix): `<footer class="app-footer">`
+    lives INSIDE `<div class="app">` (specifically as the last flex
+    item of `<div class="main">`, after `</main>`). `.sidebar` is
+    `position: sticky; top: 0; height: 100vh` and its sticky
+    containing block is `.app`; if the footer were a sibling of `.app`
+    (the pre-fix shape), `.app`'s height would fall short of the
+    document by `footerHeight` and the sticky sidebar would release at
+    the bottom — brand cut off, on barely-tall pages the entire
+    scroll range would be in the release phase and the sidebar would
+    appear to track the scroll. Keeping the footer inside `.app` makes
+    the sticky containing block extend through the whole document so
+    `.sidebar` stays pinned at viewport y=0 to the very bottom. See
+    `responsive/sidebar-sticky.spec.ts` for the regression guard +
+    AGENTS.md "Where to find what".
 
     The drawer + palette scaffolds use semantic <aside> + <dialog> with
     role/aria-label per the issue's "Testability hooks" rule that
@@ -15,6 +30,13 @@
     sb.api.call(Actions.BansSearch). The `data-palette-open`
     attribute mirrors the dialog's open/closed state for tests +
     CSS so selectors don't have to probe the `hidden` property.
+    Both are intentionally siblings of `.app` (not nested inside)
+    because they're floating overlays — the drawer is positioned via
+    `inset:0` against the viewport and `<dialog>` already promotes to
+    the top layer when `showModal()`-ed, so their containing block is
+    irrelevant to layout. Keeping them outside `.app` also avoids the
+    drawer's `position: fixed; height: 100vh` accidentally extending
+    `.app`'s flex cross-axis.
 
     Legacy hooks intentionally NOT carried over from
     web/themes/default/core/footer.tpl:
@@ -27,6 +49,38 @@
     Footer credits ($version + $git) are kept — pure display, no JS.
 *}
     </main>{* /.page *}
+
+{*
+    Footer (#1207 CC-5, CC-6, SET-2; #1271 layout fix — see file-level
+    comment above for why it lives here, inside `.main`/`.app`, instead
+    of as a body-level sibling of `.app`).
+
+    `data-version="{$version}"` mirrors the resolved SB_VERSION constant
+    (the user-visible string minus the `| Git: …` suffix). Telemetry,
+    bug reports, and E2E specs key off the attribute so they can
+    distinguish dev installs (`data-version="dev"` — the third-tier
+    fallback in init.php) from release tarball installs
+    (`data-version="2.1.0"` etc.) without parsing the visible text.
+
+    `data-testid="app-footer"` is the testability hook for SET-2's
+    save-button-doesn't-overlap-footer assertion at mobile width.
+
+    Footer link points at the sbpp/sourcebans-pp repo (CC-6) instead of
+    the marketing site so a self-hoster's first instinct ("show me the
+    code") lands them on the place that hosts both the issue tracker
+    and the install instructions. Link styling is muted by default
+    (matches the surrounding footer text colour) and only reveals the
+    accent colour + underline on `:hover` / `:focus-visible` so the
+    chrome's footer reads as a single line of text instead of having
+    a stranded blue underlined word in the middle of it. The
+    `.app-footer` class adds the SET-2 separator (top border + extra
+    margin/padding) so the "Save changes" row above no longer reads
+    as overlapping the credit on mobile.
+*}
+    <footer class="app-footer sbpp-footer" data-version="{$version}" data-testid="app-footer">
+        <a href="https://github.com/sbpp/sourcebans-pp" target="_blank" rel="noopener">SourceBans++</a>
+        {$version}{$git}
+    </footer>
   </div>{* /.main *}
 </div>{* /.app *}
 
@@ -79,36 +133,6 @@
          data-testid="palette-results"
          style="max-height:60vh;overflow-y:auto;padding:0.5rem"></div>
 </dialog>
-
-{*
-    Footer (#1207 CC-5, CC-6, SET-2).
-
-    `data-version="{$version}"` mirrors the resolved SB_VERSION constant
-    (the user-visible string minus the `| Git: …` suffix). Telemetry,
-    bug reports, and E2E specs key off the attribute so they can
-    distinguish dev installs (`data-version="dev"` — the third-tier
-    fallback in init.php) from release tarball installs
-    (`data-version="2.1.0"` etc.) without parsing the visible text.
-
-    `data-testid="app-footer"` is the testability hook for SET-2's
-    save-button-doesn't-overlap-footer assertion at mobile width.
-
-    Footer link points at the sbpp/sourcebans-pp repo (CC-6) instead of
-    the marketing site so a self-hoster's first instinct ("show me the
-    code") lands them on the place that hosts both the issue tracker
-    and the install instructions. Link styling is muted by default
-    (matches the surrounding footer text colour) and only reveals the
-    accent colour + underline on `:hover` / `:focus-visible` so the
-    chrome's footer reads as a single line of text instead of having
-    a stranded blue underlined word in the middle of it. The
-    `.app-footer` class adds the SET-2 separator (top border + extra
-    margin/padding) so the "Save changes" row above no longer reads
-    as overlapping the credit on mobile.
-*}
-<footer class="app-footer sbpp-footer" data-version="{$version}" data-testid="app-footer">
-    <a href="https://github.com/sbpp/sourcebans-pp" target="_blank" rel="noopener">SourceBans++</a>
-    {$version}{$git}
-</footer>
 
 <script src="{$theme_url}/js/lucide.min.js"></script>
 <script src="{$theme_url}/js/theme.js"></script>

--- a/web/themes/default/core/navbar.tpl
+++ b/web/themes/default/core/navbar.tpl
@@ -18,7 +18,16 @@
     "nav-<endpoint>" and aria-current="page" when active.
 *}
 <aside class="sidebar" id="sidebar" data-mobile-open="false">
-    <div class="sidebar__brand">
+    {* #1271 — `data-testid="sidebar-brand"` is the canonical hook for
+       the user-visible canary in the sidebar-sticky regression test
+       (`web/tests/e2e/specs/responsive/sidebar-sticky.spec.ts`). The
+       brand is the first element to scroll off the top if sticky
+       drifts up by `footerHeight`, so anchoring the spec on this
+       testid (rather than the `.sidebar__brand` class chain) keeps
+       the assertion compliant with AGENTS.md's "Selectors must use
+       testability hooks; never CSS class chains as the primary
+       selector" rule. *}
+    <div class="sidebar__brand" data-testid="sidebar-brand">
         <div class="sidebar__brand-mark">S</div>
         <div>
             <div class="font-semibold text-sm">SourceBans++</div>

--- a/web/themes/default/css/theme.css
+++ b/web/themes/default/css/theme.css
@@ -122,16 +122,31 @@ a { color: inherit; text-decoration: none; }
    `docHeight - viewport ≤ footerHeight`) the entire scroll range was
    in the release phase, which presented as "the sidebar scrolls with
    the page". The original #1271 misdiagnosed this as a flex
-   `align-items: stretch` interaction (#1278 added the
-   `align-self: flex-start` below as defensive parity); on evergreen
-   browsers explicit cross-sizes already win over `stretch`, so
-   without the structural fix in this PR `align-self` was a no-op.
-   The `align-self` declaration is RETAINED below as belt-and-
-   suspenders parity with the Pattern A inner rail (`.admin-sidebar`,
-   which uses `align-self: start` for the same reason) — a future
-   refactor that drops the explicit height, or wraps `.app` in a
-   transformed / `overflow: hidden` ancestor that breaks the sticky
-   containing block, would otherwise regress the chrome silently.
+   `align-items: stretch` interaction; #1278 added the
+   `align-self: flex-start` below on that hypothesis. Per CSS
+   Flexbox §9.4 `stretch` only operates on `auto` cross-sizes — the
+   sidebar's explicit `height: 100vh` already wins, so `align-self`
+   was a no-op without the structural fix in this PR.
+
+   The `align-self` declaration is RETAINED below for a different
+   defensive reason than the comment originally framed: it is NOT
+   parity with the Pattern A inner rail in the mechanism sense.
+   `.admin-sidebar` (line ~562) lives in a CSS *grid*
+   (`.admin-sidebar-shell` is `display: grid; align-items: start`)
+   where `align-self: start` is load-bearing — without it the grid
+   item stretches to its cell height. `.sidebar` lives in a flex
+   row with an explicit `height: 100vh` where `align-self:
+   flex-start` is a no-op as long as the explicit height is in
+   place. The defensive job `align-self: flex-start` does here is
+   guard against a future refactor that DROPS `height: 100vh` from
+   `.sidebar` — at that point flex `align-items: stretch` would
+   stretch the sidebar to `.app`'s cross-axis (often >100vh on
+   tall pages), making it taller than the viewport and killing
+   sticky's "room to operate". The other defensive concern an
+   ancestor `transform` / `overflow: hidden` setting up a new
+   sticky containing block is independent and not addressed by
+   this declaration; it's just a known landmine to watch for.
+
    At <=1024px the sidebar swaps to `position: fixed` (drawer mode
    in the Responsive block below), so the desktop sticky contract
    is the only thing this comment is asserting. */
@@ -1375,13 +1390,17 @@ details.queue-row > summary > .row-actions {
    classic "sticky footer" pattern — so the page doesn't paint
    the credit halfway up the viewport with a band of empty space
    below it. On tall pages where the column overflows, `auto`
-   resolves to 0 and the footer abuts the page content; the
-   1.25rem `padding-top` + `border-top` keep the visual
-   separation that the SET-2 separator promises. The previous
-   `margin-top: 1rem` is dropped — `auto` subsumes it on short
-   pages, and on tall pages the padding alone is enough breathing
-   room (a fixed `1rem` would just sit alongside `auto` and add
-   16px to short-page layout, pulling the footer off the bottom). */
+   resolves to 0 and the footer abuts the page content above it;
+   the 1.25rem `padding-top` + `border-top` are intentionally the
+   ONLY breathing room on tall pages now — the previous
+   `margin-top: 1rem` is dropped because the sticky-footer pattern
+   needs `auto` exclusively on this property (a margin-top can't
+   be "1rem on tall pages, auto on short pages" in a single
+   declaration), and the existing 20px padding-top above the
+   border was already enough visual separation from the SET-2
+   action rows. The structural #1271 fix would also work with
+   `padding-top: 2rem` instead of `1.25rem` if a future audit
+   wants to restore the prior 36px-total breathing room. */
 .app-footer {
   text-align: center;
   padding: 1.25rem 1rem;

--- a/web/themes/default/css/theme.css
+++ b/web/themes/default/css/theme.css
@@ -109,19 +109,32 @@ a { color: inherit; text-decoration: none; }
 
 /* ---- App shell ---- */
 .app { min-height: 100vh; display: flex; }
-/* #1271 — `align-self: flex-start` opts the sticky sidebar OUT of
-   `.app`'s default `align-items: stretch`. The explicit `height: 100vh`
-   below already keeps the cross-size at the viewport on current
-   evergreen engines (stretch only operates on `auto` cross-sizes), so
-   this declaration is defensive parity with the Pattern A inner rail
-   (`.admin-sidebar` below uses `align-self: start` for the same
-   reason): a future refactor that drops the explicit height — or an
-   ancestor that turns the sticky containing block into a scroll
-   container — would otherwise reintroduce the bug where a flex-
-   stretched sticky element has no "room" inside its containing block
-   and ends up scrolling with the page. At <=1024px the sidebar swaps
-   to `position: fixed` (drawer mode in the Responsive block below),
-   so the cross-axis interaction is a desktop-only concern. */
+/* #1271 — the actual fix is structural and lives in
+   `core/footer.tpl`: `<footer class="app-footer">` is rendered INSIDE
+   `.app` (as the last flex item of `.main`), not as a body-level
+   sibling. `.sidebar`'s sticky containing block is `.app`, so for
+   sticky to stay pinned at viewport y=0 across the entire scroll
+   range (including the very bottom of the document), `.app`'s height
+   must match the document height. Pre-fix the footer lived outside
+   `.app`, leaving `.app` short by `footerHeight`; sticky correctly
+   released at the bottom and on barely-tall pages (e.g.
+   `?p=banlist` / `?p=admin&c=audit` on the bare e2e seed where
+   `docHeight - viewport ≤ footerHeight`) the entire scroll range was
+   in the release phase, which presented as "the sidebar scrolls with
+   the page". The original #1271 misdiagnosed this as a flex
+   `align-items: stretch` interaction (#1278 added the
+   `align-self: flex-start` below as defensive parity); on evergreen
+   browsers explicit cross-sizes already win over `stretch`, so
+   without the structural fix in this PR `align-self` was a no-op.
+   The `align-self` declaration is RETAINED below as belt-and-
+   suspenders parity with the Pattern A inner rail (`.admin-sidebar`,
+   which uses `align-self: start` for the same reason) — a future
+   refactor that drops the explicit height, or wraps `.app` in a
+   transformed / `overflow: hidden` ancestor that breaks the sticky
+   containing block, would otherwise regress the chrome silently.
+   At <=1024px the sidebar swaps to `position: fixed` (drawer mode
+   in the Responsive block below), so the desktop sticky contract
+   is the only thing this comment is asserting. */
 .sidebar {
   width: 15rem; flex-shrink: 0; height: 100vh; position: sticky; top: 0;
   align-self: flex-start;
@@ -1343,7 +1356,7 @@ details.queue-row > summary > .row-actions {
   .permissions-grid--web { grid-template-columns: repeat(3, minmax(0, 1fr)); }
 }
 
-/* ---- Footer (#1207 CC-6 + SET-2) ----
+/* ---- Footer (#1207 CC-6 + SET-2; #1271 layout fix) ----
    The page-bottom credit footer in core/footer.tpl. A subtle
    top border + a touch more vertical padding visually separates
    it from form action rows above so the "Save changes" button on
@@ -1352,11 +1365,27 @@ details.queue-row > summary > .row-actions {
    `.text-faint` (muted), but a raw <a> would inherit the
    browser-default underlined link colour and stand out as a
    stranded blue word; only reveal the affordance on hover/focus
-   so keyboard users still get a visible focus ring (CC-6). */
+   so keyboard users still get a visible focus ring (CC-6).
+
+   `margin-top: auto` (#1271): the footer is now the last flex
+   column item of `.main` (see core/footer.tpl for why it lives
+   inside `.app` instead of as a body-level sibling). On short
+   pages where `.main`'s flex column has unused vertical space,
+   `auto` pushes the footer to the bottom of `.main` — the
+   classic "sticky footer" pattern — so the page doesn't paint
+   the credit halfway up the viewport with a band of empty space
+   below it. On tall pages where the column overflows, `auto`
+   resolves to 0 and the footer abuts the page content; the
+   1.25rem `padding-top` + `border-top` keep the visual
+   separation that the SET-2 separator promises. The previous
+   `margin-top: 1rem` is dropped — `auto` subsumes it on short
+   pages, and on tall pages the padding alone is enough breathing
+   room (a fixed `1rem` would just sit alongside `auto` and add
+   16px to short-page layout, pulling the footer off the bottom). */
 .app-footer {
   text-align: center;
   padding: 1.25rem 1rem;
-  margin-top: 1rem;
+  margin-top: auto;
   border-top: 1px solid var(--border);
   font-size: var(--fs-xs);
   color: var(--text-faint);


### PR DESCRIPTION
## Summary

- The original #1271 was misdiagnosed; #1278 added `align-self: flex-start` on a non-functional hypothesis (the commit message and CSS comment both admit this is "defensive parity" because explicit cross-sizes already win over flex `align-items: stretch` on evergreen browsers). Verified locally by reverting just `align-self: flex-start` and re-probing the layout — every scroll position produced byte-for-byte identical sidebar bounding-box coordinates with and without the declaration.
- The actual root cause is structural: `<footer class=\"app-footer\">` was rendered as a body-level sibling of `<div class=\"app\">`. `.sidebar`'s sticky containing block is `.app`, so `.app`'s height fell short of the document by `footerHeight`. Sticky correctly released as `.app`'s bottom entered the viewport, sliding the sidebar up and chopping off the brand. On barely-tall pages where `docHeight - viewport ≤ footerHeight` (e.g. `?p=admin&c=audit` on the bare e2e seed: doc=795, viewport=720), the entire scroll range fell inside the sticky-release phase and the sidebar visibly tracked the scroll — exactly the symptom rumblefrog originally reported.
- Move `<footer class=\"app-footer\">` inside `.app` (specifically as the last flex column item of `<div class=\"main\">`). Pair with `margin-top: auto` (the classic CSS sticky-footer pattern) so the footer hits the viewport bottom on short pages instead of floating halfway up. The `align-self: flex-start` from #1278 is retained as belt-and-suspenders parity with `.admin-sidebar` (#1259); the CSS comment is rewritten to credit the structural fix as load-bearing.

## Verification

Probe (Playwright, viewport 1280x720, dev seed):

| page | doc | viewport | sidebar.top @ scroll=0 | @ scroll=500 | @ scroll=BOTTOM |
| --- | --- | --- | --- | --- | --- |
| `?p=admin&c=bans` | 2121 | 720 | 0 | 0 | **0** (was -75) |
| `?p=home` | 1312 | 720 | 0 | 0 | **0** (was -75) |
| `?p=admin&c=audit` | 720 | 720 | 0 | 0 (no scroll) | n/a (was -75 on the only available scroll position) |
| `?p=banlist` | 720 | 720 | 0 | 0 (no scroll) | n/a |

I temporarily reverted just the structural fix (kept the new spec) to confirm it catches the bug:

```
2 failed
  [chromium] › specs/responsive/sidebar-sticky.spec.ts:78:9 › sidebar stays pinned at viewport y=0 across the entire scroll range of admin-bans
    Received: -75   Expected: >= -1
  [chromium] › specs/responsive/sidebar-sticky.spec.ts:183:9 › barely-tall page (audit log on the bare e2e seed) does not regress to \"sidebar tracks scroll\"
    Received: -75   Expected: >= -1
```

Post-fix both pass, plus all 14 sidebar/responsive specs:

```
14 passed (4.8s)
```

## Test plan

- [x] PHPStan — clean
- [x] ts-check — clean
- [x] Playwright e2e (chromium + mobile-chromium, workers=1) — 187 passed
- [x] New strict assertions confirmed to FAIL on pre-fix code (-75) and PASS on post-fix code (0)
- [x] Visual smoke at desktop on `?p=admin&c=bans` scroll=BOTTOM — brand visible at top, footer at viewport bottom, sidebar pinned through the full scroll range
- [x] Visual smoke at desktop on `?p=banlist` (short page) — footer pushed to viewport bottom by `margin-top: auto`, no awkward empty band
- [x] AGENTS.md cheatsheet updated (Where-to-find-what entry + two anti-patterns: don't pull the footer back out, don't pull the drawer/palette in)

Closes #1271 (the actual bug, this time).