### PR TITLE
ci(docs): fix `docs-deploy-trigger` validation rejecting `secrets.*` in `if:`

### DIFF
--- a/.github/workflows/docs-deploy-trigger.yml
+++ b/.github/workflows/docs-deploy-trigger.yml
@@ -16,12 +16,21 @@
 #   - Repo SECRET `DOCS_DEPLOY_PAT` = the token value.
 #
 # Until `DOCS_DEPLOY_PAT` is set, the dispatch step below is skipped via
-# its `if: secrets.DOCS_DEPLOY_PAT != ''` guard — every push to `docs/**`
-# shows up as a green run with the dispatch step marked "Skipped",
-# instead of red-failing on a missing credential. This stops the
-# original anti-pattern (#1339-followup) where the dispatch hard-erred
-# and an operator who hasn't done the cutover yet sees a stream of
-# confusing failures.
+# a precheck step that reads the secret into `env:` (where `secrets.*` IS
+# allowed), tests for presence in shell, and emits a step output the
+# dispatch step gates on. Every push to `docs/**` shows up as a green
+# run with the dispatch step marked "Skipped", instead of red-failing on
+# a missing credential. This stops the original anti-pattern
+# (#1339-followup) where the dispatch hard-erred and an operator who
+# hasn't done the cutover yet sees a stream of confusing failures.
+#
+# The naive shape (`if: secrets.DOCS_DEPLOY_PAT != ''` on the dispatch
+# step itself) does NOT work: `secrets.*` is unavailable in `if:` at
+# every scope (workflow / job / step) per the GitHub Actions context
+# table, and the parser rejects the workflow file with
+# "Unrecognized named-value: 'secrets'" before any job runs — the run
+# fails red on every push including dependabot branches, defeating the
+# whole point of the guard.
 #
 # The deploy shell in sbpp.github.io also has a `workflow_dispatch`
 # trigger as a manual fallback while the PAT is pending.
@@ -52,19 +61,33 @@ jobs:
     permissions: {}
 
     steps:
+      # `secrets.*` isn't available in `if:` at any scope, so we can't
+      # gate the dispatch step directly on the PAT being configured.
+      # Read the secret into the precheck step's `env:` (where
+      # `secrets.*` IS allowed), test for presence in shell, and emit
+      # a `configured=true|false` step output. The dispatch step then
+      # gates on `steps.pat.outputs.configured == 'true'` — `steps.*`
+      # IS available in `if:`, so the gate works and the dispatch step
+      # cleanly shows as "Skipped" until the secret is set.
+      - name: Check whether DOCS_DEPLOY_PAT is configured
+        id: pat
+        env:
+          DOCS_DEPLOY_PAT: ${{ secrets.DOCS_DEPLOY_PAT }}
+        run: |
+          if [ -n "$DOCS_DEPLOY_PAT" ]; then
+            echo "configured=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "configured=false" >> "$GITHUB_OUTPUT"
+            echo "::notice title=docs-deploy-trigger::DOCS_DEPLOY_PAT is unset; skipping repository_dispatch into sbpp.github.io. Configure the secret to enable automatic Pages deploys (the deploy shell still has a manual workflow_dispatch trigger as a fallback)."
+          fi
+
       # The dispatched workflow in sbpp.github.io listens for
       # `event_type: docs-changed`. The client_payload carries the
       # commit SHA and ref so the deploy job can pin its sourcebans-pp
       # checkout to the exact commit that fired the dispatch (race
       # guard for back-to-back pushes).
-      #
-      # Step-level `if:` evaluates against `secrets.*` (job-level `if:`
-      # does not), so we gate the dispatch directly on the PAT being
-      # configured — no separate feature-flag variable needed. When
-      # `DOCS_DEPLOY_PAT` is unset, the step is skipped and the run is
-      # green-with-skipped instead of red-failing.
       - name: Dispatch repository_dispatch into sbpp.github.io
-        if: secrets.DOCS_DEPLOY_PAT != ''
+        if: steps.pat.outputs.configured == 'true'
         env:
           GH_TOKEN: ${{ secrets.DOCS_DEPLOY_PAT }}
         run: |


### PR DESCRIPTION
## Summary

- The skip-when-unconfigured guard added in #1347 used `if: secrets.DOCS_DEPLOY_PAT != ''` on the dispatch step. `secrets.*` is unavailable in `if:` at every scope (workflow / job / step) per the [Actions context-availability table](https://docs.github.com/en/actions/learn-github-actions/contexts#context-availability), so GitHub rejects the file with `Unrecognized named-value: 'secrets'` before any job runs. Every push that touches the file (and on this codebase, every dependabot push too — GitHub still parses every workflow file on push) records a red `.github/workflows/docs-deploy-trigger.yml` run with no jobs and no logs. Visible on the #1346 dependabot merge: [run 25652463088](https://github.com/sbpp/sourcebans-pp/actions/runs/25652463088). Exactly the failure mode the original guard was trying to prevent.
- Replaces the bad `if:` with the canonical pattern: a precheck step reads the secret into `env:` (where `secrets.*` IS allowed), shell-tests for presence, emits a `configured=true|false` step output, and the dispatch step gates on `steps.pat.outputs.configured == 'true'` (`steps.*` IS available in step `if:`). Operator-facing UX is unchanged — the dispatch step still shows as **Skipped** until `DOCS_DEPLOY_PAT` is configured and the run is green; the existing `docs/README.md` wording ("the dispatch step is skipped on every run") still holds.
- Updates the file-level comment block and the inline step comment to spell out the actual context-availability rule so a future reader doesn't reach for the same broken shape.

## Test plan

- [ ] After this PR's branch push lands on GitHub, confirm the new SHA does **not** create a failed `.github/workflows/docs-deploy-trigger.yml` run (the YAML now parses, so GitHub evaluates the `branches: [main]` filter and skips run creation on non-main branches as intended).
- [ ] After merge to `main`, confirm the next push touching `docs/**` produces a green run with the precheck step green and the dispatch step **Skipped** (no `DOCS_DEPLOY_PAT` set yet), with the operator-facing notice annotation visible in the run summary.
- [ ] Once `DOCS_DEPLOY_PAT` is configured, confirm the dispatch step actually fires and the sibling `sbpp/sbpp.github.io` `docs-changed` repository_dispatch is received.