### PR TITLE
Fix #1302: restore IP column on the public banlist for admins

### DIFF
--- a/web/tests/e2e/specs/flows/banlist-ip-column.spec.ts
+++ b/web/tests/e2e/specs/flows/banlist-ip-column.spec.ts
@@ -1,0 +1,128 @@
+/**
+ * Flow: public banlist surfaces the IP column to admins (#1302).
+ *
+ * The v2.0 redesign of `web/themes/default/page_bans.tpl` dropped
+ * the per-row IP column entirely — even an `ADMIN_OWNER` user lost
+ * the at-a-glance IP that v1.x rendered (gated on `is_admin()`).
+ *
+ * The page handler (`web/pages/page.banlist.php`) was already
+ * computing `$hideplayerips = Config::getBool('banlist.hideplayerips')
+ * && !$userbank->is_admin()` correctly, and `BanListView` already
+ * carried the per-row `ban_ip_raw` field. Only the template was
+ * missing — `BanListIpColumnTest` covers the template-level
+ * regression in both directions (visible + suppressed). This spec
+ * closes the integration gap end-to-end: the seeded `admin/admin`
+ * user (storage state from `fixtures/global-setup.ts` —
+ * `is_admin()` = true via `ALL_WEB`) seeds an IP-bearing ban
+ * through `bans.add` and asserts the IP renders in the live
+ * desktop `<table>` AND the mobile `.ban-cards` block.
+ *
+ * Project gating
+ * --------------
+ * Runs on BOTH desktop-chromium and mobile-chromium so we cover
+ * the desktop `<table>` testid (`ban-ip`) and the mobile card
+ * mirror (`ban-ip-mobile`). The describe block branches on
+ * `isMobile` to assert the right surface per project — keeps the
+ * regression locked at every viewport.
+ */
+
+import type { Page } from '@playwright/test';
+import { expect, test } from '../../fixtures/auth.ts';
+
+const SEED_STEAM = 'STEAM_0:1:1302001';
+const SEED_NICK = 'e2e-ip-col';
+const SEED_IP = '203.0.113.42';
+
+/**
+ * Seed a Steam ban WITH an IP via `bans.add` and tolerate the
+ * `already_banned` collision (the panel runs against the dev
+ * `sourcebans` DB, which persists across `playwright test`
+ * invocations — see `responsive/banlist.spec.ts`'s `seedBan`
+ * for the per-DB rationale).
+ *
+ * The shared `seedBanViaApi` fixture hardcodes `ip: ''`, so
+ * we drive `bans.add` directly with the IP set. The handler
+ * persists `:prefix_bans.ip = '203.0.113.42'` which the page
+ * handler later reads into the per-row `ban_ip_raw` field.
+ */
+async function seedBanWithIp(page: Page): Promise<void> {
+    await page.goto('/');
+
+    const env = await page.evaluate(
+        async (args) => {
+            const w = window as unknown as {
+                sb: {
+                    api: {
+                        call: (
+                            action: string,
+                            params: Record<string, unknown>,
+                        ) => Promise<{
+                            ok: boolean;
+                            data?: { bid?: number };
+                            error?: { code: string; message: string };
+                        }>;
+                    };
+                };
+                Actions: Record<string, string>;
+            };
+            return await w.sb.api.call(w.Actions.BansAdd, {
+                nickname: args.nickname,
+                steam: args.steam,
+                type: 0,
+                ip: args.ip,
+                length: 0,
+                reason: 'e2e: banlist IP column seed (#1302)',
+            });
+        },
+        { nickname: SEED_NICK, steam: SEED_STEAM, ip: SEED_IP },
+    );
+
+    if (env && env.ok === false && env.error?.code !== 'already_banned') {
+        throw new Error(`bans.add seed failed: ${JSON.stringify(env)}`);
+    }
+}
+
+test.describe('flow: banlist IP column visible to admin (#1302)', () => {
+    test('IP column renders for the admin caller on the public banlist', async ({
+        page,
+        isMobile,
+    }) => {
+        await seedBanWithIp(page);
+        await page.goto('/index.php?p=banlist');
+
+        if (isMobile) {
+            // Mobile chrome is `.ban-cards`, not `<table>` (theme.css
+            // L266: `.table { display: none }` at <=768px). The IP
+            // line lives directly under the SteamID line on each
+            // card, gated on `{if !$hideplayerips && $ban.ban_ip_raw
+            // != ''}`.
+            const cards = page.locator('#banlist-root .ban-cards');
+            await expect(cards).toBeVisible();
+
+            const ipLine = page
+                .locator('[data-testid="ban-ip-mobile"]')
+                .filter({ hasText: SEED_IP });
+            await expect(ipLine).toBeVisible();
+        } else {
+            // Desktop column header: visible "IP" copy + `.col-ip`
+            // hook. Anchor on both so a future refactor that reuses
+            // the class for an unrelated column still trips the
+            // assertion.
+            const table = page.locator('#banlist-root .table');
+            await expect(table).toBeVisible();
+            const header = table.locator('th.col-ip');
+            await expect(header).toBeVisible();
+            await expect(header).toHaveText(/^IP$/);
+
+            // Per-row IP cell — testid contract for any future
+            // filter / styling work.
+            const seededRow = table
+                .locator('[data-testid="ban-row"]')
+                .filter({ hasText: SEED_STEAM });
+            await expect(seededRow).toBeVisible();
+            const ipCell = seededRow.locator('[data-testid="ban-ip"]');
+            await expect(ipCell).toBeVisible();
+            await expect(ipCell).toContainText(SEED_IP);
+        }
+    });
+});

--- a/web/tests/integration/BanListIpColumnTest.php
+++ b/web/tests/integration/BanListIpColumnTest.php
@@ -1,0 +1,299 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sbpp\Tests\Integration;
+
+use Sbpp\Tests\ApiTestCase;
+use Sbpp\View\BanListView;
+use Sbpp\View\Renderer;
+use Smarty\Smarty;
+
+/**
+ * Issue #1302: the public ban list dropped the IP column for admins
+ * during the v2.0 redesign of `web/themes/default/page_bans.tpl`.
+ *
+ * v1.x rendered an IP column gated on `is_admin()` (so admins always
+ * saw IPs, non-admins saw them only when `banlist.hideplayerips` was
+ * off). The v2.0 template never references the per-row `ban_ip_raw`
+ * field, so even an `ADMIN_OWNER` user got no IP at-a-glance on the
+ * marquee page.
+ *
+ * The fix restores the column gated on `{if !$hideplayerips}` —
+ * mirroring the existing `{if !$hideadminname}` guard for the Admin
+ * column. The `BanListView` DTO already carried both `hideplayerips`
+ * (built as `Config::getBool('banlist.hideplayerips') &&
+ * !$userbank->is_admin()` in `web/pages/page.banlist.php`) and the
+ * per-row `ban_ip_raw` field, so this is a template-only fix.
+ *
+ * The test renders `BanListView` end-to-end through Smarty (matching
+ * `init.php`'s wiring) and asserts on the rendered HTML in both
+ * directions:
+ *
+ *   1. `hideplayerips = false` (admin caller, OR non-admin with the
+ *      setting off) — the IP column appears in the desktop `<thead>`
+ *      AND each row's `[data-testid="ban-ip"]` cell carries the raw
+ *      IP. The mobile `.ban-cards` block also surfaces the IP under
+ *      the SteamID line via `[data-testid="ban-ip-mobile"]`.
+ *   2. `hideplayerips = true` (non-admin caller under default
+ *      `banlist.hideplayerips=1`) — neither the column header nor
+ *      the per-row testid is present anywhere in the output. The
+ *      suppression is total; we deliberately don't render an "IP
+ *      redacted" placeholder, matching how `{if !$hideadminname}`
+ *      fully omits the Admin column.
+ *
+ * Mirrors the `AdminAdminsSearchTest::bootstrapSmartyTheme` shape
+ * (init.php-equivalent Smarty wiring + per-process tmp compile dir
+ * so PHPUnit's host-user shell can write its compiled `.tpl.php`
+ * artefacts into something other than the docker-image-owned
+ * `web/cache/`).
+ */
+final class BanListIpColumnTest extends ApiTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->bootstrapSmartyTheme();
+    }
+
+    protected function tearDown(): void
+    {
+        unset($GLOBALS['theme']);
+        parent::tearDown();
+    }
+
+    /**
+     * Admin / setting-off path: the `BanListView::$hideplayerips`
+     * boolean is `false`, so the template emits the IP column
+     * (header + per-row cell) on the desktop table AND a per-row IP
+     * line on the mobile card.
+     */
+    public function testIpColumnRendersWhenHideplayeripsIsFalse(): void
+    {
+        $html = $this->renderBanList(hideplayerips: false);
+
+        // Desktop column header. Anchor on the `col-ip` class +
+        // visible "IP" copy together so a future refactor that
+        // accidentally reuses the class for a different column
+        // still trips this assertion.
+        $this->assertStringContainsString(
+            '<th scope="col" class="col-ip">IP</th>',
+            $html,
+            'IP <th> must render in the desktop <thead> when $hideplayerips is false (#1302).',
+        );
+
+        // Per-row IP cell — testid is the contract for E2E specs +
+        // any future filter/styling work, so we anchor on it
+        // directly. The seeded value is escaped through Smarty's
+        // global `escape` filter so the literal "1.2.3.4" lands
+        // verbatim in the output.
+        $this->assertStringContainsString(
+            'data-testid="ban-ip"',
+            $html,
+            'Per-row [data-testid="ban-ip"] cell must render when $hideplayerips is false (#1302).',
+        );
+        $this->assertStringContainsString(
+            '1.2.3.4',
+            $html,
+            'The per-row ban_ip_raw value must reach the rendered table when admins/operators are allowed to see it (#1302).',
+        );
+
+        // Mobile card mirror — same gate, different testid so
+        // responsive specs can address each branch independently.
+        $this->assertStringContainsString(
+            'data-testid="ban-ip-mobile"',
+            $html,
+            'The mobile .ban-cards branch must surface the IP under the SteamID line when $hideplayerips is false (#1302).',
+        );
+    }
+
+    /**
+     * Non-admin / setting-on path: `BanListView::$hideplayerips` is
+     * `true` (`banlist.hideplayerips=1` defaults on a fresh install
+     * per `data.sql`, and the page handler ANDs in `!is_admin()`).
+     * The IP column is suppressed completely — no header, no per-row
+     * cell, no mobile-card line. We deliberately don't render an
+     * "IP redacted" placeholder so the suppression mirrors the
+     * existing `{if !$hideadminname}` Admin-column omission.
+     */
+    public function testIpColumnIsSuppressedWhenHideplayeripsIsTrue(): void
+    {
+        $html = $this->renderBanList(hideplayerips: true);
+
+        $this->assertStringNotContainsString(
+            '<th scope="col" class="col-ip">IP</th>',
+            $html,
+            'IP <th> must NOT render when $hideplayerips is true — banlist.hideplayerips is the gate, mirroring the public-side IP suppression contract (#1302).',
+        );
+        $this->assertStringNotContainsString(
+            'data-testid="ban-ip"',
+            $html,
+            'Per-row [data-testid="ban-ip"] cell must NOT render when $hideplayerips is true (#1302).',
+        );
+        $this->assertStringNotContainsString(
+            'data-testid="ban-ip-mobile"',
+            $html,
+            'Mobile-card IP line must NOT render when $hideplayerips is true (#1302).',
+        );
+        $this->assertStringNotContainsString(
+            '1.2.3.4',
+            $html,
+            'The seeded raw IP must not leak into the suppressed render (#1302).',
+        );
+    }
+
+    /**
+     * The empty-state colspan must accommodate the maximum render
+     * (10 columns: Player, SteamID, IP, Reason, Server, Admin,
+     * Length, Banned, Status, Actions). A future regression that
+     * forgets to bump it back to 10 when adding another column
+     * would silently leave the empty-state cell short, drawing
+     * a wedge of background past the table-card frame on a
+     * fresh install.
+     */
+    public function testEmptyStateColspanCovers10Columns(): void
+    {
+        $html = $this->renderBanList(hideplayerips: false, banList: []);
+
+        $this->assertStringContainsString(
+            'colspan="10"',
+            $html,
+            'Empty-state row colspan must equal the max column count (10 with IP + Admin both visible) so the empty card stretches across the full table (#1302).',
+        );
+        // And the empty card itself must paint — the colspan bump
+        // shouldn't have broken the {foreachelse} branch that
+        // wraps it.
+        $this->assertStringContainsString(
+            'data-testid="banlist-empty"',
+            $html,
+            'Empty-state container must still render — the colspan bump should not have disturbed the {foreachelse} branch (#1302).',
+        );
+    }
+
+    /**
+     * Build a BanListView with one synthetic ban row, render it
+     * through Smarty, and return the full HTML output.
+     *
+     * @param list<array<string, mixed>>|null $banList Override the seeded ban list. `null` keeps the default 1-row fixture.
+     */
+    private function renderBanList(bool $hideplayerips, ?array $banList = null): string
+    {
+        $rows = $banList ?? [$this->fixtureBanRow()];
+
+        $view = new BanListView(
+            ban_list:        $rows,
+            ban_nav:         '',
+            total_bans:      count($rows),
+            view_bans:       false,
+            view_comments:   false,
+            comment:         false,
+            commenttype:     '',
+            commenttext:     '',
+            ctype:           '',
+            cid:             '',
+            page:            -1,
+            canedit:         false,
+            othercomments:   'None',
+            searchlink:      '',
+            hidetext:        'Hide',
+            hideadminname:   false,
+            hideplayerips:   $hideplayerips,
+            groupban:        false,
+            friendsban:      false,
+            general_unban:   false,
+            can_delete:      false,
+            can_export:      false,
+            admin_postkey:   'test-postkey',
+            can_add_ban:     false,
+            is_filtered:     false,
+            server_list:     [],
+            filters:         ['search' => '', 'server' => '', 'time' => ''],
+        );
+
+        ob_start();
+        try {
+            Renderer::render($GLOBALS['theme'], $view);
+        } finally {
+            $html = (string) ob_get_clean();
+        }
+        return $html;
+    }
+
+    /**
+     * Single ban row with the per-row keys page_bans.tpl reads.
+     * Mirrors the shape page.banlist.php builds in its $bans loop —
+     * just the fields the template touches plus a synthetic IP that
+     * we anchor the test assertions on.
+     *
+     * @return array<string, mixed>
+     */
+    private function fixtureBanRow(): array
+    {
+        return [
+            'bid'             => 42,
+            'name'            => 'TestPlayer',
+            'steam'           => 'STEAM_0:1:1302',
+            'state'           => 'permanent',
+            'length'          => 0,
+            'length_human'    => 'Permanent',
+            'banned'          => 1700000000,
+            'banned_human'    => '2023-11-14 22:13',
+            'banned_iso'      => '2023-11-14T22:13:20+00:00',
+            'sname'           => 'Web Ban',
+            'reason'          => 'aimbot',
+            'aname'           => 'admin',
+            'ban_ip_raw'      => '1.2.3.4',
+            'can_edit_ban'    => false,
+            'can_unban'       => false,
+            'mod_icon'        => 'web.png',
+            'country'         => '',
+            'demo_available'  => false,
+            'view_delete'     => false,
+            'type'            => 0,
+            'commentdata'     => 'None',
+            'avatar_initials' => 'TE',
+            'avatar_hue'      => 60,
+        ];
+    }
+
+    /**
+     * Spin a Smarty `$theme` matching init.php so `Renderer::render`
+     * can actually display the template. Mirrors
+     * `AdminAdminsSearchTest::bootstrapSmartyTheme` — the bare
+     * minimum plugin set the rendered template body touches plus a
+     * per-process compile dir under `sys_get_temp_dir()` (the
+     * default `web/cache/` is owned by root inside the docker image
+     * and tests run as the host user).
+     */
+    private function bootstrapSmartyTheme(): void
+    {
+        require_once INCLUDES_PATH . '/SmartyCustomFunctions.php';
+        require_once INCLUDES_PATH . '/View/View.php';
+        require_once INCLUDES_PATH . '/View/Renderer.php';
+
+        $compileDir = sys_get_temp_dir() . '/sbpp-test-smarty-' . getmypid();
+        if (!is_dir($compileDir)) {
+            mkdir($compileDir, 0o775, true);
+        }
+
+        $theme = new Smarty();
+        $theme->setUseSubDirs(false);
+        $theme->setCompileId('default');
+        $theme->setCaching(Smarty::CACHING_OFF);
+        $theme->setForceCompile(true);
+        $theme->setTemplateDir(SB_THEMES . SB_THEME);
+        $theme->setCompileDir($compileDir);
+        $theme->setCacheDir($compileDir);
+        $theme->setEscapeHtml(true);
+        $theme->registerPlugin(Smarty::PLUGIN_FUNCTION, 'help_icon',     'smarty_function_help_icon');
+        $theme->registerPlugin(Smarty::PLUGIN_FUNCTION, 'sb_button',     'smarty_function_sb_button');
+        $theme->registerPlugin(Smarty::PLUGIN_FUNCTION, 'load_template', 'smarty_function_load_template');
+        $theme->registerPlugin(Smarty::PLUGIN_FUNCTION, 'csrf_field',    'smarty_function_csrf_field');
+        $theme->registerPlugin(Smarty::PLUGIN_BLOCK,    'has_access',    'smarty_block_has_access');
+        $theme->registerPlugin('modifier', 'smarty_stripslashes',     'smarty_stripslashes');
+        $theme->registerPlugin('modifier', 'smarty_htmlspecialchars', 'smarty_htmlspecialchars');
+
+        $GLOBALS['theme']    = $theme;
+        $GLOBALS['username'] = 'admin';
+    }
+}

--- a/web/themes/default/css/theme.css
+++ b/web/themes/default/css/theme.css
@@ -797,6 +797,7 @@ html.dark .table thead tr { background: rgb(255 255 255 / 0.02); }
 .table .col-length,
 .table .col-banned,
 .table .col-admin,
+.table .col-ip,
 .table .col-status,
 .table .col-actions { white-space: nowrap; }
 .table .col-status { width: 1%; }

--- a/web/themes/default/page_bans.tpl
+++ b/web/themes/default/page_bans.tpl
@@ -170,6 +170,13 @@
         <tr>
           <th scope="col">Player</th>
           <th scope="col">SteamID</th>
+          {* #1302: IP column gated on `banlist.hideplayerips` + admin
+             status (`hideplayerips` is `Config::getBool('banlist.hideplayerips')
+             && !$userbank->is_admin()` — admins always see IPs, non-admins
+             see them only when the setting is off). Mirrors the existing
+             `{if !$hideadminname}` admin-name guard above; v1.x had this
+             column gated on `is_admin()`, the v2.0 redesign dropped it. *}
+          {if !$hideplayerips}<th scope="col" class="col-ip">IP</th>{/if}
           <th scope="col">Reason</th>
           <th scope="col">Server</th>
           {if !$hideadminname}<th scope="col" class="col-admin">Admin</th>{/if}
@@ -214,6 +221,15 @@
               {$ban.steam|escape}
             {/if}
           </td>
+          {if !$hideplayerips}
+          <td class="col-ip font-mono text-xs text-muted" data-testid="ban-ip">
+            {if $ban.ban_ip_raw == ''}
+              <i class="text-faint">none</i>
+            {else}
+              {$ban.ban_ip_raw|escape}
+            {/if}
+          </td>
+          {/if}
           <td class="text-muted truncate" style="max-width:18rem">{if empty($ban.reason)}<i class="text-faint">no reason</i>{else}{$ban.reason|escape}{/if}</td>
           <td class="text-muted truncate" style="max-width:12rem">{$ban.sname|escape}</td>
           {if !$hideadminname}
@@ -262,7 +278,13 @@
            "Clear filters" and `data-filtered="true"` so tests can
            disambiguate. *}
         <tr>
-          <td colspan="9" style="padding:0">
+          {* colspan accounts for the maximum render: Player, SteamID, IP
+             (gated on `!$hideplayerips`), Reason, Server, Admin (gated on
+             `!$hideadminname`), Length, Banned, Status, Actions = 10. The
+             empty-state cell stretches across whichever subset of columns
+             is currently visible — the wider colspan is harmless when
+             columns are conditionally hidden. *}
+          <td colspan="10" style="padding:0">
             {if $is_filtered}
             <div class="empty-state" data-testid="banlist-empty" data-filtered="true">
               <span class="empty-state__icon" aria-hidden="true">
@@ -322,6 +344,13 @@
           </div>
           <div class="text-xs text-muted truncate" style="margin-top:0.125rem">{if empty($ban.reason)}no reason{else}{$ban.reason|escape}{/if} &middot; {if $ban.length == 0}Permanent{else}{$ban.length_human|escape}{/if}</div>
           <div class="font-mono text-xs text-faint truncate" style="margin-top:0.125rem">{if empty($ban.steam)}&mdash;{else}{$ban.steam|escape}{/if}</div>
+          {* #1302: IP line on the mobile card mirrors the desktop IP
+             column above. Same `{if !$hideplayerips}` gate so an
+             admin sees IPs at-a-glance on phone too; non-admins under
+             `banlist.hideplayerips` get the same suppression contract. *}
+          {if !$hideplayerips && $ban.ban_ip_raw != ''}
+          <div class="font-mono text-xs text-faint truncate" style="margin-top:0.125rem" data-testid="ban-ip-mobile">{$ban.ban_ip_raw|escape}</div>
+          {/if}
         </div>
         <span class="text-faint" aria-hidden="true">&rsaquo;</span>
       </a>
@@ -428,4 +457,4 @@
    these props, this manifest stops being necessary, and the View
    drops them. Until then, keep this block at EOF.
    ============================================================ *}
-{if false}{$ban_nav}{$ctype}{$cid}{$page}{$canedit}{$othercomments}{$commenttype}{$commenttext}{$comment}{$friendsban}{$groupban}{$can_delete}{$general_unban}{$hidetext}{$searchlink}{$can_export}{$admin_postkey}{$view_comments}{$view_bans}{$hideadminname}{$hideplayerips}{$total_bans}{/if}
+{if false}{$ban_nav}{$ctype}{$cid}{$page}{$canedit}{$othercomments}{$commenttype}{$commenttext}{$comment}{$friendsban}{$groupban}{$can_delete}{$general_unban}{$hidetext}{$searchlink}{$can_export}{$admin_postkey}{$view_comments}{$view_bans}{$hideadminname}{$total_bans}{/if}


### PR DESCRIPTION
## Summary

Fixes #1302.

The v2.0 redesign of `web/themes/default/page_bans.tpl` dropped the per-row IP column entirely — even an `ADMIN_OWNER` user lost the at-a-glance IP that v1.x rendered (gated on `is_admin()`). The page handler (`web/pages/page.banlist.php`) was already computing `$hideplayerips = Config::getBool('banlist.hideplayerips') && !$userbank->is_admin()` correctly, and `BanListView` was already exposing `hideplayerips` plus the per-row `ban_ip_raw` field, so the fix is template-only:

- Reintroduce the IP `<th>` and per-row `<td>` on the desktop table, gated on `{if !$hideplayerips}` (mirrors the existing `{if !$hideadminname}` admin-name guard). `data-testid="ban-ip"` hooks the cell for E2E specs.
- Mirror the same gate on the mobile `.ban-cards` block, surfacing the IP under the SteamID line. `data-testid="ban-ip-mobile"` for the responsive specs.
- Bump the empty-state `colspan` from `9` to `10` to cover the maximum render (Player, SteamID, IP, Reason, Server, Admin, Length, Banned, Status, Actions). The wider colspan is harmless when conditional columns hide.
- Add `.col-ip` to the existing `white-space: nowrap` rule in `theme.css` so IPv4 strings don't wrap.
- Drop `$hideplayerips` from the EOF manifest now that the template body references it for real.

The suppression contract mirrors `{if !$hideadminname}` exactly: when `$hideplayerips` is true (anonymous viewer under default `banlist.hideplayerips=1`), the column is fully omitted — no header, no per-row cell, no mobile card line. We deliberately don't render an "IP redacted" placeholder.

## Test plan

- `./sbpp.sh phpstan` → pass (228 files, 0 errors).
- `./sbpp.sh test` → 406 tests, 1775 assertions, 0 failures (the 1 PHPUnit deprecation is unrelated, in `GroupsTest::testEditRoundTripsHighBitFlagsAsPositiveIntegers`).
- `./sbpp.sh test --filter=BanListIpColumnTest` → 3 tests, 10 assertions:
  - `testIpColumnRendersWhenHideplayeripsIsFalse` asserts the desktop `<th>`, the per-row `[data-testid="ban-ip"]` cell with the seeded `1.2.3.4`, and the mobile `[data-testid="ban-ip-mobile"]` line all render.
  - `testIpColumnIsSuppressedWhenHideplayeripsIsTrue` asserts none of the three surfaces render and the seeded IP doesn't leak.
  - `testEmptyStateColspanCovers10Columns` asserts the empty-state `<td colspan="10">` and the `[data-testid="banlist-empty"]` container both render.
- `./sbpp.sh ts-check` → pass.
- `./sbpp.sh e2e --grep "banlist|empty-states" --workers=1` → 20 passed (matches CI's `workers: 1` configuration). New `banlist-ip-column.spec.ts` runs on both chromium and mobile-chromium projects, asserting the live desktop `<th>`/per-row testid path AND the mobile card path against an admin-authenticated session that seeded an IP-bearing ban via `bans.add`.

## Files touched

- `web/themes/default/page_bans.tpl` — IP column header + per-row cell + mobile card line + colspan bump + EOF manifest cleanup.
- `web/themes/default/css/theme.css` — `.col-ip` added to the `white-space: nowrap` rule.
- `web/tests/integration/BanListIpColumnTest.php` — PHPUnit regression test (template-level coverage in both directions + empty-state colspan).
- `web/tests/e2e/specs/flows/banlist-ip-column.spec.ts` — Playwright regression spec (end-to-end coverage on chromium + mobile-chromium).