### PR TITLE
fix(mail): early-return when no mailer is configured (#1269)

### DIFF
--- a/web/includes/Mail/Mail.php
+++ b/web/includes/Mail/Mail.php
@@ -34,6 +34,18 @@ class Mail
         ?string $customSubject = null): bool
     {
         $mailer = Mailer::create();
+        if ($mailer === null) {
+            // #1269: Mailer::create() returns null when smtp.host /
+            // smtp.user / smtp.pass aren't configured — exactly the
+            // state a freshly-upgraded 1.x panel is in (the legacy
+            // PHP-mail() flow doesn't carry SMTP credentials forward).
+            // Log the actionable cause once instead of letting the
+            // dispatch below throw "Call to a member function send()
+            // on null" which then gets caught as a generic mail
+            // failure.
+            Log::add('e', 'Mail not configured', 'SMTP host / user / password are empty in sb_settings; configure them under Admin → Settings before sending mail.');
+            return false;
+        }
 
         $content = str_replace(
             array_keys($variables),


### PR DESCRIPTION
## Summary

\`Mail::send()\` calls \`Mailer::create()\` and then dereferences the result with \`\$mailer->send(...)\`. \`Mailer::create()\` returns \`null\` when \`config.smtp.host\` / \`smtp.user\` / \`smtp.pass\` are empty — exactly the state a freshly-upgraded 1.x panel is in (the legacy PHP \`mail()\` flow doesn't carry SMTP credentials forward to the new Symfony Mailer settings).

The existing \`try { … } catch (\\Throwable \$e)\` block does catch the \"Call to a member function send() on null\" error and returns false, so callers that DO check the return value behave correctly — but the only signal in the log is a generic mail-error message that doesn't tell the operator what to actually fix.

This PR adds an explicit null check before the dispatch so the failure log names the cause and we stop relying on the catch-Throwable as the contract:

> SMTP host / user / password are empty in sb_settings; configure them under Admin → Settings before sending mail.

The \`Mailer::create()\` null-return contract is unchanged (see the existing assertion in \`web/tests/api/MailerSmtpFromTest.php\`), and the \`auth.lost_password\` handler already expects \`Mail::send\` to return \`false\` on misconfigured SMTP (\`web/tests/api/AuthTest.php::testLostPasswordReportsMailFailureForKnownEmail\`), so the wire contract for callers is identical.

Refs: #1269 (bug 3: \"Mail::send() calls \$mailer->send() on a possibly-null Mailer::create() result\").

## Test plan

- [ ] PHPUnit \`./sbpp.sh test --filter=MailerSmtp\` and \`--filter=AuthTest\` still pass.
- [ ] Operator-side: with SMTP empty, trigger any mail-sending action; the new \"Mail not configured\" log row appears in the System log instead of \"Call to a member function send() on null\". Mail::send still returns false; the calling action's existing \"mail failed\" surface (toast, error envelope, etc.) is unchanged.