### PR TITLE
docs(readme): point logo to v2.0.0 brand mark

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <h1 align="center">
-    <a href="https://sbpp.github.io"><img src="https://raw.githubusercontent.com/sbpp/sourcebans-pp/v1.x/.github/logo.png" height="25%" width="25%"/></a>
+    <a href="https://sbpp.github.io"><img src="https://raw.githubusercontent.com/sbpp/sourcebans-pp/main/web/themes/default/images/favicon.svg" height="25%" width="25%"/></a>
     <br/>
     SourceBans++
 </h1>


### PR DESCRIPTION
## Description

The repo's `README.md` still embeds the v1.x logo (`.github/logo.png` on
the `v1.x` branch). Point it at the canonical 2.0.0 shield-with-cross
SVG that ships with the panel.

```diff
-    <a href="https://sbpp.github.io"><img src="https://raw.githubusercontent.com/sbpp/sourcebans-pp/v1.x/.github/logo.png" height="25%" width="25%"/></a>
+    <a href="https://sbpp.github.io"><img src="https://raw.githubusercontent.com/sbpp/sourcebans-pp/main/web/themes/default/images/favicon.svg" height="25%" width="25%"/></a>
```

## Motivation and Context

The v2.0.0 brand refresh (#1235, follow-up #1331) shipped a new shield-
with-cross mark across the panel + docs site, but the repo `README.md`
on the GitHub project page still renders the old v1.x logo.

I picked `web/themes/default/images/favicon.svg` rather than
`docs/src/assets/logo.svg` because `docs/README.md` explicitly calls
the panel file out as the canonical source ("The panel's brand mark,
copied verbatim from `web/themes/default/images/favicon.svg`"). Pointing
at the source instead of the docs-site copy means a future docs
reorganization won't break the README link.

The `height="25%" width="25%"` attrs translate cleanly from the PNG
to the SVG (percentage-of-parent semantics are the same).

## How Has This Been Tested?

Visual: GitHub renders the SVG via `raw.githubusercontent.com` the
same way it renders the old PNG (image proxy supports `image/svg+xml`).
The same SVG path is already shipped in the panel's `<link rel="icon">`
chain, so it's a known-good asset.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.