### PR TITLE
fix(updater): drop PHP notice on /updater/index.php (#1269)

### DIFF
--- a/web/phpstan-baseline.neon
+++ b/web/phpstan-baseline.neon
@@ -529,12 +529,6 @@ parameters:
 			path: sb_debug_connection.php
 
 		-
-			message: '#^Parameter \#1 \$array of function array_pop is passed by reference, so it expects variables only\.$#'
-			identifier: argument.byRef
-			count: 1
-			path: updater/Updater.php
-
-		-
 			message: '#^Variable \$this might not be defined\.$#'
 			identifier: variable.undefined
 			count: 2

--- a/web/updater/Updater.php
+++ b/web/updater/Updater.php
@@ -34,7 +34,10 @@ class Updater
     private function getLatestVersion()
     {
         if (!is_null($this->updateList)) {
-            $this->latestVersion = array_pop(array_keys($this->updateList));
+            // array_pop() requires a reference; passing array_keys() directly
+            // emits "Notice: Only variables should be passed by reference"
+            // visible at the top of every /updater/index.php response (#1269).
+            $this->latestVersion = array_key_last($this->updateList);
         }
     }
 


### PR DESCRIPTION
## Summary

`Updater::getLatestVersion()` does `array_pop(array_keys(...))`, which emits

```
Notice: Only variables should be passed by reference in /var/www/html/web/updater/Updater.php on line 37
```

at the top of every `/updater/index.php` response — visible above the migration chrome on every visit, including the no-op re-run path. Surfaced by the manual upgrade walkthrough for #1269.

`array_keys()` returns a temporary; `array_pop()` requires a reference. Swap to `array_key_last()` (PHP 7.3+; `composer.json` requires `php >= 8.2`).

Refs: #1269 (bug 1: "Notice: Only variables should be passed by reference in web/updater/Updater.php on line 37").

## Test plan

- [ ] Stand up a 1.x panel, drop a 2.0 working tree on top, walk `/updater/index.php` — no `Notice` printed above the chrome.
- [ ] Re-run `/updater/index.php` (no-op path) — no `Notice` printed above the chrome.