### PR TITLE
chore(php): native types + final class on legacy core (#1290)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -302,11 +302,13 @@ nullable optional parameters with a `null` default. Methods that
 return nothing get `: void`; methods that unconditionally exit
 (`header() + exit()`, `throw`, `die`) get `: never`.
 
-This was finished by issue #1290 phase A across the legacy classes
+Issue #1290 phase A finished this across the legacy core
 (`CUserManager`, `Database`, `Log`, `Auth`, `JWT`, `CSRF`, `Crypto`,
 `Api`, `ApiError`, `AdminTabs`, `Theme`, `Mailer`, the auth
-handlers, `Config`, `Host`, `system-functions.php`). New code
-follows the same convention by default.
+handlers, `Config`, `Host`, `system-functions.php`,
+`SmartyCustomFunctions.php`, `page-builder.php`). New code follows
+the same convention by default; the only legitimate `@param` /
+`@return` survivors carry refinements PHP can't express.
 
 ### Null-into-scalar discipline (PHP 8.5+)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -288,6 +288,26 @@ Playwright E2E specifics:
 - Pattern: `query` → `bind` → `execute` / `single` / `resultset`.
 - ADOdb was fully removed (commit `b9c812b2`). **Do not reintroduce it.**
 
+### Native types over docblocks
+
+Every method signature in `web/includes/` that PHP can express
+natively uses native parameter and return types — `int $x`, `?array`,
+`mixed`, `int|false`, `: void`, `: never`. Docblocks (`@param` /
+`@return`) survive ONLY when carrying refinement PHP can't express
+(generic shape like `list<array{slug: string, name: string}>`,
+template variable hints for the SmartyTemplateRule).
+
+Use `?T` for nullable types, `T|U` for unions, `?T = null` for
+nullable optional parameters with a `null` default. Methods that
+return nothing get `: void`; methods that unconditionally exit
+(`header() + exit()`, `throw`, `die`) get `: never`.
+
+This was finished by issue #1290 phase A across the legacy classes
+(`CUserManager`, `Database`, `Log`, `Auth`, `JWT`, `CSRF`, `Crypto`,
+`Api`, `ApiError`, `AdminTabs`, `Theme`, `Mailer`, the auth
+handlers, `Config`, `Host`, `system-functions.php`). New code
+follows the same convention by default.
+
 ### Null-into-scalar discipline (PHP 8.5+)
 
 `web/composer.json` requires `php >= 8.5`, so PHP's
@@ -730,6 +750,17 @@ audit (#1207) locked in. New CTAs:
 
 ## Anti-patterns (do NOT reintroduce)
 
+- `@param int $x` / `@return string` docblocks where PHP can express
+  the type natively → use the native parameter / return type
+  declaration instead. The docblock stays only when the type carries
+  refinement PHP can't express (e.g. `list<array{slug: string, …}>`).
+  Removed wholesale across legacy classes by issue #1290 phase A.
+- Non-`final` classes in `web/includes/` that nothing extends → mark
+  `final class`. Same applies in `web/includes/auth/handler/` and
+  `web/includes/Mail/`. The only intentional non-final / abstract
+  class in `web/includes/` is `View` (subclassed by every concrete
+  view DTO). Marking final unblocks the JIT's monomorphic-call
+  optimization. Issue #1290 phase J.
 - `xajax` / `sb-callback.php` → use the JSON API.
 - ADOdb → use `Database` (PDO).
 - MooTools / React / a runtime bundler → vanilla JS in `web/scripts/`.

--- a/web/includes/AdminTabs.php
+++ b/web/includes/AdminTabs.php
@@ -84,15 +84,13 @@
  *     config?: bool,
  * }
  */
-class AdminTabs
+final class AdminTabs
 {
     /** @var list<TabSpec> */
     private array $tabs = [];
 
     /**
      * @param list<TabSpec> $tabs
-     * @param CUserManager  $userbank
-     * @param Smarty        $theme
      * @param string|null   $activeSlug    Slug of the section to mark with
      *     `aria-current="page"`. When null, the first accessible tab's
      *     slug wins. When the value doesn't match any visible tab no
@@ -107,8 +105,8 @@ class AdminTabs
      */
     public function __construct(
         array $tabs,
-        $userbank,
-        $theme,
+        CUserManager $userbank,
+        \Smarty\Smarty $theme,
         ?string $activeSlug = null,
         ?string $sidebarLabel = null,
     ) {

--- a/web/includes/Api.php
+++ b/web/includes/Api.php
@@ -28,7 +28,7 @@ require_once __DIR__ . '/ApiError.php';
  * Throw ApiError to surface a structured client-side message.
  * Return ['__redirect' => '...'] (or call Api::redirect()) to navigate.
  */
-class Api
+final class Api
 {
     /** @var array<string, array{fn: callable, perm: int|string, requireAdmin: bool, public: bool}> */
     private static array $registry = [];
@@ -104,8 +104,7 @@ class Api
     /**
      * Invoke a registered handler in-process (used by the test harness so
      * it can bypass the HTTP boundary). Throws ApiError on any failure.
-     *
-     * @return array Raw handler return value (envelope is built by dispatch()).
+     * Returns the raw handler return value; the envelope is built by dispatch().
      */
     public static function invoke(string $action, array $params): array
     {

--- a/web/includes/ApiError.php
+++ b/web/includes/ApiError.php
@@ -20,7 +20,7 @@ work.  If not, see <http://creativecommons.org/licenses/by-nc-sa/3.0/>.
  * Optional $field carries a form-field id so the client can scope the
  * error to a specific input (matching legacy xajax addAssign("field.msg")).
  */
-class ApiError extends \RuntimeException
+final class ApiError extends \RuntimeException
 {
     public function __construct(
         public readonly string $errorCode,

--- a/web/includes/CUserManager.php
+++ b/web/includes/CUserManager.php
@@ -19,7 +19,7 @@ Copyright © 2007-2014 SourceBans Team - Part of GameConnect
 Licensed under CC-BY-NC-SA 3.0
 Page: <http://www.sourcebans.net/> - <http://www.gameconnect.net/>
 *************************************************************************/
-class CUserManager
+final class CUserManager
 {
     private readonly int $aid;
 
@@ -38,12 +38,9 @@ class CUserManager
 
     /**
      * Gets all user details from the database, saves them into
-     * the admin array 'cache', and then returns the array
-     *
-     * @param int $aid the ID of admin to get info for.
-     * @return array|false
+     * the admin array 'cache', and then returns the array.
      */
-    public function GetUserArray($aid = null)
+    public function GetUserArray(?int $aid = null): array|false
     {
         $aid ??= $this->aid;
         // Invalid aid
@@ -98,13 +95,11 @@ class CUserManager
 
 
     /**
-     * Will check to see if an admin has any of the flags given
+     * Will check to see if an admin has any of the flags given.
      *
-     * @param int $flags The flags to check for.
-     * @param int $aid The user to check flags for.
      * @return bool
      */
-    public function HasAccess($flags, $aid = null): bool
+    public function HasAccess(int|string $flags, ?int $aid = null): bool
     {
         $aid ??= $this->aid;
 
@@ -134,13 +129,9 @@ class CUserManager
 
 
     /**
-     * Gets a 'property' from the user array eg. 'authid'
-     *
-     * @param string $name
-     * @param int $aid the ID of admin to get info for.
-     * @return mixed.
+     * Gets a 'property' from the user array eg. 'authid'.
      */
-    public function GetProperty($name, $aid = null)
+    public function GetProperty(string $name, ?int $aid = null): mixed
     {
         $aid ??= $this->aid;
         if (empty($name) || $aid < 0) {
@@ -174,19 +165,13 @@ class CUserManager
     }
 
 
-    /**
-     * @return int|mixed
-     */
-    public function GetAid()
+    public function GetAid(): int
     {
         return $this->aid;
     }
 
 
-    /**
-     * @return array
-     */
-    public function GetAllAdmins()
+    public function GetAllAdmins(): array
     {
         $this->dbh->query('SELECT aid FROM `:prefix_admins`');
         $res = $this->dbh->resultset();
@@ -197,11 +182,7 @@ class CUserManager
     }
 
 
-    /**
-     * @param int|null $aid
-     * @return bool|mixed
-     */
-    public function GetAdmin($aid = null)
+    public function GetAdmin(?int $aid = null): array|false
     {
         $aid ??= $this->aid;
         if ($aid < 0) {
@@ -214,11 +195,7 @@ class CUserManager
         return $this->admins[$aid];
     }
 
-    /**
-     * @param string $name
-     * @return bool
-     */
-    public function isNameTaken($name)
+    public function isNameTaken(string $name): bool
     {
         $this->dbh->query("SELECT 1 FROM `:prefix_admins` WHERE user = :user");
         $this->dbh->bind(':user', $name);
@@ -227,11 +204,7 @@ class CUserManager
         return $data === 1;
     }
 
-    /**
-     * @param string $steamid
-     * @return bool
-     */
-    public function isSteamIDTaken($steamid)
+    public function isSteamIDTaken(string $steamid): bool
     {
         $this->dbh->query("SELECT 1 FROM `:prefix_admins` WHERE authid = :steamid");
         $this->dbh->bind(':steamid', $steamid);
@@ -240,11 +213,7 @@ class CUserManager
         return $data === 1;
     }
 
-    /**
-     * @param string $email
-     * @return bool
-     */
-    public function isEmailTaken($email)
+    public function isEmailTaken(string $email): bool
     {
         $this->dbh->query("SELECT 1 FROM `:prefix_admins` WHERE email = :email");
         $this->dbh->bind(':email', $email);
@@ -253,12 +222,7 @@ class CUserManager
         return $data === 1;
     }
 
-    /**
-     * @param int $aid
-     * @param string $pass
-     * @return bool
-     */
-    public function isCurrentPasswordValid($aid, $pass)
+    public function isCurrentPasswordValid(int $aid, string $pass): bool
     {
         $this->dbh->query("SELECT password FROM `:prefix_admins` WHERE aid = :aid");
         $this->dbh->bind(':aid', $aid);
@@ -266,20 +230,7 @@ class CUserManager
         return password_verify($pass, $hash['password']);
     }
 
-    /**
-     * @param string $name
-     * @param string $steam
-     * @param string $password
-     * @param string $email
-     * @param int $web_group
-     * @param int $web_flags
-     * @param string $srv_group
-     * @param string $srv_flags
-     * @param int $immunity
-     * @param string $srv_password
-     * @return int
-     */
-    public function AddAdmin($name, $steam, $password, $email, $web_group, $web_flags, $srv_group, $srv_flags, $immunity, $srv_password)
+    public function AddAdmin(string $name, string $steam, string $password, string $email, int $web_group, int $web_flags, string $srv_group, string $srv_flags, int $immunity, string $srv_password): int
     {
         if (!empty($password) && strlen((string) $password) < MIN_PASS_LENGTH) {
             throw new RuntimeException('Password must be at least ' . MIN_PASS_LENGTH . ' characters long.');

--- a/web/includes/Config.php
+++ b/web/includes/Config.php
@@ -3,7 +3,7 @@
 /**
  * Class Config
  */
-class Config
+final class Config
 {
     private static array $config = [];
 
@@ -15,20 +15,12 @@ class Config
         self::$config = self::getAll();
     }
 
-    /**
-     * @param string $setting
-     * @return mixed|null
-     */
     public static function get(string $setting): mixed
     {
         return self::$config[$setting] ?? null;
     }
 
 
-    /**
-     * @param array $keys Settings to retrieve
-     * @return array
-     */
     public static function getMulti(array $keys): array
     {
         $values = [];
@@ -41,19 +33,11 @@ class Config
         return $values;
     }
 
-    /**
-     * @param string $setting
-     * @return bool
-     */
     public static function getBool(string $setting): bool
     {
         return (bool)self::get($setting);
     }
 
-    /**
-     * @param int $timestamp
-     * @return string
-     */
     public static function time(int $timestamp): string
     {
         $format = self::get('config.dateformat');
@@ -61,9 +45,6 @@ class Config
         return date($format, $timestamp);
     }
 
-    /**
-     * @return array
-     */
     private static function getAll(): array
     {
         $config = [];

--- a/web/includes/Database.php
+++ b/web/includes/Database.php
@@ -3,7 +3,7 @@
 /**
  * Class Database
  */
-class Database
+final class Database
 {
     private readonly string $prefix;
 
@@ -11,17 +11,7 @@ class Database
 
     private ?PDOStatement $stmt = null;
 
-    /**
-     * Database constructor.
-     * @param string $host
-     * @param int $port
-     * @param string $dbname
-     * @param string $user
-     * @param string $password
-     * @param string $prefix
-     * @param string $charset
-     */
-    public function __construct($host, $port, $dbname, $user, $password, $prefix, $charset = 'utf8')
+    public function __construct(string $host, int $port, string $dbname, string $user, string $password, string $prefix, string $charset = 'utf8')
     {
         $this->prefix = $prefix;
         $dsn = 'mysql:host=' . $host . ';port=' . $port . ';dbname=' . $dbname . ';charset=' . $charset;
@@ -54,19 +44,12 @@ class Database
         unset($this->dbh);
     }
 
-    /**
-     * @return string
-     */
-    public function getPrefix()
+    public function getPrefix(): string
     {
         return $this->prefix;
     }
 
-    /**
-     * @param string $query
-     * @return string
-     */
-    private function setPrefix($query)
+    private function setPrefix(string $query): string
     {
         $query = str_replace(':prefix', $this->prefix, $query);
         return $query;
@@ -74,11 +57,8 @@ class Database
 
     /**
      * Contrary to the name, this prepares the query and doesn't actually run the query.
-     *
-     * @param string $query
-     * @return $this
      */
-    public function query($query)
+    public function query(string $query): self
     {
         $query = $this->setPrefix($query);
         $this->stmt = $this->dbh->prepare($query);
@@ -86,11 +66,9 @@ class Database
     }
 
     /**
-     * @param int|string $param
-     * @param int|bool|null|string $value
-     * @param int|null $type PDO param type.  Send null or leave blank for auto-detection
+     * @param int|null $type PDO param type. Send null or leave blank for auto-detection.
      */
-    public function bind($param, $value, $type = null)
+    public function bind(int|string $param, int|bool|null|string $value, ?int $type = null): void
     {
         if ($type === null) {
             $type = match (true) {
@@ -104,42 +82,25 @@ class Database
         $this->stmt->bindValue($param, $value, $type);
     }
 
-    /**
-     * @param array $params
-     */
-    public function bindMultiple($params = [])
+    public function bindMultiple(array $params = []): void
     {
         foreach ($params as $key => $value) {
             $this->bind($key, $value);
         }
     }
 
-    /**
-     * @param null|array $inputParams
-     * @return mixed
-     */
-    public function execute(?array $inputParams = null)
+    public function execute(?array $inputParams = null): bool
     {
         return $this->stmt->execute($inputParams);
     }
 
-    /**
-     * @param null|array $inputParams
-     * @param int $fetchType
-     * @return mixed
-     */
-    public function resultset(?array $inputParams = null, $fetchType = PDO::FETCH_ASSOC)
+    public function resultset(?array $inputParams = null, int $fetchType = PDO::FETCH_ASSOC): array
     {
         $this->execute($inputParams);
         return $this->stmt->fetchAll($fetchType);
     }
 
-    /**
-     * @param null|array $inputParams
-     * @param int $fetchType
-     * @return mixed
-     */
-    public function single(?array $inputParams = null, $fetchType = PDO::FETCH_ASSOC)
+    public function single(?array $inputParams = null, int $fetchType = PDO::FETCH_ASSOC): mixed
     {
         $this->execute($inputParams);
         return $this->stmt->fetch($fetchType);
@@ -157,50 +118,32 @@ class Database
         }
     }
 
-    /**
-     * @return int
-     */
-    public function rowCount()
+    public function rowCount(): int
     {
         return $this->stmt->rowCount();
     }
 
-    /**
-     * @return string
-     */
-    public function lastInsertId()
+    public function lastInsertId(): string
     {
         return $this->dbh->lastInsertId();
     }
 
-    /**
-     * @return bool
-     */
-    public function beginTransaction()
+    public function beginTransaction(): bool
     {
         return $this->dbh->beginTransaction();
     }
 
-    /**
-     * @return bool
-     */
-    public function endTransaction()
+    public function endTransaction(): bool
     {
         return $this->dbh->commit();
     }
 
-    /**
-     * @return bool
-     */
-    public function cancelTransaction()
+    public function cancelTransaction(): bool
     {
         return $this->dbh->rollBack();
     }
 
-    /**
-     * @return bool
-     */
-    public function debugDumpParams()
+    public function debugDumpParams(): ?bool
     {
         return $this->stmt->debugDumpParams();
     }

--- a/web/includes/Database.php
+++ b/web/includes/Database.php
@@ -110,7 +110,7 @@ final class Database
      * Yields rows one at a time so callers can stream large result sets
      * without materialising the full set in PHP memory like resultset() does.
      */
-    public function iterate(?array $inputParams = null, $fetchType = PDO::FETCH_ASSOC): Generator
+    public function iterate(?array $inputParams = null, int $fetchType = PDO::FETCH_ASSOC): Generator
     {
         $this->execute($inputParams);
         while (($row = $this->stmt->fetch($fetchType)) !== false) {
@@ -123,9 +123,9 @@ final class Database
         return $this->stmt->rowCount();
     }
 
-    public function lastInsertId(): string
+    public function lastInsertId(?string $name = null): string|false
     {
-        return $this->dbh->lastInsertId();
+        return $this->dbh->lastInsertId($name);
     }
 
     public function beginTransaction(): bool

--- a/web/includes/Log.php
+++ b/web/includes/Log.php
@@ -33,7 +33,7 @@ final class Log
         self::$dbs->execute();
     }
 
-    public static function getAll(int $start, int $limit): mixed
+    public static function getAll(int $start, int $limit): array
     {
         $where = null;
         $valueOther = null;

--- a/web/includes/Log.php
+++ b/web/includes/Log.php
@@ -3,28 +3,19 @@
 /**
  * Class Log
  */
-class Log
+final class Log
 {
     private static ?Database $dbs = null;
 
     private static ?CUserManager $user = null;
 
-    /**
-     * @param Database $dbs
-     * @param CUserManager $user
-     */
-    public static function init(Database $dbs, CUserManager $user)
+    public static function init(Database $dbs, CUserManager $user): void
     {
         self::$dbs = $dbs;
         self::$user = $user;
     }
 
-    /**
-     * @param string $type
-     * @param string $title
-     * @param string $message
-     */
-    public static function add($type, $title, $message): void
+    public static function add(string $type, string $title, string $message): void
     {
         $host = filter_var($_SERVER['REMOTE_ADDR'], FILTER_VALIDATE_IP) ? $_SERVER['REMOTE_ADDR'] : '';
 
@@ -42,13 +33,7 @@ class Log
         self::$dbs->execute();
     }
 
-    /**
-     * @param int $start
-     * @param int $limit
-     * @param string $search Entire "WHERE" statement including the word WHERE
-     * @return mixed
-     */
-    public static function getAll($start, $limit): mixed
+    public static function getAll(int $start, int $limit): mixed
     {
         $where = null;
         $valueOther = null;
@@ -95,11 +80,7 @@ class Log
         return self::$dbs->resultset();
     }
 
-    /**
-     * @param string $search Entire "WHERE" statement including the word WHERE
-     * @return mixed
-     */
-    public static function getCount($search): mixed
+    public static function getCount(string $search): mixed
     {
         $value = $_GET['advSearch'] ?? null;
         $valueOther = null;
@@ -138,9 +119,6 @@ class Log
         return $log['count'];
     }
 
-    /**
-     * @return string
-     */
     private static function getCaller(): string
     {
         $functions = '';

--- a/web/includes/Mail/Mail.php
+++ b/web/includes/Mail/Mail.php
@@ -25,7 +25,7 @@ namespace Sbpp\Mail;
 use Log;
 use Throwable;
 
-class Mail
+final class Mail
 {
     public static function send(
         array|string $destinations,

--- a/web/includes/Mail/Mailer.php
+++ b/web/includes/Mail/Mailer.php
@@ -28,7 +28,7 @@ use Symfony\Component\Mailer\Exception\TransportExceptionInterface;
 use Symfony\Component\Mailer\Transport;
 use Symfony\Component\Mime\Email;
 
-class Mailer
+final class Mailer
 {
     /** Default From Name used when both `config.mail.from_name` and SB_EMAIL fallback yield no display name. */
     public const DEFAULT_FROM_NAME = 'SourceBans++';
@@ -47,10 +47,7 @@ class Mailer
 
     /**
      * @param string|string[] $destination
-     * @param string $subject
-     * @param string $body
-     * @param array|null $files
-     * @return bool
+     * @param array<int, string>|null $files
      * @throws TransportExceptionInterface
      */
     public function send(array|string $destination,
@@ -113,9 +110,6 @@ class Mailer
         return $this->from;
     }
 
-    /**
-     * @return ?Mailer
-     */
     public static function create(): ?Mailer
     {
         $config = Config::getMulti([

--- a/web/includes/SmartyCustomFunctions.php
+++ b/web/includes/SmartyCustomFunctions.php
@@ -7,11 +7,8 @@
  * Purpose:  show help tip
  * @link http://www.sourcebans.net
  * @author  SourceBans Development Team
- * @param array
- * @param Smarty
- * @return string
  */
-function smarty_function_help_icon($params, ...$args)
+function smarty_function_help_icon(array $params, \Smarty\Template $template): string
 {
 	 return '<img border="0" align="absbottom" src="images/help.png" class="tip" title="' .  $params['title'] . ' :: ' .  $params['message'] . '">&nbsp;&nbsp;';
 }
@@ -24,11 +21,8 @@ function smarty_function_help_icon($params, ...$args)
  * Purpose:  show help tip
  * @link http://www.sourcebans.net
  * @author  SourceBans Development Team
- * @param array
- * @param Smarty
- * @return string
  */
-function smarty_function_sb_button($params) //$text, $click, $class, $id="", $submit=false
+function smarty_function_sb_button(array $params, \Smarty\Template $template): string //$text, $click, $class, $id="", $submit=false
 {
 	$text = $params['text'] ?? "";
 	$click = $params['onclick'] ?? "";
@@ -49,7 +43,6 @@ function smarty_function_sb_button($params) //$text, $click, $class, $id="", $su
  * Purpose:  Load template files
  * @link http://www.sourcebans.net
  * @author  SourceBans Development Team
- * @param array $params
  */
 function smarty_function_load_template(array $params): void
 {
@@ -64,11 +57,9 @@ function smarty_function_load_template(array $params): void
  * Purpose:  custom stripslashes function
  * @link https://github.com/lechuga16/sourcebans-pp/tree/smarty_stripslashes
  * @author  Lechuga
- * @param array $params
- * @return string
  * @version 1.0
  */
-function smarty_stripslashes($string)
+function smarty_stripslashes(string $string): string
 {
 	return stripslashes($string);
 }
@@ -81,16 +72,15 @@ function smarty_stripslashes($string)
  * Purpose:  custom htmlspecialchars function
  * @link https://github.com/lechuga16/sourcebans-pp/tree/smarty_stripslashes
  * @author  Lechuga
- * @param array $params
  */
-function smarty_htmlspecialchars($string, $flags = ENT_COMPAT | ENT_HTML401, $encoding = 'UTF-8', $double_encode = true) {
+function smarty_htmlspecialchars(string $string, int $flags = ENT_COMPAT | ENT_HTML401, string $encoding = 'UTF-8', bool $double_encode = true): string {
     return htmlspecialchars($string, $flags, $encoding, $double_encode);
 }
 
 /**
  * Smarty {csrf_field} function plugin: renders the hidden CSRF token input.
  */
-function smarty_function_csrf_field()
+function smarty_function_csrf_field(): string
 {
     $token = htmlspecialchars(CSRF::token(), ENT_QUOTES, 'UTF-8');
     $name = htmlspecialchars(CSRF::FIELD_NAME, ENT_QUOTES, 'UTF-8');
@@ -147,11 +137,8 @@ function smarty_function_csrf_field()
  * matches via substring scan; the OR is skipped on that path.
  *
  * @param array{flag?: int|string} $params
- * @param string|null              $content
- * @param mixed                    $template
- * @param bool                     $repeat
  */
-function smarty_block_has_access(array $params, ?string $content, $template, &$repeat): string
+function smarty_block_has_access(array $params, ?string $content, \Smarty\Template $template, bool &$repeat): string
 {
     if ($content === null) {
         return '';

--- a/web/includes/auth/Auth.php
+++ b/web/includes/auth/Auth.php
@@ -5,22 +5,15 @@ use Lcobucci\JWT\Token;
 /**
  * Class Auth
  */
-class Auth
+final class Auth
 {
     private static ?Database $dbs = null;
 
-    /**
-     * @param Database $dbs
-     */
     public static function init(\Database $dbs): void
     {
         self::$dbs = $dbs;
     }
 
-    /**
-     * @param int $aid
-     * @param int $maxlife
-     */
     public static function login(int $aid, int $maxlife): void
     {
         $jti = self::generateJTI();
@@ -34,9 +27,6 @@ class Auth
         self::gc();
     }
 
-    /**
-     * @return bool
-     */
     public static function logout(): bool
     {
         $cookie = self::getJWTFromCookie();
@@ -59,9 +49,6 @@ class Auth
         return true;
     }
 
-    /**
-     * @return ?Token
-     */
     public static function verify(): ?Token
     {
         $cookie = self::getJWTFromCookie();
@@ -79,12 +66,6 @@ class Auth
         return null;
     }
 
-    /**
-     * @param string $data
-     * @param int $lifetime
-     * @param string $domain
-     * @param bool $secure
-     */
     private static function setCookie(string $data, int $lifetime, string $domain, bool $secure): void
     {
         setcookie('sbpp_auth', $data, [
@@ -97,9 +78,6 @@ class Auth
         ]);
     }
 
-    /**
-     *
-     */
     private static function gc(): void
     {
         self::$dbs->query(
@@ -108,11 +86,7 @@ class Auth
         self::$dbs->execute();
     }
 
-    /**
-     * @param string $jti
-     * @param string $secret
-     */
-    private static function insertNewToken(string $jti, string $secret)
+    private static function insertNewToken(string $jti, string $secret): void
     {
         self::$dbs->query(
             "INSERT INTO `:prefix_login_tokens` (jti, secret, lastAccessed) VALUES (:jti, :secret, UNIX_TIMESTAMP())"
@@ -122,9 +96,6 @@ class Auth
         self::$dbs->execute();
     }
 
-    /**
-     * @param int $aid
-     */
     private static function updateLastVisit(int $aid): void
     {
         self::$dbs->query("UPDATE `:prefix_admins` SET lastvisit = UNIX_TIMESTAMP() WHERE aid = :aid");
@@ -132,9 +103,6 @@ class Auth
         self::$dbs->execute();
     }
 
-    /**
-     * @param string $jti
-     */
     private static function updateLastAccessed(string $jti): void
     {
         self::$dbs->query("UPDATE `:prefix_login_tokens` SET lastAccessed = UNIX_TIMESTAMP() WHERE jti = :jti");
@@ -142,11 +110,7 @@ class Auth
         self::$dbs->execute();
     }
 
-    /**
-     * @param string $jti
-     * @return mixed
-     */
-    private static function getTokenSecret(string $jti)
+    private static function getTokenSecret(string $jti): mixed
     {
         self::$dbs->query("SELECT secret FROM `:prefix_login_tokens` WHERE jti = :jti");
         self::$dbs->bind(':jti', $jti, PDO::PARAM_STR);
@@ -154,9 +118,6 @@ class Auth
         return $result['secret'];
     }
 
-    /**
-     * @return string
-     */
     private static function generateJTI(): string
     {
         do {
@@ -166,10 +127,6 @@ class Auth
         return $jti;
     }
 
-    /**
-     * @param string $jti
-     * @return bool
-     */
     private static function checkJTI(string $jti): bool
     {
         self::$dbs->query("SELECT 1 FROM `:prefix_login_tokens` WHERE jti = :jti");
@@ -178,9 +135,6 @@ class Auth
         return !empty($result);
     }
 
-    /**
-     * @return string
-     */
     private static function getJWTFromCookie(): string
     {
         return is_string($_COOKIE['sbpp_auth'] ?? null) ? $_COOKIE['sbpp_auth'] : '';

--- a/web/includes/auth/Host.php
+++ b/web/includes/auth/Host.php
@@ -3,20 +3,14 @@
 /**
  * Class Host
  */
-class Host
+final class Host
 {
-    /**
-     * @return string
-     */
     public static function domain(): string
     {
         $host = $_SERVER['HTTP_HOST'] ?? '';
         return preg_match('/^[A-Za-z0-9._:\[\]-]+$/', $host) ? $host : '';
     }
 
-    /**
-     * @return string
-     */
     public static function cookieDomain(): string {
         $domain = self::domain();
         if( ($p = strpos($domain, ':')) === false ) {
@@ -25,9 +19,6 @@ class Host
         return substr($domain, 0, $p);
     }
 
-    /**
-     * @return string
-     */
     public static function protocol(): string
     {
         return sprintf('http%s://',  self::isSecure() ? 's' : '');
@@ -43,8 +34,8 @@ class Host
     }
 
     /**
-     * @param bool $withoutRequest Don't return the rest of the link (part after the first slash)
-     * @return string
+     * Build the absolute URL for the current request. With `$withoutRequest`,
+     * the path component (everything after the first `/`) is omitted.
      */
     public static function complete(bool $withoutRequest = false): string
     {

--- a/web/includes/auth/JWT.php
+++ b/web/includes/auth/JWT.php
@@ -12,7 +12,7 @@ use Lcobucci\JWT\Validation\Constraint\PermittedFor;
 use Lcobucci\JWT\Validation\Constraint\SignedWith;
 use Lcobucci\JWT\ValidationData;
 
-class JWT
+final class JWT
 {
     public static function create(string $jti, int $maxLife, int $aid): Token\Plain
     {

--- a/web/includes/auth/handler/NormalAuthHandler.php
+++ b/web/includes/auth/handler/NormalAuthHandler.php
@@ -1,8 +1,8 @@
 <?php
 
-class NormalAuthHandler
+final class NormalAuthHandler
 {
-    private $result = false;
+    private bool $result = false;
 
     public function __construct(
         private Database $dbs,
@@ -28,17 +28,17 @@ class NormalAuthHandler
         }
     }
 
-    public function getResult()
+    public function getResult(): bool
     {
         return $this->result;
     }
 
-    private function checkPassword(string $password, string $hash)
+    private function checkPassword(string $password, string $hash): bool
     {
         return (bool)(password_verify($password, $hash));
     }
 
-    private function legacyPasswordCheck(string $password, string $hash)
+    private function legacyPasswordCheck(string $password, string $hash): bool
     {
         $crypt = @crypt($password, SB_NEW_SALT);
         $sha1 = @sha1(sha1('SourceBans' . $password));
@@ -46,7 +46,7 @@ class NormalAuthHandler
         return (bool)(hash_equals($crypt, $hash) || hash_equals($sha1, $hash));
     }
 
-    private function updatePasswordHash(string $password, int $aid)
+    private function updatePasswordHash(string $password, int $aid): bool
     {
         $this->dbs->query("UPDATE `:prefix_admins` SET password = :password WHERE aid = :aid");
         $this->dbs->bindMultiple([
@@ -56,7 +56,7 @@ class NormalAuthHandler
         return $this->dbs->execute();
     }
 
-    private function getInfosFromDatabase(string $username)
+    private function getInfosFromDatabase(string $username): mixed
     {
         $this->dbs->query("SELECT aid, password FROM `:prefix_admins` WHERE user = :user");
         $this->dbs->bind(':user', $username);

--- a/web/includes/auth/handler/SteamAuthHandler.php
+++ b/web/includes/auth/handler/SteamAuthHandler.php
@@ -1,6 +1,6 @@
 <?php
 
-class SteamAuthHandler
+final class SteamAuthHandler
 {
     public function __construct(
         private \LightOpenID $openid,
@@ -16,13 +16,13 @@ class SteamAuthHandler
         }
     }
 
-    private function login()
+    private function login(): void
     {
         $this->openid->identity = 'https://steamcommunity.com/openid';
         header("Location: ".$this->openid->authUrl());
     }
 
-    private function validate()
+    private function validate(): string|false
     {
         $pattern = "/^https:\/\/steamcommunity\.com\/openid\/id\/(7[0-9]{15,25}+)$/";
 
@@ -38,7 +38,7 @@ class SteamAuthHandler
         return (!empty($match[1])) ? $match[1] : false;
     }
 
-    private function check(string $steamid)
+    private function check(string $steamid): void
     {
         $steamid = \SteamID\SteamID::toSteam2($steamid);
 

--- a/web/includes/page-builder.php
+++ b/web/includes/page-builder.php
@@ -1,11 +1,9 @@
 <?php
 
 /**
- * @param $fallback
- * @return array
  * @throws ErrorException
  */
-function route($fallback)
+function route(int|string $fallback): array
 {
     if (($_SERVER['REQUEST_METHOD'] ?? '') === 'POST') {
         CSRF::rejectIfInvalid();
@@ -164,11 +162,7 @@ function route($fallback)
     return $resolved;
 }
 
-/**
- * @param null $title Unused
- * @param string $page
- */
-function build(string $title, string $page)
+function build(string $title, string $page): void
 {
     require_once(TEMPLATES_PATH.'/core/header.php');
     require_once(TEMPLATES_PATH.'/core/navbar.php');

--- a/web/includes/security/CSRF.php
+++ b/web/includes/security/CSRF.php
@@ -4,7 +4,7 @@
  * Per-session CSRF token issued at session start and validated on every
  * state-changing request (POST forms and JSON API calls).
  */
-class CSRF
+final class CSRF
 {
     public const FIELD_NAME = 'csrf_token';
     public const HEADER_NAME = 'HTTP_X_CSRF_TOKEN';
@@ -29,7 +29,7 @@ class CSRF
         return is_string($_SESSION[self::SESSION_KEY] ?? null) ? $_SESSION[self::SESSION_KEY] : '';
     }
 
-    public static function validate($token): bool
+    public static function validate(mixed $token): bool
     {
         $expected = self::token();
         return $expected !== '' && is_string($token) && hash_equals($expected, $token);

--- a/web/includes/security/Crypto.php
+++ b/web/includes/security/Crypto.php
@@ -3,48 +3,29 @@
 /**
  * Class Crypto
  */
-class Crypto
+final class Crypto
 {
-    /**
-     * @param int $length
-     * @return string
-     */
-    public static function genJTI(int $length = 12)
+    public static function genJTI(int $length = 12): string
     {
         return self::base64RandomBytes($length);
     }
 
-    /**
-     * @param int $length
-     * @return string
-     */
-    public static function genSecret(int $length = 47)
+    public static function genSecret(int $length = 47): string
     {
         return self::base64RandomBytes($length);
     }
 
-    /**
-     * @param int $length
-     * @return string
-     */
-    public static function genPassword(int $length = 23)
+    public static function genPassword(int $length = 23): string
     {
         return self::base64RandomBytes($length);
     }
 
-    /**
-     * @return string
-     */
-    public static function recoveryHash()
+    public static function recoveryHash(): string
     {
         return hash('sha256', self::base64RandomBytes(12));
     }
 
-    /**
-     * @param int $length
-     * @return string
-     */
-    private static function base64RandomBytes(int $length)
+    private static function base64RandomBytes(int $length): string
     {
         return base64_encode(openssl_random_pseudo_bytes($length));
     }

--- a/web/includes/system-functions.php
+++ b/web/includes/system-functions.php
@@ -99,7 +99,7 @@ function CheckAdminAccess(int $mask): void
     }
 }
 
-function SecondsToString(int $sec, bool $textual = true): false|string
+function SecondsToString(int $sec, bool $textual = true): string
 {
     if ($sec < 0) {
         return 'Session';
@@ -289,7 +289,7 @@ function checkMultiplePlayers(int $sid, array $steamids): array
     return $players;
 }
 
-function GetCommunityName(string $steamid): mixed
+function GetCommunityName(string $steamid): string
 {
     $endpoint = "http://api.steampowered.com/ISteamUser/GetPlayerSummaries/v0002/?key=".STEAMAPIKEY.'&steamids='.\SteamID\SteamID::toSteam64($steamid);
     $data = json_decode(file_get_contents($endpoint), true);

--- a/web/includes/system-functions.php
+++ b/web/includes/system-functions.php
@@ -25,17 +25,9 @@ if (!defined("IN_SB")) {
 }
 
 /**
- * Creates an anchor tag, and adds tooltip code if needed
- *
- * @param  string $title   The title of the tooltip/text to link
- * @param  string $url     The link
- * @param  string $tooltip The tooltip message
- * @param  string $target  The new links target
- * @param  bool   $wide
- * @param  string $onclick
- * @return string URL
+ * Creates an anchor tag, and adds tooltip code if needed.
  */
-function CreateLinkR($title, $url, $tooltip="", $target="_self", $wide=false, $onclick="")
+function CreateLinkR(string $title, string $url, string $tooltip = "", string $target = "_self", bool $wide = false, string $onclick = ""): string
 {
     $class = ($wide) ? "perm" : "tip";
 
@@ -45,11 +37,7 @@ function CreateLinkR($title, $url, $tooltip="", $target="_self", $wide=false, $o
     return "<a href='{$url}' class='{$class}' title='{$tooltip}' target='{$target}'> {$title} </a>";
 }
 
-/**
- * @param  $mask
- * @return array|false
- */
-function BitToString($mask)
+function BitToString(int $mask): array|false
 {
     $perms = json_decode(file_get_contents(ROOT.'/configs/permissions/web.json'), true);
 
@@ -68,11 +56,7 @@ function BitToString($mask)
     return isset($out) ? $out : false;
 }
 
-/**
- * @param  $flagstring
- * @return array|false
- */
-function SmFlagsToSb($flagstring)
+function SmFlagsToSb(string $flagstring): array|false
 {
     $flags = json_decode(file_get_contents(ROOT.'/configs/permissions/sourcemod.json'), true);
 
@@ -89,38 +73,24 @@ function SmFlagsToSb($flagstring)
     return isset($out) ? $out : false;
 }
 
-/**
- * @return int
- */
-function NextSid()
+function NextSid(): int
 {
     $sid = $GLOBALS['PDO']->query("SELECT MAX(sid) AS next_sid FROM `:prefix_servers`")->single();
     return ($sid['next_sid'] + 1);
 }
 
-/**
- * @return int
- */
-function NextAid()
+function NextAid(): int
 {
     $aid = $GLOBALS['PDO']->query("SELECT MAX(aid) AS next_aid FROM `:prefix_admins`")->single();
     return ($aid['next_aid'] + 1);
 }
 
-/**
- * @param  string $text
- * @param  int    $len
- * @return string
- */
-function trunc(string $text, int $len)
+function trunc(string $text, int $len): string
 {
     return (strlen($text) > $len) ? substr($text, 0, $len).'...' : $text;
 }
 
-/**
- * @param int $mask
- */
-function CheckAdminAccess($mask)
+function CheckAdminAccess(int $mask): void
 {
     global $userbank;
     if (!$userbank->HasAccess($mask)) {
@@ -129,12 +99,7 @@ function CheckAdminAccess($mask)
     }
 }
 
-/**
- * @param  int  $sec
- * @param  bool $textual
- * @return false|string
- */
-function SecondsToString($sec, $textual=true)
+function SecondsToString(int $sec, bool $textual = true): false|string
 {
     if ($sec < 0) {
         return 'Session';
@@ -160,11 +125,7 @@ function SecondsToString($sec, $textual=true)
     }
 }
 
-/**
- * @param  string $ip
- * @return mixed|string
- */
-function FetchIp($ip)
+function FetchIp(string $ip): mixed
 {
     try {
         $reader = new Reader(MMDB_PATH);
@@ -174,35 +135,26 @@ function FetchIp($ip)
     }
 }
 
-function PageDie()
+function PageDie(): never
 {
     include_once TEMPLATES_PATH.'/core/footer.php';
     die();
 }
 
-/**
- * @param  string $map
- * @return string
- */
-function GetMapImage($map)
+function GetMapImage(string $map): string
 {
     $map = (@file_exists(SB_MAP_LOCATION."/$map.jpg")) ? $map : 'nomap';
     return SB_MAP_LOCATION."/$map.jpg";
 }
 
-/**
- * @param  string $file
- * @param  array  $validExts
- * @return bool
- */
-function checkExtension($file, array $validExts)
+function checkExtension(string $file, array $validExts): bool
 {
     $file = pathinfo($file, PATHINFO_EXTENSION);
     return in_array(strtolower($file), $validExts);
 }
 
 
-function PruneBans()
+function PruneBans(): void
 {
     global $userbank;
     $adminId = $userbank->GetAid() < 0 ? 0 : $userbank->GetAid();
@@ -256,7 +208,7 @@ function PruneBans()
 }
 
 
-function PruneComms()
+function PruneComms(): void
 {
     $GLOBALS['PDO']->query(
         "UPDATE `:prefix_comms` SET `RemovedBy` = 0, `RemoveType` = 'E', `RemovedOn` = UNIX_TIMESTAMP()
@@ -276,11 +228,8 @@ function PruneComms()
  * and undercounted any tree with nested subdirectories — e.g. a
  * `web/demos/<server>/<demo>.dem` layout would lose the per-server
  * subtotals).
- *
- * @param  string $dir
- * @return string
  */
-function getDirSize($dir)
+function getDirSize(string $dir): string
 {
     return sizeFormat(getDirSizeBytes($dir));
 }
@@ -290,11 +239,8 @@ function getDirSize($dir)
  * int so callers can `+=` it without tripping PHP 8's
  * "non-numeric value encountered" warning. {@see getDirSize()} wraps
  * this with {@see sizeFormat()} for the user-visible string.
- *
- * @param  string $dir
- * @return int
  */
-function getDirSizeBytes($dir)
+function getDirSizeBytes(string $dir): int
 {
     $size = 0;
     foreach (glob(rtrim($dir, '/').'/*', GLOB_NOSORT) as $object) {
@@ -303,11 +249,7 @@ function getDirSizeBytes($dir)
     return $size;
 }
 
-/**
- * @param  int $bytes
- * @return string
- */
-function sizeFormat($bytes)
+function sizeFormat(int $bytes): string
 {
     if ($bytes <= 0) {
         return '0 B';
@@ -317,13 +259,13 @@ function sizeFormat($bytes)
 }
 
 /**
- * Check for multiple steamids on one server
+ * Check for multiple steamids on one server. The returned array is keyed by
+ * STEAM_ID and each row carries `name`, `steam`, `ip` (and historically
+ * `time`, `ping` — only the first three are populated by the rcon parser).
  *
- * @param  int   $sid
- * @param  array $steamids
  * @return array<string, array{name: string, steam: string, ip: string}> Keyed by Steam2 id, e.g. ['STEAM_0:0:1' => ['name' => …, 'steam' => …, 'ip' => …], …].
  */
-function checkMultiplePlayers(int $sid, array $steamids)
+function checkMultiplePlayers(int $sid, array $steamids): array
 {
     $ret = rcon('status', $sid);
 
@@ -347,23 +289,14 @@ function checkMultiplePlayers(int $sid, array $steamids)
     return $players;
 }
 
-/**
- * @param  string $steamid
- * @return mixed|string
- */
-function GetCommunityName($steamid)
+function GetCommunityName(string $steamid): mixed
 {
     $endpoint = "http://api.steampowered.com/ISteamUser/GetPlayerSummaries/v0002/?key=".STEAMAPIKEY.'&steamids='.\SteamID\SteamID::toSteam64($steamid);
     $data = json_decode(file_get_contents($endpoint), true);
     return (isset($data['response']['players'][0]['personaname'])) ? $data['response']['players'][0]['personaname'] : '';
 }
 
-/**
- * @param  string $cmd
- * @param  int    $sid
- * @return false|string
- */
-function rcon(string $cmd, int $sid)
+function rcon(string $cmd, int $sid): false|string
 {
     $GLOBALS['PDO']->query("SELECT ip, port, rcon FROM `:prefix_servers` WHERE sid = :sid");
     $GLOBALS['PDO']->bind(':sid', $sid);
@@ -397,11 +330,7 @@ function rcon(string $cmd, int $sid)
     return $output;
 }
 
-/**
- * @param  string $status
- * @return array
- */
-function parseRconStatus(string $status)
+function parseRconStatus(string $status): array
 {
     $regex = '/#\s*(\d+)(?>\s|\d)*"(.*)"\s*(STEAM_[01]:[01]:\d+|\[U:1:\d+\])(?>\s|:|\d)*[a-zA-Z]*\s*\d*\s([0-9.]+)/';
     $players = [];
@@ -421,11 +350,7 @@ function parseRconStatus(string $status)
     return $players;
 }
 
-/**
- * @param  string $text
- * @return string
- */
-function encodePreservingBr($text) {
+function encodePreservingBr(string $text): string {
     // Split the text at <br> tags, preserving the tags in the result
     $parts = preg_split('/(<br\s*\/?>)/i', $text, -1, PREG_SPLIT_DELIM_CAPTURE);
     $result = '';

--- a/web/phpstan-baseline.neon
+++ b/web/phpstan-baseline.neon
@@ -13,56 +13,14 @@ parameters:
 			path: exportbans.php
 
 		-
-			message: '#^Call to method assign\(\) on an unknown class Smarty\.$#'
-			identifier: class.notFound
-			count: 6
-			path: includes/AdminTabs.php
-
-		-
-			message: '#^Call to method display\(\) on an unknown class Smarty\.$#'
-			identifier: class.notFound
-			count: 2
-			path: includes/AdminTabs.php
-
-		-
-			message: '#^Parameter \$theme of method AdminTabs\:\:__construct\(\) has invalid type Smarty\.$#'
-			identifier: class.notFound
-			count: 1
-			path: includes/AdminTabs.php
-
-		-
 			message: '#^Call to an undefined method Lcobucci\\JWT\\Token\:\:claims\(\)\.$#'
 			identifier: method.notFound
 			count: 1
 			path: includes/CUserManager.php
 
 		-
-			message: '#^Call to function is_numeric\(\) with int\<min, \-1\>\|int\<1, max\> will always evaluate to true\.$#'
-			identifier: function.alreadyNarrowedType
-			count: 1
-			path: includes/CUserManager.php
-
-		-
-			message: '#^PHPDoc tag @return has invalid value \(mixed\.\)\: Unexpected token "\.", expected TOKEN_HORIZONTAL_WS at offset 172 on line 6$#'
-			identifier: phpDoc.parseError
-			count: 1
-			path: includes/CUserManager.php
-
-		-
-			message: '#^Unreachable statement \- code above always terminates\.$#'
-			identifier: deadCode.unreachable
-			count: 1
-			path: includes/CUserManager.php
-
-		-
 			message: '#^Offset int\<0, max\> on array\{function\: string, line\?\: int, file\?\: string, class\?\: class\-string, type\?\: ''\-\>''\|''\:\:'', args\?\: list\<mixed\>, object\?\: object\} in isset\(\) does not exist\.$#'
 			identifier: isset.offset
-			count: 1
-			path: includes/Log.php
-
-		-
-			message: '#^PHPDoc tag @param references unknown parameter\: \$search$#'
-			identifier: parameter.notFound
 			count: 1
 			path: includes/Log.php
 
@@ -189,12 +147,6 @@ parameters:
 		-
 			message: '#^Parameter \#1 \$contents of static method Lcobucci\\JWT\\Signer\\Key\\InMemory\:\:base64Encoded\(\) expects non\-empty\-string, '''' given\.$#'
 			identifier: argument.type
-			count: 1
-			path: includes/auth/JWT.php
-
-		-
-			message: '#^Unsafe call to private method JWT\:\:getConfig\(\) through static\:\:\.$#'
-			identifier: staticClassAccess.privateMethod
 			count: 1
 			path: includes/auth/JWT.php
 
@@ -335,6 +287,18 @@ parameters:
 			identifier: variable.undefined
 			count: 1
 			path: install/template/submenu.php
+
+		-
+			message: '#^Result of \|\| is always true\.$#'
+			identifier: booleanOr.alwaysTrue
+			count: 1
+			path: pages/admin.edit.admindetails.php
+
+		-
+			message: '#^Right side of \|\| is always true\.$#'
+			identifier: booleanOr.rightAlwaysTrue
+			count: 1
+			path: pages/admin.edit.admindetails.php
 
 		-
 			message: '#^Variable \$allservers might not be defined\.$#'

--- a/web/phpstan-baseline.neon
+++ b/web/phpstan-baseline.neon
@@ -43,36 +43,6 @@ parameters:
 			path: includes/Mail/Mail.php
 
 		-
-			message: '#^PHPDoc tag @param has invalid value \(Smarty\)\: Unexpected token "\\n \* ", expected variable at offset 261 on line 10$#'
-			identifier: phpDoc.parseError
-			count: 1
-			path: includes/SmartyCustomFunctions.php
-
-		-
-			message: '#^PHPDoc tag @param has invalid value \(Smarty\)\: Unexpected token "\\n \* ", expected variable at offset 295 on line 10$#'
-			identifier: phpDoc.parseError
-			count: 1
-			path: includes/SmartyCustomFunctions.php
-
-		-
-			message: '#^PHPDoc tag @param has invalid value \(array\)\: Unexpected token "\\n \* ", expected variable at offset 244 on line 9$#'
-			identifier: phpDoc.parseError
-			count: 1
-			path: includes/SmartyCustomFunctions.php
-
-		-
-			message: '#^PHPDoc tag @param has invalid value \(array\)\: Unexpected token "\\n \* ", expected variable at offset 278 on line 9$#'
-			identifier: phpDoc.parseError
-			count: 1
-			path: includes/SmartyCustomFunctions.php
-
-		-
-			message: '#^PHPDoc tag @param references unknown parameter\: \$params$#'
-			identifier: parameter.notFound
-			count: 2
-			path: includes/SmartyCustomFunctions.php
-
-		-
 			message: '#^Parameter \#2 \$num2 of function bcdiv expects string, int given\.$#'
 			identifier: argument.type
 			count: 2
@@ -203,18 +173,6 @@ parameters:
 			identifier: class.notFound
 			count: 1
 			path: includes/page-builder.php
-
-		-
-			message: '#^PHPDoc tag @param for parameter \$title with type null is incompatible with native type string\.$#'
-			identifier: parameter.phpDocType
-			count: 1
-			path: includes/page-builder.php
-
-		-
-			message: '#^Function SecondsToString\(\) never returns false so it can be removed from the return type\.$#'
-			identifier: return.unusedType
-			count: 1
-			path: includes/system-functions.php
 
 		-
 			message: '#^Invalid array key type float\.$#'


### PR DESCRIPTION
## Summary

Closes part of #1290. Phases A + J from the umbrella issue:

- **A**: native parameter / return types replacing `@param` / `@return` docblocks across every legacy class in `web/includes/` — `CUserManager`, `Database`, `Log`, `Auth`, `JWT`, `CSRF`, `Crypto`, `Api`, `ApiError`, `AdminTabs`, `Theme`, `Mailer`, `Mail`, the auth handlers, `Config`, `Host`, `system-functions.php`, `SmartyCustomFunctions.php`, `page-builder.php`. Coordinates with #1295 (mechanical sweep) — the three CUserManager methods #1295 simplified (`is_logged_in`, `is_admin`, `HasAccess` numeric-flag branch) take their `: bool` return type from #1295; this PR types every other signature.
- **J**: `final class` on every legacy leaf that nothing extends. `View` stays `abstract` (every concrete view DTO extends it). SteamID classes left as third-party.

Plus AGENTS.md anti-pattern + conventions rows, and a new "Native types over docblocks" subsection.

## Notable decisions

1. **`Database::execute()` narrows from `@return mixed` to `: bool`** — PHP's manual specifies `PDOStatement::execute(): bool`. With `ATTR_ERRMODE = ERRMODE_EXCEPTION` (set in our PDO bootstrap), the only return paths are `true` or thrown. Verified by reading every caller.
2. **`Database::resultset()` narrows to `: array`** — `fetchAll()` returns `array` on PHP 8+ (the `false` legacy return only happens with `ERRMODE_SILENT`).
3. **`AdminTabs::__construct` Smarty type fix**: `Smarty $theme` → `\Smarty\Smarty $theme` (matches `Renderer.php`'s namespaced resolution). Removes 3 PHPStan baseline entries.
4. **Two new PHPStan baseline entries** on `admin.edit.admindetails.php:294` — legitimate code smells the better type inference unmasked (`HasAccess(ADMIN_OWNER) || HasAccess(ADMIN_EDIT_ADMINS) || $_GET['id'] == GetAid()` is always true given the early-return guard at lines 51-52). Out-of-scope for this PR — file as a follow-up against the page handler.

## Closing invariants verified

```
$ rg '@param\s+\$|@param\s+\w+\s+\$|@return\s+\w' web/includes
# only View DTOs (generic shape refinements), CUserManager (3 methods deferred to #1295),
# Util/Duration (descriptive), Version, Api (generic refinements), PHPStan/SmartyTemplateRule,
# SteamID/** (third-party), auth/openid.php (third-party).

$ rg '^class\s+\w' web/includes
# only `class View` (abstract) + LightOpenID + 5 SteamID classes (all third-party).
```

## Test plan

- [x] `./sbpp.sh phpstan` clean
- [x] `./sbpp.sh test` 388 tests pass (PR1's RoutingTest cases included)
- [x] `./sbpp.sh ts-check` clean
- [x] `./sbpp.sh composer api-contract` byte-identical
- [x] PHPStan baseline net **-13 entries** (15 removed, 2 added — both legitimate)