### PR TITLE
fix(lostpassword): don't reset password if reset-mail fails (#1269)

### DIFF
--- a/web/pages/page.lostpassword.php
+++ b/web/pages/page.lostpassword.php
@@ -65,17 +65,34 @@ if (isset($_GET['email'], $_GET['validation']) && (!empty($_GET['email']) || !em
         PageDie();
     }
 
-    $password = Crypto::genSecret(MIN_PASS_LENGTH + 8);
+    // #1269: send the new password BEFORE mutating the DB row so a
+    // misconfigured mailer (e.g. an upgraded panel where the 1.x
+    // installer left `config.smtp.*` empty) doesn't silently lock the
+    // admin out. Pre-fix: the password was rolled to a random string,
+    // mail send was attempted, the result was assigned to $isEmailSent
+    // but never checked, and the user got "Your password has been
+    // reset and sent to your email" regardless. With mail broken that
+    // means the old password is gone, the new password was never
+    // delivered, and the validation token is consumed — no recovery
+    // path. Now: roll only after the mailer has accepted the message;
+    // surface the error otherwise so the user can retry once SMTP is
+    // configured.
+    $password    = Crypto::genSecret(MIN_PASS_LENGTH + 8);
+    $isEmailSent = Mail::send($email, EmailType::PasswordResetSuccess, [
+        '{password}' => $password,
+        '{name}'     => $result['user'],
+        '{home}'     => Host::complete(true)
+    ]);
+
+    if (!$isEmailSent) {
+        print "<script>ShowBox('Error', 'Could not send the new password by email. Your old password is still active. Please contact an administrator if this persists.', 'red');</script>";
+        PageDie();
+    }
+
     $GLOBALS['PDO']->query("UPDATE `:prefix_admins` SET `password` = :password, `validate` = NULL WHERE `aid` = :aid");
     $GLOBALS['PDO']->bind(':password', password_hash($password, PASSWORD_BCRYPT));
     $GLOBALS['PDO']->bind(':aid', $result['aid']);
     $GLOBALS['PDO']->execute();
-
-    $isEmailSent = Mail::send($email, EmailType::PasswordResetSuccess, [
-        '{password}' => $password,
-        '{name}' => $result['user'],
-        '{home}' => Host::complete(true)
-    ]);
 
     print "<script>ShowBox('Password Reset', 'Your password has been reset and sent to your email.<br />Please check your spam folder too.<br />Please login using this password, <br />then use the change password link in Your Account.', 'blue');</script>";
     PageDie();


### PR DESCRIPTION
## Summary

`web/pages/page.lostpassword.php` (the validation-link branch) used to unconditionally roll the admin's password to a random string, attempt to mail it, assign the send result to `$isEmailSent`, and then ignore that variable — printing **"Your password has been reset and sent to your email"** regardless. With mail broken (e.g. \`config.smtp.*\` empty on a freshly-upgraded panel from 1.x — see #1269 bug 3) that locks the admin out: the old password is gone, the new one was never delivered, and the validation token has been consumed. No recovery path.

This PR reorders the flow so we send the email first; the DB mutation only happens after the mailer accepts the message. If the mailer fails we surface a clear error and the validation token stays valid for a retry once SMTP is configured.

Refs: #1269 (bug 2: \"page.lostpassword.php validation-link branch silently claims 'Your password has been reset and sent to your email' even when Mail::send returned false\").

## Test plan

- [ ] With \`config.smtp.host\` set to a working SMTP relay: click the validation link from a password-reset email, see the new-password "sent" toast, log in with it. Behaviour unchanged.
- [ ] With \`config.smtp.host\` empty (the post-upgrade default): click the validation link, see the "Could not send the new password by email. Your old password is still active." error. Old password still works. Validation token still valid for a retry.
- [ ] Re-trigger the reset, configure SMTP, click the link again — succeeds.