### PR TITLE
fix(banlist+commslist): keep Remove button in view at common laptop viewports (#1359)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1571,6 +1571,35 @@ audit (#1207) locked in. New CTAs:
   every keyboard / screen-reader user. New surfaces add visible
   buttons in the same shape as `.queue-row` (admin moderation
   queue) or the comms-list desktop table (`web/themes/default/page_comms.tpl`).
+- Non-wrapping `display: flex` on `.table .row-actions` (the
+  pre-#1359 shape: `display: flex; gap: 0.25rem; justify-content:
+  flex-end` with NO `flex-wrap: wrap`) → with 3+ buttons carrying
+  text labels (Edit / Unban / Re-apply / Copy / Remove on the
+  banlist; Edit / Unmute / Re-apply / Remove on the commslist) the
+  cell's natural width is ~340-440px on a single line; combined
+  with the rest of a 9-10-column list at the default desktop
+  viewport (1280px → main ~1000px usable after the sidebar) the
+  table's natural width pushes well past the panel even after
+  tier-2 / tier-3 columns hide. `.table-scroll`'s `overflow-x: auto`
+  then triggers an in-card horizontal scrollbar and the rightmost
+  Remove button silently sits off the visible card edge until the
+  user discovers the scroll (#1359 — the user-reported regression
+  on the banlist after #1354's row-action parity sweep added the
+  text labels, but the same shape lurks on commslist too). The
+  contract is `flex-wrap: wrap` on the desktop table's
+  `.row-actions` so buttons stack onto a second line when there's
+  no horizontal room — same shape the mobile `.ban-card__actions`
+  (line ~1446) and the mobile `details.queue-row > summary >
+  .row-actions` (line ~1351) already use. The cell still carries
+  `white-space: nowrap` so each individual button's content stays
+  on one line; only the BETWEEN-button gap wraps. Regression
+  guard: `web/tests/e2e/specs/flows/banlist-table-columns.spec.ts`'s
+  "Remove button is reachable without horizontal scroll on a
+  realistic row" assertion. Don't reach for a different fix shape
+  (icon-only buttons, viewport-keyed display: none on individual
+  actions, overflow menus) without first asking whether the
+  established `flex-wrap` pattern is enough — every existing
+  row-action surface in the panel already converges on it.
 - Surfacing per-row admin-authored comments behind a silent count
   badge (`<span class="text-xs text-muted">[N]</span>`) without an
   affordance → that's the v2.0 RC regression that wiped per-ban

--- a/web/tests/e2e/specs/flows/banlist-ip-column.spec.ts
+++ b/web/tests/e2e/specs/flows/banlist-ip-column.spec.ts
@@ -88,6 +88,17 @@ test.describe('flow: banlist IP column visible to admin (#1302)', () => {
         isMobile,
     }) => {
         await seedBanWithIp(page);
+        // #1359 bumped tier-3 (IP / Length / Banned) to hide at
+        // <=1280px. The Playwright `Desktop Chrome` device defaults
+        // to 1280x720 which sits ON the breakpoint, hiding the IP
+        // column the desktop arm of this test asserts on. Resize to
+        // a viewport that surfaces tier-3 (any width > 1280 works;
+        // 1440 is the canonical "laptop with tier-3 visible"
+        // reference). Mobile arm is unaffected — the `isMobile`
+        // branch below renders `.ban-cards` regardless.
+        if (!isMobile) {
+            await page.setViewportSize({ width: 1440, height: 720 });
+        }
         await page.goto('/index.php?p=banlist');
 
         if (isMobile) {

--- a/web/tests/e2e/specs/flows/banlist-table-columns.spec.ts
+++ b/web/tests/e2e/specs/flows/banlist-table-columns.spec.ts
@@ -39,6 +39,13 @@ test.describe('flow: banlist desktop column geometry (#1207 PUB-1)', () => {
     });
 
     test('STATUS header reads in full and the BANNED cell is one line', async ({ page }) => {
+        // #1359 bumped tier-3 (IP / Length / Banned) to hide at
+        // <=1280px. The Playwright `Desktop Chrome` device defaults to
+        // 1280x720 which sits ON the breakpoint, hiding the BANNED
+        // column we want to measure. Resize to a viewport that
+        // surfaces tier-3 (any width > 1280 works; 1440 is the
+        // canonical "laptop with tier-3 visible" reference).
+        await page.setViewportSize({ width: 1440, height: 720 });
         await page.goto('/index.php?p=banlist');
 
         const table = page.locator('#banlist-root .table');
@@ -147,5 +154,71 @@ test.describe('flow: banlist desktop column geometry (#1207 PUB-1)', () => {
         // back to the default `visible`, which would re-clip the
         // overflow case the audit found.
         expect(['auto', 'scroll']).toContain(isOverflowAuto);
+    });
+
+    test('Remove button is reachable without horizontal scroll on a realistic row', async ({ page }) => {
+        // Regression for the "Remove button you have to scroll right
+        // to see" report against the post-#1354 banlist. The row-
+        // actions cell carries up to 5 buttons with text labels
+        // (Edit / Unban / Re-apply / Copy / Remove); on a single
+        // non-wrapping flex line that pushed the table's natural
+        // width well past the panel at the default desktop viewport
+        // (1280px → sidebar 240px → main ~1000px usable), even after
+        // tier-2 columns hid. The `.table-scroll` fallback then
+        // triggered an in-card horizontal scrollbar with Remove
+        // silently off-screen until the user discovered the scroll.
+        //
+        // Fix: `flex-wrap: wrap` on `.table .row-actions` (theme.css)
+        // so buttons stack onto a second line when there's no
+        // horizontal room. Same shape `.ban-card__actions` and the
+        // queue-row already use on mobile.
+        //
+        // The contract this test pins: with a realistic seeded ban,
+        // the Remove button on the desktop table renders within the
+        // card's painted box at the default Playwright viewport. A
+        // regression that drops `flex-wrap: wrap` (or pushes the
+        // actions cell back to a non-shrinkable single-line layout)
+        // will paint Remove past the card's right edge and fail this
+        // assertion. We anchor on the card's bounding box (not the
+        // table-scroll wrapper) because the card has
+        // `overflow: hidden` — its right edge is the visual right
+        // edge a user sees; a button living past it can only be
+        // reached via the in-card horizontal scrollbar.
+        await page.goto('/index.php?p=banlist');
+
+        const seededRow = page
+            .locator('[data-testid="ban-row"]')
+            .filter({ hasText: 'STEAM_0:1:1207001' });
+        await expect(seededRow).toBeVisible();
+
+        const removeBtn = seededRow.locator('[data-testid="row-action-delete"]');
+        await expect(removeBtn).toBeVisible();
+
+        // Sample three breakpoints across the desktop range to pin
+        // the contract end-to-end:
+        //   - 1280px: tier-2 + tier-3 both hidden (only tier-1 visible).
+        //   - 1440px: tier-2 still hidden, tier-3 surfaces (IP / Length
+        //     / Banned join Player / SteamID / Reason / Status /
+        //     Actions).
+        //   - 1920px: every column visible (page max-width 1400 caps
+        //     the surface; sidebar + padding still leaves comfortable
+        //     room).
+        // A regression that drops `flex-wrap: wrap` OR drops the
+        // tier-2 / tier-3 breakpoint bumps will paint Remove past
+        // the card's right edge at at least one of these viewports.
+        for (const vw of [1280, 1440, 1920]) {
+            await page.setViewportSize({ width: vw, height: 720 });
+
+            await expect(removeBtn).toBeVisible();
+            const card = page.locator('#banlist-root .card').first();
+            const cardBox = await card.boundingBox();
+            const removeBox = await removeBtn.boundingBox();
+            expect(cardBox, `banlist card renders a bounding box at ${vw}px`).not.toBeNull();
+            expect(removeBox, `Remove button renders a bounding box at ${vw}px`).not.toBeNull();
+            expect(
+                removeBox!.x + removeBox!.width,
+                `Remove button must fit within the card's right edge at viewport ${vw}px (got button right ${removeBox!.x + removeBox!.width}px vs card right ${cardBox!.x + cardBox!.width}px)`,
+            ).toBeLessThanOrEqual(cardBox!.x + cardBox!.width + 1);
+        }
     });
 });

--- a/web/themes/default/css/theme.css
+++ b/web/themes/default/css/theme.css
@@ -1023,8 +1023,32 @@ html.dark .table thead tr { background: rgb(255 255 255 / 0.02); }
    and the audit's blocker for the comms list specifically). The
    queue-row pattern (#1207 PUB-2) already drops the hover gate on
    `<details>`-rendered queues; matching the table here means every
-   list surface in the panel exposes its actions the same way. */
-.table .row-actions { display: flex; gap: 0.25rem; justify-content: flex-end; }
+   list surface in the panel exposes its actions the same way.
+
+   `flex-wrap: wrap` so buttons stack onto a second line when the row
+   doesn't have horizontal room for all of them. Before this guard the
+   banlist's row-actions cell carried up to 5 buttons with text labels
+   (Edit / Unban / Re-apply / Copy / Remove, #1354's parity sweep with
+   the commslist's already-wider Edit / Unmute / Re-apply / Remove
+   chain) on a single `<a class="btn btn--sm">` row, which pushed the
+   table's natural width well past the panel even after tier-2 / tier-3
+   columns hid — the table-scroll fallback then triggered an
+   in-card horizontal scrollbar with the rightmost Remove button
+   silently off-screen until the user noticed and scrolled. The two
+   sibling row-action surfaces (the mobile `.ban-card__actions` at
+   line ~1446 and the mobile `details.queue-row > summary > .row-actions`
+   at line ~1351) already use `flex-wrap: wrap`; this rule brings the
+   desktop table into line so every list in the panel handles the
+   "too many actions to fit" case identically. The matching cells
+   still carry `white-space: nowrap` (each button's content stays on
+   one line); only the BETWEEN-button gap is allowed to wrap. */
+.table .row-actions {
+  display: flex;
+  flex-wrap: wrap;
+  row-gap: 0.25rem;
+  column-gap: 0.25rem;
+  justify-content: flex-end;
+}
 
 /* PUB-1 (#1207): banlist column widths + horizontal-scroll fallback.
    With realistic per-row content the auto-layout previously
@@ -1058,15 +1082,23 @@ html.dark .table thead tr { background: rgb(255 255 255 / 0.02); }
 .table .col-status { width: 1%; }
 
 /* Responsive column-tier hiding (issue: "scroll table at the bottom of a
-   banlist, making the user experience not fluid").
+   banlist, making the user experience not fluid"; #1359 expanded the
+   breakpoints after the #1354 row-action parity sweep pushed the
+   table well past the panel at common laptop viewports).
    ----------------------------------------------------------------------
-   The banlist / commslist desktop tables carry 9-10 columns. At
-   769–1100px (after the main `.sidebar` collapses at <=1024px and
-   before the panel reaches its 1400px max-width) the natural sum of
-   column widths exceeds the panel and the `.table-scroll` wrapper
-   above falls back to horizontal scroll inside the card. Horizontal
-   scroll on a list view is the canonical "broken UX" smell on a
-   touch viewport (no scrollbar; users have to swipe inside a nested
+   The banlist / commslist desktop tables carry 9-10 columns. The
+   sidebar collapses at <=1023px, so above that it eats 15rem (240px)
+   of horizontal real estate before the table even sees any pixels;
+   add the p-6 page padding (48px) and a 1280px laptop viewport
+   leaves the card with ~975px to paint a row that wants ~1247px
+   when every column is visible. The `.table-scroll` wrapper would
+   then fall back to horizontal scroll inside the card and the
+   rightmost row-action button silently sits off the visible edge
+   (#1359 was the user-reported regression: the Remove button hidden
+   behind in-card scroll after #1354 added the text-labelled Edit /
+   Unban / Re-apply / Copy / Remove chain). Horizontal scroll on a
+   list view is also the canonical "broken UX" smell on a touch
+   viewport (no scrollbar; users have to swipe inside a nested
    scroll container).
 
    Two-tier responsive hide: every column carries a tier class on
@@ -1077,12 +1109,27 @@ html.dark .table thead tr { background: rgb(255 255 255 / 0.02); }
      - Tier-1 (always visible): Player, SteamID, Reason (banlist) /
        Type+Player (commslist), Status, Actions. The minimum row
        still answers "who, why, what state, what can I do".
-     - Tier-2 (`.col-tier-2`): hidden at <=1100px. Server, Admin —
+     - Tier-2 (`.col-tier-2`): hidden at <=1535px. Server, Admin —
        useful but not essential for moderation triage; both surface
-       on the player drawer / card detail anyway.
-     - Tier-3 (`.col-tier-3`): hidden at <=900px. IP / Length /
+       on the player drawer / card detail anyway. The breakpoint
+       covers every common laptop / small-desktop viewport
+       (1280 / 1366 / 1440 / 1536-with-sidebar) where main = vw -
+       240 (sidebar) - 48 (padding) falls short of the natural
+       table width with these columns visible. At 1536px viewport
+       exactly the sidebar leaves ~1248px — the table without
+       tier-2 fits in ~1097px and with tier-2 in ~1246px, so
+       <=1535 is the precise edge.
+     - Tier-3 (`.col-tier-3`): hidden at <=1280px. IP / Length /
        Banned / Started — historical metadata that's nice to glance
-       but cheap to drop on a narrow viewport.
+       but cheap to drop on a narrow viewport. The breakpoint
+       matches the smaller "tight" laptop range where even
+       hiding tier-2 leaves the table ~120px wider than the card;
+       dropping tier-3 there brings the visible row down to the
+       five tier-1 columns (Player + SteamID + Reason + Status +
+       Actions ≈ 808px) which fits comfortably with room to spare.
+       Pre-#1359 the breakpoints were <=1100 / <=900 — calibrated
+       for the pre-sidebar / pre-row-action-labels world that no
+       longer matches the chrome's actual horizontal budget.
 
    The mobile card layout (`.ban-cards`) takes over completely at
    <=768px (theme.css `.table { display: none }`), so the tier
@@ -1092,11 +1139,13 @@ html.dark .table thead tr { background: rgb(255 255 255 / 0.02); }
    `.table-scroll` stays wrapped around the table as a defensive
    safety net — if a row's content (long player name + long reason)
    still exceeds the panel after tier-3 hiding, it scrolls instead
-   of clipping. */
-@media (max-width: 1100px) {
+   of clipping. The `flex-wrap: wrap` on `.table .row-actions`
+   above is the sister-guard that keeps the row-action cell itself
+   from being the single column that blows the budget. */
+@media (max-width: 1535px) {
   .table .col-tier-2 { display: none; }
 }
-@media (max-width: 900px) {
+@media (max-width: 1280px) {
   .table .col-tier-3 { display: none; }
 }
 


### PR DESCRIPTION
## Summary

- The banlist's row-actions cell stacks 5 text-labelled buttons (Edit / Unban / Re-apply / Copy / Remove after #1354's parity sweep). On a non-wrapping `display: flex` line at the default 1280px desktop viewport — ~975px usable after the 240px sidebar and 48px page padding — that pushed the table well past the panel even after the old `<=1100 / <=900` tier breakpoints fired. `.table-scroll`'s `overflow-x: auto` fallback then triggered an in-card horizontal scrollbar with **Remove silently off-screen** until the user discovered the scroll.
- Two paired CSS edits in `web/themes/default/css/theme.css`:
  - `.table .row-actions` gains `flex-wrap: wrap` so buttons stack onto a second line when there's no horizontal room — same shape `.ban-card__actions` and the queue-row's `details > summary > .row-actions` already use on mobile.
  - Tier breakpoints bumped to reflect the post-sidebar horizontal budget: `.col-tier-2` (Server, Admin) now hides at `<=1535px` (was `<=1100`); `.col-tier-3` (IP, Length, Banned) now hides at `<=1280px` (was `<=900`). The pre-#1359 numbers were calibrated for the pre-sidebar / pre-row-action-label world.
- New `Remove button is reachable without horizontal scroll on a realistic row` E2E spec pins the contract across 1280 / 1440 / 1920px viewports. Two existing tier-3-touching specs (`banlist-ip-column`, the BANNED-cell case in `banlist-table-columns`) resize to 1440px before asserting since tier-3 now hides at the default Playwright `Desktop Chrome` 1280px viewport.
- `AGENTS.md` gains an anti-pattern entry against re-introducing the non-wrapping `display: flex` on `.table .row-actions`, with a pointer to the new regression guard.

## Test plan

- [x] `CI=1 DB_NAME=sourcebans_e2e ./sbpp.sh e2e specs/flows/banlist-ip-column.spec.ts specs/flows/banlist-table-columns.spec.ts` — 5/5 desktop specs pass (mobile arms skip; tier classes are desktop-only).
- [x] `CI=1 DB_NAME=sourcebans_e2e ./sbpp.sh e2e specs/flows/banlist-comments-visibility.spec.ts specs/responsive/banlist.spec.ts specs/responsive/filters.spec.ts specs/responsive/server-cards.spec.ts` — 10/10 pass, no regressions in adjacent banlist / responsive surfaces.
- [x] `./sbpp.sh test --filter='PublicBanListRegression|BanlistComments|BanListIp|BanListStateFilter'` — 33/33 tests pass.
- [x] `./sbpp.sh phpstan` — clean.
- [x] `./sbpp.sh ts-check` — clean.
- [ ] Manual: visit `/index.php?p=banlist` at 1280 / 1366 / 1440 / 1920px viewports; confirm the Remove button is visible on every row without horizontal scroll, and that the columns hide / surface at the documented breakpoints.
- [ ] Manual: same for `/index.php?p=commslist` — the row-action wrap is on `.table .row-actions` so commslist inherits the same shape (Edit / Unmute / Re-apply / Remove fits trivially).