### PR TITLE
ci(release): fix vendor/ verification anchor for Smarty 5.x

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,15 +100,19 @@ jobs:
       # .zipignore, an exclusion flag, etc. — fails the build loudly
       # instead of shipping a broken artifact. Two anchor files:
       #   - includes/vendor/autoload.php — the file init.php gates on.
-      #   - includes/vendor/smarty/smarty/libs/Smarty.php — the highest-
+      #   - includes/vendor/smarty/smarty/src/Smarty.php — the highest-
       #     value transitive dep (templates won't render without it).
+      #     This is the file that backs `use Smarty\Smarty;` in
+      #     web/init.php via Smarty 5.x's PSR-4 autoload (`Smarty\` =>
+      #     `src/`); the legacy libs/Smarty.class.php is only a back-
+      #     compat shim for non-composer callers, which the panel isn't.
       - name: Verify vendor/ is bundled in the zip
         run: |
           pkg="sourcebans-pp-${GITHUB_REF_NAME}.webpanel-only"
           missing=0
           for f in \
               "${pkg}/includes/vendor/autoload.php" \
-              "${pkg}/includes/vendor/smarty/smarty/libs/Smarty.php"; do
+              "${pkg}/includes/vendor/smarty/smarty/src/Smarty.php"; do
               if ! unzip -l "${pkg}.zip" "${f}" >/dev/null 2>&1; then
                   echo "::error::Missing required artifact file in ${pkg}.zip: ${f}"
                   missing=1


### PR DESCRIPTION
## Summary

- #1334's release-zip smoke check anchors on `includes/vendor/smarty/smarty/libs/Smarty.php` — a path that doesn't exist in Smarty 5.x. The actual `Smarty\Smarty` class lives at `src/Smarty.php` (PSR-4 autoloaded; `web/init.php` consumes it as `use Smarty\Smarty;`). `libs/` only carries the legacy `Smarty.class.php` shim for non-composer callers.
- Net effect pre-fix: every release tag (`2.0.0-rc1`, [run 25653011128](https://github.com/sbpp/sourcebans-pp/actions/runs/25653011128/job/75295039920)) failed at the verification step even though composer install correctly bundled `smarty/smarty 5.8.0` into vendor/. The zip was good; the check was looking in the wrong place.
- Fix: anchor on `src/Smarty.php` and expand the comment block to spell out the PSR-4 autoload contract so a future reader doesn't "fix" it back to `libs/`. The check still does its real job — catching a regression where `zip` silently drops vendor/.

## Test plan

- [ ] CI passes (the release workflow only runs on tag push, so this is exercised at the next tag).
- [ ] After merge: re-cut `2.0.0-rc1` (delete + recreate the tag, or push a new RC tag) and confirm the `Verify vendor/ is bundled in the zip` step passes.
- [ ] Spot-check the published webpanel zip locally:
  ```sh
  unzip -l sourcebans-pp-<tag>.webpanel-only.zip | grep -E 'vendor/(autoload|smarty/smarty/src/Smarty\.php)'
  ```