### PR TITLE
chore(php): mechanical syntax modernization sweep + switch→match (#1290)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -815,6 +815,41 @@ audit (#1207) locked in. New CTAs:
   value is safe HTML; without a `{* nofilter: <why> *}` comment above
   it, future readers can't tell whether it's a real escape hatch or a
   copy-paste accident waiting to be exploited (#1113 audit).
+- `intval($x)` / `strval($x)` / `floatval($x)` → `(int) $x` / `(string) $x`
+  / `(float) $x`. Cast operators are PHP-native, faster, and don't have
+  the function-call overhead. Two pitfalls: when crossing a radix boundary
+  (`intval($x, 16)`) keep `intval` (cast doesn't take a radix); when
+  casting a binary expression, keep the parentheses: `(int) ($a + $b)`,
+  not `(int) $a + $b` (cast precedence binds tighter). Issue #1290 phase F.
+- `is_null($x)` → `$x === null`. Pure stylistic swap, but the prettier
+  shape is `??=` whenever the surrounding code is
+  `if (is_null($x)) { $x = $y; }` — becomes `$x ??= $y;`. Excluded:
+  `web/includes/auth/openid.php` and `web/includes/SteamID/SteamID.php`
+  are third-party. Issue #1290 phase G.
+- `array(…)` literal constructor → `[…]` short-array syntax. PHP 5.4+
+  shape; the only reason `array(…)` survived this long was nobody got
+  around to it. Excluded: `web/includes/auth/openid.php` and
+  `web/includes/tinymce/**` are third-party. Function signatures using
+  `array $x` as a TYPE HINT are unrelated and stay. Issue #1290 phase H.
+- `if (…) { return true; } return false;` → `return …;`. Three lines
+  collapse to one when the condition itself is the boolean. When
+  simplifying a method body this way, add the `: bool` native return
+  type in the same commit (phase A pairing per the issue body). Issue
+  #1290 phase I.
+- `strstr($haystack, $needle)` (when used in boolean context) →
+  `str_contains($haystack, $needle)`. PHP 8.0+ shape; `strstr` was
+  doing double duty as substring-finder + boolean-existence-checker, and
+  the latter is more clearly expressed by `str_contains`. The third-arg
+  "before-needle" form (`strstr($haystack, $needle, true)`) stays — that
+  one really is asking for the substring, not a bool. Issue #1290 phase E.
+- `switch ($x) { case A: return [a, b]; case B: return [c, d]; … }` →
+  `match ($x) { 'A' => [a, b], 'B' => [c, d], … }` for value-returning
+  switches. `match` is strict-equal (no implicit string→int coercion),
+  exhaustive (throws `\UnhandledMatchError` on a miss instead of
+  silently falling through), and reads better. Side-effect-only switch
+  arms (e.g. `header(); exit;`) stay as a small `if` ladder OUTSIDE
+  the match — don't try to cram them into match arms. Issue #1290
+  phase C.
 - `strlen($_POST['x'])` / `trim($_POST['x'])` / `substr($row['col'], …)`
   on values that can be `null` at runtime → coalesce
   (`strlen($_POST['x'] ?? '')`) when null is "absent", or cast

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -824,8 +824,7 @@ audit (#1207) locked in. New CTAs:
 - `is_null($x)` → `$x === null`. Pure stylistic swap, but the prettier
   shape is `??=` whenever the surrounding code is
   `if (is_null($x)) { $x = $y; }` — becomes `$x ??= $y;`. Excluded:
-  `web/includes/auth/openid.php` and `web/includes/SteamID/SteamID.php`
-  are third-party. Issue #1290 phase G.
+  `web/includes/auth/openid.php` (third-party). Issue #1290 phase G.
 - `array(…)` literal constructor → `[…]` short-array syntax. PHP 5.4+
   shape; the only reason `array(…)` survived this long was nobody got
   around to it. Excluded: `web/includes/auth/openid.php` and

--- a/web/api/handlers/admins.php
+++ b/web/api/handlers/admins.php
@@ -21,7 +21,7 @@ function api_admins_remove(array $params): array
     $GLOBALS['PDO']->bind(':aid', $aid);
     $admin = $GLOBALS['PDO']->single();
 
-    if ($admin && (intval($admin['extraflags']) & ADMIN_OWNER) !== 0) {
+    if ($admin && ((int) $admin['extraflags'] & ADMIN_OWNER) !== 0) {
         throw new ApiError('cannot_delete_owner', 'Error: You cannot delete the owner.');
     }
 

--- a/web/api/handlers/bans.php
+++ b/web/api/handlers/bans.php
@@ -506,7 +506,7 @@ function api_bans_ban_friends(array $params): array
     $data = $raw ? json_decode($raw, true) : null;
     $friends = $data['friendslist']['friends'] ?? null;
 
-    if (is_null($friends)) {
+    if ($friends === null) {
         throw new ApiError('private_profile', 'There was an error retrieving the friend list.');
     }
 

--- a/web/includes/Api.php
+++ b/web/includes/Api.php
@@ -24,7 +24,7 @@ require_once __DIR__ . '/ApiError.php';
  *             { "ok": false, "error": { "code", "message", "field"? } } on handled error
  *             { "ok": false, "redirect": "..." }                on auth/redirect
  *
- * Handlers are pure functions: array $params -> array (the data envelope).
+ * Handlers are pure functions: array $params -> array — the data envelope.
  * Throw ApiError to surface a structured client-side message.
  * Return ['__redirect' => '...'] (or call Api::redirect()) to navigate.
  */

--- a/web/includes/CUserManager.php
+++ b/web/includes/CUserManager.php
@@ -45,9 +45,7 @@ class CUserManager
      */
     public function GetUserArray($aid = null)
     {
-        if (is_null($aid)) {
-            $aid = $this->aid;
-        }
+        $aid ??= $this->aid;
         // Invalid aid
         if ($aid < 0 || empty($aid)) {
             return false;
@@ -81,12 +79,12 @@ class CUserManager
         $user['gid'] = $res['gid'];
         $user['email'] = $res['email'];
         $user['validate'] = $res['validate'];
-        $user['extraflags'] = (intval($res['extraflags']) | intval($res['wgflags']));
+        $user['extraflags'] = ((int) $res['extraflags'] | (int) $res['wgflags']);
 
-        $user['srv_immunity'] = intval($res['sgimmunity']);
+        $user['srv_immunity'] = (int) $res['sgimmunity'];
 
-        if (intval($res['admimmunity']) > intval($res['sgimmunity'])) {
-            $user['srv_immunity'] = intval($res['admimmunity']);
+        if ((int) $res['admimmunity'] > (int) $res['sgimmunity']) {
+            $user['srv_immunity'] = (int) $res['admimmunity'];
         }
 
         $user['srv_password'] = $res['srv_password'];
@@ -106,11 +104,9 @@ class CUserManager
      * @param int $aid The user to check flags for.
      * @return bool
      */
-    public function HasAccess($flags, $aid = null)
+    public function HasAccess($flags, $aid = null): bool
     {
-        if (is_null($aid)) {
-            $aid = $this->aid;
-        }
+        $aid ??= $this->aid;
 
         if (empty($flags) || $aid <= 0) {
             return false;
@@ -121,14 +117,14 @@ class CUserManager
         }
 
         if (is_numeric($flags)) {
-            return ((int)$this->admins[$aid]['extraflags'] & (int)$flags) != 0 ? true : false;
+            return ((int) $this->admins[$aid]['extraflags'] & (int) $flags) !== 0;
         }
 
         $srvFlags = (string) ($this->admins[$aid]['srv_flags'] ?? '');
         $flagsStr = (string) $flags;
         for ($i=0; $i < strlen($srvFlags); $i++) {
             for ($a=0; $a < strlen($flagsStr); $a++) {
-                if (strstr($srvFlags[$i], $flagsStr[$a])) {
+                if (str_contains($srvFlags[$i], $flagsStr[$a])) {
                     return true;
                 }
             }
@@ -146,9 +142,7 @@ class CUserManager
      */
     public function GetProperty($name, $aid = null)
     {
-        if (is_null($aid)) {
-            $aid = $this->aid;
-        }
+        $aid ??= $this->aid;
         if (empty($name) || $aid < 0) {
             return false;
         }
@@ -163,28 +157,20 @@ class CUserManager
     /**
      * @return bool
      */
-    public function is_logged_in()
+    public function is_logged_in(): bool
     {
-        if ($this->aid != -1) {
-            return true;
-        }
-        return false;
+        return $this->aid !== -1;
     }
 
     /**
-     * @param null $aid
+     * @param int|null $aid
      * @return bool
      */
-    public function is_admin($aid = null)
+    public function is_admin($aid = null): bool
     {
-        if (is_null($aid)) {
-            $aid = $this->aid;
-        }
+        $aid ??= $this->aid;
 
-        if ($this->HasAccess(ALL_WEB, $aid)) {
-            return true;
-        }
-        return false;
+        return $this->HasAccess(ALL_WEB, $aid);
     }
 
 
@@ -217,9 +203,7 @@ class CUserManager
      */
     public function GetAdmin($aid = null)
     {
-        if (is_null($aid)) {
-            $aid = $this->aid;
-        }
+        $aid ??= $this->aid;
         if ($aid < 0) {
             return false;
         }

--- a/web/includes/Database.php
+++ b/web/includes/Database.php
@@ -25,7 +25,7 @@ class Database
     {
         $this->prefix = $prefix;
         $dsn = 'mysql:host=' . $host . ';port=' . $port . ';dbname=' . $dbname . ';charset=' . $charset;
-        $options = array(
+        $options = [
             PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
             // Native (non-emulated) prepares: PDOStatement::execute([...])
             // forwards values via MySQL's binary protocol with proper
@@ -40,7 +40,7 @@ class Database
             // detect PARAM_INT for ints, so this is purely additive on
             // the array-shortcut path.
             PDO::ATTR_EMULATE_PREPARES => false,
-        );
+        ];
 
         try {
             $this->dbh = new PDO($dsn, $user, $password, $options);
@@ -92,12 +92,12 @@ class Database
      */
     public function bind($param, $value, $type = null)
     {
-        if (is_null($type)) {
+        if ($type === null) {
             $type = match (true) {
-                is_int($value) => PDO::PARAM_INT,
-                is_bool($value) => PDO::PARAM_BOOL,
-                is_null($value) => PDO::PARAM_NULL,
-                default => PDO::PARAM_STR,
+                is_int($value)   => PDO::PARAM_INT,
+                is_bool($value)  => PDO::PARAM_BOOL,
+                $value === null  => PDO::PARAM_NULL,
+                default          => PDO::PARAM_STR,
             };
         }
 

--- a/web/includes/SteamID/SteamID.php
+++ b/web/includes/SteamID/SteamID.php
@@ -28,7 +28,7 @@ class SteamID
         self::$calcMethod = self::getCalcMethod();
 
         if (self::$calcMethod === 'SQL') {
-            if (is_null($dbs)) {
+            if ($dbs === null) {
                 throw new Exception('No suitable calculation Method found!');
             }
             calc\SQL::setDB($dbs);

--- a/web/includes/auth/handler/NormalAuthHandler.php
+++ b/web/includes/auth/handler/NormalAuthHandler.php
@@ -16,7 +16,7 @@ class NormalAuthHandler
         if (!$user || empty($password))
             return;
 
-        if (!empty($password) && (!empty($user['password']) || !is_null($user['password']))) {
+        if (!empty($password) && (!empty($user['password']) || $user['password'] !== null)) {
             if ($this->checkPassword($password, $user['password'])) {
                 $this->result = true;
                 Auth::login($user['aid'], $maxlife);

--- a/web/includes/auth/handler/SteamAuthHandler.php
+++ b/web/includes/auth/handler/SteamAuthHandler.php
@@ -46,7 +46,7 @@ class SteamAuthHandler
         $this->dbs->bind(':authid', $steamid);
         $result = $this->dbs->single();
 
-        if (!empty($result['aid']) && !is_null($result['aid'])) {
+        if (!empty($result['aid'])) {
             $maxlife = Config::get('auth.maxlife.steam') * 60;
             Auth::login($result['aid'], $maxlife);
             header("Location: ".Host::complete());

--- a/web/includes/page-builder.php
+++ b/web/includes/page-builder.php
@@ -143,7 +143,14 @@ function route($fallback)
         // numeric `$fallback` mode so each entry sets `$_GET['p']` to
         // the canonical slug downstream code (page-tail navbar, etc.)
         // would have seen for a direct request.
-        [$slug, $title, $template] = match ($fallback) {
+        //
+        // `$fallback` typically arrives from `Config::get('config.defaultpage')`,
+        // which reads `sb_settings.value` (a `text NOT NULL` column) and so
+        // returns a string like "1". `match` is strict (===), so we cast to
+        // int at the dispatch boundary; non-numeric strings (`"banana"`) cast
+        // to `0` and fall through to the Dashboard arm — matching the loose
+        // `==` `switch` this replaced (#1290).
+        [$slug, $title, $template] = match ((int) $fallback) {
             1       => ['banlist', 'Ban List',      '/page.banlist.php'],
             2       => ['servers', 'Server Info',   '/page.servers.php'],
             3       => ['submit',  'Submit a Ban',  '/page.submit.php'],

--- a/web/includes/page-builder.php
+++ b/web/includes/page-builder.php
@@ -11,146 +11,150 @@ function route($fallback)
         CSRF::rejectIfInvalid();
     }
 
-    $page = $_GET['p'] ?? null;
+    $page      = $_GET['p'] ?? null;
     $categorie = $_GET['c'] ?? null;
-    $option = $_GET['o'] ?? null;
+    $option    = $_GET['o'] ?? null;
 
-    switch ($page) {
-        case 'login':
-            switch ($option) {
-                case 'steam':
-                    require_once 'includes/auth/openid.php';
-                    new SteamAuthHandler(new LightOpenID(Host::complete()), $GLOBALS['PDO']);
-                    exit();
-                default:
-                    return ['Login', '/page.login.php'];
-            }
-        case 'logout':
-            Auth::logout();
-            header('Location: index.php?p=home');
-            exit();
-        case 'submit':
-            return ['Submit a Ban', '/page.submit.php'];
-        case 'banlist':
-            return ['Ban List', '/page.banlist.php'];
-        case 'commslist':
-            return ['Communications Block List', '/page.commslist.php'];
-        case 'servers':
-            return ['Server List', '/page.servers.php'];
-        case 'protest':
-            return ['Protest a Ban', '/page.protest.php'];
-        case 'account':
-            return ['Your Account', '/page.youraccount.php'];
-        case 'lostpassword':
-            return ['Lost your password', '/page.lostpassword.php'];
-        case 'home':
-            return ['Dashboard', '/page.home.php'];
-        case 'admin':
-            switch ($categorie) {
-                case 'groups':
-                    CheckAdminAccess(ADMIN_OWNER|ADMIN_LIST_GROUPS|ADMIN_ADD_GROUP|ADMIN_EDIT_GROUPS|ADMIN_DELETE_GROUPS);
-                    switch ($option) {
-                        case 'edit':
-                            return ['Edit Groups', '/admin.edit.group.php'];
-                        default:
-                            return ['Group Management', '/admin.groups.php'];
-                    }
-                case 'admins':
-                    CheckAdminAccess(ADMIN_OWNER|ADMIN_LIST_ADMINS|ADMIN_ADD_ADMINS|ADMIN_EDIT_ADMINS|ADMIN_DELETE_ADMINS);
-                    switch ($option) {
-                        case 'editgroup':
-                            return ['Edit Admin Groups', '/admin.edit.admingroup.php'];
-                        case 'editdetails':
-                            return ['Edit Admin Details', '/admin.edit.admindetails.php'];
-                        case 'editpermissions':
-                            return ['Edit Admin Permissions', '/admin.edit.adminperms.php'];
-                        case 'editservers':
-                            return ['Edit Server Access', '/admin.edit.adminservers.php'];
-                        default:
-                            return ['Admin Management', '/admin.admins.php'];
-                    }
-                case 'servers':
-                    CheckAdminAccess(ADMIN_OWNER|ADMIN_LIST_SERVERS|ADMIN_ADD_SERVER|ADMIN_EDIT_SERVERS|ADMIN_DELETE_SERVERS);
-                    switch ($option) {
-                        case 'edit':
-                            return ['Edit Server', '/admin.edit.server.php'];
-                        case 'rcon':
-                            return ['Server RCON', '/admin.rcon.php'];
-                        case 'admincheck':
-                            return ['Server Admins', '/admin.srvadmins.php'];
-                        default:
-                            return ['Server Management', '/admin.servers.php'];
-                    }
-                case 'bans':
-                    CheckAdminAccess(ADMIN_OWNER|ADMIN_ADD_BAN|ADMIN_EDIT_OWN_BANS|ADMIN_EDIT_GROUP_BANS|ADMIN_EDIT_ALL_BANS|ADMIN_BAN_PROTESTS|ADMIN_BAN_SUBMISSIONS);
-                    switch ($option) {
-                        case 'edit':
-                            return ['Edit Ban Details', '/admin.edit.ban.php'];
-                        case 'email':
-                            return ['Email', '/admin.email.php'];
-                        default:
-                            return ['Bans', '/admin.bans.php'];
-                    }
-                case 'comms':
-                    CheckAdminAccess(ADMIN_OWNER|ADMIN_ADD_BAN|ADMIN_EDIT_OWN_BANS|ADMIN_EDIT_ALL_BANS);
-                    switch ($option) {
-                        case 'edit':
-                            return ['Edit Block Details', '/admin.edit.comms.php'];
-                        default:
-                            return ['Comms', '/admin.comms.php'];
-                    }
-                case 'mods':
-                    CheckAdminAccess(ADMIN_OWNER|ADMIN_LIST_MODS|ADMIN_ADD_MODS|ADMIN_EDIT_MODS|ADMIN_DELETE_MODS);
-                    switch ($option) {
-                        case 'edit':
-                            return ['Edit Mod Details', '/admin.edit.mod.php'];
-                        default:
-                            return ['Manage Mods', '/admin.mods.php'];
-                    }
-                case 'settings':
-                    CheckAdminAccess(ADMIN_OWNER|ADMIN_WEB_SETTINGS);
-                    return ['SourceBans++ Settings', '/admin.settings.php'];
-                case 'audit':
-                    // Audit log is owner-restricted: there is no dedicated
-                    // ADMIN_LIST_LOGS / ADMIN_LIST_AUDIT flag in
-                    // web/configs/permissions/web.json (#1123 B19), and the
-                    // legacy `TRUNCATE :prefix_log` path in
-                    // admin.settings.php is also gated on ADMIN_OWNER.
-                    CheckAdminAccess(ADMIN_OWNER);
-                    return ['Audit Log', '/admin.audit.php'];
-                default:
-                    // Unrecognised `c=…` used to silently fall through to
-                    // the admin home (#1207 ADM-1), which made typos and
-                    // stale bookmarks invisible (?p=admin&c=overrides
-                    // looked indistinguishable from ?p=admin). Surface
-                    // them as a 404 instead. The naked admin landing
-                    // (`?p=admin` with no c=) still renders the home.
-                    if ($categorie !== null && $categorie !== '') {
-                        http_response_code(404);
-                        return ['Page not found', '/page.404.php'];
-                    }
-                    CheckAdminAccess(ALL_WEB);
-                    return ['Administration', '/page.admin.php'];
-        }
-        default:
-            switch ($fallback) {
-                case 1:
-                    $_GET['p'] = 'banlist';
-                    return ['Ban List', '/page.banlist.php'];
-                case 2:
-                    $_GET['p'] = 'servers';
-                    return ['Server Info', '/page.servers.php'];
-                case 3:
-                    $_GET['p'] = 'submit';
-                    return ['Submit a Ban', '/page.submit.php'];
-                case 4:
-                    $_GET['p'] = 'protest';
-                    return ['Protest a Ban', '/page.protest.php'];
-                default:
-                    $_GET['p'] = 'home';
-                    return ['Dashboard', '/page.home.php'];
-            }
+    /*
+     * Top-level dispatch. Most arms return a [$title, $template] tuple
+     * directly; admin / fallback / steam-login / logout return a sentinel
+     * the if-ladder below handles. Side-effect routes (Steam OpenID
+     * round-trip, logout) can't live inside a `match` arm because the
+     * arm has to yield a value before the side effect runs — `header()`
+     * and `exit()` need their own explicit branch above the table. The
+     * admin sentinel defers to the per-`c=…` route table further down.
+     */
+    $resolved = match ($page) {
+        'login'        => $option === 'steam' ? '__steam_login__' : ['Login', '/page.login.php'],
+        'logout'       => '__logout__',
+        'submit'       => ['Submit a Ban',                '/page.submit.php'],
+        'banlist'      => ['Ban List',                    '/page.banlist.php'],
+        'commslist'    => ['Communications Block List',   '/page.commslist.php'],
+        'servers'      => ['Server List',                 '/page.servers.php'],
+        'protest'      => ['Protest a Ban',               '/page.protest.php'],
+        'account'      => ['Your Account',                '/page.youraccount.php'],
+        'lostpassword' => ['Lost your password',          '/page.lostpassword.php'],
+        'home'         => ['Dashboard',                   '/page.home.php'],
+        'admin'        => '__admin__',
+        default        => '__fallback__',
+    };
+
+    if ($resolved === '__steam_login__') {
+        require_once 'includes/auth/openid.php';
+        new SteamAuthHandler(new LightOpenID(Host::complete()), $GLOBALS['PDO']);
+        exit();
     }
+    if ($resolved === '__logout__') {
+        Auth::logout();
+        header('Location: index.php?p=home');
+        exit();
+    }
+
+    if ($resolved === '__admin__') {
+        /*
+         * Admin sub-route table. Each top-level key is the `c=…` slug.
+         * Every category gates on its own permission mask; the option
+         * sub-table picks the leaf route and falls through to the
+         * category default when `o=…` is missing or unrecognised.
+         *
+         * @var array<string, array{permission: int, options: array<string, array{0: string, 1: string}>, default: array{0: string, 1: string}}> $adminRoutes
+         */
+        $adminRoutes = [
+            'groups' => [
+                'permission' => ADMIN_OWNER|ADMIN_LIST_GROUPS|ADMIN_ADD_GROUP|ADMIN_EDIT_GROUPS|ADMIN_DELETE_GROUPS,
+                'options'    => ['edit' => ['Edit Groups', '/admin.edit.group.php']],
+                'default'    => ['Group Management', '/admin.groups.php'],
+            ],
+            'admins' => [
+                'permission' => ADMIN_OWNER|ADMIN_LIST_ADMINS|ADMIN_ADD_ADMINS|ADMIN_EDIT_ADMINS|ADMIN_DELETE_ADMINS,
+                'options'    => [
+                    'editgroup'       => ['Edit Admin Groups',      '/admin.edit.admingroup.php'],
+                    'editdetails'     => ['Edit Admin Details',     '/admin.edit.admindetails.php'],
+                    'editpermissions' => ['Edit Admin Permissions', '/admin.edit.adminperms.php'],
+                    'editservers'     => ['Edit Server Access',     '/admin.edit.adminservers.php'],
+                ],
+                'default' => ['Admin Management', '/admin.admins.php'],
+            ],
+            'servers' => [
+                'permission' => ADMIN_OWNER|ADMIN_LIST_SERVERS|ADMIN_ADD_SERVER|ADMIN_EDIT_SERVERS|ADMIN_DELETE_SERVERS,
+                'options'    => [
+                    'edit'       => ['Edit Server',   '/admin.edit.server.php'],
+                    'rcon'       => ['Server RCON',   '/admin.rcon.php'],
+                    'admincheck' => ['Server Admins', '/admin.srvadmins.php'],
+                ],
+                'default' => ['Server Management', '/admin.servers.php'],
+            ],
+            'bans' => [
+                'permission' => ADMIN_OWNER|ADMIN_ADD_BAN|ADMIN_EDIT_OWN_BANS|ADMIN_EDIT_GROUP_BANS|ADMIN_EDIT_ALL_BANS|ADMIN_BAN_PROTESTS|ADMIN_BAN_SUBMISSIONS,
+                'options'    => [
+                    'edit'  => ['Edit Ban Details', '/admin.edit.ban.php'],
+                    'email' => ['Email',            '/admin.email.php'],
+                ],
+                'default' => ['Bans', '/admin.bans.php'],
+            ],
+            'comms' => [
+                'permission' => ADMIN_OWNER|ADMIN_ADD_BAN|ADMIN_EDIT_OWN_BANS|ADMIN_EDIT_ALL_BANS,
+                'options'    => ['edit' => ['Edit Block Details', '/admin.edit.comms.php']],
+                'default'    => ['Comms', '/admin.comms.php'],
+            ],
+            'mods' => [
+                'permission' => ADMIN_OWNER|ADMIN_LIST_MODS|ADMIN_ADD_MODS|ADMIN_EDIT_MODS|ADMIN_DELETE_MODS,
+                'options'    => ['edit' => ['Edit Mod Details', '/admin.edit.mod.php']],
+                'default'    => ['Manage Mods', '/admin.mods.php'],
+            ],
+            'settings' => [
+                'permission' => ADMIN_OWNER|ADMIN_WEB_SETTINGS,
+                'options'    => [],
+                'default'    => ['SourceBans++ Settings', '/admin.settings.php'],
+            ],
+            'audit' => [
+                // Audit log is owner-restricted: there is no dedicated
+                // ADMIN_LIST_LOGS / ADMIN_LIST_AUDIT flag in
+                // web/configs/permissions/web.json (#1123 B19), and the
+                // legacy `TRUNCATE :prefix_log` path in
+                // admin.settings.php is also gated on ADMIN_OWNER.
+                'permission' => ADMIN_OWNER,
+                'options'    => [],
+                'default'    => ['Audit Log', '/admin.audit.php'],
+            ],
+        ];
+
+        if (is_string($categorie) && isset($adminRoutes[$categorie])) {
+            $admRoute = $adminRoutes[$categorie];
+            CheckAdminAccess($admRoute['permission']);
+            return $admRoute['options'][(string) $option] ?? $admRoute['default'];
+        }
+
+        // Unrecognised `c=…` used to silently fall through to the admin
+        // home (#1207 ADM-1), which made typos and stale bookmarks
+        // invisible (?p=admin&c=overrides looked indistinguishable
+        // from ?p=admin). Surface them as a 404 instead. The naked
+        // admin landing (`?p=admin` with no c=) still renders the home.
+        if ($categorie !== null && $categorie !== '') {
+            http_response_code(404);
+            return ['Page not found', '/page.404.php'];
+        }
+        CheckAdminAccess(ALL_WEB);
+        return ['Administration', '/page.admin.php'];
+    }
+
+    if ($resolved === '__fallback__') {
+        // `?p=…` didn't match any top-level slug. The caller passes a
+        // numeric `$fallback` mode so each entry sets `$_GET['p']` to
+        // the canonical slug downstream code (page-tail navbar, etc.)
+        // would have seen for a direct request.
+        [$slug, $title, $template] = match ($fallback) {
+            1       => ['banlist', 'Ban List',      '/page.banlist.php'],
+            2       => ['servers', 'Server Info',   '/page.servers.php'],
+            3       => ['submit',  'Submit a Ban',  '/page.submit.php'],
+            4       => ['protest', 'Protest a Ban', '/page.protest.php'],
+            default => ['home',    'Dashboard',     '/page.home.php'],
+        };
+        $_GET['p'] = $slug;
+        return [$title, $template];
+    }
+
+    return $resolved;
 }
 
 /**

--- a/web/includes/system-functions.php
+++ b/web/includes/system-functions.php
@@ -321,7 +321,7 @@ function sizeFormat($bytes)
  *
  * @param  int   $sid
  * @param  array $steamids
- * @return array array('STEAM_ID_1' => array('name' => $name, 'steam' => $steam, 'ip' => $ip, 'time' => $time, 'ping' => $ping), 'STEAM_ID_2' => []....)
+ * @return array<string, array{name: string, steam: string, ip: string}> Keyed by Steam2 id, e.g. ['STEAM_0:0:1' => ['name' => …, 'steam' => …, 'ip' => …], …].
  */
 function checkMultiplePlayers(int $sid, array $steamids)
 {

--- a/web/includes/system-functions.php
+++ b/web/includes/system-functions.php
@@ -81,7 +81,7 @@ function SmFlagsToSb($flagstring)
     }
 
     foreach ($flags as $flag) {
-        if (strstr($flagstring, $flag['value']) || strstr($flagstring, 'z')) {
+        if (str_contains($flagstring, $flag['value']) || str_contains($flagstring, 'z')) {
             $out[] = $flag['display'];
         }
     }
@@ -140,8 +140,8 @@ function SecondsToString($sec, $textual=true)
         return 'Session';
     }
     if ($textual) {
-        $div = array( 2592000, 604800, 86400, 3600, 60, 1 );
-        $desc = array('mo','wk','d','hr','min','sec');
+        $div = [2592000, 604800, 86400, 3600, 60, 1];
+        $desc = ['mo', 'wk', 'd', 'hr', 'min', 'sec'];
         $ret = null;
         foreach ($div as $index => $value) {
             $quotent = floor($sec / $value); //greatest whole integer

--- a/web/init.php
+++ b/web/init.php
@@ -150,19 +150,24 @@ Log::init($GLOBALS['PDO'], $userbank);
 set_error_handler('sbError');
 function sbError($errno, $errstr, $errfile, $errline)
 {
-    switch ($errno) {
-        case E_USER_ERROR:
-            Log::add('e', 'PHP Error', "[$errno] $errstr\nFatal Error on line $errline in file $errfile");
-            return true;
-        case E_USER_WARNING:
-            Log::add('w', 'PHP Warning', "[$errno] $errstr\nError on line $errline in file $errfile");
-            return true;
-        case E_USER_NOTICE:
-            Log::add('m', 'PHP Notice', "[$errno] $errstr\nNotice on line $errline in file $errfile");
-            return true;
-        default:
-            return false;
+    // Map E_USER_* into a (log-level, log-title, error-word) triplet so the
+    // dispatch is one table read; a `default => null` arm preserves the
+    // legacy switch's "unknown errno → return false" fall-through. `match`
+    // arms can't host `Log::add(...) + return true` directly because the
+    // expression must yield a single value — the logging side effect runs
+    // outside the match below the lookup.
+    $entry = match ($errno) {
+        E_USER_ERROR   => ['e', 'PHP Error',   'Fatal Error'],
+        E_USER_WARNING => ['w', 'PHP Warning', 'Error'],
+        E_USER_NOTICE  => ['m', 'PHP Notice',  'Notice'],
+        default        => null,
+    };
+    if ($entry === null) {
+        return false;
     }
+    [$logLevel, $logTitle, $errorWord] = $entry;
+    Log::add($logLevel, $logTitle, "[$errno] $errstr\n$errorWord on line $errline in file $errfile");
+    return true;
 }
 
 $webflags = json_decode(file_get_contents(ROOT.'/configs/permissions/web.json'), true);

--- a/web/pages/admin.admins.php
+++ b/web/pages/admin.admins.php
@@ -182,7 +182,7 @@ if ($section === 'overrides') {
 $AdminsPerPage = SB_BANS_PER_PAGE;
 $page = 1;
 if (isset($_GET['page']) && $_GET['page'] > 0) {
-    $page = intval($_GET['page']);
+    $page = (int) $_GET['page'];
 }
 
 /*
@@ -427,7 +427,7 @@ if ($joinServersGroups) {
 // `http_build_query` handles array values (`admwebflag[]=…&admwebflag[]=…`)
 // natively, so multi-select filters round-trip without manual joining.
 $advSearchString = empty($activeFilters) ? '' : '&' . http_build_query($activeFilters);
-$admins = $GLOBALS['PDO']->query("SELECT * FROM `:prefix_admins` AS ADM".$join." WHERE ADM.aid > 0".$where." ORDER BY user LIMIT " . intval(($page-1) * $AdminsPerPage) . "," . intval($AdminsPerPage))->resultset($whereParams);
+$admins = $GLOBALS['PDO']->query("SELECT * FROM `:prefix_admins` AS ADM".$join." WHERE ADM.aid > 0".$where." ORDER BY user LIMIT " . (int) (($page-1) * $AdminsPerPage) . "," . (int) $AdminsPerPage)->resultset($whereParams);
 // The server filter joins through `:prefix_admins_servers_groups` and
 // `:prefix_servers_groups`, which can produce duplicate ADM.aid rows
 // when an admin reaches the same server via multiple paths. Dedupe
@@ -449,11 +449,11 @@ $query = $GLOBALS['PDO']->query("SELECT COUNT(ADM.aid) AS cnt FROM `:prefix_admi
 $admin_count = $query['cnt'];
 
 if (isset($_GET['page']) && $_GET['page'] > 0) {
-    $page = intval($_GET['page']);
+    $page = (int) $_GET['page'];
 }
 
-$AdminsStart = intval(($page - 1) * $AdminsPerPage);
-$AdminsEnd   = intval($AdminsStart + $AdminsPerPage);
+$AdminsStart = (int) (($page - 1) * $AdminsPerPage);
+$AdminsEnd   = (int) ($AdminsStart + $AdminsPerPage);
 if ($AdminsEnd > $admin_count) {
     $AdminsEnd = $admin_count;
 }

--- a/web/pages/admin.admins.search.php
+++ b/web/pages/admin.admins.search.php
@@ -148,7 +148,7 @@ $serverflag = [
  *
  * Multi-select filters accept either the legacy comma-joined string
  * (`?admwebflag=ADMIN_OWNER,ADMIN_LIST_ADMINS`, the pre-fix wire
- * shape) or the new repeated-key array (`?admwebflag[]=ADMIN_OWNER&…`).
+ * shape) or the new repeated-key array shape `?admwebflag[]=ADMIN_OWNER&…`.
  * Both are normalised to a list of validated constant names; the
  * template uses `in_array` to mark the matching option rows.
  */

--- a/web/pages/admin.bans.php
+++ b/web/pages/admin.bans.php
@@ -453,13 +453,13 @@ if ($section === 'protests') {
         $ItemsPerPage = SB_BANS_PER_PAGE;
         $page         = 1;
         if (isset($_GET['ppage']) && $_GET['ppage'] > 0) {
-            $page = intval($_GET['ppage']);
+            $page = (int) $_GET['ppage'];
         }
-        $protests       = $GLOBALS['PDO']->query("SELECT * FROM `:prefix_protests` WHERE archiv = '0' ORDER BY pid DESC LIMIT " . intval(($page - 1) * $ItemsPerPage) . "," . intval($ItemsPerPage))->resultset();
+        $protests       = $GLOBALS['PDO']->query("SELECT * FROM `:prefix_protests` WHERE archiv = '0' ORDER BY pid DESC LIMIT " . (int) (($page - 1) * $ItemsPerPage) . "," . (int) $ItemsPerPage)->resultset();
         $protests_count = $GLOBALS['PDO']->query("SELECT count(pid) AS count FROM `:prefix_protests` WHERE archiv = '0' ORDER BY pid DESC")->single();
         $page_count     = $protests_count['count'];
-        $PageStart      = intval(($page - 1) * $ItemsPerPage);
-        $PageEnd        = intval($PageStart + $ItemsPerPage);
+        $PageStart      = (int) (($page - 1) * $ItemsPerPage);
+        $PageEnd        = (int) ($PageStart + $ItemsPerPage);
         if ($PageEnd > $page_count) {
             $PageEnd = $page_count;
         }
@@ -547,13 +547,13 @@ if ($section === 'protests') {
         $ItemsPerPage = SB_BANS_PER_PAGE;
         $page         = 1;
         if (isset($_GET['papage']) && $_GET['papage'] > 0) {
-            $page = intval($_GET['papage']);
+            $page = (int) $_GET['papage'];
         }
-        $protestsarchiv       = $GLOBALS['PDO']->query("SELECT p.*, (SELECT user FROM `:prefix_admins` WHERE aid = p.archivedby) AS archivedby FROM `:prefix_protests` p WHERE archiv > '0' ORDER BY pid DESC LIMIT " . intval(($page - 1) * $ItemsPerPage) . "," . intval($ItemsPerPage))->resultset();
+        $protestsarchiv       = $GLOBALS['PDO']->query("SELECT p.*, (SELECT user FROM `:prefix_admins` WHERE aid = p.archivedby) AS archivedby FROM `:prefix_protests` p WHERE archiv > '0' ORDER BY pid DESC LIMIT " . (int) (($page - 1) * $ItemsPerPage) . "," . (int) $ItemsPerPage)->resultset();
         $protestsarchiv_count = $GLOBALS['PDO']->query("SELECT count(pid) AS count FROM `:prefix_protests` WHERE archiv > '0' ORDER BY pid DESC")->single();
         $page_count           = $protestsarchiv_count['count'];
-        $PageStart            = intval(($page - 1) * $ItemsPerPage);
-        $PageEnd              = intval($PageStart + $ItemsPerPage);
+        $PageStart            = (int) (($page - 1) * $ItemsPerPage);
+        $PageEnd              = (int) ($PageStart + $ItemsPerPage);
         if ($PageEnd > $page_count) {
             $PageEnd = $page_count;
         }
@@ -665,13 +665,13 @@ if ($section === 'submissions') {
         $ItemsPerPage = SB_BANS_PER_PAGE;
         $page         = 1;
         if (isset($_GET['spage']) && $_GET['spage'] > 0) {
-            $page = intval($_GET['spage']);
+            $page = (int) $_GET['spage'];
         }
-        $submissions       = $GLOBALS['PDO']->query("SELECT * FROM `:prefix_submissions` WHERE archiv = '0' ORDER BY subid DESC LIMIT " . intval(($page - 1) * $ItemsPerPage) . "," . intval($ItemsPerPage))->resultset();
+        $submissions       = $GLOBALS['PDO']->query("SELECT * FROM `:prefix_submissions` WHERE archiv = '0' ORDER BY subid DESC LIMIT " . (int) (($page - 1) * $ItemsPerPage) . "," . (int) $ItemsPerPage)->resultset();
         $submissions_count = $GLOBALS['PDO']->query("SELECT count(subid) AS count FROM `:prefix_submissions` WHERE archiv = '0' ORDER BY subid DESC")->single();
         $page_count        = $submissions_count['count'];
-        $PageStart         = intval(($page - 1) * $ItemsPerPage);
-        $PageEnd           = intval($PageStart + $ItemsPerPage);
+        $PageStart         = (int) (($page - 1) * $ItemsPerPage);
+        $PageEnd           = (int) ($PageStart + $ItemsPerPage);
         if ($PageEnd > $page_count) {
             $PageEnd = $page_count;
         }
@@ -744,13 +744,13 @@ if ($section === 'submissions') {
         $ItemsPerPage = SB_BANS_PER_PAGE;
         $page         = 1;
         if (isset($_GET['sapage']) && $_GET['sapage'] > 0) {
-            $page = intval($_GET['sapage']);
+            $page = (int) $_GET['sapage'];
         }
-        $submissionsarchiv       = $GLOBALS['PDO']->query("SELECT s.*, (SELECT user FROM `:prefix_admins` WHERE aid = s.archivedby) AS archivedby FROM `:prefix_submissions` s WHERE archiv > '0' ORDER BY subid DESC LIMIT " . intval(($page - 1) * $ItemsPerPage) . "," . intval($ItemsPerPage))->resultset();
+        $submissionsarchiv       = $GLOBALS['PDO']->query("SELECT s.*, (SELECT user FROM `:prefix_admins` WHERE aid = s.archivedby) AS archivedby FROM `:prefix_submissions` s WHERE archiv > '0' ORDER BY subid DESC LIMIT " . (int) (($page - 1) * $ItemsPerPage) . "," . (int) $ItemsPerPage)->resultset();
         $submissionsarchiv_count = $GLOBALS['PDO']->query("SELECT count(subid) AS count FROM `:prefix_submissions` WHERE archiv > '0' ORDER BY subid DESC")->single();
         $page_count              = $submissionsarchiv_count['count'];
-        $PageStart               = intval(($page - 1) * $ItemsPerPage);
-        $PageEnd                 = intval($PageStart + $ItemsPerPage);
+        $PageStart               = (int) (($page - 1) * $ItemsPerPage);
+        $PageEnd                 = (int) ($PageStart + $ItemsPerPage);
         if ($PageEnd > $page_count) {
             $PageEnd = $page_count;
         }

--- a/web/pages/admin.edit.admindetails.php
+++ b/web/pages/admin.edit.admindetails.php
@@ -80,7 +80,7 @@ if (isset($_POST['adminname'])) {
         $errorScript .= "$('adminname.msg').innerHTML = 'You must type a name for the admin.';";
         $errorScript .= "$('adminname.msg').setStyle('display', 'block');";
     } else {
-        if (strstr($a_name, "'")) {
+        if (str_contains($a_name, "'")) {
             $error++;
             $errorScript .= "$('adminname.msg').innerHTML = 'An admin name can not contain a \" \' \".';";
             $errorScript .= "$('adminname.msg').setStyle('display', 'block');";

--- a/web/pages/admin.edit.adminperms.php
+++ b/web/pages/admin.edit.adminperms.php
@@ -64,7 +64,7 @@ if (!$userbank->HasAccess(ADMIN_OWNER | ADMIN_EDIT_ADMINS)) {
 
 $web_root  = $userbank->HasAccess(ADMIN_OWNER, $_GET['id']);
 $steam     = trim((string) $userbank->GetProperty("authid", $_GET['id']));
-$web_flags = intval($userbank->GetProperty("extraflags", $_GET['id']));
+$web_flags = (int) $userbank->GetProperty("extraflags", $_GET['id']);
 $name      = $userbank->GetProperty("user", $_GET['id'])?>
 <div id="admin-page-content">
 <div id="add-group">

--- a/web/pages/admin.edit.group.php
+++ b/web/pages/admin.edit.group.php
@@ -54,7 +54,7 @@ $GLOBALS['PDO']->query("SELECT flags, name, immunity FROM `:prefix_srvgroups` WH
 $GLOBALS['PDO']->bind(':id', $_GET['id']);
 $srv_group = $GLOBALS['PDO']->single();
 
-$web_flags = intval($web_group['flags'] ?? null);
+$web_flags = (int) ($web_group['flags'] ?? null);
 $srv_flags = $srv_group['flags'] ?? '';
 
 $name = $userbank->GetProperty("user", $_GET['id'])?>
@@ -220,28 +220,28 @@ $('p31').checked = <?=(($web_flags & ADMIN_DELETE_MODS) != 0) ? "true" : "false"
 } elseif ($_GET['type'] == "srv") {
 ?>
 $('groupname').value = "<?=$srv_group['name']?>";
-$('s14').checked = <?=strstr($srv_flags, SM_ROOT) ? "true" : "false"?>;
-$('s1').checked = <?=strstr($srv_flags, SM_RESERVED_SLOT) ? "true" : "false"?>;
-$('s23').checked = <?=strstr($srv_flags, SM_GENERIC) ? "true" : "false"?>;
-$('s2').checked = <?=strstr($srv_flags, SM_KICK) ? "true" : "false"?>;
-$('s3').checked = <?=strstr($srv_flags, SM_BAN) ? "true" : "false"?>;
-$('s4').checked = <?=strstr($srv_flags, SM_UNBAN) ? "true" : "false"?>;
-$('s5').checked = <?=strstr($srv_flags, SM_SLAY) ? "true" : "false"?>;
-$('s6').checked = <?=strstr($srv_flags, SM_MAP) ? "true" : "false"?>;
-$('s7').checked = <?=strstr($srv_flags, SM_CVAR) ? "true" : "false"?>;
-$('s8').checked = <?=strstr($srv_flags, SM_CONFIG) ? "true" : "false"?>;
-$('s9').checked = <?=strstr($srv_flags, SM_CHAT) ? "true" : "false"?>;
-$('s10').checked = <?=strstr($srv_flags, SM_VOTE) ? "true" : "false"?>;
-$('s11').checked = <?=strstr($srv_flags, SM_PASSWORD) ? "true" : "false"?>;
-$('s12').checked = <?=strstr($srv_flags, SM_RCON) ? "true" : "false"?>;
-$('s13').checked = <?=strstr($srv_flags, SM_CHEATS) ? "true" : "false"?>;
+$('s14').checked = <?=str_contains($srv_flags, SM_ROOT) ? "true" : "false"?>;
+$('s1').checked = <?=str_contains($srv_flags, SM_RESERVED_SLOT) ? "true" : "false"?>;
+$('s23').checked = <?=str_contains($srv_flags, SM_GENERIC) ? "true" : "false"?>;
+$('s2').checked = <?=str_contains($srv_flags, SM_KICK) ? "true" : "false"?>;
+$('s3').checked = <?=str_contains($srv_flags, SM_BAN) ? "true" : "false"?>;
+$('s4').checked = <?=str_contains($srv_flags, SM_UNBAN) ? "true" : "false"?>;
+$('s5').checked = <?=str_contains($srv_flags, SM_SLAY) ? "true" : "false"?>;
+$('s6').checked = <?=str_contains($srv_flags, SM_MAP) ? "true" : "false"?>;
+$('s7').checked = <?=str_contains($srv_flags, SM_CVAR) ? "true" : "false"?>;
+$('s8').checked = <?=str_contains($srv_flags, SM_CONFIG) ? "true" : "false"?>;
+$('s9').checked = <?=str_contains($srv_flags, SM_CHAT) ? "true" : "false"?>;
+$('s10').checked = <?=str_contains($srv_flags, SM_VOTE) ? "true" : "false"?>;
+$('s11').checked = <?=str_contains($srv_flags, SM_PASSWORD) ? "true" : "false"?>;
+$('s12').checked = <?=str_contains($srv_flags, SM_RCON) ? "true" : "false"?>;
+$('s13').checked = <?=str_contains($srv_flags, SM_CHEATS) ? "true" : "false"?>;
 
-$('s17').checked = <?=strstr($srv_flags, SM_CUSTOM1) ? "true" : "false"?>;
-$('s18').checked = <?=strstr($srv_flags, SM_CUSTOM2) ? "true" : "false"?>;
-$('s19').checked = <?=strstr($srv_flags, SM_CUSTOM3) ? "true" : "false"?>;
-$('s20').checked = <?=strstr($srv_flags, SM_CUSTOM4) ? "true" : "false"?>;
-$('s21').checked = <?=strstr($srv_flags, SM_CUSTOM5) ? "true" : "false"?>;
-$('s22').checked = <?=strstr($srv_flags, SM_CUSTOM6) ? "true" : "false"?>;
+$('s17').checked = <?=str_contains($srv_flags, SM_CUSTOM1) ? "true" : "false"?>;
+$('s18').checked = <?=str_contains($srv_flags, SM_CUSTOM2) ? "true" : "false"?>;
+$('s19').checked = <?=str_contains($srv_flags, SM_CUSTOM3) ? "true" : "false"?>;
+$('s20').checked = <?=str_contains($srv_flags, SM_CUSTOM4) ? "true" : "false"?>;
+$('s21').checked = <?=str_contains($srv_flags, SM_CUSTOM5) ? "true" : "false"?>;
+$('s22').checked = <?=str_contains($srv_flags, SM_CUSTOM6) ? "true" : "false"?>;
 
 $('immunity').value = <?=$srv_group['immunity'] ? (int) $srv_group['immunity'] : "0"?>;
 <?php

--- a/web/pages/admin.srvadmins.php
+++ b/web/pages/admin.srvadmins.php
@@ -38,7 +38,7 @@ $GLOBALS['PDO']->bind(':sid', (int) $_GET['id']);
 $srv_admins = $GLOBALS['PDO']->resultset();
 $i = 0;
 foreach ($srv_admins as $admin) {
-    if (!is_null($admin['authid'])) {
+    if ($admin['authid'] !== null) {
         $admsteam[] = $admin['authid'];
     }
 }

--- a/web/pages/page.banlist.php
+++ b/web/pages/page.banlist.php
@@ -48,7 +48,7 @@ $pagelink = "";
 PruneBans();
 
 if (isset($_GET['page']) && $_GET['page'] > 0) {
-    $page     = intval($_GET['page']);
+    $page     = (int) $_GET['page'];
     $pagelink = "&page=" . $page;
 }
 if (isset($_GET['a']) && $_GET['a'] == "unban" && isset($_GET['id'])) {
@@ -59,14 +59,12 @@ if (isset($_GET['a']) && $_GET['a'] == "unban" && isset($_GET['id'])) {
     if (isset($_GET['bulk'])) {
         $bids = explode(",", $_GET['id']);
     } else {
-        $bids = array(
-            $_GET['id']
-        );
+        $bids = [$_GET['id']];
     }
     $ucount = 0;
     $fail   = 0;
     foreach ($bids as $bid) {
-        $bid = intval($bid);
+        $bid = (int) $bid;
         $GLOBALS['PDO']->query("SELECT a.aid, a.gid FROM `:prefix_bans` b INNER JOIN `:prefix_admins` a ON a.aid = b.aid WHERE bid = :bid");
         $GLOBALS['PDO']->bind(':bid', $bid);
         $res = $GLOBALS['PDO']->single();
@@ -152,14 +150,12 @@ if (isset($_GET['a']) && $_GET['a'] == "unban" && isset($_GET['id'])) {
     if (isset($_GET['bulk'])) {
         $bids = explode(",", $_GET['id']);
     } else {
-        $bids = array(
-            $_GET['id']
-        );
+        $bids = [$_GET['id']];
     }
     $dcount = 0;
     $fail   = 0;
     foreach ($bids as $bid) {
-        $bid    = intval($bid);
+        $bid    = (int) $bid;
         $GLOBALS['PDO']->query("SELECT filename FROM `:prefix_demos` WHERE `demid` = :bid");
         $GLOBALS['PDO']->bind(':bid', $bid);
         $demres = $GLOBALS['PDO']->single();
@@ -210,8 +206,8 @@ if (isset($_GET['a']) && $_GET['a'] == "unban" && isset($_GET['id'])) {
     }
 }
 
-$BansStart = intval(($page - 1) * $BansPerPage);
-$BansEnd   = intval($BansStart + $BansPerPage);
+$BansStart = (int) (($page - 1) * $BansPerPage);
+$BansEnd   = (int) ($BansStart + $BansPerPage);
 
 // hide inactive bans feature
 if (isset($_GET["hideinactive"]) && $_GET["hideinactive"] == "true") { // hide
@@ -326,7 +322,7 @@ if (isset($_GET['searchText'])) {
         $search_array,
         [$authidParam, $search, $search],
         $publicFilterArgs,
-        [intval($BansStart), intval($BansPerPage)]
+        [(int) $BansStart, (int) $BansPerPage]
     ));
 
 
@@ -358,7 +354,7 @@ if (isset($_GET['searchText'])) {
    ORDER BY created DESC
    LIMIT ?,?")->resultset(array_merge(
         $publicFilterArgs,
-        [intval($BansStart), intval($BansPerPage)]
+        [(int) $BansStart, (int) $BansPerPage]
     ));
 
     $res_count  = $GLOBALS['PDO']->query("SELECT count(bid) AS cnt FROM `:prefix_bans` AS BA" . $branch2WhereSuffix)->resultset($publicFilterArgs);
@@ -384,15 +380,11 @@ if (isset($_GET['advSearch'])) {
     switch ($type) {
         case "name":
             $where   = "WHERE BA.name LIKE ?";
-            $advcrit = array(
-                "%$value%"
-            );
+            $advcrit = ["%$value%"];
             break;
         case "banid":
             $where   = "WHERE BA.bid = ?";
-            $advcrit = array(
-                $value
-            );
+            $advcrit = [$value];
             break;
         case "steamid":
             // #1130: match both STEAM_0:Y:Z and STEAM_1:Y:Z stored variants;
@@ -403,17 +395,15 @@ if (isset($_GET['advSearch'])) {
             $authidPattern = SteamID::toSearchPattern($value);
             if ($authidPattern !== null) {
                 $where   = "WHERE BA.authid REGEXP ?";
-                $advcrit = array($authidPattern);
+                $advcrit = [$authidPattern];
             } else {
                 $where   = "WHERE BA.authid = ?";
-                $advcrit = array($value);
+                $advcrit = [$value];
             }
             break;
         case "steam":
             $where   = "WHERE BA.authid LIKE ?";
-            $advcrit = array(
-                "%$value%"
-            );
+            $advcrit = ["%$value%"];
             break;
         case "ip":
             // disable ip search if hiding player ips
@@ -422,26 +412,19 @@ if (isset($_GET['advSearch'])) {
                 $advcrit = [];
             } else {
                 $where   = "WHERE BA.ip LIKE ?";
-                $advcrit = array(
-                    "%$value%"
-                );
+                $advcrit = ["%$value%"];
             }
             break;
         case "reason":
             $where   = "WHERE BA.reason LIKE ?";
-            $advcrit = array(
-                "%$value%"
-            );
+            $advcrit = ["%$value%"];
             break;
         case "date":
             $date    = explode(",", $value);
             $time    = mktime(0, 0, 0, (int)$date[1], (int)$date[0], (int)$date[2]);
             $time2   = mktime(23, 59, 59, (int)$date[1], (int)$date[0], (int)$date[2]);
             $where   = "WHERE BA.created > ? AND BA.created < ?";
-            $advcrit = array(
-                $time,
-                $time2
-            );
+            $advcrit = [$time, $time2];
             break;
         case "length":
             $len         = explode(",", $value);
@@ -466,15 +449,11 @@ if (isset($_GET['advSearch'])) {
                     break;
             }
             $where .= " ?";
-            $advcrit = array(
-                $length
-            );
+            $advcrit = [$length];
             break;
         case "btype":
             $where   = "WHERE BA.type = ?";
-            $advcrit = array(
-                $value
-            );
+            $advcrit = [$value];
             break;
         case "admin":
             if (Config::getBool('banlist.hideadminname') && !$userbank->is_admin()) {
@@ -482,35 +461,25 @@ if (isset($_GET['advSearch'])) {
                 $advcrit = [];
             } else {
                 $where   = "WHERE BA.aid=?";
-                $advcrit = array(
-                    $value
-                );
+                $advcrit = [$value];
             }
             break;
         case "where_banned":
             $where   = "WHERE BA.sid=?";
-            $advcrit = array(
-                $value
-            );
+            $advcrit = [$value];
             break;
         case "nodemo":
             $where   = "WHERE BA.aid = ? AND NOT EXISTS (SELECT DM.demid FROM " . DB_PREFIX . "_demos AS DM WHERE DM.demid = BA.bid)";
-            $advcrit = array(
-                $value
-            );
+            $advcrit = [$value];
             break;
         case "bid":
             $where   = "WHERE BA.bid = ?";
-            $advcrit = array(
-                $value
-            );
+            $advcrit = [$value];
             break;
         case "comment":
             if ($userbank->is_admin()) {
                 $where   = "WHERE CO.type = 'B' AND CO.commenttxt LIKE ?";
-                $advcrit = array(
-                    "%$value%"
-                );
+                $advcrit = ["%$value%"];
             } else {
                 $where   = "";
                 $advcrit = [];
@@ -553,7 +522,7 @@ if (isset($_GET['advSearch'])) {
    LIMIT ?,?")->resultset(array_merge(
         $advcrit,
         $publicFilterArgs,
-        [intval($BansStart), intval($BansPerPage)]
+        [(int) $BansStart, (int) $BansPerPage]
     ));
 
     $res_count  = $GLOBALS['PDO']->query("SELECT count(BA.bid) AS cnt FROM `:prefix_bans` AS BA
@@ -632,7 +601,7 @@ foreach ($res as $row) {
         $data['admin'] = stripslashes($row['admin_name']);
     }
     $data['reason']     = stripslashes($row['ban_reason']);
-    $data['ban_length'] = $row['ban_length'] == 0 ? 'Permanent' : SecondsToString(intval($row['ban_length']));
+    $data['ban_length'] = $row['ban_length'] == 0 ? 'Permanent' : SecondsToString((int) $row['ban_length']);
 
     // Custom "listtable_1_banned" & "listtable_1_permanent" addition entries
     // Comment the 14 lines below out if they cause issues

--- a/web/pages/page.commslist.php
+++ b/web/pages/page.commslist.php
@@ -55,7 +55,7 @@ $pagelink = "";
 PruneComms();
 
 if (isset($_GET['page']) && $_GET['page'] > 0) {
-    $page     = intval($_GET['page']);
+    $page     = (int) $_GET['page'];
     $pagelink = "&page=" . $page;
 }
 
@@ -64,7 +64,7 @@ if (isset($_GET['a']) && $_GET['a'] == "ungag" && isset($_GET['id'])) {
         die("Possible hacking attempt (URL Key mismatch)");
     }
     //we have a multiple unban asking
-    $bid = intval($_GET['id']);
+    $bid = (int) $_GET['id'];
     $GLOBALS['PDO']->query("SELECT a.aid, a.gid FROM `:prefix_comms` c INNER JOIN `:prefix_admins` a ON a.aid = c.aid WHERE bid = :bid AND c.type = 2");
     $GLOBALS['PDO']->bind(':bid', $bid);
     $res = $GLOBALS['PDO']->single();
@@ -113,7 +113,7 @@ if (isset($_GET['a']) && $_GET['a'] == "ungag" && isset($_GET['id'])) {
         die("Possible hacking attempt (URL Key mismatch)");
     }
     //we have a multiple unban asking
-    $bid = intval($_GET['id']);
+    $bid = (int) $_GET['id'];
     $GLOBALS['PDO']->query("SELECT a.aid, a.gid FROM `:prefix_comms` c INNER JOIN `:prefix_admins` a ON a.aid = c.aid WHERE bid = :bid AND c.type = 1");
     $GLOBALS['PDO']->bind(':bid', $bid);
     $res = $GLOBALS['PDO']->single();
@@ -167,7 +167,7 @@ if (isset($_GET['a']) && $_GET['a'] == "ungag" && isset($_GET['id'])) {
         PageDie();
     }
 
-    $bid = intval($_GET['id']);
+    $bid = (int) $_GET['id'];
 
     $GLOBALS['PDO']->query("SELECT name, authid, ends, length, RemoveType, type, UNIX_TIMESTAMP() AS now
 									FROM `:prefix_comms` WHERE bid = :bid");
@@ -210,8 +210,8 @@ if (isset($_GET['a']) && $_GET['a'] == "ungag" && isset($_GET['id'])) {
 }
 
 // LIMIT для SQL запроса - по номеру страницы и числу банов на страницу
-$BansStart = intval(($page - 1) * $BansPerPage);
-$BansEnd   = intval($BansStart + $BansPerPage);
+$BansStart = (int) (($page - 1) * $BansPerPage);
+$BansEnd   = (int) ($BansStart + $BansPerPage);
 
 // hide inactive bans feature
 if (isset($_GET["hideinactive"]) && $_GET["hideinactive"] == "true") { // hide
@@ -328,8 +328,8 @@ if (isset($_GET['searchText'])) {
         $search,
         $search,
     ], $chipTypeBind, [
-        intval($BansStart),
-        intval($BansPerPage)
+        (int) $BansStart,
+        (int) $BansPerPage
     ]));
 
 
@@ -369,8 +369,8 @@ if (isset($_GET['searchText'])) {
 		" . $branchWhereSuffix . "
 		ORDER BY created DESC
 		LIMIT ?,?")->resultset(array_merge($chipTypeBind, [
-        intval($BansStart),
-        intval($BansPerPage)
+        (int) $BansStart,
+        (int) $BansPerPage
     ]));
 
     $res_count  = $GLOBALS['PDO']->query("SELECT count(bid) AS cnt FROM `:prefix_comms`" . $branchCountSuffix)->resultset($chipTypeBind);
@@ -396,15 +396,11 @@ if (isset($_GET['advSearch'])) {
     switch ($type) {
         case "name":
             $where   = "WHERE CO.name LIKE ?";
-            $advcrit = array(
-                "%$value%"
-            );
+            $advcrit = ["%$value%"];
             break;
         case "banid":
             $where   = "WHERE CO.bid = ?";
-            $advcrit = array(
-                $value
-            );
+            $advcrit = [$value];
             break;
         case "steamid":
             // #1130: match both STEAM_0:Y:Z and STEAM_1:Y:Z stored variants;
@@ -412,33 +408,26 @@ if (isset($_GET['advSearch'])) {
             $authidPattern = SteamID::toSearchPattern($value);
             if ($authidPattern !== null) {
                 $where   = "WHERE CO.authid REGEXP ?";
-                $advcrit = array($authidPattern);
+                $advcrit = [$authidPattern];
             } else {
                 $where   = "WHERE CO.authid = ?";
-                $advcrit = array($value);
+                $advcrit = [$value];
             }
             break;
         case "steam":
             $where   = "WHERE CO.authid LIKE ?";
-            $advcrit = array(
-                "%$value%"
-            );
+            $advcrit = ["%$value%"];
             break;
         case "reason":
             $where   = "WHERE CO.reason LIKE ?";
-            $advcrit = array(
-                "%$value%"
-            );
+            $advcrit = ["%$value%"];
             break;
         case "date":
             $date    = explode(",", $value);
             $time    = mktime(0, 0, 0, (int)$date[1], (int)$date[0], (int)$date[2]);
             $time2   = mktime(23, 59, 59, (int)$date[1], (int)$date[0], (int)$date[2]);
             $where   = "WHERE CO.created > ? AND CO.created < ?";
-            $advcrit = array(
-                $time,
-                $time2
-            );
+            $advcrit = [$time, $time2];
             break;
         case "length":
             $len         = explode(",", $value);
@@ -463,15 +452,11 @@ if (isset($_GET['advSearch'])) {
                     break;
             }
             $where .= " ?";
-            $advcrit = array(
-                $length
-            );
+            $advcrit = [$length];
             break;
         case "btype":
             $where   = "WHERE CO.type = ?";
-            $advcrit = array(
-                $value
-            );
+            $advcrit = [$value];
             break;
         case "admin":
             if (Config::getBool('banlist.hideadminname') && !$userbank->is_admin()) {
@@ -479,29 +464,21 @@ if (isset($_GET['advSearch'])) {
                 $advcrit = [];
             } else {
                 $where   = "WHERE CO.aid=?";
-                $advcrit = array(
-                    $value
-                );
+                $advcrit = [$value];
             }
             break;
         case "where_banned":
             $where   = "WHERE CO.sid=?";
-            $advcrit = array(
-                $value
-            );
+            $advcrit = [$value];
             break;
         case "bid":
             $where   = "WHERE CO.bid = ?";
-            $advcrit = array(
-                $value
-            );
+            $advcrit = [$value];
             break;
         case "comment":
             if ($userbank->is_admin()) {
                 $where   = "WHERE CM.type ='C' AND CM.commenttxt LIKE ?";
-                $advcrit = array(
-                    "%$value%"
-                );
+                $advcrit = ["%$value%"];
             } else {
                 $where   = "";
                 $advcrit = [];
@@ -543,8 +520,8 @@ if (isset($_GET['advSearch'])) {
       " . $where . $hideinactive . $advChipType . "
    ORDER BY CO.created DESC
    LIMIT ?,?")->resultset(array_merge($advcrit, $chipTypeBind, [
-        intval($BansStart),
-        intval($BansPerPage)
+        (int) $BansStart,
+        (int) $BansPerPage
     ]));
 
     $res_count  = $GLOBALS['PDO']->query("SELECT count(CO.bid) AS cnt FROM `:prefix_comms` AS CO
@@ -622,7 +599,7 @@ foreach ($res as $row) {
     $data['reason'] = stripslashes($row['ban_reason']);
 
     if ($row['ban_length'] > 0) {
-        $data['ban_length'] = SecondsToString(intval($row['ban_length']));
+        $data['ban_length'] = SecondsToString((int) $row['ban_length']);
         $data['expires']    = Config::time($row['ban_ends']);
     } else if ($row['ban_length'] == 0) {
         $data['ban_length'] = 'Permanent';
@@ -982,10 +959,10 @@ if (isset($_GET["comment"])) {
 											(SELECT user FROM `:prefix_admins` WHERE aid = C.aid) AS comname,
 											(SELECT user FROM `:prefix_admins` WHERE aid = C.editaid) AS editname
 											FROM `:prefix_comments` AS C
-											WHERE type = ? AND bid = ?" . $cotherdataedit . " ORDER BY added desc")->resultset(array(
+											WHERE type = ? AND bid = ?" . $cotherdataedit . " ORDER BY added desc")->resultset([
         $_GET["ctype"],
-        $_GET["comment"]
-    ));
+        $_GET["comment"],
+    ]);
 
     foreach ($cotherdata as $cdrow) {
         $coment               = [];

--- a/web/pages/page.home.php
+++ b/web/pages/page.home.php
@@ -135,7 +135,7 @@ foreach ($rows as $row) {
     $cleaned_name = trim($cleaned_name);
     $info['name']    = htmlspecialchars(addslashes($cleaned_name), ENT_QUOTES, 'UTF-8');
     $info['created'] = Config::time($row['created']);
-    $ltemp           = explode(",", $row['length'] == 0 ? 'Permanent' : SecondsToString(intval($row['length'])));
+    $ltemp           = explode(",", $row['length'] == 0 ? 'Permanent' : SecondsToString((int) $row['length']));
     $info['length']  = $ltemp[0];
     $info['icon']    = empty($row['icon']) ? 'web.png' : $row['icon'];
     $info['authid']  = $row['authid'];
@@ -217,7 +217,7 @@ foreach ($rows as $row) {
     $cleaned_name = trim($cleaned_name);
     $info['name']        = htmlspecialchars(addslashes($cleaned_name), ENT_QUOTES, 'UTF-8');
     $info['created']     = Config::time($row['created']);
-    $ltemp               = explode(",", $row['length'] == 0 ? 'Permanent' : SecondsToString(intval($row['length'])));
+    $ltemp               = explode(",", $row['length'] == 0 ? 'Permanent' : SecondsToString((int) $row['length']));
     $info['length']      = $ltemp[0];
     $info['icon']        = empty($row['icon']) ? 'web.png' : $row['icon'];
     $info['authid']      = $row['authid'];

--- a/web/pages/page.login.php
+++ b/web/pages/page.login.php
@@ -94,7 +94,7 @@ HTML;
 
         case 'locked':
             if (isset($_GET['time'])) {
-                $remainingTime = intval($_GET['time']);
+                $remainingTime = (int) $_GET['time'];
                 echo <<<HTML
                     <script>
                         if (typeof ShowBox === 'function') ShowBox(

--- a/web/pages/page.lostpassword.php
+++ b/web/pages/page.lostpassword.php
@@ -60,7 +60,7 @@ if (isset($_GET['email'], $_GET['validation']) && (!empty($_GET['email']) || !em
     $GLOBALS['PDO']->bind(':validate', $validation);
     $result = $GLOBALS['PDO']->single();
 
-    if (empty($result['aid']) || is_null($result['aid'])) {
+    if (empty($result['aid'])) {
         print "<script>ShowBox('Error', 'The validation string does not match the email for this reset request.', 'red');</script>";
         PageDie();
     }

--- a/web/pages/page.protest.php
+++ b/web/pages/page.protest.php
@@ -139,13 +139,13 @@ if (!isset($_POST['subprotest']) || $_POST['subprotest'] != 1) {
         $requestUri = (string) ($_SERVER['REQUEST_URI'] ?? '');
         $requri    = substr($requestUri, 0, (int) strrpos($requestUri, ".php") + 4);
         if (Config::getBool('protest.emailonlyinvolved') && !empty($emailinfo['email'])) {
-            $admins = array(
-                array(
-                    'aid' => $emailinfo['aid'],
-                    'user' => $emailinfo['user'],
-                    'email' => $emailinfo['email']
-                )
-            );
+            $admins = [
+                [
+                    'aid'   => $emailinfo['aid'],
+                    'user'  => $emailinfo['user'],
+                    'email' => $emailinfo['email'],
+                ],
+            ];
         } else {
             $admins = $userbank->GetAllAdmins();
         }

--- a/web/phpstan-baseline.neon
+++ b/web/phpstan-baseline.neon
@@ -37,12 +37,6 @@ parameters:
 			path: includes/CUserManager.php
 
 		-
-			message: '#^Call to function is_null\(\) with null will always evaluate to true\.$#'
-			identifier: function.alreadyNarrowedType
-			count: 1
-			path: includes/CUserManager.php
-
-		-
 			message: '#^Call to function is_numeric\(\) with int\<min, \-1\>\|int\<1, max\> will always evaluate to true\.$#'
 			identifier: function.alreadyNarrowedType
 			count: 1
@@ -237,12 +231,6 @@ parameters:
 		-
 			message: '#^Call to method validate\(\) on an unknown class LightOpenID\.$#'
 			identifier: class.notFound
-			count: 1
-			path: includes/auth/handler/SteamAuthHandler.php
-
-		-
-			message: '#^Negated boolean expression is always true\.$#'
-			identifier: booleanNot.alwaysTrue
 			count: 1
 			path: includes/auth/handler/SteamAuthHandler.php
 
@@ -497,12 +485,6 @@ parameters:
 			identifier: variable.undefined
 			count: 1
 			path: pages/page.commslist.php
-
-		-
-			message: '#^Right side of \|\| is always false\.$#'
-			identifier: booleanOr.rightAlwaysFalse
-			count: 1
-			path: pages/page.lostpassword.php
 
 		-
 			message: '#^Variable \$errors in empty\(\) always exists and is not falsy\.$#'

--- a/web/tests/integration/RoutingTest.php
+++ b/web/tests/integration/RoutingTest.php
@@ -178,4 +178,52 @@ final class RoutingTest extends ApiTestCase
         $this->assertSame('/page.admin.php', $file);
         $this->assertSame(200, http_response_code());
     }
+
+    /**
+     * #1290 regression guard: the fallback dispatch (`route($fallback)`
+     * when `?p=…` doesn't match any top-level slug) is fed by
+     * `Config::get('config.defaultpage')`, which reads `sb_settings.value`
+     * — a `text NOT NULL` column. The persisted value is therefore a
+     * STRING ("1", "2", …), not an int.
+     *
+     * The pre-#1290 code dispatched on a loose-`==` `switch`, so `'1'`
+     * matched `case 1`. The mechanical sweep replaced it with `match`,
+     * which is strict (`===`), and `'1' === 1` is false — every
+     * non-zero string default silently fell through to the Dashboard
+     * arm.
+     *
+     * The fix casts `$fallback` to int at the dispatch boundary; this
+     * test pins both the per-arm string-input behaviour AND the
+     * string-vs-int parity that `match` broke.
+     *
+     * The fallback path mutates `$_GET['p']` (so downstream code sees
+     * the canonical slug), so each case has to re-arm the unknown-slug
+     * sentinel before calling `route()` again — otherwise the second
+     * call resolves the now-canonical slug via the top-level `match`
+     * and never hits the fallback dispatch under test.
+     *
+     * @return iterable<string, array{0: int|string, 1: string, 2: string}>
+     */
+    public static function fallbackCases(): iterable
+    {
+        yield 'string "1" → Ban List'           => ['1',      'Ban List',      '/page.banlist.php'];
+        yield 'int 1 → Ban List (parity)'       => [1,        'Ban List',      '/page.banlist.php'];
+        yield 'string "2" → Server Info'        => ['2',      'Server Info',   '/page.servers.php'];
+        yield 'string "3" → Submit a Ban'       => ['3',      'Submit a Ban',  '/page.submit.php'];
+        yield 'string "4" → Protest a Ban'      => ['4',      'Protest a Ban', '/page.protest.php'];
+        yield 'string "0" → Dashboard'          => ['0',      'Dashboard',     '/page.home.php'];
+        yield 'int 0 → Dashboard'               => [0,        'Dashboard',     '/page.home.php'];
+        yield 'non-numeric "banana" → Dashboard' => ['banana', 'Dashboard',     '/page.home.php'];
+    }
+
+    #[DataProvider('fallbackCases')]
+    public function testRouteFallbackAcceptsStringIntegers(int|string $fallback, string $expectedTitle, string $expectedTemplate): void
+    {
+        $_GET['p'] = 'unknown-slug-that-falls-through';
+
+        [$title, $template] = route($fallback);
+
+        $this->assertSame($expectedTitle, $title);
+        $this->assertSame($expectedTemplate, $template);
+    }
 }


### PR DESCRIPTION
## Summary

Closes part of #1290 (umbrella: Adopt modern PHP features across legacy core).

This is the mechanical-sweep PR — pure syntax modernization with PHPStan + PHPUnit as the safety net. Bundles phases F + G + H + I + E + C from the umbrella issue:

- **F**: `intval` / `strval` / `floatval` → cast operators
- **G**: `is_null($x)` → `$x === null` / `??=`
- **H**: `array(…)` → `[…]`
- **I**: `if (…) { return true; } return false;` → `return …;` (paired with `: bool` native return type per the issue's phase A pairing rule)
- **E**: `strstr` → `str_contains` (boolean-context only; the substring-finder third-arg form preserved)
- **C**: `switch` → `match` for `page-builder.php`'s `route()` (route table refactor with sentinel-string side-effect dispatch) and `init.php`'s `sbError()`

Plus AGENTS.md anti-pattern rows for the legacy idioms removed.

## What's not in this PR

`Log.php`'s switch-based search WHERE builder is deferred to the enum PR (#1290 phase D.1 — paired with the `LogType` enum) — touching it here would conflict with that work.

## Closing invariants verified

```
$ rg '\bintval\(|\bstrval\(|\bfloatval\(' web/includes web/pages web/api
# only auth/openid.php (third-party)

$ rg '\bis_null\(' web/includes web/pages web/api
# only auth/openid.php (third-party)

$ rg '\bstrstr\b' web/includes web/pages web/api
# empty
```

## Notable non-mechanical decisions

1. **`route()` fallback dispatch casts to int** — `Config::get('config.defaultpage')` reads from `sb_settings.value` (a `text NOT NULL` column) so it returns a string. The replacement `match` is strict `===`, so `'1' === 1` is false and the original loose-`==` `switch` semantics needed `match ((int) \$fallback)` to preserve. Regression coverage added in `RoutingTest::testRouteFallbackAcceptsStringIntegers`.
2. **`HasAccess` numeric branch simplification + `: bool`** — body collapsed from `((int) \$extraflags & (int) \$flags) != 0 ? true : false` to `((int) \$extraflags & (int) \$flags) !== 0` with paired `: bool` return type per phase I + phase A pairing. The string-flag branch is a nested for-loop with early return — not the pure `if(…){return true;}return false;` shape — so left structurally intact (only `strstr` → `str_contains` inside).
3. **Two redundant null half-checks cleaned up** in `page.lostpassword.php` and `SteamAuthHandler.php`: the original `empty(\$x) || is_null(\$x)` is functionally equivalent to `empty(\$x)` (PHP semantics: `empty(null)` is true). Three baseline entries that no longer apply were dropped.

## Test plan

- [x] `./sbpp.sh phpstan` clean
- [x] `./sbpp.sh test` 388 tests pass (8 new RoutingTest cases for the string-fallback regression guard)
- [x] `./sbpp.sh ts-check` clean
- [x] `./sbpp.sh composer api-contract` byte-identical (no wire-format change)
- [x] PHPStan baseline net **−18 lines** (3 paired drops; 0 added)