### PR TITLE
chore(php): adopt PHP 8.4/8.5 features (#1290)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -358,6 +358,57 @@ top-level `class Foo {}` in `web/includes/` (see "Anti-patterns").
 - Pattern: `query` → `bind` → `execute` / `single` / `resultset`.
 - ADOdb was fully removed (commit `b9c812b2`). **Do not reintroduce it.**
 
+### PHP 8.5 idioms (post-#1289 floor bump)
+
+The codebase floor is PHP 8.5. Beyond native types and constructor
+promotion, four 8.4/8.5 features are documented here (#1290 phase K):
+two adopted today (`#[\NoDiscard]`, the pipe operator), two declined
+for now (property hooks, asymmetric visibility — neither has a paying
+candidate in the current codebase):
+
+- `#[\NoDiscard]` (PHP 8.5) on methods whose return value is the
+  meaningful signal: `Api::redirect()` (the redirect envelope is the
+  navigation; `Api::redirect(...);` without a `return` silently no-ops),
+  `CSRF::validate()` (running the check and ignoring the verdict is
+  the textbook bug shape this attribute exists to catch). New methods
+  whose return is the only meaningful output should carry the
+  attribute too. `Database::execute()` is a strong future candidate
+  but adopting it requires a paired sweep of every legacy
+  `$db->execute();` discard across `web/updater/data/*.php`,
+  `web/pages/*.php`, and `web/api/handlers/*.php` (≈40 runtime sites
+  the static gate can't see through `$GLOBALS['PDO']` / `$this->dbs`)
+  — tracked as a follow-up in issue #1294.
+- Property hooks (PHP 8.4) for computed / lazy / validated
+  accessors. None currently in use — the codebase's getter methods
+  (`UserManager::GetAid()`, `GetProperty()`, etc.) are simple
+  delegators where a property hook would add call overhead without
+  paying for itself. Reach for hooks when you have actual compute
+  inside the getter (lazy DB lookup, derived value caching, value
+  validation on set). For plain stored data, `public readonly` is
+  the right shape.
+- Asymmetric visibility (PHP 8.4): `public private(set) X $foo;`
+  for properties that need to be written more than once internally
+  but read-only externally. None currently in use —
+  `public private(set) readonly X $foo;` is indistinguishable from
+  plain `public readonly X $foo;` (the engine enforces single-write
+  in both shapes), so reach for `private(set)` only when there's a
+  concrete multi-write internal flow. For plain "single-write,
+  externally read-only", `public readonly` is the right shape.
+- Pipe operator `|>` (PHP 8.5) for multi-step value transformations
+  that read better left-to-right than as nested function calls. The
+  `IntroRenderer` chain is the canonical site:
+  `($raw ?? '') |> strval(...) |> IntroRenderer::renderIntroText(...)`.
+  Pipe is best when each step takes ONE argument and is named (no
+  ad-hoc `fn() => f($x, ...)` lambda noise); reach for it only when
+  the form is obviously clearer than the nested-call shape.
+
+  **Precedence pitfall**: `|>` binds tighter than `??`, `?:`, `=`,
+  and the boolean `&&` / `||` / `and` / `or`. When chaining a
+  coalesce, parenthesize the LHS: `($raw ?? '') |> strval(...)`,
+  NOT `$raw ?? '' |> strval(...)` (the latter parses as
+  `$raw ?? ('' |> strval(...))` and silently never coerces when
+  `$raw` is non-null).
+
 ### Native types over docblocks
 
 Every method signature in `web/includes/` that PHP can express
@@ -1083,6 +1134,14 @@ audit (#1207) locked in. New CTAs:
   runtime gate (for PHPStan-excluded files like `auth/openid.php`) is
   `Php82DeprecationsTest`. See "Null-into-scalar discipline" in
   Conventions for the per-shape idiom.
+- Discarded return values from `Api::redirect()` or `CSRF::validate()`
+  → these carry `#[\NoDiscard]` (PHP 8.5). The return is the
+  meaningful signal — `Api::redirect()`'s envelope IS the navigation
+  (callers must `return Api::redirect(...)` so the dispatcher honours
+  it), and `CSRF::validate()`'s bool IS the verdict (callers either
+  branch on it or use the higher-level `rejectIfInvalid()` helper).
+  PHPStan's `method.resultDiscarded` rule fails the build on a
+  discarded site. Issue #1290 phase K.1.
 - `setTimeout` / `waitForTimeout` waits in E2E specs → wait on
   terminal attributes (`[data-loading="false"]` settled, `[data-skeleton]`
   removed) per #1123's "Testability hooks" rule.

--- a/web/includes/Api/Api.php
+++ b/web/includes/Api/Api.php
@@ -84,7 +84,16 @@ final class Api
         self::$bootstrapped = true;
     }
 
-    /** Sentinel a handler can return to issue a client-side redirect. */
+    /**
+     * Sentinel a handler can return to issue a client-side redirect.
+     *
+     * #[\NoDiscard]: the returned envelope IS the redirect signal — the
+     * dispatcher only honours it when the handler bubbles it back via
+     * `return Api::redirect(...)`. A bare `Api::redirect(...);` call (no
+     * `return`) silently no-ops the navigation while looking like it
+     * worked. Issue #1290 phase K.1.
+     */
+    #[\NoDiscard('Api::redirect() returns the redirect envelope; bubble it back with `return`.')]
     public static function redirect(string $url): array
     {
         return ['__redirect' => $url];

--- a/web/includes/Security/CSRF.php
+++ b/web/includes/Security/CSRF.php
@@ -31,6 +31,15 @@ final class CSRF
         return is_string($_SESSION[self::SESSION_KEY] ?? null) ? $_SESSION[self::SESSION_KEY] : '';
     }
 
+    /**
+     * #[\NoDiscard]: validating the CSRF token but discarding the result
+     * means you ran the check and ignored the answer — the textbook bug
+     * pattern this attribute exists to catch (the request would proceed
+     * regardless of whether the token matched). Callers either branch on
+     * the bool (`if (!CSRF::validate(...)) { ... }`) or use the
+     * higher-level `rejectIfInvalid()` helper. Issue #1290 phase K.1.
+     */
+    #[\NoDiscard('CSRF::validate() returns the verdict; branch on it or use rejectIfInvalid().')]
     public static function validate(mixed $token): bool
     {
         $expected = self::token();

--- a/web/pages/page.home.php
+++ b/web/pages/page.home.php
@@ -270,9 +270,14 @@ require(TEMPLATES_PATH . "/page.servers.php"); //populates $serversView
 $homePerms = \Sbpp\View\Perms::for($userbank);
 \Sbpp\View\Renderer::render($theme, new \Sbpp\View\HomeDashboardView(
     dashboard_title: (string) (Config::get('dash.intro.title') ?? ''),
-    dashboard_text: \Sbpp\Markup\IntroRenderer::renderIntroText(
-        (string) (Config::get('dash.intro.text') ?? '')
-    ),
+    // #1290 phase K.4 — PHP 8.5 pipe operator. Reads left-to-right
+    // ("take the raw setting → coerce to string → render Markdown") vs
+    // the inside-out `IntroRenderer::renderIntroText((string)(Config::get(...) ?? ''))`
+    // shape. The IntroRenderer chain is the canonical pipe site
+    // called out in the issue body.
+    dashboard_text: (Config::get('dash.intro.text') ?? '')
+        |> strval(...)
+        |> \Sbpp\Markup\IntroRenderer::renderIntroText(...),
     dashboard_lognopopup: Config::getBool('dash.lognopopup'),
     players_blocked: $stopped,
     total_blocked: $totalstopped,


### PR DESCRIPTION
## Summary

Phase K from #1290 — now unblocked by #1289 landing PHP 8.5 as the floor and #1298 landing the namespace move. Each sub-phase is small and surgical; the goal is the canonical sites the issue body calls out, not a "sprinkle 8.5 features everywhere" sweep.

### K.1 — `#[\NoDiscard]` (PHP 8.5)

Annotate methods whose return value is the meaningful signal so the PHPStan `method.resultDiscarded` rule fails the build on a discarded call site:

- `Sbpp\Api\Api::redirect()` — the returned envelope IS the redirect. A bare `Api::redirect(...);` call (no `return`) silently no-ops the navigation while looking like it worked.
- `Sbpp\Security\CSRF::validate()` — running the check and ignoring the bool is the textbook bug shape this attribute exists to catch. Callers either branch on the bool or use the higher-level `rejectIfInvalid()` helper.

`Sbpp\Db\Database::execute()` was surveyed and intentionally **deferred**: PHPStan flags 9 sites the static gate can see, but the runtime gate (PHPUnit) catches another ≈40 discards in updater migrations / page handlers / API handlers that go through `$GLOBALS['PDO']` / `$this->dbs` (invisible to PHPStan). Adopting it requires the paired sweep, which belongs in its own PR — tracked as a follow-up in #1294.

### K.2 — Property hooks (PHP 8.4)

Surveyed; **no current candidate**. The codebase's getter methods (`UserManager::GetAid()`, `GetProperty()`, etc.) are simple delegators where a property hook would add measurable read overhead (~4x slower on tight loops) without paying for itself. Reach for hooks when there's actual compute inside the getter (lazy DB lookup, derived value caching, value validation on set). For plain stored data, `public readonly` is the right shape — engine-enforced single-write, faster than the equivalent hook.

### K.3 — Asymmetric visibility (PHP 8.4)

Surveyed; **no current candidate**. `public private(set) readonly X $foo;` is indistinguishable from plain `public readonly X $foo;` (the engine enforces single-write in both shapes), so reach for `private(set)` only when there's a concrete multi-write internal flow. The codebase's read-mostly properties are all single-write, so plain `public readonly` is the right shape.

### K.4 — Pipe operator `|>` (PHP 8.5)

Adopted at the canonical site called out in the issue body: `web/pages/page.home.php`'s dashboard intro renders through:

```php
dashboard_text: (Config::get('dash.intro.text') ?? '')
    |> strval(...)
    |> \Sbpp\Markup\IntroRenderer::renderIntroText(...),
```

Reads left-to-right ("take the raw setting → coerce to string → render Markdown") vs the inside-out `IntroRenderer::renderIntroText((string)(Config::get(...) ?? ''))` shape.

## Documentation

- AGENTS.md gains a **"PHP 8.5 idioms (post-#1289 floor bump)"** Conventions subsection covering all four features (two adopted, two declined-with-rationale, plus the precedence pitfall: `|>` binds tighter than `??`, so a coalesce LHS must be parenthesized: `($raw ?? '') |> strval(...)`).
- AGENTS.md gains an **Anti-pattern row** for discarded return values from `Api::redirect()` / `CSRF::validate()`, pointing at the `method.resultDiscarded` PHPStan rule + the `#[\NoDiscard]` attribute.

## Test plan

- [x] `./sbpp.sh phpstan` — clean (0 errors over 225 files).
- [x] `./sbpp.sh test` — 393 tests, 1692 assertions, all pass (the 1 PHPUnit deprecation is pre-existing in `GroupsTest`'s docblock metadata, unrelated to this PR).
- [x] `./sbpp.sh ts-check` — clean.
- [x] `./sbpp.sh composer api-contract` — regenerates byte-identical (no diff).
- [x] No phpstan-baseline.neon delta. No wire-format change.

Stacked on top of #1295 (PR1 mechanical sweep) + #1296 (PR2 native types + `final class`) + #1297 (PR3 backed enums) + #1298 (PR4 namespace move). Closes the issue once merged. Issue #1290.