### PR TITLE
fix(banlist+commslist): cast LEFT JOIN admin_name before stripslashes (PHP 8.1+ deprecation)

### DIFF
--- a/web/pages/page.banlist.php
+++ b/web/pages/page.banlist.php
@@ -770,7 +770,15 @@ foreach ($res as $row) {
     if (Config::getBool('banlist.hideadminname') && !$userbank->is_admin()) {
         $data['admin'] = false;
     } else {
-        $data['admin'] = stripslashes($row['admin_name']);
+        // `AD.user admin_name` is nullable via the LEFT JOIN on
+        // `:prefix_admins`: bans whose issuing admin row was deleted
+        // (and any imported ban with an aid that never matched a real
+        // admin) leave `admin_name` IS NULL. The schema column itself
+        // is NOT NULL — phpstan-dba can't see through LEFT JOIN — so
+        // the static gate misses this site (#1273 null-into-scalar
+        // discipline: cast at the call site when the value should
+        // always be a string but the type system can't see it).
+        $data['admin'] = stripslashes((string) $row['admin_name']);
     }
     $data['reason']     = stripslashes($row['ban_reason']);
     $data['ban_length'] = $row['ban_length'] == 0 ? 'Permanent' : SecondsToString((int) $row['ban_length']);

--- a/web/pages/page.commslist.php
+++ b/web/pages/page.commslist.php
@@ -611,7 +611,10 @@ foreach ($res as $row) {
     if (Config::getBool('banlist.hideadminname') && !$userbank->is_admin()) {
         $data['admin'] = false;
     } else {
-        $data['admin'] = stripslashes($row['admin_name']);
+        // Same LEFT JOIN nullability as page.banlist.php:773 — see
+        // the matching comment there for the rationale (deleted-
+        // admin scenario, #1273 null-into-scalar discipline).
+        $data['admin'] = stripslashes((string) $row['admin_name']);
     }
     $data['reason'] = stripslashes($row['ban_reason']);
 

--- a/web/tests/integration/Php82DeprecationsTest.php
+++ b/web/tests/integration/Php82DeprecationsTest.php
@@ -183,6 +183,85 @@ final class Php82DeprecationsTest extends ApiTestCase
     }
 
     /**
+     * Regression for the deleted-admin scenario on the public ban
+     * list. The page handler does:
+     *
+     *     LEFT JOIN `:prefix_admins` AS AD ON BA.aid = AD.aid
+     *     ...
+     *     $data['admin'] = stripslashes($row['admin_name']);   // line 773 pre-fix
+     *
+     * When a ban was issued by an admin whose row has since been
+     * deleted (or, more rarely, when a ban was imported with an aid
+     * that never matched a real admin), `AD.user admin_name` IS NULL
+     * for that row and `stripslashes(null)` raises the PHP 8.1
+     * deprecation. The fixture's `data.sql` re-seeds a CONSOLE row at
+     * `aid = 0`, so the existing `testBanlistRendersWithoutDeprecationsForNullIpRow`
+     * coverage (which seeds `aid = 0`) does NOT exercise this branch
+     * — that row resolves to CONSOLE. We need an aid that NO admin
+     * row owns to land in the NULL branch.
+     *
+     * phpstan-dba can't see this either (the column is
+     * `varchar(64) NOT NULL` per `struc.sql`; the LEFT JOIN
+     * nullability is invisible to the typer), so PHPStan is silent
+     * on the site and this runtime gate is the only catch.
+     *
+     * Same JOIN shape lives on the public comm list — covered by
+     * the analogous test below.
+     */
+    #[RunInSeparateProcess]
+    #[PreserveGlobalState(false)]
+    public function testBanlistRendersWithoutDeprecationsForBanByDeletedAdmin(): void
+    {
+        $this->loginAsAdmin();
+        $this->seedBanWithOrphanedAid();
+        $this->bootRenderHarness();
+
+        $_SESSION = [];
+        $_GET     = [];
+
+        self::trapDeprecations();
+        ob_start();
+        try {
+            require ROOT . 'pages/page.banlist.php';
+        } finally {
+            ob_end_clean();
+            restore_error_handler();
+        }
+
+        $this->assertTrue(true, 'page.banlist.php rendered without raising any deprecation notice for a ban whose admin has been deleted.');
+    }
+
+    /**
+     * commslist mirror of `testBanlistRendersWithoutDeprecationsForBanByDeletedAdmin`.
+     * `page.commslist.php` carries the same `LEFT JOIN
+     * :prefix_admins ... stripslashes($row['admin_name'])` shape
+     * (pre-fix line 614), with the same NULL-on-deleted-admin
+     * exposure.
+     */
+    #[RunInSeparateProcess]
+    #[PreserveGlobalState(false)]
+    public function testCommsListRendersWithoutDeprecationsForCommByDeletedAdmin(): void
+    {
+        $this->loginAsAdmin();
+        $this->seedCommsWithOrphanedAid();
+        $this->bootRenderHarness();
+
+        $_SESSION = [];
+        $_GET     = [];
+
+        self::trapDeprecations();
+        ob_start();
+        try {
+            require ROOT . 'pages/page.commslist.php';
+        } finally {
+            ob_end_clean();
+            restore_error_handler();
+        }
+
+        $this->assertTrue(true, 'page.commslist.php rendered without raising any deprecation notice for a comm whose admin has been deleted.');
+    }
+
+    /**
      * admin.bans.php has the worst per-file count (8 sites in #1273's
      * `rg -c` table), all on the `$prev`/`$next` pagination shape
      * across four nested sections (current protests / archive /
@@ -308,6 +387,58 @@ final class Php82DeprecationsTest extends ApiTestCase
             'STEAM_0:0:1',
             'NullIpPlayer',
             'no-ip ban (deprecation regression fixture for #1273)',
+            '127.0.0.1',
+        ]);
+    }
+
+    /**
+     * Insert one ban whose `aid` doesn't match any row in
+     * `:prefix_admins`. Simulates the production scenario where the
+     * admin who issued the ban has since been deleted from the
+     * panel, but their old bans are still on file. The
+     * `LEFT JOIN :prefix_admins ON BA.aid = AD.aid` then yields
+     * `admin_name = NULL` for this row.
+     *
+     * Picks an aid (`999999`) high enough that it's certain to be
+     * above `AUTO_INCREMENT` for any test run — the only admins
+     * inserted via `Fixture::seedAdmin` are the `admin/admin` row
+     * (aid 1) and the `data.sql`-seeded CONSOLE (aid 0).
+     */
+    private function seedBanWithOrphanedAid(): void
+    {
+        $pdo  = Fixture::rawPdo();
+        $stmt = $pdo->prepare(sprintf(
+            'INSERT INTO `%s_bans`
+                (ip, authid, name, created, ends, length, reason, aid, adminIp, sid, country, type)
+             VALUES (NULL, ?, ?, UNIX_TIMESTAMP(), 0, 0, ?, 999999, ?, 0, NULL, 0)',
+            DB_PREFIX
+        ));
+        $stmt->execute([
+            'STEAM_0:0:2',
+            'DeletedAdminTarget',
+            'ban whose issuing admin has been deleted (deprecation regression fixture)',
+            '127.0.0.1',
+        ]);
+    }
+
+    /**
+     * commslist sibling of `seedBanWithOrphanedAid`. Same shape on
+     * `:prefix_comms` (no `country` column, otherwise identical NOT
+     * NULL set per `struc.sql`).
+     */
+    private function seedCommsWithOrphanedAid(): void
+    {
+        $pdo  = Fixture::rawPdo();
+        $stmt = $pdo->prepare(sprintf(
+            'INSERT INTO `%s_comms`
+                (authid, name, created, ends, length, reason, aid, adminIp, sid, type)
+             VALUES (?, ?, UNIX_TIMESTAMP(), 0, 0, ?, 999999, ?, 0, 1)',
+            DB_PREFIX
+        ));
+        $stmt->execute([
+            'STEAM_0:0:3',
+            'DeletedAdminCommTarget',
+            'comm whose issuing admin has been deleted (deprecation regression fixture)',
             '127.0.0.1',
         ]);
     }


### PR DESCRIPTION
## Summary

- Public ban list (and comm list) raise `Deprecated: stripslashes(): Passing null to parameter #1 ($string) of type string is deprecated` on `web/pages/page.banlist.php:773` and `web/pages/page.commslist.php:614` for every row whose issuing admin has been deleted from the panel — visible to logged-in admins as a yellow PHP warning banner across the page.
- Root cause: `AD.user admin_name` is nullable via `LEFT JOIN :prefix_admins ON BA.aid = AD.aid` (deleted admin, or an imported ban with an aid that never matched a real admin). The schema column itself is `varchar(64) NOT NULL`, so `phpstan-dba` can't see the LEFT-JOIN nullability and the static gate stayed silent. The existing `Php82DeprecationsTest::testBanlistRendersWithoutDeprecationsForNullIpRow` didn't catch it either because its seed uses `aid = 0` and `data.sql` re-seeds a CONSOLE admin at that aid, so the JOIN resolves.
- Fix: apply the canonical [AGENTS.md "Null-into-scalar discipline"](https://github.com/sbpp/sourcebans-pp/blob/main/AGENTS.md) cast idiom — `stripslashes((string) \$row['admin_name'])` at both sites, with a comment pointing at the LEFT-JOIN nullability so a future reader doesn't strip the cast back out.
- Test coverage: two new methods on `Php82DeprecationsTest` (`testBanlistRendersWithoutDeprecationsForBanByDeletedAdmin` + the commslist sibling) that seed a ban/comm at `aid = 999999` (no matching admin) to force the NULL branch on both pages. Stash-revert proof: the new tests fail on the unpatched code with `ErrorException: stripslashes(): Passing null to parameter #1 ... is deprecated` pointing at exactly `page.banlist.php:773` and `page.commslist.php:614`.

## Test plan

- [x] `./sbpp.sh test tests/integration/Php82DeprecationsTest.php` — 7/7 pass with the fix; both new tests fail at the reported lines without it (verified by `git stash`-ing the production fix while keeping the new tests, re-running, then restoring).
- [x] `./sbpp.sh test` — full PHPUnit suite green (510 tests, 2235 assertions).
- [x] `./sbpp.sh phpstan` — `[OK] No errors`.
- [x] `./sbpp.sh ts-check` — clean.
- [x] `./sbpp.sh composer api-contract` — regenerated, no diff (PHP-only change).
- [x] Manual repro confirmed: `INSERT INTO sb_bans (..., aid=9999, ...)` against the dev DB → `SELECT ... LEFT JOIN sb_admins ON aid = aid` returns `admin_name = NULL` → `stripslashes(NULL)` raises the deprecation pre-fix, silent post-fix.

## Notes

- The user's report mentioned "When public ban export feature is on" — that was incidental. The bug fires on any banlist render where the result set contains a row with an orphaned `aid`; the user just noticed it while toggling the export feature.
- Stayed scoped to the actual `admin_name` defect on both pages. The same files have `stripslashes(\$row['ban_reason'])` calls (lines 775 / 616) which read a `text NOT NULL` column — not nullable per the schema, no demonstrated NULL path, so left alone.