### PR TITLE
build: bump minimum PHP version to 8.5 (#1289)

### DIFF
--- a/.github/workflows/api-contract.yml
+++ b/.github/workflows/api-contract.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.2'
+          php-version: '8.5'
           extensions: pdo, openssl, gmp, mbstring, sodium
           coverage: none
           tools: composer:v2

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.2'
+          php-version: '8.5'
           extensions: pdo, pdo_mysql, openssl, gmp, mbstring, sodium
           coverage: none
           tools: composer:v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.2'
+          php-version: '8.5'
           extensions: pdo, pdo_mysql, openssl, gmp, mbstring, sodium
           coverage: none
           tools: composer:v2

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ codebase; this file is the cheatsheet.
 
 ## Stack at a glance
 
-- `web/` — PHP 8.2 panel (Smarty 5, PDO/MariaDB, vanilla JS). Entry:
+- `web/` — PHP 8.5 panel (Smarty 5, PDO/MariaDB, vanilla JS). Entry:
   `web/index.php` (pages) and `web/api.php` (JSON API).
 - `game/addons/sourcemod/` — SourceMod plugin sources (`.sp`).
 - `docker/` + `docker-compose.yml` + `sbpp.sh` — local dev stack.
@@ -288,11 +288,12 @@ Playwright E2E specifics:
 - Pattern: `query` → `bind` → `execute` / `single` / `resultset`.
 - ADOdb was fully removed (commit `b9c812b2`). **Do not reintroduce it.**
 
-### Null-into-scalar discipline (PHP 8.2+)
+### Null-into-scalar discipline (PHP 8.5+)
 
-`web/composer.json` requires `php >= 8.2`, so PHP's
+`web/composer.json` requires `php >= 8.5`, so PHP's
 "`Deprecated: <fn>(): Passing null to parameter #1 of type string`"
-surface is active. PHP 9 will turn it into a `TypeError`. Every
+surface (introduced in PHP 8.1) is active. PHP 9 will turn it into a
+`TypeError`. Every
 `strlen` / `trim` / `substr` / `preg_match` / `mb_strlen` / etc.
 call against a value that can be `null` at runtime needs one of
 two idiomatic shapes (#1273):
@@ -317,7 +318,7 @@ two idiomatic shapes (#1273):
 
 - Never `if (!is_null($x) && strlen($x) > 0)` — verbose and the
   conditional reads worse than the coalesce.
-- `phpstan/phpstan-deprecation-rules` + `phpVersion: 80200` is the
+- `phpstan/phpstan-deprecation-rules` + `phpVersion: 80500` is the
   static gate; `Php82DeprecationsTest` (PHPUnit) is the runtime gate
   for the bits PHPStan doesn't see (excluded paths like
   `includes/auth/openid.php`, runtime values that look non-null to
@@ -820,7 +821,7 @@ audit (#1207) locked in. New CTAs:
   (`strlen((string) $row['col'])`) when the value should always be a
   string. PHP 8.1 deprecated this implicit null-into-scalar coercion;
   PHP 9 makes it a `TypeError` (#1273). The static gate is
-  `phpstan/phpstan-deprecation-rules` + `phpVersion: 80200`; the
+  `phpstan/phpstan-deprecation-rules` + `phpVersion: 80500`; the
   runtime gate (for PHPStan-excluded files like `auth/openid.php`) is
   `Php82DeprecationsTest`. See "Null-into-scalar discipline" in
   Conventions for the per-shape idiom.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -15,7 +15,7 @@ A tour of the codebase for new contributors (human or LLM). Pair this with
 SourceBans++ is a Source-engine admin/ban/comms management system. It has
 two halves that are deployed separately:
 
-- **Web panel** (`web/`) — a PHP 8.2 + MariaDB application that admins use
+- **Web panel** (`web/`) — a PHP 8.5 + MariaDB application that admins use
   in a browser to manage bans, server admins, groups, etc. It also serves
   the public ban list and a JSON API consumed by its own client-side JS.
 - **SourceMod plugins** (`game/addons/sourcemod/`) — `.sp` plugins that
@@ -47,7 +47,7 @@ plugins are stable and updated less often.
 
 ### Stack
 
-- **PHP 8.2** with `pdo`, `pdo_mysql`, `gmp`, `intl`, `mbstring`, `openssl`,
+- **PHP 8.5** with `pdo`, `pdo_mysql`, `gmp`, `intl`, `mbstring`, `openssl`,
   `sodium`. Composer manages dependencies into `web/includes/vendor/`
   (note the non-default `vendor-dir`, set in `composer.json`).
 - **MariaDB 10.11** in dev (MySQL 5.6+ supported in production).
@@ -683,11 +683,11 @@ Build with the standard SourceMod compiler — see the
 Spelt out fully in [`docker/README.md`](docker/README.md). Quick mental
 model:
 
-- **`docker-compose.yml`** brings up four services: `web` (PHP 8.2 +
+- **`docker-compose.yml`** brings up four services: `web` (PHP 8.5 +
   Apache, bind-mounting `./web`), `db` (MariaDB 10.11), `adminer`
   (DB UI), and `mailpit` (catch-all SMTP).
 - **`docker/Dockerfile`** layers the PHP extensions, OPcache config, and
-  Composer onto `php:8.2-apache`.
+  Composer onto `php:8.5-apache`.
 - **`docker/php/web-entrypoint.sh`** waits for MariaDB, renders
   `web/config.php` from env vars (only if absent), runs `composer install`
   if `vendor/` is empty, then `exec`s Apache.
@@ -725,7 +725,7 @@ strings against the schema. Set `PHPSTAN_DBA_DISABLE=1` to skip it; CI
 sets `DBA_REQUIRE=1` so credential drift fails loudly.
 
 `phpstan/phpstan-deprecation-rules` (#1273) is wired in via
-`phpstan.neon` with `phpVersion: 80200` so the analyser flags the
+`phpstan.neon` with `phpVersion: 80500` so the analyser flags the
 PHP 8.1 null-into-scalar deprecation surface (`strlen($null)`,
 `trim($null)`, `substr($null, ...)`, `preg_match($null, ...)`, …)
 before it bites us on the PHP 9 bump. `web/includes/auth/openid.php`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,7 +45,7 @@ Legend:
         and an action-to-permission matrix lock
         (`PermissionMatrixTest`)
 13. * Configurable SMTP `From Email` / `From Name` (#1109)
-14. * Local Docker dev stack (PHP 8.2 + Apache, MariaDB, Adminer,
+14. * Local Docker dev stack (PHP 8.5 + Apache, MariaDB, Adminer,
         Mailpit) driven by `./sbpp.sh`
 15. * Static analysis: PHPStan level 5 + custom Smarty rule +
         staabm/phpstan-dba SQL type-checking against the live schema
@@ -82,8 +82,9 @@ Legend:
         Mailer
 32. ! Gated normal-login flow on its own `config.enablenormallogin`
         setting (#1102)
-33. ? PHP 8.2 minimum; Smarty 5; lcobucci/jwt for the auth cookie;
-        league/commonmark for admin Markdown
+33. ? PHP 8.5 minimum (was 8.2); Smarty 5; lcobucci/jwt for the
+        auth cookie; league/commonmark for admin Markdown (#1289
+        bumped the floor pre-tag)
 34. ? `web/themes/default/` is the new default theme; the previous
         default ships as a compatibility shape (legacy property
         names, alias keys) so third-party themes that forked it

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ or read how to report issues effectively [here](https://coenjacobs.me/2013/12/06
 
 ```
 * Webserver
-  o PHP 8.2 or higher
+  o PHP 8.5 or higher
     * ini setting: memory_limit greater than or equal to 64M
     * GMP extension
   o MySQL 5.6 or MariaDB 10 and higher
@@ -57,7 +57,7 @@ After successfully installing all dependencies you can procede with the [quickst
 
 ### Local development with Docker
 
-A one-command Docker stack (PHP 8.2 + Apache, MariaDB, Adminer, Mailpit) is
+A one-command Docker stack (PHP 8.5 + Apache, MariaDB, Adminer, Mailpit) is
 included for rapid local iteration:
 
 ```sh
@@ -89,7 +89,6 @@ includes/vendor/bin/phpstan analyse --generate-baseline=phpstan-baseline.neon
 
 Configuration lives in `web/phpstan.neon`.
 
-### PHP 8.1 major changes
 ## Upgrade
 *If you ran the installer, this step is unnecessary.*
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,9 +1,9 @@
 # SourceBans++ local-development image.
-# Built on the official PHP 8.2 + Apache image. Adds the PHP extensions the
+# Built on the official PHP 8.5 + Apache image. Adds the PHP extensions the
 # panel needs at runtime, Composer, and the entrypoint that renders config.php
 # and runs `composer install` on first boot. NOT intended for production.
 
-FROM php:8.2-apache
+FROM php:8.5-apache
 
 ENV DEBIAN_FRONTEND=noninteractive \
     COMPOSER_ALLOW_SUPERUSER=1 \
@@ -27,9 +27,14 @@ RUN apt-get update \
         intl \
         zip \
         mbstring \
-        opcache \
  && a2enmod rewrite \
  && rm -rf /var/lib/apt/lists/*
+
+# opcache is bundled into PHP 8.5 core (no longer a separate ext module);
+# `docker-php-ext-install opcache` fails on the 8.5 image with
+# "cp: cannot stat 'modules/*'" because there's no .so to copy. The
+# zz-sbpp-dev.ini block below still tunes the bundled opcache via
+# opcache.* INI knobs — verify with `php -m` (Zend OPcache) after build.
 
 # Composer (pinned to the official multi-stage image so we get the latest 2.x).
 COPY --from=composer:2 /usr/bin/composer /usr/bin/composer

--- a/docker/README.md
+++ b/docker/README.md
@@ -38,7 +38,7 @@ To stop:
 ## What's in the box
 
 ```
-Dockerfile               php:8.2-apache + pdo_mysql, gmp, intl, zip, mbstring, opcache, composer
+Dockerfile               php:8.5-apache + pdo_mysql, gmp, intl, zip, mbstring, opcache, composer
 docker-compose.yml       web, db, adminer, mailpit
 docker/php/
     web-entrypoint.sh    waits for DB, renders config.php, runs composer install, fixes cache perms

--- a/web/api/handlers/system.php
+++ b/web/api/handlers/system.php
@@ -134,12 +134,12 @@ function _api_system_release_fetch_upstream(): ?array
     }
 
     // `ignore_errors=true` makes file_get_contents return the body even on
-    // a non-2xx status, so reject anything outside 2xx explicitly. The
-    // response status line lives in the magic local $http_response_header
-    // array file_get_contents seeds; PHPStan knows it's always defined
-    // post-call so no `isset()` guard is needed.
-    /** @var list<string> $http_response_header */
-    if (isset($http_response_header[0]) && preg_match('~HTTP/\S+\s+(\d+)~', $http_response_header[0], $m)) {
+    // a non-2xx status, so reject anything outside 2xx explicitly. PHP 8.5
+    // deprecated the magic local $http_response_header in favour of
+    // http_get_last_response_headers() (introduced in 8.4); the panel's
+    // floor is 8.5 (#1289) so the function is always available.
+    $responseHeaders = http_get_last_response_headers();
+    if (is_array($responseHeaders) && isset($responseHeaders[0]) && preg_match('~HTTP/\S+\s+(\d+)~', $responseHeaders[0], $m)) {
         $status = (int) $m[1];
         if ($status < 200 || $status >= 300) {
             return null;

--- a/web/composer.json
+++ b/web/composer.json
@@ -27,7 +27,7 @@
         "symfony/mailer": "^7.2",
         "ext-pdo": "*",
         "ext-openssl": "*",
-        "php": ">=8.2"
+        "php": ">=8.5"
     },
 
     "autoload": {

--- a/web/composer.lock
+++ b/web/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "216890b7211751ba9ceef7fa10d497aa",
+    "content-hash": "88f587f1f2473bfc704b5fcc4be58488",
     "packages": [
         {
             "name": "dflydev/dot-access-data",
@@ -4098,7 +4098,7 @@
     "platform": {
         "ext-pdo": "*",
         "ext-openssl": "*",
-        "php": ">=8.2"
+        "php": ">=8.5"
     },
     "platform-dev": {},
     "plugin-api-version": "2.9.0"

--- a/web/includes/SteamID/SteamID.php
+++ b/web/includes/SteamID/SteamID.php
@@ -23,7 +23,7 @@ class SteamID
      * @param  Database|null $dbs
      * @throws Exception
      */
-    public static function init(Database $dbs = null)
+    public static function init(?Database $dbs = null)
     {
         self::$calcMethod = self::getCalcMethod();
 

--- a/web/includes/auth/openid.php
+++ b/web/includes/auth/openid.php
@@ -453,8 +453,12 @@ class LightOpenID
         $data = file_get_contents($url, false, $context);
         # This is a hack for providers who don't support HEAD requests.
         # It just creates the headers array for the last request in $this->headers.
-        if(isset($http_response_header)) {
-            $this->headers = $this->parse_header_array($http_response_header, $update_claimed_id);
+        # PHP 8.5 deprecated the magic local $http_response_header; the
+        # http_get_last_response_headers() helper (PHP 8.4+) returns the
+        # same array. SBPP requires PHP 8.5+ as of #1289.
+        $responseHeaders = http_get_last_response_headers();
+        if (is_array($responseHeaders)) {
+            $this->headers = $this->parse_header_array($responseHeaders, $update_claimed_id);
         }
 
         return $data;

--- a/web/install/template/page.3.php
+++ b/web/install/template/page.3.php
@@ -32,9 +32,9 @@ if (isset($_POST['username'], $_POST['password'], $_POST['server'], $_POST['port
    <tr>
   <td width="33%" height="16" class="listtable_1"><b>PHP Version</b></td>
   <td width="22%" height="16" class="listtable_top">N/A</td>
-    <td width="22%" height="16" class="listtable_1"><b>7.4</b></td>
+    <td width="22%" height="16" class="listtable_1"><b>8.5</b></td>
     <?php
-    if (version_compare(PHP_VERSION, "7.4") != -1) {
+    if (version_compare(PHP_VERSION, "8.5") != -1) {
         $class = "green";
     } else {
         $class = "red";

--- a/web/phpstan-baseline.neon
+++ b/web/phpstan-baseline.neon
@@ -319,7 +319,7 @@ parameters:
 			path: install/template/page.2.php
 
 		-
-			message: '#^Loose comparison using \!\= between 1 and \-1 will always evaluate to true\.$#'
+			message: '#^Loose comparison using \!\= between 0\|1 and \-1 will always evaluate to true\.$#'
 			identifier: notEqual.alwaysTrue
 			count: 1
 			path: install/template/page.3.php

--- a/web/phpstan.neon
+++ b/web/phpstan.neon
@@ -8,7 +8,7 @@ includes:
 
 parameters:
     level: 5
-    phpVersion: 80200
+    phpVersion: 80500
     bootstrapFiles:
         - includes/vendor/autoload.php
         - phpstan-bootstrap.php

--- a/web/tests/integration/Php82DeprecationsTest.php
+++ b/web/tests/integration/Php82DeprecationsTest.php
@@ -15,8 +15,19 @@ use Smarty\Smarty;
  * Issue #1273: PHP 8.1 deprecated implicit `null` -> scalar coercion for
  * internal functions (`strlen($null)`, `trim($null)`, `substr($null,...)`,
  * etc.). PHP 9 will turn the deprecation into a `TypeError`. Per
- * `web/composer.json`, the panel already requires `php >= 8.2`, so we're
- * firmly inside the deprecation window.
+ * `web/composer.json`, the panel requires `php >= 8.5`, so we're firmly
+ * inside the deprecation window.
+ *
+ * Naming note: the class + filename keep their `Php82` prefix because
+ * that's the panel's PHP floor at the time the gate was added (#1273).
+ * The actual surface this test validates is the null-into-scalar
+ * coercion that PHP 8.1 deprecated and PHP 9 will fatal on — the
+ * deprecation predates our floor and outlives any single floor bump
+ * (we landed `>=8.5` in #1289 and the gate is unchanged). Renaming to
+ * `NullIntoScalarDeprecationsTest` would be more descriptive but the
+ * `git mv` churn isn't worth it; the AGENTS.md "Where to find what"
+ * row at "Trap PHP 8.1 null-into-scalar deprecations at runtime"
+ * already describes what the test does, not when the floor was.
  *
  * The PHPStan deprecation-rules plugin (#1273) is the static gate that
  * blocks new offenders inside the analyzable codebase. This test is the


### PR DESCRIPTION
Closes #1289.

## Summary

Bumps the panel's declared PHP floor from 8.2 to 8.5 (the current
latest stable, released 20 Nov 2025). The bump moves the static
gate from `phpVersion: 80200` to `80500`, which flips on the
deprecation surface for everything between 8.2 and 8.5; CI pins
`php-version: '8.5'` in the three PHP workflows and the dev image
rebases onto `php:8.5-apache`. Documentation cross-references
updated end-to-end.

## Trade-off worth surfacing (8.5 vs 8.4)

PHP 8.5 is ~5.5 months old (Nov 2025). Some self-hosters' distros /
shared hosts won't ship it yet (Debian stable, RHEL 9, older
cPanel images). The conservative alternative is bumping to **8.4**
— still gets us active support through Dec 2026 and is broadly
available now. The maintainer call:

- **8.5** — advertise the latest, force self-hosters onto modern
  PHP, leans on the release timing where 2.x is still stabilizing.
- **8.4** — same EOL-avoidance win without cutting off self-hosters
  whose distro hasn't caught up. Re-bump to 8.5 in a follow-up
  after distros catch up.

This PR is filed against 8.5 since that's what the issue asked for;
happy to retarget to 8.4 if a self-hoster shows up needing it
before merge.

## Acceptance criteria (from #1289)

- [x] `web/composer.json` declares `"php": ">=8.5"`. `web/composer.lock`
      regenerated; lock churn was just the `content-hash` + the
      `platform.php` marker — no package versions moved (every
      transitive in the lock already supports 8.5).
- [x] `web/phpstan.neon`'s `phpVersion: 80500`. Baseline
      regenerated. The only NEW entries surfaced were:
  1. **Real PHP 8.4 deprecation** in `SteamID::init`
     (`Database $dbs = null` → `?Database $dbs = null`).
     Fixed inline.
  2. **Wording shift** on the existing
     `install/template/page.3.php` baselined entry — the
     `version_compare` arg moved from `"7.4"` to `"8.5"` so
     PHPStan's narrowed return type went from `1` to `0|1`
     and the message string changed accordingly. Same
     conceptual error (PHPStan can't see runtime
     `PHP_VERSION` so the gate is provably-true at analysis
     time but meaningful at runtime). Kept baselined.

  Two further runtime deprecations surfaced via the
  `Php82DeprecationsTest` runtime gate (PHP 8.5 deprecated the
  magic local `$http_response_header` in favour of
  `http_get_last_response_headers()`); fixed both call sites
  (`web/api/handlers/system.php`, `web/includes/auth/openid.php`).
- [x] `phpstan.yml` / `test.yml` / `api-contract.yml` all pin
      `php-version: '8.5'`. `e2e.yml` inherits PHP from the docker
      image and stays untouched.
- [x] `docker/Dockerfile` runs on `php:8.5-apache`; `./sbpp.sh up`
      brings up the panel; `./sbpp.sh phpstan` / `test` /
      `ts-check` / `composer api-contract` / `e2e` all pass against
      the new image.
- [x] `web/install/template/page.3.php`'s PHP version check is
      updated to 8.5 (both the displayed label and the
      `version_compare` call).
- [x] All `README.md` / `AGENTS.md` / `ARCHITECTURE.md` /
      `docker/README.md` / `CHANGELOG.md` references updated.
      `rg 'PHP 8\.2|php:8\.2|phpVersion: 80200|php-version.*8\.2'`
      returns nothing.
- [x] PR description spells out the 8.5-vs-8.4 trade-off (above).

## Notable build surprise: `docker-php-ext-install opcache` fails on PHP 8.5

PHP 8.5 bundles opcache into core; `docker-php-ext-install opcache`
errors out with `cp: cannot stat 'modules/*': No such file or
directory` because there's no .so to copy (see
[docker-library/php#1137](https://github.com/docker-library/php/issues/1137)
and [php/php-src#20557](https://github.com/php/php-src/issues/20557)).

Fix: dropped `opcache` from the Dockerfile's
`docker-php-ext-install` line and added a comment explaining the
8.5 behaviour. The bundled opcache is enabled out of the box and
the existing `opcache.*` INI tunings in `zz-sbpp-dev.ini` apply
unchanged. Verified via `php -m` and the live phpinfo:

```
Zend OPcache
opcache.enable => On => On
```

The Debian base did flip from `bookworm` to `trixie` in the
upgrade — every other apt package (`libgmp-dev`, `libicu-dev`,
`libzip-dev`, `libonig-dev`, `default-mysql-client`,
`gettext-base`, `nodejs`, `npm`) resolved cleanly without
changes.

## Lock churn

Just the `content-hash` and `platform.php` marker. No package
version moved. Every transitive (Nette declares `8.2-8.5`,
Smarty 5 / lcobucci/jwt / league/commonmark / symfony/mailer 7 /
phpunit 11 / phpstan 2 etc.) already supports 8.5.

## Test class naming (item 7, option a)

Kept `Php82DeprecationsTest` named as-is per option (a) in the
issue. Added a docblock note explaining the class name reflects
when the gate was added (PHP 8.2 floor at the time of #1273) and
not what it actually validates (the PHP 8.1 null-into-scalar
coercion that PHP 9 will fatal on — outlives any single floor
bump). The AGENTS.md row at "Trap PHP 8.1 null-into-scalar
deprecations at runtime" already describes the right thing; no
further AGENTS.md edits needed for this item.

## CHANGELOG entry

Folded the bump into the staged 2.0.0 release block (items 14 +
33 updated to reflect 8.5; item 33 now reads "PHP 8.5 minimum
(was 8.2)" with a `(#1289 bumped the floor pre-tag)` note).
2.0.0 has not been tagged yet, so per the issue's
release-staging logic this lands inside 2.0.0 rather than as a
separate post-release entry. The result is the topmost block of
CHANGELOG.md says "PHP 8.5 minimum", which is the
"top-of-file entry" the issue asked for without duplicating the
information.

## README.md `### PHP 8.1 major changes` heading

Removed (option "either retitle or remove" in the issue body
item 6). The body underneath was about a long-ago 1.6→1.7
upgrade with stale `/blob/php81/` branch refs, not about PHP
8.1 specifically. The `## Upgrade` heading stays for the
historical 1.6/1.7 upgrade note.

## Quality gates run locally

- `./sbpp.sh phpstan` — pass (0 errors against the new baseline).
- `./sbpp.sh test` — 380 tests, 1546 assertions, **0 PHP
  deprecations**, 1 PHPUnit-internal deprecation about
  doc-comment metadata in `GroupsTest::testEditRoundTripsHighBitFlagsAsPositiveIntegers`
  (a PHPUnit 11 → 12 transition, **pre-existing**, unrelated to
  the PHP bump).
- `./sbpp.sh ts-check` — pass.
- `./sbpp.sh composer api-contract` — clean (no diff after
  regen).
- `./sbpp.sh e2e --workers=1` — 192/192 pass (matches CI's
  `workers: 1` config; the AGENTS.md "Playwright E2E specifics"
  block documents that local parallel runs flake on the shared
  `sourcebans_e2e` DB and is the canonical configuration).

## Test plan

- [ ] Reviewer confirms the 8.5-vs-8.4 trade-off call.
- [ ] Reviewer confirms the `Php82DeprecationsTest` rename
      decline (option a) is the right call vs renaming.
- [ ] Reviewer confirms the CHANGELOG fold-into-2.0.0 read of
      "top-of-file entry".
- [ ] CI matrix: phpstan / test / api-contract / e2e all green
      against `php-version: '8.5'`.