### PR TITLE
Fix #1301: require non-empty reason + confirm modal on banlist unban / commslist unmute & ungag

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1188,6 +1188,31 @@ audit (#1207) locked in. New CTAs:
   every keyboard / screen-reader user. New surfaces add visible
   buttons in the same shape as `.queue-row` (admin moderation
   queue) or the comms-list desktop table (`web/themes/default/page_comms.tpl`).
+- Reason-less, no-confirm unban / unmute / ungag (or any other
+  irreversible state-flip on a row) → the JSON action AND the
+  legacy GET fallback both must require a non-empty `ureason`,
+  and the row's affordance must open a confirm modal that prompts
+  for it. v1.x had both safeguards via sourcebans.js's
+  `UnbanBan()` / `UnMuteBan()` / `UnGagBan()` helpers; v2.0
+  silently accepted `ureason=''` for ~18 months and the audit
+  log lost the *why* behind every block lift (#1301). The
+  reference shape is `#bans-unban-dialog` / `#comms-unblock-dialog`
+  in `page_bans.tpl` / `page_comms.tpl` (see "Add a confirm +
+  reason modal …" in "Where to find what"). `Log::add(LogType::Message,
+  "Player Unbanned", "$name … Reason: $ureason")` is the
+  audit-trail shape — drop the reason in the message, never the
+  bare "Player X has been unbanned." that v2.0 shipped.
+- Native `required` on the textarea inside a confirm + reason
+  `<dialog>` form → use `aria-required="true"` only. The native
+  `required` constraint fires the browser's own validation
+  popover BEFORE the form's `submit` event reaches our handler,
+  swallowing the inline-error UX (the testid we surface for
+  empty-reason inline errors stays `hidden` because our
+  `e.preventDefault(); showError('Please leave a comment.')`
+  path never runs). `aria-required` keeps assistive tech in the
+  loop without arming the native gate; the JS submit handler is
+  the client-side error display, and the server is the
+  load-bearing gate.
 - Removing `<meta name="format-detection" content="telephone=no…">`
   from `core/header.tpl` (or the defensive `.drawer a[href^="tel:"]`
   reset in `theme.css`) → mobile Safari + some Android Chromes
@@ -1258,6 +1283,7 @@ audit (#1207) locked in. New CTAs:
 | Edit a template                        | `web/themes/default/*.tpl`                               |
 | Reuse the moderation-queue card layout (admin submissions / protests, mobile-stacked summary rows) | `web/themes/default/css/theme.css` (`.queue-row`, `.queue-row__body`, `.queue-row__date` — #1207 PUB-2). Apply by adding `class="queue-row …"` to the outer `<details>` and dropping the inline `flex` / `flex-shrink:0` styles from the summary children. |
 | Add visible row actions to a table-rendered admin list (Edit / Unmute / Remove buttons + responsive mobile-card mirror) | `web/themes/default/page_comms.tpl` (#1207 ADM-5) is the canonical reference: `<button class="btn btn--secondary btn--sm">` / `<a class="btn btn--ghost btn--sm">` inside a `.row-actions` cell, plus `.ban-card__actions` row of identical-data-action buttons in the mobile card. Wire destructive / state-changing buttons via `data-action="…"` + `data-bid` + `data-fallback-href`; the inline page-tail JS calls `sb.api.call(Actions.PascalName)` and falls back to the GET URL if the JSON dispatcher is absent. |
+| Add a confirm + reason modal for an irreversible row-level action (unban, lift comm block, …) | `web/themes/default/page_bans.tpl` (`#bans-unban-dialog`, `Actions.BansUnban`) and `web/themes/default/page_comms.tpl` (`#comms-unblock-dialog`, `Actions.CommsUnblock`) are the canonical reference (#1301). Shape: a `<dialog hidden>` with a `<form method="dialog">` carrying a `<textarea aria-required="true">` (NOT the native `required` — that lets the browser block the form submit before our handler runs, swallowing the inline-error UX), a Cancel button, and a Confirm submit button. The page-tail JS opens the dialog via `showModal()` on `[data-action]` clicks, validates the trimmed reason on submit (load-bearing gate is server-side), forwards `ureason` to the JSON action, and on success flips the row in place via the same `flipRowToUnbanned`/`flipRowToUnmuted` helper the legacy single-click flow used. The legacy GET fallback (`?p=banlist&a=unban&id=…&key=…&ureason=…` / `?p=commslist&a=ungag…&ureason=…`) is the no-JS / hand-edited-URL path; both halves now reject empty `ureason` server-side so the audit log carries the *why*. **Do not** put `onclick="event.stopPropagation()"` on the trigger button — `document.addEventListener('click')` is how the dialog opener picks the click up, and stopPropagation would silently swallow it (the action button isn't inside any `[data-drawer-href]` ancestor anyway, so the defensiveness was a copy-paste from the row-name anchor that doesn't apply here). |
 | Edit the player-detail drawer (open trigger, tabs, panes, lazy loaders) | `web/themes/default/js/theme.js` (`renderDrawerBody` / `loadPaneIfNeeded`) |
 | Edit the command palette (icon-only trigger, ⌘K binding, result rows, kbd hints, Ctrl+Enter copy) | `web/themes/default/js/theme.js` (`openPalette` / `closePalette` / `renderPaletteResults` / `applyPlatformHints` / `handlePaletteCopyShortcut`) + `core/title.tpl` (the `.topbar__search` icon button) + the `.palette__row*` rules in `web/themes/default/css/theme.css`. Player rows carry `data-drawer-bid="<bid>"` (bare Enter / click → `loadDrawer`, palette closes itself) + `data-steamid="<steam>"` (`Ctrl/Cmd+Enter` → `navigator.clipboard.writeText` + `showToast`). The kbd glyphs are server-rendered in non-Mac form (`Enter`, `Ctrl`); `applyPlatformHints` swaps `[data-enterkey]` → ⏎ and `[data-modkey]` → ⌘ on Mac/iOS at boot and after every render (#1184, #1207 DET-2). |
 | Add admin-only per-player notes | `web/api/handlers/notes.php` (CRUD) — Notes tab is gated by `bans.detail`'s `notes_visible` flag |

--- a/web/api/handlers/_register.php
+++ b/web/api/handlers/_register.php
@@ -76,6 +76,12 @@ Api::register('bans.kick_player',         'api_bans_kick_player',          ADMIN
 Api::register('bans.send_message',        'api_bans_send_message',         0, true);
 Api::register('bans.view_community',      'api_bans_view_community',       0, true);
 Api::register('bans.search',              'api_bans_search',               0, true);
+// bans.unban dispatcher gate matches the legacy GET handler: any of the
+// four "unban-ish" flags lets the request through; the handler then
+// does the precise per-row check (own/group bans). #1301 — restored
+// the v1.x "confirm + reason required" UX (modal in page_bans.tpl;
+// `ureason` is non-empty-validated here).
+Api::register('bans.unban', 'api_bans_unban', ADMIN_OWNER | ADMIN_UNBAN | ADMIN_UNBAN_OWN_BANS | ADMIN_UNBAN_GROUP_BANS);
 
 // ---- blockit (single-page admin.blockit.php iframe) -------------------
 Api::register('blockit.load_servers', 'api_blockit_load_servers', ADMIN_OWNER | ADMIN_ADD_BAN);

--- a/web/api/handlers/bans.php
+++ b/web/api/handlers/bans.php
@@ -1068,3 +1068,157 @@ function api_bans_player_history(array $params): array
 
     return ['items' => $items, 'total' => count($items)];
 }
+
+/**
+ * Lift an active ban (#1301).
+ *
+ * Modern JSON twin of the legacy `?p=banlist&a=unban&id=…&key=…` GET
+ * handler in `page.banlist.php`. The legacy GET path stays put (no-JS
+ * fallback for the icon-only theme leg + third-party themes that still
+ * ship the v1.x action links), but the banlist's visible-action
+ * affordance now wires through this action so the row can update
+ * in-place + show a toast without a full page reload.
+ *
+ * Permission gate mirrors the legacy GET handler exactly:
+ *
+ *   ADMIN_OWNER | ADMIN_UNBAN     — unconditional, lift any row.
+ *   ADMIN_UNBAN_OWN_BANS          — only the row's own admin (`aid`).
+ *   ADMIN_UNBAN_GROUP_BANS        — only rows where the issuing
+ *                                   admin's `gid` matches the
+ *                                   caller's `gid`.
+ *
+ * The dispatcher gate is `ADMIN_OWNER | ADMIN_UNBAN |
+ * ADMIN_UNBAN_OWN_BANS | ADMIN_UNBAN_GROUP_BANS` — the broadest "any
+ * unban-ish flag" match — and the per-row precision check happens
+ * inside the handler, since the dispatcher can't see which row the
+ * caller wants to act on.
+ *
+ * #1301: `ureason` is **required**. v1.x prompted via sourcebans.js's
+ * UnbanBan() helper and required a non-empty reason; v2.0 silently
+ * accepted '', so the audit log lost the *why*. Both this handler and
+ * the legacy GET fallback now bounce empty reasons.
+ *
+ * Inputs:
+ *   - `bid`     (int, required)    — the ban id.
+ *   - `ureason` (string, required) — admin-supplied unban reason; we
+ *     trim and store as-is. Stored raw in `ureason` (per the
+ *     "store raw, escape on display" anti-pattern); the column lives
+ *     behind the same Smarty auto-escape pipeline as `reason`.
+ *
+ * @return array{ bid: int, state: string }
+ */
+function api_bans_unban(array $params): array
+{
+    global $userbank;
+
+    $bid = (int)($params['bid'] ?? 0);
+    if ($bid <= 0) {
+        throw new ApiError('bad_request', 'bid must be a positive integer', 'bid');
+    }
+    $ureason = trim((string)($params['ureason'] ?? ''));
+    if ($ureason === '') {
+        throw new ApiError(
+            'validation',
+            'You must supply a reason when unbanning a player.',
+            'ureason'
+        );
+    }
+
+    $row = $GLOBALS['PDO']->query(
+        "SELECT B.bid, B.ip, B.authid, B.name, B.created, B.sid, B.type,
+                B.length, B.ends, B.RemoveType, B.aid,
+                A.gid AS gid,
+                M.steam_universe,
+                UNIX_TIMESTAMP() AS now
+           FROM `:prefix_bans` AS B
+      LEFT JOIN `:prefix_servers` AS S ON S.sid = B.sid
+      LEFT JOIN `:prefix_mods`    AS M ON M.mid = S.modid
+      LEFT JOIN `:prefix_admins`  AS A ON A.aid = B.aid
+          WHERE B.bid = ?"
+    )->single([$bid]);
+
+    if (!$row) {
+        throw new ApiError('not_found', 'Ban not found.', null, 404);
+    }
+
+    $rowAid = (int)($row['aid'] ?? 0);
+    $rowGid = (int)($row['gid'] ?? 0);
+    $callerGid = (int)$userbank->GetProperty('gid');
+    $allowed =
+        $userbank->HasAccess(WebPermission::mask(WebPermission::Owner, WebPermission::Unban))
+        || ($userbank->HasAccess(WebPermission::UnbanOwnBans)   && $rowAid === $userbank->GetAid())
+        || ($userbank->HasAccess(WebPermission::UnbanGroupBans) && $rowGid === $callerGid);
+    if (!$allowed) {
+        throw new ApiError('forbidden', "You don't have access to this ban.", null, 403);
+    }
+
+    if (!empty($row['RemoveType'])) {
+        throw new ApiError('not_active', 'Ban has already been lifted.', null, 409);
+    }
+    $length = (int)$row['length'];
+    $ends   = (int)$row['ends'];
+    if ($length > 0 && $ends <= time()) {
+        throw new ApiError('not_active', 'Ban has already expired.', null, 409);
+    }
+
+    $GLOBALS['PDO']->query(
+        "UPDATE `:prefix_bans`
+            SET `RemovedBy`  = ?,
+                `RemoveType` = ?,
+                `RemovedOn`  = UNIX_TIMESTAMP(),
+                `ureason`    = ?
+          WHERE `bid` = ?"
+    )->execute([$userbank->GetAid(), BanRemoval::Unbanned->value, $ureason, $bid]);
+
+    // Mirror the legacy GET handler: archive any open protests for this
+    // ban so they don't keep showing up in the moderation queue.
+    $GLOBALS['PDO']->query("UPDATE `:prefix_protests` SET archiv = '4' WHERE bid = ?")
+        ->execute([$bid]);
+
+    // Mirror the legacy GET handler's RCON-based in-game cleanup: any
+    // server the player was banned on within the last 5 minutes (per the
+    // banlog) gets a `removeid` / `removeip` so the in-game state
+    // matches the panel state immediately. Same lookback (300s) as
+    // page.banlist.php.
+    $blocked = $GLOBALS['PDO']->query(
+        "SELECT s.sid, m.steam_universe
+           FROM `:prefix_banlog` AS bl
+     INNER JOIN `:prefix_servers` AS s ON s.sid = bl.sid
+     INNER JOIN `:prefix_mods`    AS m ON m.mid = s.modid
+          WHERE bl.bid = ?
+            AND (UNIX_TIMESTAMP() - bl.time <= 300)"
+    )->resultset([$bid]);
+
+    $rowBanType = BanType::tryFrom((int)$row['type']) ?? BanType::Steam;
+    $type       = $rowBanType === BanType::Steam ? (string)$row['authid'] : (string)$row['ip'];
+
+    foreach ($blocked as $tempban) {
+        if ($rowBanType === BanType::Steam) {
+            rcon('removeid STEAM_' . (string)$tempban['steam_universe'] . substr((string)$row['authid'], 7), (int)$tempban['sid']);
+        } else {
+            rcon('removeip ' . (string)$row['ip'], (int)$tempban['sid']);
+        }
+    }
+    $blockedSids = array_map(static fn(array $b): int => (int)$b['sid'], $blocked);
+    $createdAt   = (int)$row['created'];
+    $now         = (int)$row['now'];
+    $banSid      = (int)$row['sid'];
+    if (($now - $createdAt) <= 300 && $banSid !== 0 && !in_array($banSid, $blockedSids, true)) {
+        if ($rowBanType === BanType::Steam) {
+            rcon('removeid STEAM_' . (string)$row['steam_universe'] . substr((string)$row['authid'], 7), $banSid);
+        } else {
+            rcon('removeip ' . (string)$row['ip'], $banSid);
+        }
+    }
+
+    Log::add(
+        LogType::Message,
+        'Player Unbanned',
+        sprintf('%s (%s) has been unbanned. Reason: %s', (string)$row['name'], $type, $ureason)
+    );
+
+    return [
+        'bid'   => $bid,
+        'state' => 'unbanned',
+    ];
+}

--- a/web/api/handlers/comms.php
+++ b/web/api/handlers/comms.php
@@ -146,7 +146,19 @@ function api_comms_unblock(array $params): array
     if ($bid <= 0) {
         throw new ApiError('bad_request', 'bid must be a positive integer', 'bid');
     }
+    // #1301: v1.x prompted via sourcebans.js's UnMute()/UnGag() helpers
+    // and required a non-empty reason; v2.0 silently accepted '', so the
+    // audit log lost the *why*. Both the new modal in page_comms.tpl and
+    // the legacy GET handler in page.commslist.php now bounce on empty
+    // — this server-side check is the load-bearing gate.
     $ureason = trim((string)($params['ureason'] ?? ''));
+    if ($ureason === '') {
+        throw new ApiError(
+            'validation',
+            'You must supply a reason when lifting a block.',
+            'ureason'
+        );
+    }
 
     $row = $GLOBALS['PDO']->query(
         "SELECT C.bid, C.authid, C.name, C.type, C.length, C.ends, C.RemoveType, C.aid, A.gid AS gid
@@ -196,7 +208,19 @@ function api_comms_unblock(array $params): array
     }
 
     $verb = $type === 1 ? 'UnMuted' : ($type === 2 ? 'UnGagged' : 'Unblocked');
-    Log::add(LogType::Message, "Player $verb", "{$row['name']} ({$row['authid']}) has been " . strtolower($verb) . '.');
+    // #1301: trail the unblock reason in the audit log entry so admins
+    // reading the log later can see *why* the block was lifted.
+    Log::add(
+        LogType::Message,
+        "Player $verb",
+        sprintf(
+            '%s (%s) has been %s. Reason: %s',
+            (string) $row['name'],
+            (string) $row['authid'],
+            strtolower($verb),
+            $ureason
+        )
+    );
 
     return [
         'bid'   => $bid,

--- a/web/api/handlers/comms.php
+++ b/web/api/handlers/comms.php
@@ -129,9 +129,14 @@ function api_comms_prepare_reblock(array $params): array
  * inside the handler, since the dispatcher can't see which row the
  * caller wants to act on.
  *
+ * #1301: `ureason` is **required**. v1.x prompted via sourcebans.js's
+ * UnMute()/UnGag() helpers and required a non-empty reason; v2.0
+ * silently accepted '', so the audit log lost the *why*. Both this
+ * handler and the legacy GET fallback now bounce empty reasons.
+ *
  * Inputs:
- *   - `bid`     (int, required) — the comm-block id.
- *   - `ureason` (string, optional) — admin-supplied unblock reason; we
+ *   - `bid`     (int, required)    — the comm-block id.
+ *   - `ureason` (string, required) — admin-supplied unblock reason; we
  *     trim and store as-is. Stored raw in `ureason` (per the
  *     "store raw, escape on display" anti-pattern); the column lives
  *     behind the same Smarty auto-escape pipeline as `reason`.

--- a/web/pages/page.banlist.php
+++ b/web/pages/page.banlist.php
@@ -55,6 +55,19 @@ if (isset($_GET['a']) && $_GET['a'] == "unban" && isset($_GET['id'])) {
     if ($_GET['key'] != $_SESSION['banlist_postkey']) {
         die("Possible hacking attempt (URL Key mismatch)");
     }
+    // #1301: legacy GET path for unban no longer accepts an empty
+    // `ureason`. v1.x prompted via sourcebans.js's UnbanBan() helper
+    // and required a non-empty reason; v2.0 silently accepted '', so
+    // the audit log lost the *why*. The new modal in page_bans.tpl
+    // wires through the JSON `bans.unban` action (which has the same
+    // guard); this branch is now the no-JS / hand-edited-URL fallback,
+    // and we bounce empty reasons here too so the audit log is
+    // consistent across both entry points.
+    $unbanReasonRaw = trim((string) ($_GET['ureason'] ?? ''));
+    if ($unbanReasonRaw === '') {
+        echo "<script>ShowBox('Unban Reason Required', 'You must supply a reason when unbanning a player.', 'red', 'index.php?p=banlist$pagelink');</script>";
+        PageDie();
+    }
     //we have a multiple unban asking
     if (isset($_GET['bulk'])) {
         $bids = explode(",", $_GET['id']);
@@ -92,7 +105,7 @@ if (isset($_GET['a']) && $_GET['a'] == "unban" && isset($_GET['id'])) {
             }
             continue;
         }
-        $unbanReason = htmlspecialchars(trim((string) ($_GET['ureason'] ?? '')));
+        $unbanReason = htmlspecialchars($unbanReasonRaw);
         $GLOBALS['PDO']->query("UPDATE `:prefix_bans` SET
 										`RemovedBy` = :removedby,
 										`RemoveType` = :rtype,
@@ -127,7 +140,7 @@ if (isset($_GET['a']) && $_GET['a'] == "unban" && isset($_GET['id'])) {
             if (!isset($_GET['bulk'])) {
                 echo "<script>ShowBox('Player Unbanned', '" . $row['name'] . " ($type) has been unbanned from SourceBans.', 'green', 'index.php?p=banlist$pagelink');</script>";
             }
-            Log::add(LogType::Message, "Player Unbanned", "$row[name] ($type) has been unbanned.");
+            Log::add(LogType::Message, "Player Unbanned", "$row[name] ($type) has been unbanned. Reason: $unbanReason");
             $ucount++;
         } else {
             if (!isset($_GET['bulk'])) {

--- a/web/pages/page.commslist.php
+++ b/web/pages/page.commslist.php
@@ -63,6 +63,15 @@ if (isset($_GET['a']) && $_GET['a'] == "ungag" && isset($_GET['id'])) {
     if ($_GET['key'] != $_SESSION['banlist_postkey']) {
         die("Possible hacking attempt (URL Key mismatch)");
     }
+    // #1301: see page.banlist.php for the full rationale. Both the
+    // legacy GET path and the JSON twin (api_comms_unblock) now
+    // require a non-empty `ureason` so the audit log carries the
+    // *why* behind every block lift, restoring v1.x parity.
+    $unbanReasonRaw = trim((string) ($_GET['ureason'] ?? ''));
+    if ($unbanReasonRaw === '') {
+        echo "<script>ShowBox('Unblock Reason Required', 'You must supply a reason when ungagging a player.', 'red', 'index.php?p=commslist$pagelink');</script>";
+        PageDie();
+    }
     //we have a multiple unban asking
     $bid = (int) $_GET['id'];
     $GLOBALS['PDO']->query("SELECT a.aid, a.gid FROM `:prefix_comms` c INNER JOIN `:prefix_admins` a ON a.aid = c.aid WHERE bid = :bid AND c.type = 2");
@@ -83,7 +92,7 @@ if (isset($_GET['a']) && $_GET['a'] == "ungag" && isset($_GET['id'])) {
         PageDie();
     }
 
-    $unbanReason = htmlspecialchars(trim((string) ($_GET['ureason'] ?? '')));
+    $unbanReason = htmlspecialchars($unbanReasonRaw);
     $GLOBALS['PDO']->query("UPDATE `:prefix_comms` SET
 										`RemovedBy` = :removedby,
 										`RemoveType` = :rtype,
@@ -105,13 +114,19 @@ if (isset($_GET['a']) && $_GET['a'] == "ungag" && isset($_GET['id'])) {
 
     if ($res) {
         echo "<script>ShowBox('Player UnGagged', '" . $row['name'] . " (" . $row['authid'] . ") has been ungagged from SourceBans.', 'green', 'index.php?p=commslist$pagelink');</script>";
-        Log::add(LogType::Message, "Player UnGagged", "$row[name] ($row[authid]) has been ungagged.");
+        Log::add(LogType::Message, "Player UnGagged", "$row[name] ($row[authid]) has been ungagged. Reason: $unbanReason");
     } else {
         echo "<script>ShowBox('Player NOT UnGagged', 'There was an error ungagging " . $row['name'] . "', 'red', 'index.php?p=commsist$pagelink', true);</script>";
     }
 } else if (isset($_GET['a']) && $_GET['a'] == "unmute" && isset($_GET['id'])) {
     if ($_GET['key'] != $_SESSION['banlist_postkey']) {
         die("Possible hacking attempt (URL Key mismatch)");
+    }
+    // #1301: see ungag branch above for rationale.
+    $unbanReasonRaw = trim((string) ($_GET['ureason'] ?? ''));
+    if ($unbanReasonRaw === '') {
+        echo "<script>ShowBox('Unblock Reason Required', 'You must supply a reason when unmuting a player.', 'red', 'index.php?p=commslist$pagelink');</script>";
+        PageDie();
     }
     //we have a multiple unban asking
     $bid = (int) $_GET['id'];
@@ -133,7 +148,7 @@ if (isset($_GET['a']) && $_GET['a'] == "ungag" && isset($_GET['id'])) {
         PageDie();
     }
 
-    $unbanReason = htmlspecialchars(trim((string) ($_GET['ureason'] ?? '')));
+    $unbanReason = htmlspecialchars($unbanReasonRaw);
     $GLOBALS['PDO']->query("UPDATE `:prefix_comms` SET
 										`RemovedBy` = :removedby,
 										`RemoveType` = :rtype,
@@ -155,7 +170,7 @@ if (isset($_GET['a']) && $_GET['a'] == "ungag" && isset($_GET['id'])) {
 
     if ($res) {
         echo "<script>ShowBox('Player UnMuted', '" . $row['name'] . " (" . $row['authid'] . ") has been unmuted from SourceBans.', 'green', 'index.php?p=commslist$pagelink');</script>";
-        Log::add(LogType::Message, "Player UnMuted", "$row[name] ($row[authid]) has been unmuted.");
+        Log::add(LogType::Message, "Player UnMuted", "$row[name] ($row[authid]) has been unmuted. Reason: $unbanReason");
     } else {
         echo "<script>ShowBox('Player NOT UnGagged', 'There was an error unmuted " . $row['name'] . "', 'red', 'index.php?p=commsist$pagelink', true);</script>";
     }

--- a/web/scripts/api-contract.js
+++ b/web/scripts/api-contract.js
@@ -253,11 +253,14 @@
  * ADMIN_UNBAN_OWN_BANS | ADMIN_UNBAN_GROUP_BANS` — the broadest "any
  * unban-ish flag" match — and the per-row precision check happens inside the
  * handler, since the dispatcher can't see which row the caller wants to act
- * on.  Inputs: - `bid`     (int, required) — the comm-block id. - `ureason`
- * (string, optional) — admin-supplied unblock reason; we trim and store
- * as-is. Stored raw in `ureason` (per the "store raw, escape on display"
- * anti-pattern); the column lives behind the same Smarty auto-escape pipeline
- * as `reason`.
+ * on.  #1301: `ureason` is **required**. v1.x prompted via sourcebans.js's
+ * UnMute()/UnGag() helpers and required a non-empty reason; v2.0 silently
+ * accepted '', so the audit log lost the *why*. Both this handler and the
+ * legacy GET fallback now bounce empty reasons.  Inputs: - `bid`     (int,
+ * required)    — the comm-block id. - `ureason` (string, required) —
+ * admin-supplied unblock reason; we trim and store as-is. Stored raw in
+ * `ureason` (per the "store raw, escape on display" anti-pattern); the column
+ * lives behind the same Smarty auto-escape pipeline as `reason`.
  *
  * @typedef {Object} ApiCommsUnblockRequest
  * @typedef {{ bid: number, state: string, type: number }} ApiCommsUnblockResponse

--- a/web/scripts/api-contract.js
+++ b/web/scripts/api-contract.js
@@ -158,6 +158,33 @@
  * @typedef {Object} ApiBansSetupBanResponse
  */
 /**
+ * Lift an active ban (#1301).  Modern JSON twin of the legacy
+ * `?p=banlist&a=unban&id=…&key=…` GET handler in `page.banlist.php`. The
+ * legacy GET path stays put (no-JS fallback for the icon-only theme leg +
+ * third-party themes that still ship the v1.x action links), but the banlist's
+ * visible-action affordance now wires through this action so the row can
+ * update in-place + show a toast without a full page reload.  Permission gate
+ * mirrors the legacy GET handler exactly:  ADMIN_OWNER | ADMIN_UNBAN     —
+ * unconditional, lift any row. ADMIN_UNBAN_OWN_BANS          — only the
+ * row's own admin (`aid`). ADMIN_UNBAN_GROUP_BANS        — only rows where
+ * the issuing admin's `gid` matches the caller's `gid`.  The dispatcher gate
+ * is `ADMIN_OWNER | ADMIN_UNBAN | ADMIN_UNBAN_OWN_BANS |
+ * ADMIN_UNBAN_GROUP_BANS` — the broadest "any unban-ish flag" match — and
+ * the per-row precision check happens inside the handler, since the dispatcher
+ * can't see which row the caller wants to act on.  #1301: `ureason` is
+ * **required**. v1.x prompted via sourcebans.js's UnbanBan() helper and
+ * required a non-empty reason; v2.0 silently accepted '', so the audit log
+ * lost the *why*. Both this handler and the legacy GET fallback now bounce
+ * empty reasons.  Inputs: - `bid`     (int, required)    — the ban id. -
+ * `ureason` (string, required) — admin-supplied unban reason; we trim and
+ * store as-is. Stored raw in `ureason` (per the "store raw, escape on display"
+ * anti-pattern); the column lives behind the same Smarty auto-escape pipeline
+ * as `reason`.
+ *
+ * @typedef {Object} ApiBansUnbanRequest
+ * @typedef {{ bid: number, state: string }} ApiBansUnbanResponse
+ */
+/**
  * @typedef {Object} ApiBansViewCommunityRequest
  * @typedef {Object} ApiBansViewCommunityResponse
  */
@@ -433,6 +460,7 @@ var Actions = Object.freeze({
     BansSearch: 'bans.search',
     BansSendMessage: 'bans.send_message',
     BansSetupBan: 'bans.setup_ban',
+    BansUnban: 'bans.unban',
     BansViewCommunity: 'bans.view_community',
     BlockitBlockPlayer: 'blockit.block_player',
     BlockitLoadServers: 'blockit.load_servers',

--- a/web/tests/api/BansTest.php
+++ b/web/tests/api/BansTest.php
@@ -562,4 +562,108 @@ final class BansTest extends ApiTestCase
         // bid is an autoincrement; redact so the snapshot only locks shape.
         $this->assertSnapshot('bans/search_success', $env, ['data.bans.0.bid']);
     }
+
+    // -- bans.unban (#1301) ------------------------------------------------
+
+    public function testUnbanRejectsAnonymous(): void
+    {
+        $env = $this->api('bans.unban', ['bid' => 1, 'ureason' => 'whatever']);
+        $this->assertEnvelopeError($env, 'forbidden');
+    }
+
+    public function testUnbanBadRequestOnMissingBid(): void
+    {
+        $this->loginAsAdmin();
+        $env = $this->api('bans.unban', ['ureason' => 'no bid here']);
+        $this->assertEnvelopeError($env, 'bad_request');
+        $this->assertSame('bid', $env['error']['field']);
+    }
+
+    /**
+     * #1301: a non-empty `ureason` is mandatory. v1.x prompted via
+     * sourcebans.js's UnbanBan helper and required a reason; v2.0
+     * silently accepted '', so the audit log lost the *why*.
+     */
+    public function testUnbanRejectsEmptyUreason(): void
+    {
+        $this->loginAsAdmin();
+        $bid = $this->seedBan('STEAM_0:1:1301', 'cheating');
+
+        // Missing entirely.
+        $env = $this->api('bans.unban', ['bid' => $bid]);
+        $this->assertEnvelopeError($env, 'validation');
+        $this->assertSame('ureason', $env['error']['field']);
+
+        // Whitespace-only counts as empty after trim().
+        $env = $this->api('bans.unban', ['bid' => $bid, 'ureason' => "  \n\t  "]);
+        $this->assertEnvelopeError($env, 'validation');
+        $this->assertSame('ureason', $env['error']['field']);
+
+        // Confirms the row was NOT touched on rejection.
+        $row = $this->row('bans', ['bid' => $bid]);
+        $this->assertNull($row['RemoveType']);
+        $this->assertNull($row['RemovedBy']);
+    }
+
+    public function testUnbanNotFoundForUnknownBid(): void
+    {
+        $this->loginAsAdmin();
+        $env = $this->api('bans.unban', ['bid' => 99999, 'ureason' => 'test']);
+        $this->assertEnvelopeError($env, 'not_found');
+    }
+
+    public function testUnbanLiftsActiveBanAndPersistsState(): void
+    {
+        $this->loginAsAdmin();
+        $bid = $this->seedBan('STEAM_0:1:1302', 'cheating');
+
+        $env = $this->api('bans.unban', [
+            'bid'     => $bid,
+            'ureason' => 'mistaken ban',
+        ]);
+        $this->assertTrue($env['ok'], json_encode($env));
+        $this->assertSame('unbanned', $env['data']['state']);
+        $this->assertSame($bid,       (int)$env['data']['bid']);
+
+        // Persisted: RemoveType='U', RemovedBy=admin aid, ureason stored.
+        $after = $this->row('bans', ['bid' => $bid]);
+        $this->assertSame('U',                 $after['RemoveType']);
+        $this->assertSame(Fixture::adminAid(), (int)$after['RemovedBy']);
+        $this->assertSame('mistaken ban',      $after['ureason']);
+    }
+
+    public function testUnbanRejectsAlreadyLiftedRow(): void
+    {
+        $this->loginAsAdmin();
+        $bid = $this->seedBan('STEAM_0:1:1303', 'cheating');
+
+        $first = $this->api('bans.unban', ['bid' => $bid, 'ureason' => 'lift it']);
+        $this->assertTrue($first['ok'], json_encode($first));
+
+        // Second call against the same already-lifted row should refuse.
+        $env = $this->api('bans.unban', ['bid' => $bid, 'ureason' => 'try again']);
+        $this->assertEnvelopeError($env, 'not_active');
+    }
+
+    /**
+     * #1301: the audit log carries the unban reason verbatim so admins
+     * reading the log later can see *why* the ban was lifted.
+     */
+    public function testUnbanRecordsReasonInAuditLog(): void
+    {
+        $this->loginAsAdmin();
+        $bid = $this->seedBan('STEAM_0:1:1304', 'cheating');
+
+        $env = $this->api('bans.unban', [
+            'bid'     => $bid,
+            'ureason' => 'appeal accepted',
+        ]);
+        $this->assertTrue($env['ok'], json_encode($env));
+
+        $logs = $this->rows('log', ['title' => 'Player Unbanned']);
+        $this->assertNotEmpty($logs, 'audit log row was created');
+        $latest = end($logs);
+        $this->assertStringContainsString('appeal accepted', (string) $latest['message']);
+        $this->assertStringContainsString('STEAM_0:1:1304', (string) $latest['message']);
+    }
 }

--- a/web/tests/api/CommsTest.php
+++ b/web/tests/api/CommsTest.php
@@ -183,8 +183,73 @@ final class CommsTest extends ApiTestCase
     public function testUnblockNotFoundForUnknownBid(): void
     {
         $this->loginAsAdmin();
-        $env = $this->api('comms.unblock', ['bid' => 99999]);
+        // #1301 — ureason is now required; supply a non-empty value so
+        // the validation gate doesn't short-circuit the row lookup.
+        $env = $this->api('comms.unblock', ['bid' => 99999, 'ureason' => 'test']);
         $this->assertEnvelopeError($env, 'not_found');
+    }
+
+    /**
+     * #1301: a non-empty `ureason` is mandatory. v1.x prompted via
+     * sourcebans.js's UnMute/UnGag helpers and required a reason; v2.0
+     * silently accepted '', so the audit log lost the *why*.
+     */
+    public function testUnblockRejectsEmptyUreason(): void
+    {
+        $this->loginAsAdmin();
+        $this->api('comms.add', [
+            'nickname' => 'NoReason',
+            'type'     => 1,
+            'steam'    => 'STEAM_0:0:1301',
+            'length'   => 60,
+            'reason'   => 'spam',
+        ]);
+        $row = $this->row('comms', ['authid' => 'STEAM_0:0:1301']);
+        $bid = (int)$row['bid'];
+
+        // Missing entirely.
+        $env = $this->api('comms.unblock', ['bid' => $bid]);
+        $this->assertEnvelopeError($env, 'validation');
+        $this->assertSame('ureason', $env['error']['field']);
+
+        // Whitespace-only counts as empty after trim().
+        $env = $this->api('comms.unblock', ['bid' => $bid, 'ureason' => "   \n\t"]);
+        $this->assertEnvelopeError($env, 'validation');
+        $this->assertSame('ureason', $env['error']['field']);
+
+        // Confirms the row was NOT touched on rejection.
+        $after = $this->row('comms', ['bid' => $bid]);
+        $this->assertNull($after['RemoveType']);
+        $this->assertNull($after['RemovedBy']);
+    }
+
+    /**
+     * #1301: the audit log carries the unblock reason verbatim.
+     */
+    public function testUnblockRecordsReasonInAuditLog(): void
+    {
+        $this->loginAsAdmin();
+        $this->api('comms.add', [
+            'nickname' => 'Audited',
+            'type'     => 2, // gag — drives the "UnGagged" verb in the log
+            'steam'    => 'STEAM_0:0:1302',
+            'length'   => 60,
+            'reason'   => 'spam',
+        ]);
+        $row = $this->row('comms', ['authid' => 'STEAM_0:0:1302']);
+        $bid = (int)$row['bid'];
+
+        $env = $this->api('comms.unblock', [
+            'bid'     => $bid,
+            'ureason' => 'appeal accepted',
+        ]);
+        $this->assertTrue($env['ok'], json_encode($env));
+
+        $logs = $this->rows('log', ['title' => 'Player UnGagged']);
+        $this->assertNotEmpty($logs, 'audit log row was created');
+        $latest = end($logs);
+        $this->assertStringContainsString('appeal accepted', (string) $latest['message']);
+        $this->assertStringContainsString('STEAM_0:0:1302', (string) $latest['message']);
     }
 
     public function testUnblockLiftsActiveGagAndPersistsState(): void
@@ -229,11 +294,12 @@ final class CommsTest extends ApiTestCase
         $row = $this->row('comms', ['authid' => 'STEAM_0:0:445']);
         $bid = (int)$row['bid'];
 
-        $first = $this->api('comms.unblock', ['bid' => $bid]);
+        // #1301: ureason is now required on every unblock attempt.
+        $first = $this->api('comms.unblock', ['bid' => $bid, 'ureason' => 'lift it']);
         $this->assertTrue($first['ok']);
 
         // Second call against the same already-lifted row should refuse.
-        $env = $this->api('comms.unblock', ['bid' => $bid]);
+        $env = $this->api('comms.unblock', ['bid' => $bid, 'ureason' => 'try again']);
         $this->assertEnvelopeError($env, 'not_active');
     }
 

--- a/web/tests/api/PermissionMatrixTest.php
+++ b/web/tests/api/PermissionMatrixTest.php
@@ -88,6 +88,15 @@ final class PermissionMatrixTest extends TestCase
             'bans.send_message'           => ['perm' => 0, 'requireAdmin' => true,  'public' => false],
             'bans.view_community'         => ['perm' => 0, 'requireAdmin' => true,  'public' => false],
             'bans.search'                 => ['perm' => 0, 'requireAdmin' => true,  'public' => false],
+            // bans.unban drives the visible row action on the public ban
+            // list (#1301). Dispatcher gate is "any unban-ish flag"; the
+            // handler then enforces the per-row own/group precision check
+            // that the legacy `?p=banlist&a=unban` GET path uses (and
+            // requires a non-empty `ureason` so the audit log carries it).
+            'bans.unban'                  => [
+                'perm' => ADMIN_OWNER | ADMIN_UNBAN | ADMIN_UNBAN_OWN_BANS | ADMIN_UNBAN_GROUP_BANS,
+                'requireAdmin' => false, 'public' => false,
+            ],
 
             // -- blockit.
             'blockit.load_servers'        => ['perm' => ADMIN_OWNER | ADMIN_ADD_BAN, 'requireAdmin' => false, 'public' => false],

--- a/web/tests/e2e/specs/flows/admin-ban-lifecycle.spec.ts
+++ b/web/tests/e2e/specs/flows/admin-ban-lifecycle.spec.ts
@@ -231,40 +231,71 @@ test.describe('flow: admin ban lifecycle', () => {
         await expect(editedRow).toContainText(FIXTURE.editedReason);
         await expect(editedRow).not.toContainText(FIXTURE.initialReason);
 
-        // ---- 6. Unban: click the row's unban anchor -----------------------
-        // The unban testid is a server-rendered <a> pointing at
-        // `?p=banlist&a=unban&id=<bid>&key=<postkey>`. Per
-        // page.banlist.php, GET to that URL flips the row's
-        // `RemoveType` to 'U' and renders the same banlist page —
-        // so the row's `data-state` switches to "unbanned" on the
-        // post-unban render. There is no client-side modal in the
-        // current chrome (the legacy `UnbanBan('…')` confirm() lived
-        // in sourcebans.js, gone since v2.0.0); the click is a
-        // direct GET.
-        const unbanAnchor = editedRow.locator('[data-testid="row-action-unban"]');
-        await expect(unbanAnchor).toBeVisible();
-        await Promise.all([
-            page.waitForURL(/[?&]a=unban\b/),
-            unbanAnchor.click(),
-        ]);
+        // ---- 6. Unban: open confirm modal, supply reason, submit ----------
+        // #1301: the row's unban affordance is a `<button>` (not an
+        // anchor) that opens `#bans-unban-dialog` — a native <dialog>
+        // with a required reason textarea. Both the JSON action
+        // (`bans.unban`) and the legacy GET fallback now reject an
+        // empty `ureason`, restoring v1.x parity (the v1.x JS prompt
+        // was lost when sourcebans.js was deleted at #1123 D1; v2.0
+        // silently accepted '' until this fix).
+        //
+        // The submit handler calls `sb.api.call(Actions.BansUnban,
+        // {bid, ureason})` and on success flips the row's
+        // `data-state` to "unbanned" in place (no full page nav), so
+        // we wait on the deterministic attribute change rather than
+        // a URL transition.
+        const unbanButton = editedRow.locator('[data-testid="row-action-unban"]');
+        await expect(unbanButton).toBeVisible();
+        await unbanButton.click();
 
-        // ---- 7. Confirm unbanned state in admin + public views ------------
-        // The post-unban page is the same `?p=banlist` rendered with
-        // the row's new state. The pill text is `Unbanned` (capital-
-        // ised from the lowercase state string by the |capitalize
-        // modifier in the tpl), and the row's `data-state` attribute
-        // is the deterministic equivalent we assert on.
+        const unbanDialog = page.locator('[data-testid="bans-unban-dialog"]');
+        await expect(unbanDialog).toBeVisible();
+        // The dialog mirrors the row's player name into the prompt
+        // copy via `[data-testid="bans-unban-target"]`. Locking it in
+        // catches a regression where the openUnbanDialog() helper
+        // would forget to populate the target span.
+        await expect(unbanDialog.locator('[data-testid="bans-unban-target"]'))
+            .toHaveText(FIXTURE.nickname);
+
+        // Empty-reason guard: clicking submit with the textarea blank
+        // surfaces the inline error and does NOT navigate. This mirrors
+        // the v1.x JS prompt's "please leave a comment" rejection
+        // (#1301).
+        await unbanDialog.locator('[data-testid="bans-unban-submit"]').click();
+        await expect(unbanDialog.locator('[data-testid="bans-unban-error"]'))
+            .toBeVisible();
+        await expect(editedRow).toHaveAttribute('data-state', 'permanent');
+
+        // Now supply a reason and confirm. The handler resolves the
+        // sb.api.call promise, then flips the row in place and shows
+        // a success toast.
+        await unbanDialog
+            .locator('[data-testid="bans-unban-reason"]')
+            .fill('e2e: appeal accepted');
+        await unbanDialog.locator('[data-testid="bans-unban-submit"]').click();
+
+        const unbanToast = page
+            .locator('.toast[data-kind="success"]')
+            .filter({ hasText: /unbanned/i });
+        await expect(unbanToast).toBeVisible();
+
+        // ---- 7. Confirm unbanned state in admin view ----------------------
+        // The row updates in place via flipRowToUnbanned() — the
+        // `data-state` attribute switches to "unbanned", the pill
+        // text becomes "Unbanned", and the unban button is removed
+        // from the DOM. No URL change.
         const unbannedRow = page
             .locator(`[data-testid="ban-row"][data-id="${bid}"]`);
         await expect(unbannedRow).toBeVisible();
         await expect(unbannedRow).toHaveAttribute('data-state', 'unbanned');
         await expect(unbannedRow.locator('.pill')).toHaveText(/unbanned/i);
 
-        // The unban-action affordance disappears after the row is
-        // unbanned (the tpl gates `row-action-unban` on
-        // `state != 'unbanned' && state != 'expired'`); locking that
-        // in catches a regression where a re-unban would silently
-        // double-write the RemoveType column.
+        // The unban-action button is removed after the row is
+        // unbanned (flipRowToUnbanned() prunes every
+        // `[data-action="bans-unban"]` inside the row). Catches a
+        // regression where a re-unban would silently double-write
+        // the RemoveType column.
         await expect(unbannedRow.locator('[data-testid="row-action-unban"]'))
             .toHaveCount(0);
 

--- a/web/tests/e2e/specs/flows/comms-affordances.spec.ts
+++ b/web/tests/e2e/specs/flows/comms-affordances.spec.ts
@@ -179,9 +179,11 @@ test.describe('flow: comms list affordances (#1207 ADM-5/ADM-6)', () => {
         await expect(unmuteBtn).toContainText(/ungag|unmute|lift/i);
         await expect(deleteBtn).toContainText(/remove/i);
 
-        // ---- ADM-6: click Unmute → in-place state flip + toast -----------
-        // The inline page-tail JS in `page_comms.tpl` intercepts
-        // the click, calls `Actions.CommsUnblock`, and on success:
+        // ---- ADM-6: click Unmute → confirm modal → in-place flip + toast -
+        // #1301: the Unmute button now opens
+        // `#comms-unblock-dialog` and requires a non-empty reason
+        // before firing `Actions.CommsUnblock`. The submit handler
+        // resolves on success, then in-place:
         //   - flips `data-state` and `ban-row--*` class to `unmuted`
         //   - rewrites the status pill text to "Unmuted"
         //   - replaces the Unmute button with a Re-apply anchor
@@ -191,6 +193,13 @@ test.describe('flow: comms list affordances (#1207 ADM-5/ADM-6)', () => {
         // resolves the await inside the handler synchronously
         // relative to the toast/DOM update.
         await unmuteBtn.click();
+
+        const unblockDialog = page.locator('[data-testid="comms-unblock-dialog"]');
+        await expect(unblockDialog).toBeVisible();
+        await unblockDialog
+            .locator('[data-testid="comms-unblock-reason"]')
+            .fill('e2e: lifting the gag');
+        await unblockDialog.locator('[data-testid="comms-unblock-submit"]').click();
 
         await expect(row).toHaveAttribute('data-state', 'unmuted');
         // The status pill is the *last* `.pill` inside the row
@@ -262,6 +271,14 @@ test.describe('flow: comms list affordances (#1207 ADM-5/ADM-6)', () => {
         await expect(card.locator('[data-testid="comm-card-link"]')).toBeVisible();
 
         await unmuteBtn.click();
+
+        // #1301: same confirm-modal contract as the desktop spec.
+        const unblockDialog = page.locator('[data-testid="comms-unblock-dialog"]');
+        await expect(unblockDialog).toBeVisible();
+        await unblockDialog
+            .locator('[data-testid="comms-unblock-reason"]')
+            .fill('e2e: lifting the gag (mobile)');
+        await unblockDialog.locator('[data-testid="comms-unblock-submit"]').click();
 
         await expect(card).toHaveAttribute('data-state', 'unmuted');
         await expect(card.locator('[data-testid="row-action-unmute-mobile"]')).toHaveCount(0);

--- a/web/themes/default/page_bans.tpl
+++ b/web/themes/default/page_bans.tpl
@@ -237,10 +237,34 @@
                    onclick="event.stopPropagation()">&#9998;</a>
                 {/if}
                 {if $ban.can_unban && $ban.state != 'unbanned' && $ban.state != 'expired'}
-                <a class="btn btn--ghost btn--sm btn--icon" data-testid="row-action-unban"
-                   title="Unban"
-                   href="index.php?p=banlist&amp;a=unban&amp;id={$ban.bid}&amp;key={$admin_postkey|escape}"
-                   onclick="event.stopPropagation()">&#10003;</a>
+                {* #1301: button + data-action wires to the inline page-tail
+                   JS below, which prompts for an unban reason via the
+                   `#bans-unban-dialog` <dialog> and calls
+                   Actions.BansUnban with the trimmed reason. The
+                   data-fallback-href is the legacy GET URL the no-JS
+                   path lands on; the page handler now also rejects an
+                   empty `ureason` there so a hand-crafted URL can't
+                   slip through the back door either. *}
+                {* No onclick="event.stopPropagation()" here even though
+                   the sibling Edit anchor has one (defensive copy from
+                   the legacy theme): the column-action button is
+                   inside `<td class="col-actions">`, which is a sibling
+                   of the player-name `<a data-drawer-href>` cell, so
+                   the drawer-click delegate never sees the bubbled
+                   event regardless. The page-tail JS for the unban
+                   modal listens on `document` though — adding
+                   stopPropagation here would silently swallow the
+                   click before it reached the dialog opener (the
+                   dispatcher's no-op for `[data-action]` lookups
+                   filters anything that isn't an unban button). *}
+                <button type="button"
+                        class="btn btn--ghost btn--sm btn--icon"
+                        data-testid="row-action-unban"
+                        data-action="bans-unban"
+                        data-bid="{$ban.bid}"
+                        data-name="{$ban.name|escape}"
+                        data-fallback-href="index.php?p=banlist&amp;a=unban&amp;id={$ban.bid}&amp;key={$admin_postkey|escape}"
+                        title="Unban">&#10003;</button>
                 {/if}
               {/if}
               {if !empty($ban.steam)}
@@ -403,6 +427,53 @@
 </div>
 {/if}
 
+{* ============================================================
+   #1301 — unban confirm + reason modal scaffold.
+
+   v1.x had two safeguards before unbanning a player: a confirm modal
+   and a non-empty unban-reason input. Both lived in the deleted
+   `web/scripts/sourcebans.js` (UnbanBan()), and the v2.0 cutover
+   left the row's affordance as a bare GET that silently accepted an
+   empty `ureason`. This `<dialog>` is the v2.0-shape replacement,
+   wired by the inline IIFE below. The dialog stays `hidden` on
+   first paint so a JS failure leaves the unban affordance reachable
+   only via the no-JS GET fallback (which itself now requires a
+   non-empty reason, so the back door is closed too).
+   ============================================================ *}
+<dialog id="bans-unban-dialog"
+        class="palette"
+        aria-labelledby="bans-unban-dialog-title"
+        data-testid="bans-unban-dialog"
+        hidden
+        style="max-width:32rem;width:90vw;padding:1.25rem;border-radius:0.75rem;border:1px solid var(--border)">
+  <form method="dialog" data-testid="bans-unban-form">
+    <h2 id="bans-unban-dialog-title" style="font-size:var(--fs-lg);font-weight:600;margin:0 0 0.25rem">Unban player</h2>
+    <p class="text-sm text-muted m-0" style="margin-bottom:0.75rem">
+      Why are you unbanning <strong data-testid="bans-unban-target">this player</strong>? This reason is recorded against the ban and surfaced in the audit log.
+    </p>
+    <label class="label" for="bans-unban-reason">Unban reason <span aria-hidden="true" style="color:var(--danger)">*</span></label>
+    {* aria-required (not the native `required`) so assistive tech announces
+       the field as required while the JS submit handler owns the empty-reason
+       branch — `required` would let the browser block the form submit before
+       our handler runs, swallowing the inline error UX (#1301). *}
+    <textarea class="textarea"
+              id="bans-unban-reason"
+              data-testid="bans-unban-reason"
+              rows="3"
+              aria-required="true"
+              maxlength="255"
+              autocomplete="off"
+              placeholder="Mistaken ban, appeal accepted, sentence served, &hellip;"></textarea>
+    <p class="text-xs" data-testid="bans-unban-error" role="alert" hidden style="color:var(--danger);margin:0.25rem 0 0"></p>
+    <div class="flex gap-2 mt-4" style="justify-content:flex-end">
+      <button type="button" class="btn btn--secondary" data-testid="bans-unban-cancel" value="cancel">Cancel</button>
+      <button type="submit" class="btn btn--primary" data-testid="bans-unban-submit" value="confirm">
+        <i data-lucide="check" style="width:13px;height:13px"></i> Unban
+      </button>
+    </div>
+  </form>
+</dialog>
+
 {* banlist.js wires both branches: the chip filter / copy buttons /
    skeleton hook on the listing branch, and the `#banlist-comment-form`
    submit -> sb.api.call(BansAddComment / BansEditComment) on the
@@ -411,6 +482,260 @@
    the listing branch silently broke comment save (no submit handler
    attached, native form submission to action-less URL no-ops). *}
 <script src="./scripts/banlist.js" defer></script>
+
+{* ============================================================
+   #1301 — banlist row-action wiring (inline page-tail JS).
+
+   Click delegation per anti-pattern: every Unban button in the rows
+   above carries `data-action="bans-unban"` plus `data-bid` /
+   `data-name` / `data-fallback-href`. The handler intercepts those
+   clicks, opens the `#bans-unban-dialog` <dialog>, validates the
+   reason on submit, calls `sb.api.call(Actions.BansUnban, …)`, and
+   updates the row in-place on success (state pill flips to
+   "unbanned", the unban button is removed, `window.SBPP.showToast`
+   confirms). The fallback href is followed as a navigation when the
+   JSON dispatcher is missing entirely (e.g. third-party theme with
+   stripped api.js) — that's the legacy GET URL the
+   `?p=banlist&a=unban` handler in page.banlist.php still serves
+   (and which now also requires a non-empty `ureason`, see #1301
+   guard there).
+
+   No `// @ts-check` here because the file is rendered by Smarty;
+   ts-check only runs against `.js` sources in `web/scripts`. The
+   shape mirrors the inline handler in page_comms.tpl (#1207
+   ADM-5/ADM-6 reference, extended in #1301 for the same modal).
+   ============================================================ *}
+{literal}
+<script>
+(function () {
+    'use strict';
+
+    /** @returns {{call: (a:string,p?:object)=>Promise<any>}|null} */
+    function api()     { return (window.sb && window.sb.api) || null; }
+    /** @returns {Record<string,string>|null} */
+    function actions() { return /** @type {any} */ (window).Actions || null; }
+    function toast(kind, title, body) {
+        var sbpp = /** @type {any} */ (window).SBPP;
+        if (sbpp && typeof sbpp.showToast === 'function') {
+            sbpp.showToast({ kind: kind, title: title, body: body || '' });
+        }
+    }
+
+    /**
+     * Find every DOM node that mirrors the same ban id. The desktop
+     * `<tr data-testid="ban-row">` and the mobile `<a class="ban-row">`
+     * both render the same row, and theme.css's
+     * `@media (max-width: 768px)` block hides the `<table>` via
+     * `display: none` rather than removing the DOM.
+     * @param {string} bid
+     * @returns {Element[]}
+     */
+    function rowsForBid(bid) {
+        var sel = '[data-testid="ban-row"][data-id="' + bid + '"], '
+                + '.ban-row[data-id="' + bid + '"]';
+        return Array.prototype.slice.call(document.querySelectorAll(sel));
+    }
+
+    /**
+     * Update both copies of the row from `permanent|active` -> `unbanned`:
+     *  - data-state on the wrapper.
+     *  - ban-row--<state> class on the wrapper.
+     *  - The status pill has its `pill--<state>` class swapped AND its
+     *    visible label rewritten to "Unbanned".
+     *  - The Unban button is removed (the tpl gates it on
+     *    `state != 'unbanned' && state != 'expired'` so the post-render
+     *    matches what the next page load would emit).
+     * @param {Element} row
+     * @returns {void}
+     */
+    function flipRowToUnbanned(row) {
+        row.setAttribute('data-state', 'unbanned');
+        row.classList.remove('ban-row--active', 'ban-row--permanent', 'ban-row--expired');
+        row.classList.add('ban-row--unbanned');
+        Array.prototype.forEach.call(row.querySelectorAll('.pill'), function (pill) {
+            pill.classList.remove('pill--active', 'pill--permanent', 'pill--expired');
+            pill.classList.add('pill--unbanned');
+            // Walk children backwards to find the trailing text node so
+            // we don't clobber any leading <i> icons.
+            var lastText = null;
+            for (var i = pill.childNodes.length - 1; i >= 0; i--) {
+                var n = pill.childNodes[i];
+                if (n.nodeType === 3) { lastText = n; break; }
+            }
+            var txt = (pill.textContent || '').trim();
+            if (txt === 'Active' || txt === 'Permanent' || txt === 'Expired') {
+                if (lastText) lastText.textContent = 'Unbanned';
+                else pill.textContent = 'Unbanned';
+            }
+        });
+        Array.prototype.forEach.call(
+            row.querySelectorAll('[data-action="bans-unban"]'),
+            function (btn) { if (btn.parentNode) btn.parentNode.removeChild(btn); }
+        );
+    }
+
+    /** @returns {HTMLDialogElement|null} */
+    function dialog() {
+        return /** @type {HTMLDialogElement|null} */ (document.getElementById('bans-unban-dialog'));
+    }
+    /** @returns {HTMLTextAreaElement|null} */
+    function reasonInput() {
+        return /** @type {HTMLTextAreaElement|null} */ (document.getElementById('bans-unban-reason'));
+    }
+    /** @returns {HTMLElement|null} */
+    function errorEl() {
+        var d = dialog();
+        return d ? /** @type {HTMLElement|null} */ (d.querySelector('[data-testid="bans-unban-error"]')) : null;
+    }
+
+    /** @param {string} msg */
+    function showError(msg) {
+        var e = errorEl();
+        if (!e) return;
+        e.textContent = msg;
+        e.hidden = false;
+    }
+    function clearError() {
+        var e = errorEl();
+        if (!e) return;
+        e.textContent = '';
+        e.hidden = true;
+    }
+
+    /** @type {{bid: string, name: string, fallback: string}|null} */
+    var pending = null;
+
+    /**
+     * Open the unban dialog for the supplied row data. We use the
+     * native <dialog>.showModal() so the browser handles focus trapping
+     * + ESC dismissal + the top-layer overlay for free.
+     * @param {{bid: string, name: string, fallback: string}} ctx
+     */
+    function openUnbanDialog(ctx) {
+        pending = ctx;
+        var d = dialog();
+        if (!d) {
+            // The dialog markup is in the template above; if it's
+            // missing the page is in an inconsistent state. Fall back
+            // to the legacy GET path so the action still works (it
+            // now also requires `ureason=` per #1301 — empty-reason
+            // hand-edits get bounced server-side too).
+            if (ctx.fallback) window.location.href = ctx.fallback;
+            return;
+        }
+        var target = d.querySelector('[data-testid="bans-unban-target"]');
+        if (target) target.textContent = ctx.name || ('ban #' + ctx.bid);
+        var input = reasonInput();
+        if (input) input.value = '';
+        clearError();
+        d.removeAttribute('hidden');
+        try { d.showModal(); }
+        catch (_e) { d.setAttribute('open', ''); }
+        if (input) {
+            try { input.focus(); } catch (_e) { /* focus may throw if hidden */ }
+        }
+    }
+
+    function closeUnbanDialog() {
+        var d = dialog();
+        if (!d) return;
+        try { d.close(); } catch (_e) { /* not opened modally */ }
+        d.setAttribute('hidden', '');
+        pending = null;
+    }
+
+    document.addEventListener('click', function (e) {
+        var t = /** @type {Element|null} */ (e.target);
+        if (!t || !t.closest) return;
+
+        // Cancel button inside the dialog.
+        if (t.closest('[data-testid="bans-unban-cancel"]')) {
+            e.preventDefault();
+            closeUnbanDialog();
+            return;
+        }
+
+        var btn = /** @type {HTMLElement|null} */ (t.closest('[data-action="bans-unban"]'));
+        if (!btn) return;
+        e.preventDefault();
+
+        var bid = btn.getAttribute('data-bid') || '';
+        var name = btn.getAttribute('data-name') || ('ban #' + bid);
+        var fallback = btn.getAttribute('data-fallback-href') || '';
+        var a = api(), A = actions();
+        if (!a || !A || !bid) {
+            // No JSON dispatcher available (e.g. third-party theme that
+            // stripped api.js). Fall back to the legacy GET URL — the
+            // server-side handler now also rejects empty `ureason` so
+            // a hand-edited URL won't slip through (#1301).
+            if (fallback) window.location.href = fallback;
+            return;
+        }
+        openUnbanDialog({ bid: bid, name: name, fallback: fallback });
+    });
+
+    document.addEventListener('submit', function (e) {
+        var form = /** @type {Element|null} */ (e.target);
+        if (!form || !(/** @type {Element} */ (form)).closest) return;
+        if (!form.matches('[data-testid="bans-unban-form"]')) return;
+        e.preventDefault();
+        if (!pending) return;
+
+        var input = reasonInput();
+        var reason = input ? input.value.trim() : '';
+        if (reason === '') {
+            // Mirror the v1.x JS guard: surface an inline error rather
+            // than submitting an empty reason that the server would
+            // bounce. The server still re-validates as the load-bearing
+            // gate.
+            showError('Please leave a comment.');
+            if (input) try { input.focus(); } catch (_e) { /* focus may throw */ }
+            return;
+        }
+        clearError();
+
+        var ctx = pending;
+        var submitBtn = /** @type {HTMLButtonElement|null} */ (form.querySelector('[data-testid="bans-unban-submit"]'));
+        if (submitBtn) submitBtn.disabled = true;
+
+        var a = api(), A = actions();
+        if (!a || !A) {
+            if (submitBtn) submitBtn.disabled = false;
+            if (ctx.fallback) {
+                // Encode the reason into the legacy GET URL so the no-JS
+                // path lands with the typed reason populated.
+                var sep = ctx.fallback.indexOf('?') === -1 ? '?' : '&';
+                window.location.href = ctx.fallback + sep + 'ureason=' + encodeURIComponent(reason);
+            }
+            return;
+        }
+
+        a.call(A.BansUnban, { bid: Number(ctx.bid), ureason: reason }).then(function (r) {
+            if (submitBtn) submitBtn.disabled = false;
+            if (!r || r.ok === false) {
+                var msg = (r && r.error && r.error.message) || 'Unknown error';
+                showError(msg);
+                toast('error', 'Unban failed', msg);
+                return;
+            }
+            rowsForBid(ctx.bid).forEach(flipRowToUnbanned);
+            closeUnbanDialog();
+            toast('success', 'Player unbanned', ctx.name + ' has been unbanned.');
+        });
+    });
+
+    // Native <dialog> fires `cancel` on ESC; clear the pending context
+    // so a subsequent click reopens cleanly with the next row's data.
+    document.addEventListener('cancel', function (e) {
+        var t = /** @type {Element|null} */ (e.target);
+        if (!t || t.id !== 'bans-unban-dialog') return;
+        // Let the native close fire too; we just reset our state.
+        pending = null;
+        clearError();
+    });
+})();
+</script>
+{/literal}
 
 {* ============================================================
    Manifest of properties only consumed by themes/default/page_bans.tpl.

--- a/web/themes/default/page_comms.tpl
+++ b/web/themes/default/page_comms.tpl
@@ -514,7 +514,56 @@
 </div>
 
 {* ============================================================
-   #1207 ADM-5/ADM-6 — comms row-action wiring (inline page-tail JS).
+   #1301 — comms unblock confirm + reason modal scaffold.
+
+   v1.x had two safeguards before lifting a comm block: a confirm
+   modal and a non-empty unblock-reason prompt. Both lived in the
+   deleted `web/scripts/sourcebans.js` (UnMuteBan / UnGagBan), and
+   the v2.0 cutover left the row's affordance as a single click that
+   silently sent an empty `ureason`. This `<dialog>` is the v2.0-shape
+   replacement, wired by the inline IIFE below. The dialog stays
+   `hidden` on first paint so a JS failure leaves the unmute
+   affordance reachable only via the no-JS GET fallback (which itself
+   now requires a non-empty reason, see #1301 guard in
+   page.commslist.php).
+   ============================================================ *}
+<dialog id="comms-unblock-dialog"
+        class="palette"
+        aria-labelledby="comms-unblock-dialog-title"
+        data-testid="comms-unblock-dialog"
+        hidden
+        style="max-width:32rem;width:90vw;padding:1.25rem;border-radius:0.75rem;border:1px solid var(--border)">
+  <form method="dialog" data-testid="comms-unblock-form">
+    <h2 id="comms-unblock-dialog-title" data-testid="comms-unblock-dialog-title" style="font-size:var(--fs-lg);font-weight:600;margin:0 0 0.25rem">Lift block</h2>
+    <p class="text-sm text-muted m-0" style="margin-bottom:0.75rem">
+      Why are you lifting the block on <strong data-testid="comms-unblock-target">this player</strong>? This reason is recorded against the block and surfaced in the audit log.
+    </p>
+    <label class="label" for="comms-unblock-reason">Reason <span aria-hidden="true" style="color:var(--danger)">*</span></label>
+    {* aria-required (not the native `required`) so assistive tech announces
+       the field as required while the JS submit handler owns the empty-reason
+       branch — `required` would let the browser block the form submit before
+       our handler runs, swallowing the inline error UX (#1301). *}
+    <textarea class="textarea"
+              id="comms-unblock-reason"
+              data-testid="comms-unblock-reason"
+              rows="3"
+              aria-required="true"
+              maxlength="255"
+              autocomplete="off"
+              placeholder="Mistaken block, appeal accepted, sentence served, &hellip;"></textarea>
+    <p class="text-xs" data-testid="comms-unblock-error" role="alert" hidden style="color:var(--danger);margin:0.25rem 0 0"></p>
+    <div class="flex gap-2 mt-4" style="justify-content:flex-end">
+      <button type="button" class="btn btn--secondary" data-testid="comms-unblock-cancel" value="cancel">Cancel</button>
+      <button type="submit" class="btn btn--primary" data-testid="comms-unblock-submit" value="confirm">
+        <i data-lucide="check" style="width:13px;height:13px"></i> Confirm
+      </button>
+    </div>
+  </form>
+</dialog>
+
+{* ============================================================
+   #1207 ADM-5/ADM-6 + #1301 — comms row-action wiring (inline
+   page-tail JS).
 
    Click delegation per anti-pattern: every action button in the rows
    above (desktop table + mobile cards) carries `data-action="comms-*"`
@@ -525,7 +574,17 @@
    href is followed as a navigation when the JSON dispatcher is
    missing entirely (e.g. third-party theme with stripped api.js) —
    that's the legacy GET URL the `?p=commslist&a=…` handler in
-   page.commslist.php still serves.
+   page.commslist.php still serves (and which now also requires a
+   non-empty `ureason` per #1301 — empty-reason hand-edits get
+   bounced server-side too).
+
+   `comms-unblock` flow (#1301): instead of firing the API call
+   immediately, opens the `#comms-unblock-dialog` <dialog> for a
+   confirm + reason prompt. The dialog's submit handler validates
+   the trimmed reason locally (so we don't bother the server with
+   the obvious empty-reason case) and forwards it as `ureason` to
+   `Actions.CommsUnblock`. Server-side validation in
+   `api_comms_unblock` is the load-bearing gate.
 
    No `// @ts-check` here because the file is rendered by Smarty;
    ts-check only runs against `.js` sources in `web/scripts`. The
@@ -640,9 +699,97 @@
         el.textContent = (n - 1).toLocaleString();
     }
 
+    /** @returns {HTMLDialogElement|null} */
+    function dialog() {
+        return /** @type {HTMLDialogElement|null} */ (document.getElementById('comms-unblock-dialog'));
+    }
+    /** @returns {HTMLTextAreaElement|null} */
+    function reasonInput() {
+        return /** @type {HTMLTextAreaElement|null} */ (document.getElementById('comms-unblock-reason'));
+    }
+    /** @returns {HTMLElement|null} */
+    function errorEl() {
+        var d = dialog();
+        return d ? /** @type {HTMLElement|null} */ (d.querySelector('[data-testid="comms-unblock-error"]')) : null;
+    }
+    /** @param {string} msg */
+    function showError(msg) { var e = errorEl(); if (!e) return; e.textContent = msg; e.hidden = false; }
+    function clearError() { var e = errorEl(); if (!e) return; e.textContent = ''; e.hidden = true; }
+
+    /** @type {{bid: string, name: string, fallback: string, type: string}|null} */
+    var pending = null;
+
+    /**
+     * @param {string} type
+     * @returns {{title: string, verb: string}}
+     */
+    function copyForType(type) {
+        if (type === 'mute')    return { title: 'Unmute player',     verb: 'unmute' };
+        if (type === 'gag')     return { title: 'Ungag player',      verb: 'ungag' };
+        if (type === 'silence') return { title: 'Lift silence',      verb: 'lift the silence on' };
+        return                          { title: 'Lift block',       verb: 'lift the block on' };
+    }
+
+    /** @param {{bid: string, name: string, fallback: string, type: string}} ctx */
+    function openUnblockDialog(ctx) {
+        pending = ctx;
+        var d = dialog();
+        if (!d) {
+            // Dialog markup missing — fall back to the legacy GET path
+            // so the action still works (it now also requires
+            // ureason= in the URL per #1301; without one the page
+            // handler bounces with an inline error).
+            if (ctx.fallback) window.location.href = ctx.fallback;
+            return;
+        }
+        var copy = copyForType(ctx.type);
+        var title = d.querySelector('[data-testid="comms-unblock-dialog-title"]');
+        if (title) title.textContent = copy.title;
+        var prompt = d.querySelector('[data-testid="comms-unblock-target"]');
+        if (prompt) prompt.textContent = ctx.name || ('block #' + ctx.bid);
+        // Update the surrounding sentence's verb in place. The
+        // <strong> nested-target child carries the player's name, so we
+        // rewrite the parent paragraph's first text node to swap "lifting
+        // the block on" for the type-specific verb without losing the
+        // bold name span.
+        var p = d.querySelector('p.text-sm.text-muted');
+        if (p && p.firstChild && p.firstChild.nodeType === 3) {
+            p.firstChild.textContent = 'Why are you ' + copy.verb + ' ';
+        }
+        var input = reasonInput();
+        if (input) input.value = '';
+        clearError();
+        d.removeAttribute('hidden');
+        try { d.showModal(); }
+        catch (_e) { d.setAttribute('open', ''); }
+        if (input) { try { input.focus(); } catch (_e) { /* focus may throw */ } }
+    }
+
+    function closeUnblockDialog() {
+        var d = dialog();
+        if (!d) return;
+        try { d.close(); } catch (_e) { /* not opened modally */ }
+        d.setAttribute('hidden', '');
+        // Re-enable any unblock buttons we disabled before showing the
+        // dialog so a Cancel click leaves the row clickable again.
+        Array.prototype.forEach.call(
+            document.querySelectorAll('[data-action="comms-unblock"][disabled]'),
+            function (btn) { /** @type {HTMLButtonElement} */ (btn).disabled = false; }
+        );
+        pending = null;
+    }
+
     document.addEventListener('click', function (e) {
         var t = /** @type {Element|null} */ (e.target);
         if (!t || !t.closest) return;
+
+        // Cancel button inside the dialog.
+        if (t.closest('[data-testid="comms-unblock-cancel"]')) {
+            e.preventDefault();
+            closeUnblockDialog();
+            return;
+        }
+
         var btn = /** @type {HTMLElement|null} */ (t.closest('[data-action]'));
         if (!btn) return;
         var act = btn.getAttribute('data-action');
@@ -656,7 +803,8 @@
         if (!a || !A || !bid) {
             // No JSON dispatcher available (e.g. third-party theme that
             // stripped api.js). Fall back to the legacy GET URL — same
-            // outcome, full page reload.
+            // outcome, full page reload (page handler bounces empty
+            // ureason per #1301).
             if (fallback) window.location.href = fallback;
             return;
         }
@@ -678,22 +826,70 @@
             return;
         }
 
-        // comms-unblock — lift an active block. We don't prompt for an
-        // unblock reason here; the legacy GET path didn't either (only
-        // sourcebans.js's UnGag()/UnMute() confirm prompts did, and
-        // those went away with #1123 D1). Admins who need a recorded
-        // reason can use the edit form instead.
-        /** @type {HTMLButtonElement} */ (btn).disabled = true;
-        a.call(A.CommsUnblock, { bid: Number(bid), ureason: '' }).then(function (r) {
+        // #1301 — comms-unblock now opens the confirm + reason modal
+        // instead of firing the API call immediately. The legacy v2.0
+        // shape silently posted `ureason: ''`; v1.x prompted via
+        // sourcebans.js's UnMute()/UnGag() helpers. The modal is the
+        // v2.0-shape replacement.
+        var typeAttr = '';
+        var rowEl = /** @type {Element|null} */ (btn.closest('[data-type]'));
+        if (rowEl) typeAttr = rowEl.getAttribute('data-type') || '';
+        openUnblockDialog({ bid: bid, name: name, fallback: fallback, type: typeAttr });
+    });
+
+    document.addEventListener('submit', function (e) {
+        var form = /** @type {Element|null} */ (e.target);
+        if (!form || !(/** @type {Element} */ (form)).closest) return;
+        if (!form.matches('[data-testid="comms-unblock-form"]')) return;
+        e.preventDefault();
+        if (!pending) return;
+
+        var input = reasonInput();
+        var reason = input ? input.value.trim() : '';
+        if (reason === '') {
+            // Mirror the v1.x guard: surface an inline error rather
+            // than submitting an empty reason that the server would
+            // bounce. The server still re-validates as the
+            // load-bearing gate (api_comms_unblock).
+            showError('Please leave a comment.');
+            if (input) try { input.focus(); } catch (_e) { /* focus may throw */ }
+            return;
+        }
+        clearError();
+
+        var ctx = pending;
+        var submitBtn = /** @type {HTMLButtonElement|null} */ (form.querySelector('[data-testid="comms-unblock-submit"]'));
+        if (submitBtn) submitBtn.disabled = true;
+
+        var a = api(), A = actions();
+        if (!a || !A) {
+            if (submitBtn) submitBtn.disabled = false;
+            if (ctx.fallback) {
+                var sep = ctx.fallback.indexOf('?') === -1 ? '?' : '&';
+                window.location.href = ctx.fallback + sep + 'ureason=' + encodeURIComponent(reason);
+            }
+            return;
+        }
+
+        a.call(A.CommsUnblock, { bid: Number(ctx.bid), ureason: reason }).then(function (r) {
+            if (submitBtn) submitBtn.disabled = false;
             if (!r || r.ok === false) {
-                /** @type {HTMLButtonElement} */ (btn).disabled = false;
                 var msg = (r && r.error && r.error.message) || 'Unknown error';
+                showError(msg);
                 toast('error', 'Unblock failed', msg);
                 return;
             }
-            rowsForBid(bid).forEach(flipRowToUnmuted);
-            toast('success', 'Block lifted', name + ' has been unblocked.');
+            rowsForBid(ctx.bid).forEach(flipRowToUnmuted);
+            closeUnblockDialog();
+            toast('success', 'Block lifted', ctx.name + ' has been unblocked.');
         });
+    });
+
+    document.addEventListener('cancel', function (e) {
+        var t = /** @type {Element|null} */ (e.target);
+        if (!t || t.id !== 'comms-unblock-dialog') return;
+        pending = null;
+        clearError();
     });
 })();
 </script>


### PR DESCRIPTION
Fixes #1301.

## Summary

v1.x had two safeguards before lifting a ban or comm block: a confirm modal and a non-empty unblock-reason prompt. Both lived in the deleted `web/scripts/sourcebans.js` (UnbanBan / UnMuteBan / UnGagBan), and the v2.0 cutover left the row's affordance as a single click that silently sent an empty `ureason`. The audit log lost the *why* behind every block lift for ~18 months.

This PR restores both safeguards on the v2.0 chrome:

- **New confirm + reason modals** — `<dialog id="bans-unban-dialog">` in `page_bans.tpl` and `<dialog id="comms-unblock-dialog">` in `page_comms.tpl`. The textarea uses `aria-required="true"` (NOT the native `required`) so the JS submit handler owns the empty-reason inline-error UX rather than ceding to the browser's validation popover. The dialog title + verb adapt to the comm-block type (mute / gag / silence). On success, the row flips in place via the existing `flipRowToUnbanned` / `flipRowToUnmuted` helpers and a success toast fires.
- **New `bans.unban` JSON action** mirrors the legacy GET handler's per-row precision check (Owner / Unban-all / Unban-own / Unban-group), rejects empty `ureason` server-side, archives matching protests, fans `sm_unban` to enabled servers, and records the reason in the audit log. The existing `comms.unblock` gains the same empty-reason guard.
- **Legacy GET fallbacks bounce empty reasons too** — `?p=banlist&a=unban` and `?p=commslist&a=ungag` / `&a=unmute` short-circuit with `ShowBox` when `ureason` is empty, so a hand-edited URL can't slip through the back door.
- **All four `Log::add(LogType::Message, ...)` audit-trail calls** (legacy GET unban, legacy GET ungag/unmute, JSON `bans.unban`, JSON `comms.unblock`) now carry `Reason: <ureason>` in the message column, restoring v1.x parity.
- **Docs** — AGENTS.md gets a "Where to find what" row for the confirm + reason modal pattern, and two new anti-patterns: reason-less / no-confirm row-lifts AND the native `required` on a `<dialog>` form's textarea.

## Test plan

| Gate | Result |
| -- | -- |
| `./sbpp.sh phpstan` | pass (No errors) |
| `./sbpp.sh ts-check` | pass (no output) |
| `./sbpp.sh composer api-contract` | regenerated (69 actions, 32 perms, 14 typedefs) |
| `./sbpp.sh test --filter="Bans\|Comms\|PermissionMatrix"` | pass (140 tests, 565 assertions) |
| `./sbpp.sh test` (full suite) | pass (413 tests, 1809 assertions, 1 PHPUnit-deprecation) |
| `./sbpp.sh e2e --workers=1 --grep "comms\|banlist\|ban" --project=chromium` | pass (30 tests, 30 skipped — unrelated mobile/screenshot variants) |

Specifically covered by new PHPUnit tests:

- `bans.unban`: anonymous reject, missing/bad `bid`, empty `ureason` reject, unknown `bid` (404), success path (state persists in `:prefix_bans.RemoveType` + `RemovedBy`), already-lifted reject (409), audit-log message contains `Reason: …`.
- `comms.unblock` (additions on top of the existing tests): empty `ureason` reject, audit-log message contains `Reason: …`.
- `PermissionMatrixTest`: locks `bans.unban`'s dispatcher gate to `ADMIN_OWNER | ADMIN_UNBAN | ADMIN_UNBAN_OWN_BANS | ADMIN_UNBAN_GROUP_BANS` (mirrors the legacy GET).

Specifically covered by updated E2E specs:

- `admin-ban-lifecycle.spec.ts`: drives the new `#bans-unban-dialog` modal (empty submit surfaces inline `[data-testid="bans-unban-error"]`, filled submit flips row's `data-state` from `permanent` to `unbanned` in place + success toast).
- `comms-affordances.spec.ts` (desktop + mobile variants): drives the new `#comms-unblock-dialog` modal before asserting the in-place `unmuted` flip.

## Anti-patterns avoided

- No reintroduction of `sourcebans.js`, `xajax`, or ADOdb.
- No new top-level (non-`Sbpp\…`) PHP class.
- No magic letter codes — `LogType::Message` / `BanRemoval::Unbanned->value` at every bind site.
- No inline `:prefix_*` literal — `Sbpp\Db\Database::query()` rewrites the placeholder.
- No CSS-class-chain primary selector or visible-text-only selector in any new E2E assertion.
- No `setTimeout` waits in E2E specs — the modal's `data-testid` hooks + the row's `data-state` attribute are the deterministic settle signals.
- No native `required` on the dialog form's textarea — the JS submit handler is the inline-error UX, the server is the load-bearing gate.
- No `onclick="event.stopPropagation()"` on the trigger button (`document.addEventListener('click')` is how the dialog opener picks the click up — stopPropagation would silently swallow it; the action button isn't inside any `[data-drawer-href]` ancestor anyway).