### PR TITLE
Fix #1304: server-render permission-filtered command palette nav entries

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -705,6 +705,53 @@ different surfaces — don't conflate them. `Perms::for` is what page
 Views consume to gate `{if $can_add_ban}`; `PermissionCatalog` is
 what the rare display-the-user's-flags-back-to-them surfaces consume.
 
+### Filtered chrome navigation surfaces (sidebar + palette)
+
+Two chrome surfaces ship the user a list of "where you can go from
+here" entries:
+
+- The sidebar (`web/pages/core/navbar.php` → `core/navbar.tpl`) — the
+ vertical nav on the left of every page.
+- The command palette (`web/includes/View/PaletteActions.php` →
+ `<script id="palette-actions">` in `core/footer.tpl` →
+ `theme.js`'s `loadNavItems()`) — the Ctrl/Cmd-K dialog's "Navigate"
+ section (#1304).
+
+Both **must filter against the same per-(user, permission) gates**.
+Anything else leaks admin entries to logged-out / partial-permission
+users; clicking such an entry lands them on the "you must be logged
+in" / 403 surface and the chrome reads as broken (#1304 is the
+audit issue).
+
+The contract for either surface:
+
+- Public entries (Dashboard, Banlist, Servers) are always shown.
+- Public entries that ride a `config.enable*` toggle (Comm blocks /
+ Submit / Appeals) are dropped on installs that disabled the
+ surface — both surfaces honour the same toggle.
+- Admin entries are gated via `HasAccess($mask | ADMIN_OWNER)` so
+ owners see everything and per-flag holders see only what they
+ can actually use.
+- A `null` userbank (CSRF reject path / unhandled-error path
+ reaches the chrome before auth) is treated identically to
+ logged-out — fail closed.
+
+When adding a new entry to either surface, add the matching entry
+to the other in the same PR. The catalog files live next to each
+other (`web/pages/core/navbar.php` for the sidebar,
+`web/includes/View/PaletteActions.php` for the palette) for exactly
+this reason; the two regression suites
+(`web/tests/integration/PaletteActionsTest.php` and the existing
+navbar coverage in `web/tests/integration/LostPasswordChromeTest.php`)
+are the gates.
+
+`web/includes/View/PaletteActions.php` is the only PaletteActions
+catalog — never reintroduce the pre-#1304 hardcoded `NAV_ITEMS`
+array in `theme.js`. The wire format from the server to the JS
+client is the JSON blob's `{icon, label, href}` triple — never
+expose the raw `permission` mask to the client (the gate is
+server-side, full stop).
+
 ### `nofilter` discipline
 
 Smarty auto-escape is on globally (`$theme->setEscapeHtml(true)` in
@@ -1172,6 +1219,19 @@ audit (#1207) locked in. New CTAs:
   branch on it or use the higher-level `rejectIfInvalid()` helper).
   PHPStan's `method.resultDiscarded` rule fails the build on a
   discarded site. Issue #1290 phase K.1.
+- Hardcoded chrome-navigation lists in `theme.js` (the pre-#1304
+  `NAV_ITEMS` array shape) → the command palette's "Navigate" entries
+  are server-rendered + permission-filtered via
+  `Sbpp\View\PaletteActions::for($userbank)` and emitted as a JSON
+  blob inside `<script type="application/json" id="palette-actions">`
+  in `core/footer.tpl`. theme.js consumes the blob via `loadNavItems()`
+  with a fail-empty fallback. The pre-fix array showed `Admin panel`
+  and `Add ban` to logged-out / partial-permission users, who got
+  bounced off the "you must be logged in" / 403 surface when they
+  clicked through (#1304). New chrome-navigation entries land in
+  `PaletteActions::entries()` next to the existing rows; never inline
+  a parallel hardcoded list client-side. See "Filtered chrome
+  navigation surfaces" in Conventions for the per-surface contract.
 - `setTimeout` / `waitForTimeout` waits in E2E specs → wait on
   terminal attributes (`[data-loading="false"]` settled, `[data-skeleton]`
   removed) per #1123's "Testability hooks" rule.
@@ -1260,6 +1320,7 @@ audit (#1207) locked in. New CTAs:
 | Add visible row actions to a table-rendered admin list (Edit / Unmute / Remove buttons + responsive mobile-card mirror) | `web/themes/default/page_comms.tpl` (#1207 ADM-5) is the canonical reference: `<button class="btn btn--secondary btn--sm">` / `<a class="btn btn--ghost btn--sm">` inside a `.row-actions` cell, plus `.ban-card__actions` row of identical-data-action buttons in the mobile card. Wire destructive / state-changing buttons via `data-action="…"` + `data-bid` + `data-fallback-href`; the inline page-tail JS calls `sb.api.call(Actions.PascalName)` and falls back to the GET URL if the JSON dispatcher is absent. |
 | Edit the player-detail drawer (open trigger, tabs, panes, lazy loaders) | `web/themes/default/js/theme.js` (`renderDrawerBody` / `loadPaneIfNeeded`) |
 | Edit the command palette (icon-only trigger, ⌘K binding, result rows, kbd hints, Ctrl+Enter copy) | `web/themes/default/js/theme.js` (`openPalette` / `closePalette` / `renderPaletteResults` / `applyPlatformHints` / `handlePaletteCopyShortcut`) + `core/title.tpl` (the `.topbar__search` icon button) + the `.palette__row*` rules in `web/themes/default/css/theme.css`. Player rows carry `data-drawer-bid="<bid>"` (bare Enter / click → `loadDrawer`, palette closes itself) + `data-steamid="<steam>"` (`Ctrl/Cmd+Enter` → `navigator.clipboard.writeText` + `showToast`). The kbd glyphs are server-rendered in non-Mac form (`Enter`, `Ctrl`); `applyPlatformHints` swaps `[data-enterkey]` → ⏎ and `[data-modkey]` → ⌘ on Mac/iOS at boot and after every render (#1184, #1207 DET-2). |
+| Add or edit a palette "Navigate" entry (the icon-label-href rows the palette renders alongside player results) | `web/includes/View/PaletteActions.php` (`Sbpp\View\PaletteActions::for($userbank)` — catalog + filter). The catalog's `entries()` method declares each entry as `{icon, label, href, permission, config?}`; `for()` drops entries the user can't reach (admin entries gated via `HasAccess` with `ADMIN_OWNER` OR'd in; public entries optionally gated on a `config.enable*` toggle) and emits the public `{icon, label, href}` triple. The filtered list is JSON-encoded by `web/pages/core/footer.php` (with `JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT` so the content can never escape its `<script>` wrapper) and emitted by `core/footer.tpl` inside `<script type="application/json" id="palette-actions" data-testid="palette-actions">`. `theme.js`'s `loadNavItems()` reads + `JSON.parse`s the blob at boot. Pre-#1304 the entry list was a hardcoded `NAV_ITEMS` array in `theme.js` with no permission check, leaking admin entries to logged-out + partial-permission users; the regression guard is `web/tests/integration/PaletteActionsTest.php` (server-side filter) plus `web/tests/e2e/specs/flows/ui/command-palette-permissions.spec.ts` (end-to-end blob → DOM contract). |
 | Add admin-only per-player notes | `web/api/handlers/notes.php` (CRUD) — Notes tab is gated by `bans.detail`'s `notes_visible` flag |
 | Render admin-authored Markdown to safe HTML | `web/includes/Markup/IntroRenderer.php` (`Sbpp\Markup`) |
 | Build / extend the anonymous opt-out daily telemetry payload (#1126) | `web/includes/Telemetry/Telemetry.php` (`Sbpp\Telemetry\Telemetry` — `tickIfDue`, `collect`, `send`) + `web/includes/Telemetry/Schema1.php` (`Sbpp\Telemetry\Schema1::payloadFieldNames()`, drives the parity tests) + `web/includes/Telemetry/schema-1.lock.json` (vendored from [sbpp/cf-analytics](https://github.com/sbpp/cf-analytics) — manual sync via `make sync-telemetry-schema`). Tick is registered at the tail of `init.php` via `register_shutdown_function`; on FPM, `fastcgi_finish_request()` flushes the response BEFORE the cURL POST so telemetry never delays a panel page. Slot reservation is atomic (`UPDATE :prefix_settings WHERE CAST(value AS UNSIGNED) <= :threshold`) at the START of the attempt, so a flapping endpoint costs one ping/day, not one ping/request. Audit-log only enable/disable transitions, never individual pings. Help-icon copy in `page_admin_settings_features.tpl` + `README.md`'s `## Privacy & telemetry` section + `UPGRADING.md` are the in-panel + upgrade-time disclosure surfaces (no first-login modal). |

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -392,6 +392,24 @@ in non-Mac form (`Enter`, `Ctrl`); `applyPlatformHints` rewrites
 boot and after every render so glyph swaps don't require re-fetching
 results (#1184, #1207 DET-2).
 
+The palette's "Navigate" entries are server-rendered + permission
+filtered (#1304). `Sbpp\View\PaletteActions::for($userbank)` builds
+the entry catalog the way `web/pages/core/navbar.php` builds the
+sidebar: each entry carries a `permission` (int bitmask checked via
+`HasAccess` with `ADMIN_OWNER` OR'd in, or `true` for public) and an
+optional `config` key (a `sb_settings` boolean — same `config.enable*`
+toggles the sidebar already honours). `web/pages/core/footer.php`
+encodes the filtered list (with `JSON_HEX_TAG | JSON_HEX_AMP |
+JSON_HEX_APOS | JSON_HEX_QUOT` so the content can never break out of
+its `<script>` wrapper) and assigns it as `$palette_actions_json`;
+`core/footer.tpl` emits it inside `<script type="application/json"
+id="palette-actions" data-testid="palette-actions">`. `theme.js`'s
+`loadNavItems()` reads + `JSON.parse`s the blob at boot and uses it
+in place of the pre-#1304 hardcoded `NAV_ITEMS` array (which leaked
+admin links — `Admin panel`, `Add ban` — to logged-out and
+partial-permission users). The player-search half (`bans.search`)
+stays public; the leak was strictly the navigation entries.
+
 The preferred way to render is via typed view-model DTOs:
 
 ```php

--- a/web/includes/View/PaletteActions.php
+++ b/web/includes/View/PaletteActions.php
@@ -1,0 +1,237 @@
+<?php
+declare(strict_types=1);
+
+namespace Sbpp\View;
+
+use Sbpp\Auth\UserManager;
+use Sbpp\Config;
+
+/**
+ * Build the permission-filtered navigation set the command palette
+ * (Ctrl/Cmd-K, `<dialog id="palette-root">`) renders into its
+ * "Navigate" section.
+ *
+ * Issue #1304: pre-fix, the palette's nav set was a hardcoded
+ * `NAV_ITEMS` array in `web/themes/default/js/theme.js` with no
+ * permission filter — every visitor (logged-out, partial-permission
+ * admins) saw the admin-only entries (`Admin panel`, `Add ban`)
+ * alongside the public ones, then got bounced off the "you must be
+ * logged in" / 403 surface when they clicked one. The sibling sidebar
+ * (`web/pages/core/navbar.php` + `core/navbar.tpl`) already built a
+ * filtered link set; the palette didn't.
+ *
+ * The fix server-renders the filtered set as a JSON blob inside a
+ * `<script type="application/json" id="palette-actions">` block in
+ * `core/footer.tpl`; `theme.js` reads `JSON.parse` of that blob at
+ * boot and uses it instead of the hardcoded array. The player search
+ * half (`bans.search`) is intentionally public and stays unchanged —
+ * the leak was strictly the navigation entries.
+ *
+ * Each entry carries:
+ *   - `icon`        Lucide icon name rendered into the row.
+ *   - `label`       Display text the palette filters by case-insensitive
+ *                   substring match.
+ *   - `href`        Navigation target. Anchors clicked / Enter-fired
+ *                   from a keyboard-focused palette row land here.
+ *   - `permission`  Either an `int` bitmask (admin entries — `HasAccess`
+ *                   gate) or `true`/`false`/`null` for "always shown"
+ *                   public entries. The `int` shape matches the legacy
+ *                   `ADMIN_OWNER | ADMIN_ADD_BAN` form already in use
+ *                   throughout `web/pages/core/navbar.php`. Owner is OR'd
+ *                   in by the caller via the `ADMIN_OWNER | …` shape, so
+ *                   the bitmask itself documents the gate at the call site.
+ *   - `config`      Optional `sb_settings` boolean key — entry is dropped
+ *                   when the bool is false. Mirrors `navbar.php`'s
+ *                   `Config::getBool('config.enablecomms')` etc. so the
+ *                   palette agrees with the sidebar on which public
+ *                   surfaces are reachable for this install.
+ *
+ * The output shape (after filtering) drops `permission` / `config` so
+ * the JSON blob carries only the three keys `theme.js` consumes —
+ * smaller wire payload, less DOM noise, and no temptation to use
+ * `permission` as a client-side gate (the gate is server-side,
+ * full stop).
+ *
+ * Anti-leakage discipline (mirrors `navbar.php`):
+ *   - `is_logged_in()` short-circuits ALL admin entries. A null userbank
+ *     (CSRF reject path / unhandled error) is treated identically to
+ *     logged-out.
+ *   - Admin entries OR `ADMIN_OWNER` into their permission mask so an
+ *     owner sees every entry without the catalog having to track the
+ *     bypass — same convention as `CheckAdminAccess` everywhere else.
+ *
+ * Adding a new palette entry:
+ *   - Drop a new row into `entries()` below.
+ *   - For admin entries, name the matching `web/configs/permissions/web.json`
+ *     flag (OR'd with `ADMIN_OWNER`); the `PaletteActionsTest` regression
+ *     suite asserts the entry stays gated.
+ *   - For public entries, decide whether the install can disable the
+ *     surface via a `config.enable*` toggle and add the `config` key
+ *     if so. Without `config`, the entry shows for every install.
+ *
+ * The entry list intentionally matches the pre-#1304 hardcoded JS
+ * array's ordering (Dashboard → Servers → Banlist → Comms → Submit →
+ * Appeals → Admin → Add ban) so the visible behaviour for an owner
+ * is byte-identical to the pre-fix rendering — only the leak is
+ * gone.
+ */
+final class PaletteActions
+{
+    /**
+     * Disallow instantiation — this class is a static helper namespace.
+     */
+    private function __construct()
+    {
+    }
+
+    /**
+     * Build the public output shape for $userbank. Each entry is an
+     * `{icon, label, href}` map suitable for direct JSON encoding into
+     * the `<script type="application/json" id="palette-actions">` blob.
+     *
+     * @return list<array{icon: string, label: string, href: string}>
+     */
+    public static function for(?UserManager $userbank): array
+    {
+        $isLoggedIn = $userbank !== null && $userbank->is_logged_in();
+        $owner = defined('ADMIN_OWNER') ? (int) constant('ADMIN_OWNER') : 0;
+
+        $out = [];
+        foreach (self::entries() as $entry) {
+            // Optional `config.enable*` toggle. Mirrors navbar.php so a
+            // disabled surface (e.g. config.enablecomms = 0) drops out
+            // of both the sidebar and the palette in the same request.
+            if (isset($entry['config']) && !Config::getBool($entry['config'])) {
+                continue;
+            }
+
+            $perm = $entry['permission'];
+            // The catalog's permission shape is `bool|int|null`:
+            //   - `true` / `null` → public, always shown
+            //   - `false`         → disabled in source (kept for symmetry with
+            //                       navbar.php's literal-false branch; no entry
+            //                       currently uses it but keeping the case
+            //                       avoids a silent leak if a future entry
+            //                       drops the value back in)
+            //   - `int`           → admin entry, must be logged in AND hold
+            //                       the mask. `HasAccess` itself short-circuits
+            //                       on aid <= 0, but the explicit
+            //                       `is_logged_in()` guard documents the intent
+            //                       at the filter site (matches navbar.php).
+            //
+            // The `match (true)` here pairs the discriminator with the
+            // resulting bool in one expression, and is exhaustive over the
+            // catalog's declared shape — PHPStan can prove that the `int`
+            // arm is reached on the int branch (which is why the previous
+            // `is_int($perm)` guard tripped `function.alreadyNarrowedType`).
+            // `$isLoggedIn` already implies `$userbank !== null`, so the
+            // explicit non-null guard from before was redundant too
+            // (`notIdentical.alwaysTrue`).
+            $allowed = match (true) {
+                $perm === true, $perm === null => true,
+                $perm === false => false,
+                default => $isLoggedIn && $userbank->HasAccess($perm | $owner),
+            };
+
+            if (!$allowed) {
+                continue;
+            }
+
+            $out[] = [
+                'icon'  => $entry['icon'],
+                'label' => $entry['label'],
+                'href'  => $entry['href'],
+            ];
+        }
+
+        return $out;
+    }
+
+    /**
+     * The catalog. New entries land here; `for()` does the filtering.
+     *
+     * The shape is `array{icon, label, href, permission, config?}`
+     * declared inline rather than as a `@phpstan-type` because PHPStan's
+     * level-5 array shape inference reads the literal here directly.
+     *
+     * @return list<array{
+     *     icon: string,
+     *     label: string,
+     *     href: string,
+     *     permission: bool|int|null,
+     *     config?: string,
+     * }>
+     */
+    private static function entries(): array
+    {
+        // Using `defined()` for the ADMIN_* constants so the catalog
+        // is safely loadable from contexts (PHPStan analysis,
+        // PHPUnit bootstrap variants) where init.php's permission
+        // define() pass hasn't run yet. At runtime in the panel,
+        // init.php has already populated them; in tests/bootstrap.php
+        // pulls in web.json and define()s them too.
+        $addBan = (defined('ADMIN_OWNER') ? (int) constant('ADMIN_OWNER') : 0)
+            | (defined('ADMIN_ADD_BAN') ? (int) constant('ADMIN_ADD_BAN') : 0);
+
+        return [
+            [
+                'icon'       => 'layout-dashboard',
+                'label'      => 'Dashboard',
+                'href'       => '?',
+                'permission' => true,
+            ],
+            [
+                'icon'       => 'server',
+                'label'      => 'Servers',
+                'href'       => '?p=servers',
+                'permission' => true,
+            ],
+            [
+                'icon'       => 'ban',
+                'label'      => 'Ban list',
+                'href'       => '?p=banlist',
+                'permission' => true,
+            ],
+            [
+                'icon'       => 'mic-off',
+                'label'      => 'Comm blocks',
+                'href'       => '?p=commslist',
+                'permission' => true,
+                'config'     => 'config.enablecomms',
+            ],
+            [
+                'icon'       => 'flag',
+                'label'      => 'Submit a ban',
+                'href'       => '?p=submit',
+                'permission' => true,
+                'config'     => 'config.enablesubmit',
+            ],
+            [
+                'icon'       => 'megaphone',
+                'label'      => 'Appeals',
+                'href'       => '?p=protest',
+                'permission' => true,
+                'config'     => 'config.enableprotest',
+            ],
+            // Admin landing — gated on ALL_WEB to mirror page-builder.php's
+            // CheckAdminAccess(ALL_WEB) on the bare admin landing route.
+            // Any admin (any web flag) reaches the page; non-admins (no
+            // web flags) are kept off the palette so they don't hit
+            // "you must be logged in / 403" surfaces from the chrome.
+            [
+                'icon'       => 'shield',
+                'label'      => 'Admin panel',
+                'href'       => '?p=admin',
+                'permission' => defined('ALL_WEB') ? (int) constant('ALL_WEB') : 0,
+            ],
+            // Add ban — same gate as the sub-route's CheckAdminAccess in
+            // page-builder.php: ADMIN_OWNER | ADMIN_ADD_BAN.
+            [
+                'icon'       => 'plus-circle',
+                'label'      => 'Add ban',
+                'href'       => '?p=admin&c=bans&section=add-ban',
+                'permission' => $addBan,
+            ],
+        ];
+    }
+}

--- a/web/pages/core/footer.php
+++ b/web/pages/core/footer.php
@@ -1,5 +1,5 @@
 <?php
-global $theme;
+global $theme, $userbank;
 
 if (!defined("IN_SB")) {
     die("You should not be here. Only follow links!");
@@ -13,4 +13,31 @@ if (!defined("IN_SB")) {
 $theme->assign('git', SB_GITREV ? ' | Git: '.SB_GITREV : '');
 $theme->assign('version', SB_VERSION);
 $theme->assign('query', !empty($GLOBALS['server_qry']) ? $GLOBALS['server_qry'] : '');
+
+// Issue #1304: server-render the command palette's "Navigate" entries
+// as a permission-filtered JSON blob the chrome emits inside a
+// `<script type="application/json" id="palette-actions">` tag in
+// `core/footer.tpl`. theme.js reads + JSON.parses the blob at boot;
+// pre-fix the entry list was a hardcoded JS array that leaked admin
+// links (`Admin panel`, `Add ban`) to logged-out / partial-permission
+// users.
+//
+// JSON_HEX_TAG / _AMP / _APOS / _QUOT escape `<>&'"` as Unicode
+// escapes so the JSON content can never break out of the surrounding
+// `<script>` element regardless of what a future label / href adds.
+// JSON_THROW_ON_ERROR makes encoding failures loud (the catalog is
+// pure ASCII today, but the throw protects future edits).
+$paletteActions = \Sbpp\View\PaletteActions::for($userbank ?? null);
+$theme->assign(
+    'palette_actions_json',
+    json_encode(
+        $paletteActions,
+        JSON_THROW_ON_ERROR
+        | JSON_HEX_TAG
+        | JSON_HEX_AMP
+        | JSON_HEX_APOS
+        | JSON_HEX_QUOT,
+    ),
+);
+
 $theme->display('core/footer.tpl');

--- a/web/tests/e2e/specs/flows/ui/command-palette-permissions.spec.ts
+++ b/web/tests/e2e/specs/flows/ui/command-palette-permissions.spec.ts
@@ -1,0 +1,174 @@
+/**
+ * Command palette permission filtering (#1304).
+ *
+ * Pre-fix the palette's "Navigate" entries were a hardcoded `NAV_ITEMS`
+ * array in `web/themes/default/js/theme.js` with no permission filter,
+ * so logged-out + partial-permission users saw `Admin panel` and
+ * `Add ban` alongside the public entries — clicking either bounced
+ * them off the "you must be logged in" / 403 surface.
+ *
+ * The fix server-renders the entry set via
+ * `Sbpp\View\PaletteActions::for($userbank)` and emits it as a JSON
+ * blob inside `<script type="application/json" id="palette-actions">`
+ * in `core/footer.tpl`; theme.js reads + JSON.parses the blob at boot
+ * and uses it instead of the hardcoded array. The PHPUnit suite
+ * (`PaletteActionsTest`) holds the helper accountable in isolation;
+ * this spec exercises the wire contract end-to-end (server-rendered
+ * blob → JSON.parse → palette result rows) by asserting on the
+ * rendered DOM as the user would see it.
+ *
+ * Two contracts pinned here:
+ *   1. The server-rendered JSON blob (`#palette-actions`) carries the
+ *      filtered shape — never the admin entries for an anonymous
+ *      visitor, never `Add ban` for a partial-permission admin.
+ *   2. The palette's rendered nav rows match the blob — opening the
+ *      palette + reading the `[data-result-kind="nav"]` rows agrees
+ *      with the JSON the chrome shipped, so a future regression in
+ *      either half (server filter or JS consumer) gets caught.
+ */
+
+import { expect, test } from '../../../fixtures/auth.ts';
+
+test.describe('command palette: permission-filtered nav entries (#1304)', () => {
+    test.describe('logged-out visitor', () => {
+        // Per-describe override: opt out of the project-default
+        // storageState (which carries the seeded admin's session
+        // cookie). The leak the issue describes is most visible to
+        // unauthenticated visitors, so this is the load-bearing
+        // subtest.
+        test.use({ storageState: { cookies: [], origins: [] } });
+
+        test('server-rendered #palette-actions blob excludes admin entries', async ({ page }) => {
+            await page.goto('/');
+
+            // The `<script type="application/json" id="palette-actions">`
+            // tag is in the DOM regardless of whether the palette has
+            // been opened — theme.js reads it at boot. We assert on the
+            // textContent (JSON.parse-able payload) directly so the
+            // server-side filter is the contract under test.
+            const blob = page.locator('[data-testid="palette-actions"]');
+            await expect(blob).toBeAttached();
+            const json = await blob.textContent();
+            expect(json, 'palette-actions blob must carry a JSON payload').toBeTruthy();
+
+            // Decode + assert. Each entry is `{icon, label, href}`;
+            // we filter on `label` because that's the user-visible
+            // dimension the palette displays + filters on.
+            const entries = JSON.parse(json ?? '[]') as Array<{
+                icon: string;
+                label: string;
+                href: string;
+            }>;
+            const labels = entries.map((e) => e.label);
+
+            // Primary leak: no admin entries for an unauthenticated
+            // visitor.
+            expect(labels).not.toContain('Admin panel');
+            expect(labels).not.toContain('Add ban');
+
+            // Public entries that should always render so the palette
+            // stays useful for anonymous visitors who want to jump to
+            // the public banlist / submit form.
+            expect(labels).toContain('Dashboard');
+            expect(labels).toContain('Servers');
+            expect(labels).toContain('Ban list');
+        });
+
+        test('opening the palette renders only the filtered nav rows', async ({ page }) => {
+            await page.goto('/');
+
+            // Open the palette via Meta+K (theme.js's keydown listener
+            // accepts metaKey || ctrlKey, so this works on every
+            // runner). Cross-references the existing
+            // command-palette.spec.ts harness — we pin the *content*
+            // of the rendered rows rather than the open/close
+            // mechanics that spec already covers.
+            await page.keyboard.press('Meta+k');
+            const dialog = page.locator('#palette-root');
+            await expect(dialog).toHaveAttribute('data-palette-open', 'true');
+
+            // theme.js's renderPaletteResults emits each nav entry as
+            // `<a data-testid="palette-result" data-result-kind="nav">`
+            // with the label as the visible text. The first paint shows
+            // the unfiltered nav set (palette opens with empty input);
+            // we read those rows and assert on their labels.
+            const navRows = page.locator(
+                '[data-testid="palette-result"][data-result-kind="nav"]',
+            );
+
+            // Wait for at least one nav row to render. The blob is
+            // server-rendered so the rows should appear synchronously
+            // on open() — the count poll guards against a Lucide
+            // icon-init race that could empty the container briefly.
+            await expect(navRows.first()).toBeVisible();
+            const renderedLabels = await navRows.allTextContents();
+
+            // Trim each label — each row contains a Lucide icon +
+            // whitespace + label text; allTextContents() returns the
+            // trimmed combined text but we strip again defensively.
+            const cleaned = renderedLabels.map((s) => s.trim());
+
+            // Anti-leakage: clicking these would land the visitor on
+            // the "you must be logged in" / 403 surface. Pre-fix they
+            // were both visible.
+            expect(cleaned).not.toContain('Admin panel');
+            expect(cleaned).not.toContain('Add ban');
+
+            // Public entries remain — the palette is still useful for
+            // anonymous visitors.
+            expect(cleaned).toContain('Dashboard');
+            expect(cleaned).toContain('Ban list');
+        });
+    });
+
+    test.describe('logged-in admin (owner)', () => {
+        // No storageState override here: this block inherits the
+        // project-default session minted by `fixtures/global-setup.ts`
+        // for the seeded admin (admin/admin, ADMIN_OWNER). The owner
+        // bypass means every entry surfaces — this subtest is the
+        // anti-confusion guard so a future PR that "fixes" the leak
+        // by hiding admin entries from EVERYONE fails the build.
+        test('owner sees admin entries in the rendered palette', async ({ page }) => {
+            await page.goto('/');
+
+            const blob = page.locator('[data-testid="palette-actions"]');
+            await expect(blob).toBeAttached();
+            const json = await blob.textContent();
+            const entries = JSON.parse(json ?? '[]') as Array<{
+                icon: string;
+                label: string;
+                href: string;
+            }>;
+            const labels = entries.map((e) => e.label);
+
+            // Owner sees every admin entry — the bypass is the
+            // documented contract (mirrors the `is_admin()` shape in
+            // `core/navbar.tpl`).
+            expect(labels).toContain('Admin panel');
+            expect(labels).toContain('Add ban');
+            expect(labels).toContain('Dashboard');
+            expect(labels).toContain('Ban list');
+
+            // And the palette's rendered rows agree.
+            await page.keyboard.press('Meta+k');
+            const dialog = page.locator('#palette-root');
+            await expect(dialog).toHaveAttribute('data-palette-open', 'true');
+
+            const navRows = page.locator(
+                '[data-testid="palette-result"][data-result-kind="nav"]',
+            );
+            await expect(navRows.first()).toBeVisible();
+
+            // hasText filters to disambiguate the multi-row case —
+            // each filter expects a single-row match. Per AGENTS.md
+            // these are fine for narrowing once the primary
+            // data-testid selector has matched a set.
+            await expect(
+                navRows.filter({ hasText: 'Admin panel' }).first(),
+            ).toBeVisible();
+            await expect(
+                navRows.filter({ hasText: 'Add ban' }).first(),
+            ).toBeVisible();
+        });
+    });
+});

--- a/web/tests/integration/PaletteActionsTest.php
+++ b/web/tests/integration/PaletteActionsTest.php
@@ -1,0 +1,314 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sbpp\Tests\Integration;
+
+use Sbpp\Tests\ApiTestCase;
+use Sbpp\Tests\Fixture;
+use Sbpp\View\PaletteActions;
+
+/**
+ * Issue #1304: the command palette (Ctrl/Cmd-K, `<dialog id="palette-root">`)
+ * leaked admin-only navigation entries (`Admin panel`, `Add ban`) to
+ * unauthenticated and partial-permission users because its `NAV_ITEMS`
+ * was a hardcoded JS array in `web/themes/default/js/theme.js` with no
+ * permission filter.
+ *
+ * The fix server-renders the entry set via `Sbpp\View\PaletteActions::for()`
+ * and emits it as a JSON blob inside `<script type="application/json"
+ * id="palette-actions">` in `core/footer.tpl`; theme.js reads that blob
+ * at boot. This test holds the helper accountable: the same per-(user,
+ * permission) gating the sibling sidebar (`web/pages/core/navbar.php` +
+ * `core/navbar.tpl`) already enforced now also gates the palette.
+ *
+ * Each subtest pins the contract for one of the four user shapes the
+ * panel actually serves:
+ *   - null userbank (CSRF reject path / unhandled error before auth ran)
+ *   - anonymous (logged out)
+ *   - partial-permission admin (e.g. only ADMIN_LIST_SERVERS)
+ *   - owner (full bypass via ADMIN_OWNER)
+ *
+ * The player-search half of the palette (`bans.search`) is intentionally
+ * public and stays accessible regardless — the issue's leak was strictly
+ * the navigation entries.
+ */
+final class PaletteActionsTest extends ApiTestCase
+{
+    /**
+     * Null userbank → public entries only, zero admin entries. The CSRF
+     * reject path / hard-error path can reach the chrome without an
+     * authenticated user; null must be treated identically to logged-out
+     * (fail closed, never let null look like an admin).
+     */
+    public function testNullUserBankSeesOnlyPublicEntries(): void
+    {
+        $entries = PaletteActions::for(null);
+
+        $labels = self::labelsOf($entries);
+        $this->assertNotContains('Admin panel', $labels,
+            'Admin panel must be hidden when userbank is null (CSRF reject / error path).');
+        $this->assertNotContains('Add ban', $labels,
+            'Add ban must be hidden when userbank is null.');
+
+        // Public entries that should always render. Comm blocks /
+        // Submit / Appeals are also public but each rides a
+        // `config.enable*` toggle — they're asserted in
+        // testPublicTogglesGateEntries below.
+        $this->assertContains('Dashboard', $labels);
+        $this->assertContains('Servers',   $labels);
+        $this->assertContains('Ban list',  $labels);
+    }
+
+    /**
+     * Anonymous user (aid = -1, what `Auth::verify()` returns when the
+     * cookie is missing). `CUserManager::HasAccess()` short-circuits on
+     * aid <= 0; the helper must propagate that closed gate to admin
+     * entries while keeping public entries reachable.
+     */
+    public function testAnonymousUserSeesOnlyPublicEntries(): void
+    {
+        $userbank = new \CUserManager(null);
+
+        $entries = PaletteActions::for($userbank);
+        $labels = self::labelsOf($entries);
+
+        $this->assertNotContains('Admin panel', $labels,
+            'Admin panel must be hidden for unauthenticated visitors (#1304 — primary leak in the issue).');
+        $this->assertNotContains('Add ban', $labels,
+            'Add ban must be hidden for unauthenticated visitors (#1304 — primary leak in the issue).');
+
+        $this->assertContains('Dashboard', $labels);
+        $this->assertContains('Servers',   $labels);
+        $this->assertContains('Ban list',  $labels);
+    }
+
+    /**
+     * The owner sees every entry (admin bypass). Mirrors the convention
+     * baked into every `CheckAdminAccess(ADMIN_OWNER|…)` call site in
+     * `web/includes/page-builder.php`: an owner trumps every per-flag
+     * check. The helper OR's `ADMIN_OWNER` into each admin entry's
+     * mask before calling `HasAccess`, so an owner sees every gated
+     * entry without the catalog having to track the bypass.
+     */
+    public function testOwnerSeesEveryEntry(): void
+    {
+        $this->loginAsAdmin();
+        /** @var \CUserManager $userbank */
+        $userbank = $GLOBALS['userbank'];
+
+        $entries = PaletteActions::for($userbank);
+        $labels = self::labelsOf($entries);
+
+        $this->assertContains('Admin panel', $labels,
+            'Owner must see Admin panel — ADMIN_OWNER bypass.');
+        $this->assertContains('Add ban', $labels,
+            'Owner must see Add ban — ADMIN_OWNER bypass.');
+        $this->assertContains('Dashboard', $labels);
+        $this->assertContains('Servers',   $labels);
+        $this->assertContains('Ban list',  $labels);
+    }
+
+    /**
+     * Partial-permission admin: holds ADMIN_LIST_SERVERS but NOT
+     * ADMIN_OWNER and NOT ADMIN_ADD_BAN. The "Add ban" palette entry
+     * is gated on `ADMIN_OWNER | ADMIN_ADD_BAN` — must stay hidden.
+     * The "Admin panel" entry is gated on ALL_WEB (any web flag); a
+     * holder of any single flag IS an admin per `is_admin()` so the
+     * panel landing IS reachable for them — surfacing the entry in
+     * the palette matches the sidebar (`navbar.php` ships the
+     * "Admin Panel" entry to every `is_admin()` user).
+     */
+    public function testPartialPermissionAdminHidesAddBan(): void
+    {
+        $aid = $this->createAdminWithFlags(ADMIN_LIST_SERVERS);
+        $this->loginAs($aid);
+        /** @var \CUserManager $userbank */
+        $userbank = $GLOBALS['userbank'];
+
+        $entries = PaletteActions::for($userbank);
+        $labels = self::labelsOf($entries);
+
+        $this->assertNotContains('Add ban', $labels,
+            'A non-owner admin lacking ADMIN_ADD_BAN must NOT see the Add ban palette entry (#1304).');
+
+        // Admin panel surfaces because ALL_WEB matches any web flag —
+        // the user IS an admin (sidebar's same gate).
+        $this->assertContains('Admin panel', $labels,
+            'Any admin (any web flag) reaches the admin landing — entry surfaces in the palette to match navbar.tpl.');
+
+        // Public entries unaffected.
+        $this->assertContains('Dashboard', $labels);
+        $this->assertContains('Servers',   $labels);
+    }
+
+    /**
+     * Comm blocks / Submit / Appeals each ride a `config.enable*`
+     * boolean in `sb_settings` — same gate `web/pages/core/navbar.php`
+     * already honours so the sidebar drops them on installs that
+     * disabled the surface. The palette must agree (otherwise a
+     * disabled-comms install would still surface "Comm blocks" in the
+     * palette and land the user on a blank route).
+     *
+     * `Config::init` reads `sb_settings` at bootstrap; this test
+     * mutates the row, re-inits the cache, and asserts each toggle
+     * gates the corresponding entry. Order intentionally tests one
+     * toggle at a time so a regression in one branch doesn't mask the
+     * others.
+     */
+    public function testPublicTogglesGateEntries(): void
+    {
+        $userbank = new \CUserManager(null);
+
+        // Baseline: every config.enable* defaults to truthy from
+        // data.sql (Fixture::reset re-seeds it).
+        $labels = self::labelsOf(PaletteActions::for($userbank));
+        $this->assertContains('Comm blocks',   $labels);
+        $this->assertContains('Submit a ban',  $labels);
+        $this->assertContains('Appeals',       $labels);
+
+        $this->setSetting('config.enablecomms', '0');
+        \Sbpp\Config::init($GLOBALS['PDO']);
+        $labels = self::labelsOf(PaletteActions::for($userbank));
+        $this->assertNotContains('Comm blocks', $labels,
+            'config.enablecomms=0 must drop Comm blocks from the palette (mirrors navbar.tpl).');
+
+        $this->setSetting('config.enablesubmit', '0');
+        \Sbpp\Config::init($GLOBALS['PDO']);
+        $labels = self::labelsOf(PaletteActions::for($userbank));
+        $this->assertNotContains('Submit a ban', $labels,
+            'config.enablesubmit=0 must drop Submit a ban from the palette.');
+
+        $this->setSetting('config.enableprotest', '0');
+        \Sbpp\Config::init($GLOBALS['PDO']);
+        $labels = self::labelsOf(PaletteActions::for($userbank));
+        $this->assertNotContains('Appeals', $labels,
+            'config.enableprotest=0 must drop Appeals from the palette.');
+    }
+
+    /**
+     * The wire-format contract the JSON blob promises: every entry is
+     * an `{icon, label, href}` triple — no extra keys leak (e.g. the
+     * raw `permission` mask, which the client must never use as a
+     * gate). The server is the single source of truth for visibility.
+     */
+    public function testEntryShapeIsExactlyIconLabelHref(): void
+    {
+        $entries = PaletteActions::for(null);
+
+        $this->assertNotEmpty($entries);
+        foreach ($entries as $entry) {
+            $this->assertSame(['icon', 'label', 'href'], array_keys($entry),
+                'Each entry must expose exactly icon/label/href to the wire — no permission/config keys (the client must never gate on them; the gate is server-side).');
+            $this->assertIsString($entry['icon']);
+            $this->assertIsString($entry['label']);
+            $this->assertIsString($entry['href']);
+            $this->assertNotSame('', $entry['icon']);
+            $this->assertNotSame('', $entry['label']);
+            $this->assertNotSame('', $entry['href']);
+        }
+    }
+
+    /**
+     * Direct rendering check: `web/pages/core/footer.php` builds the
+     * blob via PaletteActions and json-encodes it with
+     * JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT so
+     * the content can never break out of its `<script>` wrapper. This
+     * test asserts the encoded shape round-trips through json_decode
+     * for every user state — defensive against a future PaletteActions
+     * edit that introduced a non-encodable value.
+     */
+    public function testJsonEncodingRoundTripsForEveryUserShape(): void
+    {
+        // null userbank
+        $this->assertRoundTrips(PaletteActions::for(null));
+
+        // anonymous
+        $this->assertRoundTrips(PaletteActions::for(new \CUserManager(null)));
+
+        // owner
+        $this->loginAsAdmin();
+        /** @var \CUserManager $owner */
+        $owner = $GLOBALS['userbank'];
+        $this->assertRoundTrips(PaletteActions::for($owner));
+    }
+
+    /**
+     * @param list<array{icon: string, label: string, href: string}> $entries
+     * @return list<string>
+     */
+    private static function labelsOf(array $entries): array
+    {
+        $labels = [];
+        foreach ($entries as $entry) {
+            $labels[] = $entry['label'];
+        }
+        return $labels;
+    }
+
+    /**
+     * Verify the entries survive json_encode (with the same flag set
+     * footer.php uses) + json_decode and decode to the same array.
+     *
+     * @param list<array{icon: string, label: string, href: string}> $entries
+     */
+    private function assertRoundTrips(array $entries): void
+    {
+        $json = json_encode(
+            $entries,
+            JSON_THROW_ON_ERROR
+            | JSON_HEX_TAG
+            | JSON_HEX_AMP
+            | JSON_HEX_APOS
+            | JSON_HEX_QUOT,
+        );
+
+        $this->assertIsString($json);
+        // Defense-in-depth: the JSON_HEX_* flags must keep the
+        // canonical "</script>" sentinel (and `<` / `>` / `&` / `'` /
+        // `"` in general) out of the encoded blob.
+        $this->assertStringNotContainsString('</script', (string) $json);
+        $this->assertStringNotContainsString('<', (string) $json);
+        $this->assertStringNotContainsString('>', (string) $json);
+
+        $this->assertSame($entries, json_decode((string) $json, true));
+    }
+
+    /**
+     * Insert a non-owner admin row directly via the test PDO so we can
+     * exercise an arbitrary `extraflags` mask without going through the
+     * `admins.add` JSON handler. Mirrors the helper in PermsHelperTest.
+     */
+    private function createAdminWithFlags(int $mask): int
+    {
+        $pdo = Fixture::rawPdo();
+        $stmt = $pdo->prepare(sprintf(
+            'INSERT INTO `%s_admins` (user, authid, password, gid, email, validate, extraflags, immunity)
+             VALUES (?, ?, ?, -1, ?, NULL, ?, 50)',
+            DB_PREFIX,
+        ));
+        $stmt->execute([
+            'palette-flagged-' . $mask,
+            'STEAM_0:0:' . (3_000_000 + $mask),
+            password_hash('x', PASSWORD_BCRYPT),
+            'palette-flagged@example.test',
+            $mask,
+        ]);
+        return (int) $pdo->lastInsertId();
+    }
+
+    /**
+     * Update a single sb_settings row directly via the test PDO. We
+     * write the literal string the column expects (the column is
+     * `text NOT NULL`; Config::getBool casts to bool at read-time).
+     */
+    private function setSetting(string $key, string $value): void
+    {
+        $pdo = Fixture::rawPdo();
+        $stmt = $pdo->prepare(sprintf(
+            'UPDATE `%s_settings` SET value = ? WHERE setting = ?',
+            DB_PREFIX,
+        ));
+        $stmt->execute([$value, $key]);
+    }
+}

--- a/web/themes/default/core/footer.tpl
+++ b/web/themes/default/core/footer.tpl
@@ -143,6 +143,34 @@
          style="max-height:60vh;overflow-y:auto;padding:0.5rem"></div>
 </dialog>
 
+{*
+    Issue #1304: server-render the palette's "Navigate" entries as a
+    JSON blob theme.js reads at boot. Pre-fix the entry list lived as
+    a hardcoded `NAV_ITEMS` array in `web/themes/default/js/theme.js`
+    with no permission check, leaking admin entries (`Admin panel`,
+    `Add ban`) to logged-out + partial-permission users (clicking either
+    landed them on the "you must be logged in" / 403 surface).
+
+    The blob is built by `Sbpp\View\PaletteActions::for($userbank)` in
+    `web/pages/core/footer.php` and assigned as `$palette_actions_json`.
+    The encoder uses JSON_HEX_TAG / _AMP / _APOS / _QUOT so the content
+    can never break out of the surrounding `<script>` element regardless
+    of what a future label / href adds (`</script>` would otherwise let
+    the blob escape its container — defense-in-depth on top of the
+    catalog being all-ASCII today).
+
+    `<script type="application/json">` is the standards-blessed shape
+    for embedded data: browsers don't execute the body, JSON.parse
+    consumes it as text content. theme.js falls back to an empty list
+    (palette renders only the player-search half) when the blob is
+    absent, so a chrome-only render in test contexts doesn't crash.
+
+    `data-testid="palette-actions"` is the testability hook the e2e
+    spec anchors on instead of probing the script element by tag.
+*}
+{* nofilter: server-encoded JSON from PaletteActions::for($userbank) using JSON_HEX_TAG|_AMP|_APOS|_QUOT — every potentially-dangerous char (<>&'") is escaped as a \uXXXX sequence, so the blob can't break out of its <script> wrapper or carry HTML entities that would corrupt JSON.parse. *}
+<script type="application/json" id="palette-actions" data-testid="palette-actions">{$palette_actions_json nofilter}</script>
+
 <script src="{$theme_url}/js/lucide.min.js"></script>
 <script src="{$theme_url}/js/theme.js"></script>
 

--- a/web/themes/default/js/theme.js
+++ b/web/themes/default/js/theme.js
@@ -269,17 +269,53 @@
 
   /** @typedef {{icon: string, label: string, href: string}} NavItem */
 
+  /**
+   * Parse the server-rendered, permission-filtered palette nav set
+   * out of `<script type="application/json" id="palette-actions">`.
+   *
+   * Pre-#1304 this list was a hardcoded `NAV_ITEMS` array right here
+   * in JS, so every visitor (logged-out, partial-permission admins)
+   * saw the admin-only entries (`Admin panel`, `Add ban`) alongside
+   * the public ones, then got bounced off the "you must be logged
+   * in" / 403 surface when they clicked one. The blob is now built
+   * by `Sbpp\View\PaletteActions::for($userbank)` server-side
+   * (see `web/pages/core/footer.php` + `core/footer.tpl`); this
+   * function is just the consumer.
+   *
+   * Falls back to an empty list when:
+   *   - the script tag is missing (chrome-only render in test
+   *     contexts where the chrome was injected without a page
+   *     handler having run footer.php — defensive, the palette
+   *     just renders the player-search half),
+   *   - the JSON is malformed (a broken catalog entry would
+   *     otherwise silently nuke the palette; surfacing as empty
+   *     keeps the player-search half working).
+   *
+   * @returns {NavItem[]}
+   */
+  function loadNavItems() {
+    const blob = document.getElementById('palette-actions');
+    if (!blob) return [];
+    try {
+      const parsed = JSON.parse(blob.textContent || '[]');
+      if (!Array.isArray(parsed)) return [];
+      // Defensive shape filter — drop entries missing any of the
+      // three keys theme.js renders. Server-side PaletteActions
+      // always emits the full triple, but the wire format is the
+      // contract and a future PR can't accidentally trim a key
+      // without breaking the tests too.
+      return parsed.filter((n) =>
+        n && typeof n.icon === 'string'
+          && typeof n.label === 'string'
+          && typeof n.href === 'string'
+      );
+    } catch (_e) {
+      return [];
+    }
+  }
+
   /** @type {NavItem[]} */
-  const NAV_ITEMS = [
-    { icon: 'layout-dashboard', label: 'Dashboard',     href: '?' },
-    { icon: 'ban',              label: 'Ban list',      href: '?p=banlist' },
-    { icon: 'mic-off',          label: 'Comm blocks',   href: '?p=commslist' },
-    { icon: 'flag',             label: 'Submit a ban',  href: '?p=submit' },
-    { icon: 'megaphone',        label: 'Appeals',       href: '?p=appeal' },
-    { icon: 'server',           label: 'Servers',       href: '?p=servers' },
-    { icon: 'shield',           label: 'Admin panel',   href: '?p=admin' },
-    { icon: 'plus-circle',      label: 'Add ban',       href: '?p=admin&c=bans&section=add-ban' },
-  ];
+  const NAV_ITEMS = loadNavItems();
 
   /**
    * Render filtered navigation + player search results into the palette.


### PR DESCRIPTION
Fixes #1304

## Summary

The command palette (Ctrl/Cmd-K) leaked admin-only navigation entries (`Admin panel`, `Add ban`) to logged-out and partial-permission users. Pre-fix the entry list was a hardcoded `NAV_ITEMS` array in `web/themes/default/js/theme.js` with no permission filter, so clicking either of those entries dropped the user on the "you must be logged in" / 403 surface — the chrome read as broken. The sibling sidebar (`web/pages/core/navbar.php` + `core/navbar.tpl`) already shipped a properly filtered link set; the palette didn't.

This PR moves the catalog server-side: a new `Sbpp\View\PaletteActions::for($userbank)` helper builds the entry list, applies per-(user, permission) gates that mirror the sidebar's contract, and emits the filtered list as a JSON blob in the footer. `theme.js` reads + `JSON.parse`s the blob at boot and uses it instead of the hardcoded array.

### Architecture

- **`web/includes/View/PaletteActions.php`** (new) — catalog + filter:
  - Each entry: `{icon, label, href, permission, config?}`.
  - `permission` is either an `int` bitmask (admin entries — `HasAccess` gate) or `true`/`false`/`null` for public entries. Owner is OR'd in by the catalog so an owner sees every entry.
  - Optional `config` key gates the entry on a `sb_settings` boolean (mirrors `navbar.php`'s `Config::getBool('config.enablecomms')` etc., so disabling Comms / Submit / Appeals drops them from both the sidebar and the palette in the same request).
  - `null` userbank treated identically to logged-out (CSRF reject / unhandled error path → fail closed).
  - Output shape drops `permission` / `config` so the wire blob carries only the three keys `theme.js` consumes — never expose the gate to the client.
- **`web/pages/core/footer.php`** — calls `PaletteActions::for($userbank)`, JSON-encodes the result with `JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT` so the content can never break out of the surrounding `<script>` element regardless of what a future label / href adds, and assigns it as `$palette_actions_json`.
- **`web/themes/default/core/footer.tpl`** — emits the blob inside `<script type="application/json" id="palette-actions" data-testid="palette-actions">` with the canonical safety annotation above the `nofilter` line.
- **`web/themes/default/js/theme.js`** — replaces the hardcoded `NAV_ITEMS` array with `loadNavItems()` which reads + `JSON.parse`s the blob, with a fail-empty fallback so chrome-only render contexts (where footer.php hasn't run) don't crash.

### Out of scope

The player-search half of the palette (`bans.search`) is intentionally public and stays unchanged — the leak was strictly the navigation entries.

### Docs (paired per `AGENTS.md` "Keep the docs in sync")

- New convention block in `AGENTS.md`: **Filtered chrome navigation surfaces (sidebar + palette)** — both surfaces ship per-(user, permission) filtered link sets and adding an entry to one needs a paired entry in the other.
- New entry in the `AGENTS.md` "Anti-patterns" section for the pre-fix hardcoded `NAV_ITEMS` shape.
- New row in `AGENTS.md` "Where to find what" pointing at `PaletteActions` + the JSON wire format.
- New paragraph in `ARCHITECTURE.md` chrome section explaining the server-rendered filtered nav contract.

## Test plan

### PHPUnit — `web/tests/integration/PaletteActionsTest.php`

7 cases:
- `testNullUserBankSeesOnlyPublicEntries` — null userbank treated as logged-out.
- `testAnonymousUserSeesOnlyPublicEntries` — primary leak from the issue.
- `testOwnerSeesEveryEntry` — `ADMIN_OWNER` bypass.
- `testPartialPermissionAdminHidesAddBan` — `ADMIN_LIST_SERVERS`-only admin hides Add ban (gated on `ADMIN_OWNER | ADMIN_ADD_BAN`) but sees Admin panel (gated on `ALL_WEB`, matches any flag — same as sidebar).
- `testPublicTogglesGateEntries` — `config.enablecomms=0` / `config.enablesubmit=0` / `config.enableprotest=0` each drop the corresponding entry.
- `testEntryShapeIsExactlyIconLabelHref` — wire-format contract (no `permission` key leaks to the client).
- `testJsonEncodingRoundTripsForEveryUserShape` — defense-in-depth: `<` / `>` / `</script` never appear in the encoded blob.

### Playwright E2E — `web/tests/e2e/specs/flows/ui/command-palette-permissions.spec.ts`

3 specs × 2 projects (chromium + mobile-chromium) = 6 runs:
- Logged-out visitor: server-rendered `#palette-actions` blob excludes admin entries.
- Logged-out visitor: opening the palette renders only the filtered nav rows (DOM contract).
- Logged-in admin (owner): owner sees admin entries in both the blob and the rendered palette.

### Local quality gates

| Gate | Result |
| ---- | ------ |
| `./sbpp.sh phpstan` | pass (0 errors) |
| `./sbpp.sh test` (full suite, 410 tests) | pass (1848 assertions) |
| `./sbpp.sh ts-check` | pass |
| `./sbpp.sh composer api-contract` | pass (no diff — handlers unchanged) |
| `./sbpp.sh e2e --grep "permission-filtered nav"` | 6 / 6 pass |
| `./sbpp.sh e2e --grep "command-palette\|palette"` | 19 / 19 pass (11 skipped, project-specific) |
| `./sbpp.sh e2e specs/smoke` | 58 / 58 pass |