### PR TITLE
fix(theme): show visible loading state on async actions + drawer fetches

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -673,15 +673,146 @@ enum.
 
 - Vanilla JS only — `// @ts-check` + JSDoc on every file.
 - DOM helpers and the `sb` namespace live in `sb.js`. Use
-  `sb.$idRequired(id)` when a missing element is a programmer error;
-  `sb.$id(id)` returns `HTMLElement | null` and must be narrowed.
+ `sb.$idRequired(id)` when a missing element is a programmer error;
+ `sb.$id(id)` returns `HTMLElement | null` and must be narrowed.
 - For new code, prefer typed selectors
-  (`document.querySelector<HTMLInputElement>(...)`) over `SbAnyEl`.
-  `SbAnyEl` is intentionally permissive for legacy form-element access.
+ (`document.querySelector<HTMLInputElement>(...)`) over `SbAnyEl`.
+ `SbAnyEl` is intentionally permissive for legacy form-element access.
 - API calls go through `sb.api.call(Actions.PascalName, params)` — never
-  string literals.
+ string literals.
 - **Do not** reintroduce MooTools, React, or a runtime bundler.
-  Self-hosters install by unzipping the release tarball.
+ Self-hosters install by unzipping the release tarball.
+
+### Loading state on action buttons (`window.SBPP.setBusy`)
+
+Every action button that fires `sb.api.call(...)` from a click handler
+without an immediate page navigation MUST flip to a busy state for the
+duration of the in-flight call. Pre-fix the confirm modals
+(`#bans-unban-dialog`, `#comms-unblock-dialog`, `#admins-delete-dialog`)
+read as frozen for 100-1000ms between the click and the response —
+users instinctively double-clicked "to make it work" and queued
+duplicate requests until the post-response `disabled` flag landed.
+
+The contract:
+
+- `window.SBPP.setBusy(btn, true)` runs BEFORE the `sb.api.call(...)`
+ leaves the page (so the disabled flag lands on the first paint of
+ the click).
+- `setBusy(btn, false)` runs on every non-navigating response branch
+ (success that flips state in-place, error toast, validation reject)
+ so retries are possible. The success-then-navigate path can leave
+ the button busy because the new paint resets the DOM.
+- The helper (defined inside `web/themes/default/js/theme.js`'s IIFE
+ and re-exposed via `window.SBPP.setBusy`) sets three things on the
+ button: `data-loading="true"` (drives the CSS spinner), `aria-busy="true"`
+ (announces to AT users), and the native `disabled` flag (the
+ load-bearing gate against double-clicks). All three are the
+ contract; do NOT split them.
+- The visual spinner lives in `theme.css` under the
+ `.btn[data-loading="true"]` rule and its `::after` donut + the
+ `sbpp-btn-spin` keyframe. The CSS hides the button's content
+ (`color: transparent !important` for text, `visibility: hidden`
+ for icon children) but keeps the layout width locked so there's
+ no shift between idle and busy. `cursor: progress` and
+ `pointer-events: none` are the visual gate; `disabled` is the
+ load-bearing one.
+- Inline page-tail scripts inside `.tpl` files define a local
+ `setBusy(btn, busy)` wrapper that delegates to `window.SBPP.setBusy`
+ when present and falls back to `btn.disabled = busy` otherwise. The
+ fallback keeps the double-click gate working on third-party themes
+ that strip `theme.js`; the spinner naturally disappears with the
+ missing CSS, which is the right degradation (no fake spinner on a
+ theme that hasn't opted in).
+- `prefers-reduced-motion: reduce` is handled by the global
+ reset in `theme.css` (pins every `animation-duration` to ~0ms).
+ The spinner sits still for reduced-motion users; they still see
+ the donut shape + `cursor: progress` + the disabled state.
+
+Adding a new action button that fires `sb.api.call`:
+
+1. Define the button with `class="btn btn--*"` so it picks up
+ `--btn-color` (the spinner's border colour).
+2. In the inline `<script>` (or in a `web/scripts/*.js` page-tail
+ file), add the local `setBusy(btn, busy)` wrapper.
+3. Call `setBusy(submitBtn, true)` immediately before the
+ `sb.api.call(...)` line.
+4. Call `setBusy(submitBtn, false)` in every non-navigating branch
+ of the `.then`. The simplest shape is the canonical
+ `page_comms.tpl` / `page_bans.tpl` confirm-dialog flow.
+5. For drawer surfaces (Notes pane add/delete in `theme.js`),
+ reach for the module-scope `setBusy(...)` directly — same
+ helper, no wrapper needed.
+
+The regression guard is `web/tests/e2e/specs/flows/action-loading-indicator.spec.ts`:
+it stalls the `Actions.CommsUnblock` route via `page.route`, asserts
+`data-loading="true"` + `aria-busy="true"` + `disabled` on the submit
+button during the in-flight window, releases the route, and confirms
+the row flips in-place. The second test in the file proves the
+disabled gate blocks a double-click by counting the number of
+`Comms.Unblock` requests that reach the stall (exactly one).
+
+### Loading state on drawers + lazy panes (`.skel` shimmer)
+
+Two drawer surfaces fire a JSON action between user-click and
+content-paint and need a visible loading indicator over that window
+(otherwise the chrome reads as blank for the 100-1000ms the request
+takes to resolve):
+
+- **Initial drawer open** — `loadDrawer(bid)` in
+  `web/themes/default/js/theme.js` fires `Actions.BansDetail`. Until
+  the envelope returns, the drawer paints `renderDrawerLoading()`:
+  a `[data-testid="drawer-loading"]` header with `aria-busy="true"`
+  + `aria-label="Loading player details"` wrapping `.skel` shimmer
+  rows tagged with `[data-skeleton]`. The `#drawer-root` element
+  also carries `data-loading="true"` so the `_base.ts` page-load
+  waiter (and the existing `responsive/drawer.spec.ts` /
+  `flows/ui/player-drawer.spec.ts` assertions) gate on the same
+  terminal marker.
+- **Lazy pane activation** — clicking History / Comms / Notes for
+  the first time fires `bans.player_history` / `comms.player_history`
+  / `notes.list`. The panel placeholder is `renderPaneSkeleton()`:
+  the same `.skel` shimmer rows wrapped in
+  `[data-pane-empty][aria-busy="true"]`. The panel itself carries
+  `data-loading="true"` for the duration of `loadPaneIfNeeded(tabId)`.
+
+The contract:
+
+- The `.skel` CSS rule lives in `theme.css` (linear-gradient + the
+  `shimmer` keyframe + dark-mode override). The class name is
+  `.skel` (singular) — NOT `.skeleton`. Pre-fix
+  `renderDrawerLoading()` used `class="skeleton"`, which had no
+  matching rule, so the shimmer divs rendered with zero background
+  and the drawer read as "just blank" for the entire `bans.detail`
+  window.
+- `prefers-reduced-motion: reduce` is handled by the global reset
+  in `theme.css` (pins every `animation-duration` to ~0ms). The
+  shimmer freezes for reduced-motion users; they still see the
+  static gradient colour as a "something's loading" affordance.
+- The drawer header skeleton blocks carry `[data-skeleton]`
+  (terminal marker for the page-level waiter — they live under
+  `#drawer-root[data-loading="true"]`, so they cycle in/out
+  cleanly when `bans.detail` resolves). The lazy-pane skeleton
+  blocks do NOT carry `[data-skeleton]`: the panel parent starts
+  with the `hidden` attribute, but `[data-skeleton]:not([hidden])`
+  only checks the matched element's own attribute. A nested
+  `[data-skeleton]` block inside a hidden tabpanel would still
+  match the selector and stall every page-load wait that runs
+  AFTER the drawer opens.
+- Use `[data-pane-empty]` as the testability hook for the
+  lazy-pane skeleton; the `refreshNotesPane` reset path already
+  resets the panel innerHTML with the same helper so the visual
+  contract is symmetric across initial-activation and
+  post-mutation refreshes.
+
+The regression guard is `web/tests/e2e/specs/flows/drawer-loading-indicator.spec.ts`:
+it stalls `bans.detail` via `page.route`, asserts the skeleton
+header is visible, the `.skel` block paints a `linear-gradient`
+background (the computed-style probe is the regression catch for
+the `class="skeleton"` typo — the missing rule leaves
+`background-image: none`), releases the route, and confirms the
+drawer flips to `renderDrawerBody`. The second test stalls
+`bans.player_history` and asserts the History pane's
+`renderPaneSkeleton()` paints the same shimmer rows.
 
 ### Templates + View DTOs
 
@@ -1179,6 +1310,55 @@ audit (#1207) locked in. New CTAs:
 
 ## Anti-patterns (do NOT reintroduce)
 
+- `btn.disabled = true` (or any other manual `disabled` flip) inside
+ a confirm-modal submit handler or any other action button that
+ fires `sb.api.call(...)` from a click handler without an immediate
+ page navigation → use `window.SBPP.setBusy(btn, true)` (theme.js)
+ with the inline-script local fallback shim. The `disabled` flag is
+ the load-bearing gate but it ships without the visual spinner +
+ ARIA + reduced-motion contract; users see no feedback during the
+ 100-1000ms in-flight window and double-click "to make it work",
+ queuing duplicate requests until the post-response setter fires.
+ See "Loading state on action buttons" in Conventions for the
+ contract and the canonical reference shapes
+ (`page_comms.tpl` / `page_bans.tpl` / `page_admin_admins_list.tpl`
+ confirm dialogs; `page_admin_groups_list.tpl` / `page_admin_groups_add.tpl`
+ form submits; `theme.js`'s drawer Notes paths). Regression guard:
+ `web/tests/e2e/specs/flows/action-loading-indicator.spec.ts`
+ (stalls `Actions.CommsUnblock` via `page.route` and asserts the
+ three-attribute busy contract on the submit button + the
+ double-click rejection).
+- Splitting the `data-loading` + `aria-busy` + `disabled` triple
+ (the three attributes `window.SBPP.setBusy` writes) into separate
+ setters → reach for `window.SBPP.setBusy` (or the inline-script
+ local wrapper that delegates to it). Hand-rolling one of the three
+ silently drops one of: the spinner visual, the AT announcement, or
+ the double-click gate. The contract is single-source for a reason.
+- `class="skeleton"` (singular `.skeleton`) on a drawer / lazy-pane
+ placeholder block → the CSS rule has always been `.skel`. Pre-fix
+ `renderDrawerLoading()` in `theme.js` emitted `class="skeleton"`,
+ which had no matching rule, so the drawer header skeleton rows
+ rendered transparent and the drawer read as "just blank" for the
+ entire `bans.detail` in-flight window. The fix is single-character:
+ `class="skel"`. Regression guard:
+ `web/tests/e2e/specs/flows/drawer-loading-indicator.spec.ts`'s
+ `getComputedStyle(el).backgroundImage` probe (asserts
+ `linear-gradient(...)`; the missing rule leaves it at the UA
+ default `none`). Same shape applies to any new skeleton surface:
+ reuse the `.skel` class from `theme.css`; don't roll a new
+ `.skeleton-*` rule.
+- `[data-skeleton]` on a placeholder block nested inside a `hidden`
+ ancestor (lazy tabpanels, off-screen drawers, collapsed
+ `<details>`) → the `_base.ts` page-load waiter blocks until
+ `'[data-loading="true"], [data-skeleton]:not([hidden])'` returns
+ no nodes. `:not([hidden])` only checks the matched element's own
+ attribute, not its ancestors, so a `[data-skeleton]` block inside
+ a hidden tabpanel still matches the selector and stalls every
+ page-load wait that runs AFTER the drawer opens (silent 30s
+ timeout in CI). Keep `[data-skeleton]` reserved for surfaces
+ where the marker itself (or its direct container) carries the
+ visibility toggle. The lazy-pane skeletons use `[data-pane-empty]`
+ + `aria-busy="true"` as the testability hooks instead.
 - Top-level `class Foo {}` (global namespace) in `web/includes/`
   → all classes there live under `Sbpp\…` (see "Namespacing" in
   Conventions for the per-class table). The only intentional
@@ -1743,7 +1923,9 @@ audit (#1207) locked in. New CTAs:
 | Edit a template                        | `web/themes/default/*.tpl`                               |
 | Reuse the moderation-queue card layout (admin submissions / protests, mobile-stacked summary rows) | `web/themes/default/css/theme.css` (`.queue-row`, `.queue-row__body`, `.queue-row__date` — #1207 PUB-2). Apply by adding `class="queue-row …"` to the outer `<details>` and dropping the inline `flex` / `flex-shrink:0` styles from the summary children. |
 | Add visible row actions to a table-rendered admin list (Edit / Unmute / Remove buttons + responsive mobile-card mirror) | `web/themes/default/page_comms.tpl` (#1207 ADM-5) is the canonical reference: `<button class="btn btn--secondary btn--sm">` / `<a class="btn btn--ghost btn--sm">` inside a `.row-actions` cell, plus `.ban-card__actions` row of identical-data-action buttons in the mobile card. Wire destructive / state-changing buttons via `data-action="…"` + `data-bid` + `data-fallback-href`; the inline page-tail JS calls `sb.api.call(Actions.PascalName)` and falls back to the GET URL if the JSON dispatcher is absent. The public banlist (`web/themes/default/page_bans.tpl`) follows the same shape — same chrome (Lucide icon + visible text label inside `.btn--ghost` / `.btn--secondary btn--sm`), same `.ban-card__actions` mobile row, same `data-action` / `data-fallback-href` wiring (`bans-unban` / `bans-delete`). The Remove affordance points at the legacy GET handler (`?p=banlist&a=delete&id=…&key=…` at the top of `page.banlist.php`) because no JSON `bans.delete` action exists yet — the inline JS `confirm()`-prompts then navigates, mirroring commslist's flow without adding a new handler / snapshot / permission-matrix entry. |
-| Add a confirm + reason modal for an irreversible row-level action (unban, lift comm block, delete admin, …) | `web/themes/default/page_bans.tpl` (`#bans-unban-dialog`, `Actions.BansUnban`) and `web/themes/default/page_comms.tpl` (`#comms-unblock-dialog`, `Actions.CommsUnblock`) are the canonical reference (#1301), with `web/themes/default/page_admin_admins_list.tpl` (`#admins-delete-dialog`, `Actions.AdminsRemove`, #1352) as the third reference for the optional-reason variant. Shape: a `<dialog hidden>` with a `<form method="dialog">` carrying a `<textarea aria-required="true">` (or `aria-required="false"` for the optional-reason variant — see admins-delete) (NOT the native `required` — that lets the browser block the form submit before our handler runs, swallowing the inline-error UX), a Cancel button, and a Confirm submit button. The page-tail JS opens the dialog via `showModal()` on `[data-action]` clicks, validates the trimmed reason on submit (load-bearing gate is server-side), forwards `ureason` to the JSON action, and on success flips the row in place via the same `flipRowToUnbanned`/`flipRowToUnmuted` helper the legacy single-click flow used (or removes the row outright + decrements the count badge for the admins-delete variant where there's no "now-unbanned" state to render). The legacy GET fallback (`?p=banlist&a=unban&id=…&key=…&ureason=…` / `?p=commslist&a=ungag…&ureason=…`) is the no-JS / hand-edited-URL path; both halves now reject empty `ureason` server-side so the audit log carries the *why*. The admins-delete variant has no legacy GET handler — `RemoveAdmin()` always went through the JSON dispatcher pre-#1123 D1 — so its `data-fallback-href` lands the operator back at the admins list as a graceful no-op when the JSON dispatcher is missing entirely (third-party theme stripping `api.js`); the audit-log "Reason: …" suffix is only emitted when `ureason` is non-empty (vs always-emitted on the bans / comms variants where reason is required). **Do not** put `onclick="event.stopPropagation()"` on the trigger button — `document.addEventListener('click')` is how the dialog opener picks the click up, and stopPropagation would silently swallow it (the action button isn't inside any `[data-drawer-href]` ancestor anyway, so the defensiveness was a copy-paste from the row-name anchor that doesn't apply here). |
+| Add a confirm + reason modal for an irreversible row-level action (unban, lift comm block, delete admin, …) | `web/themes/default/page_bans.tpl` (`#bans-unban-dialog`, `Actions.BansUnban`) and `web/themes/default/page_comms.tpl` (`#comms-unblock-dialog`, `Actions.CommsUnblock`) are the canonical reference (#1301), with `web/themes/default/page_admin_admins_list.tpl` (`#admins-delete-dialog`, `Actions.AdminsRemove`, #1352) as the third reference for the optional-reason variant. Shape: a `<dialog hidden>` with a `<form method="dialog">` carrying a `<textarea aria-required="true">` (or `aria-required="false"` for the optional-reason variant — see admins-delete) (NOT the native `required` — that lets the browser block the form submit before our handler runs, swallowing the inline-error UX), a Cancel button, and a Confirm submit button. The page-tail JS opens the dialog via `showModal()` on `[data-action]` clicks, validates the trimmed reason on submit (load-bearing gate is server-side), forwards `ureason` to the JSON action, and on success flips the row in place via the same `flipRowToUnbanned`/`flipRowToUnmuted` helper the legacy single-click flow used (or removes the row outright + decrements the count badge for the admins-delete variant where there's no "now-unbanned" state to render). The legacy GET fallback (`?p=banlist&a=unban&id=…&key=…&ureason=…` / `?p=commslist&a=ungag…&ureason=…`) is the no-JS / hand-edited-URL path; both halves now reject empty `ureason` server-side so the audit log carries the *why*. The admins-delete variant has no legacy GET handler — `RemoveAdmin()` always went through the JSON dispatcher pre-#1123 D1 — so its `data-fallback-href` lands the operator back at the admins list as a graceful no-op when the JSON dispatcher is missing entirely (third-party theme stripping `api.js`); the audit-log "Reason: …" suffix is only emitted when `ureason` is non-empty (vs always-emitted on the bans / comms variants where reason is required). **Do not** put `onclick="event.stopPropagation()"` on the trigger button — `document.addEventListener('click')` is how the dialog opener picks the click up, and stopPropagation would silently swallow it (the action button isn't inside any `[data-drawer-href]` ancestor anyway, so the defensiveness was a copy-paste from the row-name anchor that doesn't apply here). The submit button MUST flip through `setBusy(submitBtn, true)` BEFORE `sb.api.call(...)` leaves the page and clear via `setBusy(submitBtn, false)` on every non-navigating response branch — see "Loading state on action buttons" in Conventions for the contract, the inline-script local wrapper shape, and the regression guard. |
+| Add a loading indicator to an action button that fires `sb.api.call(...)` without a page refresh | `window.SBPP.setBusy(btn, busy)` (`web/themes/default/js/theme.js`) writes the `data-loading="true"` + `aria-busy="true"` + `disabled` triple atomically; the CSS spinner lives in `web/themes/default/css/theme.css` under `.btn[data-loading="true"]` + the `sbpp-btn-spin` keyframe. Inline page-tail scripts inside `.tpl` files define a local `setBusy(btn, busy)` wrapper that delegates to `window.SBPP.setBusy` when present and falls back to `btn.disabled = busy` so third-party themes that strip `theme.js` still gate against double-clicks. Canonical reference shapes: the three confirm-dialog flows (`page_comms.tpl` / `page_bans.tpl` / `page_admin_admins_list.tpl`), the form-submit flows (`page_admin_groups_list.tpl` / `page_admin_groups_add.tpl` / `page_admin_bans_add.tpl` / `page_admin_bans_email.tpl` / `page_youraccount.tpl` / `page_lostpassword.tpl` / `page_login.tpl`), the row-action flows (`page_admin_servers_list.tpl` / `page_admin_bans_protests.tpl` / `page_admin_bans_protests_archiv.tpl` / `page_admin_bans_submissions.tpl` / `page_admin_bans_submissions_archiv.tpl`), and the drawer Notes paths (`theme.js`'s `submitNoteForm` / `deleteNote`). Comment edit on the banlist (`web/scripts/banlist.js`) carries the same pattern for the `sb.api.call(BansEditComment)` round-trip. Regression guard: `web/tests/e2e/specs/flows/action-loading-indicator.spec.ts` (stalls `Actions.CommsUnblock` via `page.route`, asserts the busy-attribute triple on the submit button while in flight, releases the route, and confirms the row flips in-place; the second test counts requests to prove the disabled gate blocks a double-click). |
+| Add a loading indicator to the player drawer or one of its lazy panes (so the chrome doesn't read as blank while the JSON action is in flight) | `renderDrawerLoading()` (header skeleton for the in-flight `bans.detail`) and `renderPaneSkeleton()` (placeholder for History / Comms / Notes activation) in `web/themes/default/js/theme.js`. Both lean on the `.skel` CSS rule in `theme.css` (linear-gradient + `shimmer` keyframe + dark-mode override; `prefers-reduced-motion: reduce` freezes the shimmer via the global reset). The header skeleton carries `[data-testid="drawer-loading"]` + `aria-busy="true"` + per-block `[data-skeleton]` (terminal markers under `#drawer-root[data-loading="true"]`); the lazy-pane skeleton carries `[data-pane-empty]` + `aria-busy="true"` and deliberately omits `[data-skeleton]` because the panel parent's `hidden` attribute doesn't compose into `[data-skeleton]:not([hidden])` and a nested marker would stall every page-load waiter that runs after the drawer opens. Class name is `.skel` (singular) — NOT `.skeleton`; the pre-fix `class="skeleton"` typo had no matching rule and the shimmer rows rendered as transparent zero-background divs (the user-visible "drawer is blank" regression). Regression guard: `web/tests/e2e/specs/flows/drawer-loading-indicator.spec.ts` (stalls `bans.detail` then `bans.player_history` via `page.route`, asserts the skeleton header is visible + the `.skel` block paints a `linear-gradient` background via `getComputedStyle(el).backgroundImage`, releases the routes, and confirms the drawer flips to `renderDrawerBody` / the pane fills with content). |
 | Surface unban-reason / removed-by inline on a public-list row (admin-lifted bans / comms — banlist-ureason or commslist-ureason inline) | `web/themes/default/page_bans.tpl` + `web/themes/default/page_comms.tpl` (#1315). Reason cell on the desktop table emits a `<div class="text-xs text-faint mt-1" data-testid="ban-unban-meta">` (or `comm-unban-meta` for comms) with "Unbanned by `<admin>`: `<reason>`" when `$ban.state == 'unbanned'` (or `$comm.state == 'unmuted'`); mobile cards mirror with the `-mobile` testid suffix. Always gated on `!$hideadminname` so anonymous viewers under a hidden-admins config don't get the admin name leaked. The `ureason` / `removedby` row fields come from the page handler's existing data path (`page.banlist.php` lines 635-643, `page.commslist.php` lines 626-635) — read-only render, no write-side overlap with #1301 / #1323's unban-reason flow. The commslist surface is higher-priority than the banlist (no drawer fallback on `<tr data-testid="comm-row">`); banlist users have the drawer as the canonical detail view. |
 | Re-apply (Reban) affordance on the public banlist for expired / unbanned rows | `web/themes/default/page_bans.tpl`. The desktop row-actions cell emits `<a class="btn btn--secondary btn--sm" data-testid="row-action-reapply" href="index.php?p=admin&c=bans&section=add-ban&rebanid={$ban.bid}&key={$admin_postkey}">…<i data-lucide="rotate-ccw">…Re-apply</a>` when `$can_add_ban && ($ban.state == 'expired' \|\| $ban.state == 'unbanned')`. The smart-default block on `admin.bans.php`'s `add-ban` section detects `?rebanid=…` and pre-populates the form via `BansPrepareReban`. Mobile parity (this PR) — the mobile card was restructured from a single wrapping `<a>` to the `page_comms.tpl` shape (`<div data-testid="ban-card">` wrapping `<a class="ban-card__summary" data-testid="drawer-trigger">` + a sibling `<div class="row-actions ban-card__actions">`), so the same Re-apply button surfaces under `data-testid="row-action-reapply-mobile"`. The drawer trigger stays the inner anchor's `data-drawer-href` + `data-testid="drawer-trigger"` so the existing responsive spec selector keeps working. |
 | Wrap a public-list legacy advanced-search form (banlist / commslist) in a default-collapsed `<details class="filters-details">` disclosure | `web/themes/default/page_bans.tpl` + `web/themes/default/page_comms.tpl` (#1315). The same `.filters-details` rules in `web/themes/default/css/theme.css` cover the chrome (summary chevron, `[open]` state, hover bg, focus ring, count badge); the public-list usage adds a `.filters-details__body > form.card` rule that suppresses the inner card framing because the disclosure body wraps a `{load_template file="admin.bans.search"}` (or `…comms.search`) — i.e. a sibling page-render that emits its own `<form class="card">`. The View DTO (`Sbpp\View\BanListView` / `Sbpp\View\CommsListView`) carries a `bool $is_advanced_search_open` set by the page handler from `isset($_GET['advSearch']) && (string) $_GET['advSearch'] !== ''` so the legacy `?advSearch=…&advType=…` URL shim auto-opens the disclosure. Bare `?p=banlist` / `?p=commslist` and simple-bar filters (`?searchText=` / `?server=` / `?time=`) leave it closed so the unfiltered list reaches above the fold. Selectors anchor on `[data-testid="banlist-advsearch-disclosure"]` / `[data-testid="commslist-advsearch-disclosure"]` (the `<details>`) + the `…-toggle` (the `<summary>`) + the `…-active` count badge. The same `.filters-details` chrome was introduced for admin-admins by #1303 — both surfaces share the CSS so a future tweak is single-source. |

--- a/web/pages/admin.comms.php
+++ b/web/pages/admin.comms.php
@@ -82,6 +82,15 @@ function changeReason(szListValue)
 {
     $('dreason').style.display = (szListValue == "other" ? "block" : "none");
 }
+// Local wrapper around window.SBPP.setBusy with a `disabled`-only fallback
+// so a third-party theme that strips theme.js still gates against double-clicks.
+function __sbppSetBusy(btn, busy) {
+    if (!btn) return;
+    var S = window.SBPP;
+    if (S && typeof S.setBusy === 'function') S.setBusy(btn, busy);
+    else btn.disabled = busy === undefined ? true : !!busy;
+}
+
 function ProcessBan()
 {
     var reason = $('listReason')[$('listReason').selectedIndex].value;
@@ -89,6 +98,8 @@ function ProcessBan()
     if (reason == "other") {
         reason = $('txtReason').value;
     }
+    var submitBtn = document.getElementById('addcomm-submit');
+    __sbppSetBusy(submitBtn, true);
     sb.api.call(Actions.CommsAdd, {
         nickname: $('nickname').value,
         type:     Number($('type').value),
@@ -102,6 +113,9 @@ function ProcessBan()
         // fires `sc_fw_block` via rcon for each one. Without it the DB row exists but no live
         // server learns about the gag/mute, matching the bans/kickit shape one branch above.
         if (r && r.ok && r.data && r.data.block) {
+            // Success — the message dialog covers the form and the page reloads
+            // shortly after; leave the button busy so the operator can't queue a
+            // second submit while the iframe fires rcon at every server.
             var b = r.data.block;
             sb.message.show(
                 'Block Added',
@@ -114,6 +128,7 @@ function ProcessBan()
             if (r.data.reload) setTimeout(function () { window.location.href = window.location.href.replace(/#\^.*$/, ''); }, 2000);
             return;
         }
+        __sbppSetBusy(submitBtn, false);
         if (!r) return;
         if (r.redirect) return;
         if (r.ok === false) {

--- a/web/scripts/banlist.js
+++ b/web/scripts/banlist.js
@@ -72,13 +72,26 @@
         return;
       }
 
+      // Surface the busy state on the submit button while the comment
+      // POST is in flight. The success branch navigates to the banlist
+      // (`window.location.href = …`), so the disabled state hangs around
+      // until the new page paints; the catch branch releases it.
+      const SBPP = /** @type {any} */ (window).SBPP;
+      const submitBtn = /** @type {HTMLButtonElement | null} */ (cform.querySelector('button[type="submit"]'));
+      const setBusy = (/** @type {boolean} */ on) => {
+        if (!submitBtn) return;
+        if (SBPP && typeof SBPP.setBusy === 'function') SBPP.setBusy(submitBtn, on);
+        else submitBtn.disabled = on;
+      };
+      setBusy(true);
+
       const action = cid > 0 ? Actions.BansEditComment : Actions.BansAddComment;
       sb.api.call(action, { bid: bid, cid: cid, ctype: ctype, ctext: value, page: page })
         .then(() => {
           window.location.href = 'index.php?p=banlist' + (page > 0 ? '&page=' + page : '');
         })
         .catch((/** @type {Error} */ err) => {
-          const SBPP = /** @type {any} */ (window).SBPP;
+          setBusy(false);
           if (SBPP && SBPP.showToast) {
             SBPP.showToast({ kind: 'error', title: 'Failed to save comment', body: err.message });
           } else {

--- a/web/tests/e2e/specs/flows/action-loading-indicator.spec.ts
+++ b/web/tests/e2e/specs/flows/action-loading-indicator.spec.ts
@@ -1,0 +1,302 @@
+/**
+ * Loading-indicator contract for action buttons that fire
+ * `sb.api.call(...)` without a page refresh. The motivating example
+ * was the Comms-list "Confirm" button inside `#comms-unblock-dialog`:
+ * pre-fix the click had no visible feedback for the 100-1000ms the
+ * server took to respond, and users instinctively double-clicked
+ * "to make it work" — queuing duplicate `Actions.CommsUnblock`
+ * requests until the manual `disabled = true` line ran inside the
+ * `.then` callback (which is too late, since the second click had
+ * already fired during the in-flight network round-trip).
+ *
+ * The single-source contract this spec locks in
+ * ---------------------------------------------
+ * Every action button that issues `sb.api.call(...)` from a click
+ * handler flips through `window.SBPP.setBusy(btn, true)` BEFORE
+ * the API call leaves the page (so the disabled flag lands on
+ * the first paint of the click) and `setBusy(btn, false)` after
+ * the envelope is processed (so retries are possible on the
+ * non-navigating failure paths). The CSS rule
+ * `.btn[data-loading="true"]` paints the spinner + locks the
+ * width; theme.js's `setBusy()` flips the attribute + the
+ * `aria-busy` + the underlying `<button disabled>`.
+ *
+ * Why test on the Comms unblock dialog
+ * ------------------------------------
+ * It's the surface the user explicitly called out as the
+ * motivating case, AND it exercises every load-bearing layer:
+ *
+ *   1. `<dialog>` confirm modal with a textarea-bound submit button
+ *      (so we cover the form-submit path, not the row-button path).
+ *   2. Inline `setBusy(...)` helper that wraps `window.SBPP.setBusy`
+ *      with a `disabled`-only fallback (so the contract still holds
+ *      when a third-party theme strips theme.js).
+ *   3. `Actions.CommsUnblock` — the JSON action that actually mutates
+ *      DB state. We stall it via `page.route(...)` so the loading
+ *      state stays visible for the assertion window without depending
+ *      on a slow test box.
+ *   4. On success the row flips in-place (`data-state` → `unmuted`),
+ *      the dialog closes, and the button is removed from the DOM
+ *      with the rest of the dialog — so the success path is asserted
+ *      implicitly by the row flip, NOT by re-reading the now-detached
+ *      button's `data-loading` attribute.
+ *
+ * Per #1123 testability hooks: `data-testid="comms-unblock-submit"`
+ * is the canonical selector for the Confirm button; `data-loading`
+ * and `aria-busy` are the busy-state contract; the underlying
+ * `disabled` flag is the load-bearing gate against double-clicks
+ * regardless of CSS state.
+ */
+
+import { expect, test } from '../../fixtures/auth.ts';
+import { truncateE2eDb } from '../../fixtures/db.ts';
+
+const COMMSLIST_ROUTE = '/index.php?p=commslist';
+
+const FIXTURE = {
+    steam: 'STEAM_0:1:1207040',
+    nickname: 'e2e-loading-indicator',
+    reason: 'e2e: loading-indicator on unblock',
+    /** 60 minutes — keeps the row `state="active"` for the spec. */
+    lengthMinutes: 60,
+};
+
+interface SeededComm {
+    steam: string;
+    nickname: string;
+}
+
+/**
+ * Seed an active gag via `Actions.CommsAdd` (same path
+ * `comms-affordances.spec.ts` uses). The row is keyed to the
+ * default admin's `aid`; `truncateE2eDb()` clears it between
+ * tests.
+ */
+async function seedGagViaApi(
+    page: import('@playwright/test').Page,
+    seed: { steam: string; nickname: string; reason: string; length: number },
+): Promise<SeededComm> {
+    await page.goto('/');
+    const envelope = await page.evaluate(async (args) => {
+        const w = window as unknown as {
+            sb: {
+                api: {
+                    call: (
+                        action: string,
+                        params: Record<string, unknown>,
+                    ) => Promise<{ ok: boolean; data?: unknown; error?: { code: string; message: string } }>;
+                };
+            };
+            Actions: Record<string, string>;
+        };
+        return await w.sb.api.call(w.Actions.CommsAdd, {
+            steam: args.steam,
+            nickname: args.nickname,
+            type: 2,
+            length: args.length,
+            reason: args.reason,
+        });
+    }, seed);
+
+    const env = envelope as { ok: boolean; error?: { message: string } };
+    if (!env.ok) {
+        throw new Error(`seedGagViaApi failed: ${JSON.stringify(env)}`);
+    }
+    return { steam: seed.steam, nickname: seed.nickname };
+}
+
+test.describe('flow: action-button loading indicator (comms unblock)', () => {
+    test.describe.configure({ mode: 'serial' });
+
+    test.beforeEach(async () => {
+        await truncateE2eDb();
+    });
+
+    test('clicking Confirm flips the submit button to data-loading="true" until the API resolves', async ({
+        page,
+        isMobile,
+    }) => {
+        test.skip(isMobile, 'desktop is the canonical surface; mobile follows the same JS path');
+
+        await seedGagViaApi(page, {
+            steam: FIXTURE.steam,
+            nickname: FIXTURE.nickname,
+            reason: FIXTURE.reason,
+            length: FIXTURE.lengthMinutes,
+        });
+
+        // Intercept the in-flight `Actions.CommsUnblock` call and hold
+        // it open until we've asserted the busy state. We DO eventually
+        // resolve the route — the success branch then flips the row
+        // in-place and removes the dialog, which is the implicit
+        // "loading state cleared" assertion. The `Promise<() => void>`
+        // shape exposes the release function to the test body.
+        let releaseRoute: (() => void) | null = null;
+        const routeStalled = new Promise<void>((resolve) => {
+            // Mark the route handler installed BEFORE the click so the
+            // capture-side `routeStalled` await below has something to
+            // pivot on. `page.route` is sync; the handler fires when
+            // the matching request lands. The wire-format action name
+            // is the dotted-lowercase id from `_register.php`
+            // (`comms.unblock`), NOT the JS `Actions.CommsUnblock`
+            // constant — `Actions.PascalName` is just a typo-safe
+            // string alias for the same on-the-wire id.
+            void page.route('**/api.php', async (route) => {
+                let body: unknown = null;
+                try {
+                    body = JSON.parse(route.request().postData() || '{}');
+                } catch {
+                    body = null;
+                }
+                const action = (body as { action?: string } | null)?.action;
+                if (action !== 'comms.unblock') {
+                    await route.continue();
+                    return;
+                }
+                resolve();
+                // Wait for the test body to release us before letting
+                // the real handler run. The await on `releasePromise`
+                // is what gives the assertions their window.
+                await new Promise<void>((releaseInner) => {
+                    releaseRoute = releaseInner;
+                });
+                await route.continue();
+            });
+        });
+
+        await page.goto(COMMSLIST_ROUTE);
+
+        const row = page
+            .locator('[data-testid="comm-row"]')
+            .filter({ hasText: FIXTURE.steam });
+        await expect(row).toHaveCount(1);
+        await expect(row).toHaveAttribute('data-state', 'active');
+
+        const unmuteBtn = row.locator('[data-testid="row-action-unmute"]');
+        await unmuteBtn.click();
+
+        const dialog = page.locator('[data-testid="comms-unblock-dialog"]');
+        await expect(dialog).toBeVisible();
+
+        await dialog
+            .locator('[data-testid="comms-unblock-reason"]')
+            .fill('e2e: loading-state assertion');
+
+        const submitBtn = dialog.locator('[data-testid="comms-unblock-submit"]');
+        // Pre-click the busy attributes are absent.
+        await expect(submitBtn).not.toHaveAttribute('data-loading', 'true');
+
+        await submitBtn.click();
+
+        // Wait for the request to actually land on the network so we
+        // know `setBusy(submitBtn, true)` has run on the renderer.
+        // Without this await we'd race the click — a flake nobody
+        // would diagnose for a year.
+        await routeStalled;
+
+        // ---- The contract: data-loading + aria-busy + disabled ----
+        // All three attributes are the load-bearing surfaces:
+        //   - `data-loading="true"`  drives the CSS spinner (visual).
+        //   - `aria-busy="true"`     announces the state to AT users.
+        //   - `disabled`             gates against double-clicks.
+        // theme.js's `setBusy` is the only source-of-truth for this
+        // triple; a regression that drops any one of them fails here.
+        await expect(submitBtn).toHaveAttribute('data-loading', 'true');
+        await expect(submitBtn).toHaveAttribute('aria-busy', 'true');
+        await expect(submitBtn).toBeDisabled();
+
+        // Release the API call. The success branch flips the row in
+        // place + closes the dialog (which detaches the submit
+        // button), so we assert against the row's post-flip state
+        // rather than the now-gone button. Pre-fix this branch's
+        // explicit `setBusy(submitBtn, false)` was needed for the
+        // failure path; on success the dialog teardown handles
+        // cleanup. Either way the operator sees the spinner clear.
+        if (releaseRoute) releaseRoute();
+        else throw new Error('releaseRoute was never wired by the route handler');
+
+        await expect(row).toHaveAttribute('data-state', 'unmuted');
+        await expect(dialog).toBeHidden();
+    });
+
+    test('an in-flight Confirm rejects the second click (disabled gate against double-submit)', async ({
+        page,
+        isMobile,
+    }) => {
+        test.skip(isMobile, 'desktop is the canonical surface; mobile follows the same JS path');
+
+        await seedGagViaApi(page, {
+            steam: FIXTURE.steam,
+            nickname: FIXTURE.nickname,
+            reason: FIXTURE.reason,
+            length: FIXTURE.lengthMinutes,
+        });
+
+        // Same stall pattern as above; we want one outstanding
+        // CommsUnblock that we control the lifetime of.
+        let firstSeen = false;
+        let releaseRoute: (() => void) | null = null;
+        const routeStalled = new Promise<void>((resolve) => {
+            void page.route('**/api.php', async (route) => {
+                let body: unknown = null;
+                try {
+                    body = JSON.parse(route.request().postData() || '{}');
+                } catch {
+                    body = null;
+                }
+                const action = (body as { action?: string } | null)?.action;
+                if (action !== 'comms.unblock') {
+                    await route.continue();
+                    return;
+                }
+                // Only the FIRST `comms.unblock` is allowed to reach
+                // the stall; a second arrival is a bug — the
+                // disabled gate should have blocked the click.
+                if (firstSeen) {
+                    throw new Error('Second comms.unblock request fired — double-submit gate broke');
+                }
+                firstSeen = true;
+                resolve();
+                await new Promise<void>((releaseInner) => {
+                    releaseRoute = releaseInner;
+                });
+                await route.continue();
+            });
+        });
+
+        await page.goto(COMMSLIST_ROUTE);
+
+        const row = page
+            .locator('[data-testid="comm-row"]')
+            .filter({ hasText: FIXTURE.steam });
+        await expect(row).toHaveCount(1);
+        await row.locator('[data-testid="row-action-unmute"]').click();
+
+        const dialog = page.locator('[data-testid="comms-unblock-dialog"]');
+        await expect(dialog).toBeVisible();
+        await dialog.locator('[data-testid="comms-unblock-reason"]').fill('e2e: double-click');
+
+        const submitBtn = dialog.locator('[data-testid="comms-unblock-submit"]');
+        await submitBtn.click();
+        await routeStalled;
+
+        // The button is disabled — Playwright's `.click()` waits for
+        // actionability by default, so a naive second `.click()` here
+        // would hang for 30s rather than dispatch. `{ force: true }`
+        // bypasses the wait so we can prove the disabled gate
+        // catches the click event even when actionability is forced.
+        // The route handler's `if (firstSeen)` throw is the safety
+        // net: if the click leaks through despite `disabled`, the
+        // second request fires and we trip the throw.
+        await submitBtn.click({ force: true });
+
+        // Give the browser a tick to flush any queued click events
+        // before we conclude no second request fired.
+        await page.waitForTimeout(50);
+
+        if (releaseRoute) releaseRoute();
+        else throw new Error('releaseRoute was never wired by the route handler');
+
+        await expect(row).toHaveAttribute('data-state', 'unmuted');
+    });
+});

--- a/web/tests/e2e/specs/flows/drawer-loading-indicator.spec.ts
+++ b/web/tests/e2e/specs/flows/drawer-loading-indicator.spec.ts
@@ -1,0 +1,214 @@
+/**
+ * Loading-indicator contract for the player drawer's in-flight states.
+ *
+ * The drawer surfaces two distinct loading windows the user has to be
+ * able to *see* something happening for, not just notice a blank panel:
+ *
+ *   1. Initial drawer open — the click fires `Actions.BansDetail`. Until
+ *      the envelope returns, the drawer paints `renderDrawerLoading()`
+ *      (the `.skel` shimmer rows under `[data-testid="drawer-loading"]`).
+ *      Pre-fix the function emitted `class="skeleton"` (singular), which
+ *      had NO matching CSS rule — the shimmer divs rendered with zero
+ *      background and the operator saw a literal blank pane for the
+ *      100-1000ms `bans.detail` took to resolve. The CSS the markup
+ *      was meant to hit has always been `.skel` (used by the banlist
+ *      skeleton hook); the renderer just hadn't matched.
+ *
+ *   2. Lazy pane activation — clicking History / Comms / Notes for the
+ *      first time fires the matching `*.player_history` / `notes.list`
+ *      action. Pre-fix the panel started with bare "Loading…" text,
+ *      which read as static copy. The shared `renderPaneSkeleton()`
+ *      helper now drops the same `.skel` shimmer rows the drawer header
+ *      uses so all four panes share one loading vocabulary.
+ *
+ * Both windows are gated by `page.route('**\/api.php', …)` stalls so the
+ * assertion window doesn't depend on slow test infrastructure.
+ */
+
+import { expect, test } from '../../fixtures/auth.ts';
+import { truncateE2eDb } from '../../fixtures/db.ts';
+import { seedBanViaApi } from '../../fixtures/seeds.ts';
+
+const BANLIST_ROUTE = '/index.php?p=banlist';
+
+const FIXTURE = {
+    steam: 'STEAM_0:1:1207050',
+    nickname: 'e2e-drawer-loading',
+    reason: 'e2e: drawer-loading indicator',
+    lengthMinutes: 60,
+};
+
+test.describe('flow: drawer loading indicator', () => {
+    test.describe.configure({ mode: 'serial' });
+
+    test.beforeEach(async () => {
+        await truncateE2eDb();
+    });
+
+    test('initial drawer open paints visible .skel shimmer until bans.detail resolves', async ({
+        page,
+        isMobile,
+    }) => {
+        test.skip(isMobile, 'desktop is the canonical surface; the .skel rule is viewport-independent');
+
+        const seeded = await seedBanViaApi(page, {
+            steam: FIXTURE.steam,
+            nickname: FIXTURE.nickname,
+            reason: FIXTURE.reason,
+            length: FIXTURE.lengthMinutes,
+        });
+
+        let releaseRoute: (() => void) | null = null;
+        const routeStalled = new Promise<void>((resolve) => {
+            void page.route('**/api.php', async (route) => {
+                let body: unknown = null;
+                try {
+                    body = JSON.parse(route.request().postData() || '{}');
+                } catch {
+                    body = null;
+                }
+                const action = (body as { action?: string } | null)?.action;
+                if (action !== 'bans.detail') {
+                    await route.continue();
+                    return;
+                }
+                resolve();
+                await new Promise<void>((releaseInner) => {
+                    releaseRoute = releaseInner;
+                });
+                await route.continue();
+            });
+        });
+
+        await page.goto(BANLIST_ROUTE);
+
+        const drawerRoot = page.locator('#drawer-root');
+        await expect(drawerRoot).toHaveAttribute('data-drawer-open', 'false');
+
+        const trigger = page
+            .locator(`[data-testid="drawer-trigger"][data-drawer-href*="id=${seeded.bid}"]`)
+            .first();
+        await trigger.click();
+        // Without page.route's stall, `bans.detail` resolves before we
+        // can probe the skeleton; the await on `routeStalled` below is
+        // the synchronisation point.
+
+        await routeStalled;
+
+        // ---- The contract: the skeleton paints visibly ----
+        // [data-testid="drawer-loading"] is the header marker, and
+        // [data-skeleton] tags every `.skel` block inside it. Both
+        // are visible by virtue of `.skel`'s gradient + shimmer —
+        // an opacity readback proves the regression that re-renames
+        // to `class="skeleton"` would NOT pass (the unstyled class
+        // has no background so the readback fails the bounding-box
+        // assertion).
+        const loadingHeader = drawerRoot.locator('[data-testid="drawer-loading"]');
+        await expect(loadingHeader).toBeVisible();
+        await expect(loadingHeader).toHaveAttribute('aria-busy', 'true');
+
+        const skel = drawerRoot.locator('[data-skeleton]').first();
+        await expect(skel).toBeVisible();
+        // The block has to have a non-zero painted area — the prior
+        // `.skeleton` typo rendered transparent so width was non-zero
+        // but the *visual* skeleton was missing. A computed-style
+        // probe against `background-image` catches both shapes: the
+        // matching `.skel` rule sets a `linear-gradient(...)`, the
+        // missing rule leaves it at the UA default `none`.
+        const bg = await skel.evaluate((el) => getComputedStyle(el).backgroundImage);
+        expect(
+            bg,
+            'skeleton block paints a linear-gradient shimmer (regression guard for the class="skeleton" typo)',
+        ).toContain('linear-gradient');
+
+        // Release bans.detail → drawer flips to renderDrawerBody.
+        if (releaseRoute) releaseRoute();
+        else throw new Error('releaseRoute was never wired');
+
+        await expect(drawerRoot).not.toHaveAttribute('data-loading', /.+/);
+        await expect(drawerRoot.locator('[data-testid="drawer-panel-overview"]')).toBeVisible();
+        await expect(drawerRoot.locator('[data-testid="drawer-loading"]')).toHaveCount(0);
+    });
+
+    test('opening History pane paints .skel shimmer until bans.player_history resolves', async ({
+        page,
+        isMobile,
+    }) => {
+        test.skip(isMobile, 'desktop is the canonical surface; the .skel rule is viewport-independent');
+
+        const seeded = await seedBanViaApi(page, {
+            steam: FIXTURE.steam.replace(':1207050', ':1207051'),
+            nickname: FIXTURE.nickname + '-pane',
+            reason: FIXTURE.reason,
+            length: FIXTURE.lengthMinutes,
+        });
+
+        // Let bans.detail through unstalled — we only want to stall
+        // the pane-level fetch so the test's window is the pane skeleton,
+        // not the drawer header skeleton (the previous test covers that).
+        let releaseRoute: (() => void) | null = null;
+        const routeStalled = new Promise<void>((resolve) => {
+            void page.route('**/api.php', async (route) => {
+                let body: unknown = null;
+                try {
+                    body = JSON.parse(route.request().postData() || '{}');
+                } catch {
+                    body = null;
+                }
+                const action = (body as { action?: string } | null)?.action;
+                if (action !== 'bans.player_history') {
+                    await route.continue();
+                    return;
+                }
+                resolve();
+                await new Promise<void>((releaseInner) => {
+                    releaseRoute = releaseInner;
+                });
+                await route.continue();
+            });
+        });
+
+        await page.goto(BANLIST_ROUTE);
+
+        const drawerRoot = page.locator('#drawer-root');
+        const trigger = page
+            .locator(`[data-testid="drawer-trigger"][data-drawer-href*="id=${seeded.bid}"]`)
+            .first();
+        await trigger.click();
+        await expect(drawerRoot).not.toHaveAttribute('data-loading', /.+/);
+
+        // Click the History tab — fires bans.player_history.
+        await drawerRoot.locator('[data-testid="drawer-tab-history"]').click();
+        await routeStalled;
+
+        // The pane was created with the placeholder skeleton; clicking
+        // the tab activates the panel + the lazy loader flips
+        // `data-loading="true"` on the panel itself.
+        const panel = drawerRoot.locator('[data-testid="drawer-panel-history"]');
+        await expect(panel).toBeVisible();
+        await expect(panel).toHaveAttribute('data-loading', 'true');
+
+        const emptyMarker = panel.locator('[data-pane-empty]');
+        await expect(emptyMarker).toBeVisible();
+        await expect(emptyMarker).toHaveAttribute('aria-busy', 'true');
+
+        const skelInPanel = panel.locator('.skel').first();
+        await expect(skelInPanel).toBeVisible();
+        const bg = await skelInPanel.evaluate((el) => getComputedStyle(el).backgroundImage);
+        expect(
+            bg,
+            'history pane skeleton paints a linear-gradient shimmer (the visual loading contract)',
+        ).toContain('linear-gradient');
+
+        // Release bans.player_history → pane swaps in the empty state
+        // (the seeded ban is the player's only ban so the history list
+        // is intentionally empty — the empty-state heading is the
+        // post-load assertion).
+        if (releaseRoute) releaseRoute();
+        else throw new Error('releaseRoute was never wired');
+
+        await expect(panel).not.toHaveAttribute('data-loading', /.+/);
+        await expect(panel.locator('[data-testid="drawer-history-heading"]')).toBeVisible();
+        await expect(panel.locator('[data-pane-empty]')).toHaveCount(0);
+    });
+});

--- a/web/themes/default/css/theme.css
+++ b/web/themes/default/css/theme.css
@@ -360,6 +360,77 @@ html.dark .btn--secondary[aria-pressed="true"] {
    so width/padding stay locked to the square shape. */
 .btn--xs { height: 1.5rem; width: 1.5rem; min-width: 1.5rem; }
 
+/* ---- In-flight action buttons (`window.SBPP.setBusy(btn, true)`) ----
+   Paired with the `setBusy` helper in `theme.js`. Inline page-tail
+   scripts that fire `sb.api.call(…)` from a click handler (the
+   `#bans-unban-dialog` / `#comms-unblock-dialog` / `#admins-delete-dialog`
+   Confirm buttons, server-delete / protests-archive / submissions-archive
+   row buttons, the addban / account / lostpassword / login forms,
+   etc.) flip the trigger to `data-loading="true"` on submit so the
+   user gets immediate visual feedback that the click was received
+   and the API call is in flight. Without this every Confirm modal
+   looked frozen between the click and the API response (it took 100s
+   of milliseconds on a typical install) and users instinctively
+   double-clicked to "make it work", queuing duplicate requests until
+   the disabled flag landed.
+
+   How the visual works
+   --------------------
+   The button's existing content (icon + label) is hidden via the
+   visibility-hidden / color-transparent combo (the icon is a child
+   element so `visibility: hidden` covers it; labels are direct text
+   nodes so `color: transparent !important` is the only way to hide
+   them in CSS), and a `::after` donut takes its place at the button's
+   center. The button's width stays locked because the original
+   content still occupies its layout space — no layout shift between
+   the busy and idle states. `pointer-events: none` is the visual
+   contract; the load-bearing gate against double-clicks is `disabled`
+   on the underlying `<button>` (theme.js sets both together).
+
+   `--btn-color` instead of `currentColor`
+   ---------------------------------------
+   `color: transparent !important` sets the rendered color of the
+   button to transparent; `currentColor` inside the pseudo-element
+   resolves to the inherited color, which would be transparent too
+   (an invisible spinner). Every `.btn--*` modifier sets `--btn-color`
+   to its semantic foreground colour, so the spinner can pull that
+   variable directly. The `currentColor` fallback covers third-party
+   button shapes that ride the loading class without going through
+   `.btn--primary` / `.btn--secondary` / etc. — they'll still get a
+   visible spinner, just in the inherited color.
+
+   Reduced motion
+   --------------
+   The global `prefers-reduced-motion: reduce` block (later in this
+   file) already pins `animation-duration` to 0.001ms on every
+   `::after`, so the spinner sits still for reduced-motion users.
+   They still see the donut shape + `cursor: progress` + the
+   disabled button state, which is enough to convey "in flight"
+   without the rotation. Don't add a per-rule override that
+   pre-empts the global reset — that's the anti-pattern called out
+   in the matching `@keyframes slide-in` block. */
+.btn[data-loading="true"] {
+  position: relative;
+  cursor: progress;
+  pointer-events: none;
+  color: transparent !important;
+  text-shadow: none !important;
+}
+.btn[data-loading="true"] > * { visibility: hidden; }
+.btn[data-loading="true"]::after {
+  content: "";
+  position: absolute;
+  top: 50%; left: 50%;
+  width: 1em; height: 1em;
+  margin: -0.5em 0 0 -0.5em;
+  border-radius: 50%;
+  border: 2px solid var(--btn-color, currentColor);
+  border-right-color: transparent;
+  border-top-color: transparent;
+  animation: sbpp-btn-spin 0.6s linear infinite;
+}
+@keyframes sbpp-btn-spin { to { transform: rotate(360deg); } }
+
 /* #1207 AUTH-2 — "Continue with Steam" contrast in dark theme. The
    button is rendered as `.btn--secondary` (page_login.tpl), which in
    dark mode resolves to `--bg-surface` (zinc-900) on `--bg-page`

--- a/web/themes/default/js/theme.js
+++ b/web/themes/default/js/theme.js
@@ -591,6 +591,15 @@
      * `[hidden]` UA rule (`display:none`) and every panel would render
      * stacked on top of the active one. `activateDrawerTab` flips both
      * attributes together when a tab is activated.
+     *
+     * Pre-fix the placeholder was a single muted `Loading…` text node.
+     * That worked but read as static text — the user never saw "the
+     * panel is doing something" beyond the eight-character label.
+     * `renderPaneSkeleton()` (below) wraps the same `[data-pane-empty]`
+     * + `aria-busy` testability contract around two `.skel` shimmer
+     * rows so History / Comms / Notes all share the visual vocabulary
+     * the drawer header uses for its own loading state.
+     *
      * @param {string} id
      * @returns {string}
      */
@@ -603,7 +612,7 @@
       + ' tabindex="0"'
       + ' hidden'
       + ' style="padding:1rem 1.25rem;display:none;flex-direction:column;gap:0.75rem;overflow-y:auto;flex:1">'
-      +   '<div data-pane-empty class="text-sm text-muted">Loading\u2026</div>'
+      +   renderPaneSkeleton()
       + '</div>';
 
     let panelsHtml = overviewHtml + lazyPanel('history') + lazyPanel('comms');
@@ -691,6 +700,41 @@
     }
 
     return idHtml + banHtml + commentsHtml;
+  }
+
+  /**
+   * Build the lazy-pane loading placeholder. Mirrors the drawer
+   * header's `renderDrawerLoading()` shape with `.skel` shimmer rows
+   * so a user opening History / Comms / Notes sees the same
+   * "something's loading" vocabulary as the initial drawer open.
+   *
+   * The `data-pane-empty` attribute is the existing contract for the
+   * unloaded placeholder (the `refreshNotesPane` reset path keys off
+   * it implicitly when it overwrites innerHTML); `aria-busy="true"`
+   * announces the busy state to AT users.
+   *
+   * Why NO `data-skeleton` here
+   * ---------------------------
+   * The page-level waiter in `web/tests/e2e/pages/_base.ts` blocks
+   * until `'[data-loading="true"], [data-skeleton]:not([hidden])'`
+   * returns no nodes. The lazy panels start with `hidden` on the
+   * tabpanel *parent*, but `:not([hidden])` only checks the matched
+   * element's own attribute — a `data-skeleton` block nested inside
+   * a `hidden` tabpanel would still match and stall every page-load
+   * wait that runs after the drawer opens. Confine `[data-skeleton]`
+   * to surfaces where the marker itself (or its direct container)
+   * carries the visibility toggle (the drawer header skeleton lives
+   * under `#drawer-root[data-loading="true"]`, which IS a terminal
+   * marker, so it's safe there).
+   *
+   * @returns {string}
+   */
+  function renderPaneSkeleton() {
+    return '<div data-pane-empty aria-busy="true" aria-label="Loading\u2026" style="display:flex;flex-direction:column;gap:0.625rem">'
+      +   '<div class="skel" style="height:0.875rem;width:40%"></div>'
+      +   '<div class="skel" style="height:0.875rem"></div>'
+      +   '<div class="skel" style="height:0.875rem;width:70%"></div>'
+      + '</div>';
   }
 
   /**
@@ -890,7 +934,9 @@
 
   /**
    * Reload the Notes pane after an add/delete mutation. Forces the
-   * lazy loader to re-run by clearing `data-loaded`.
+   * lazy loader to re-run by clearing `data-loaded` and dropping the
+   * same `renderPaneSkeleton()` placeholder back in so the operator
+   * gets the same shimmer treatment they got on first activation.
    * @returns {Promise<void>}
    */
   async function refreshNotesPane() {
@@ -898,25 +944,43 @@
     const panel = /** @type {HTMLElement | null} */ (drawerRoot.querySelector('[role="tabpanel"][data-drawer-panel="notes"]'));
     if (!panel) return;
     delete panel.dataset.loaded;
-    panel.innerHTML = '<div data-pane-empty class="text-sm text-muted">Loading\u2026</div>';
+    panel.innerHTML = renderPaneSkeleton();
     await loadPaneIfNeeded('notes');
   }
 
   /**
-   * Render the placeholder skeleton shown during the in-flight fetch.
+   * Render the placeholder skeleton shown during the in-flight `bans.detail`
+   * fetch. The blocks use the `.skel` class (defined in `theme.css` —
+   * `linear-gradient` + `shimmer` keyframe + dark-mode override; the
+   * global `prefers-reduced-motion: reduce` rule pins
+   * `animation-duration` to ~0ms so reduced-motion users see the
+   * static placeholder colour, not the shimmer).
+   *
+   * Pre-fix the function emitted `class="skeleton"` (singular, no CSS
+   * rule defined), so the skeleton blocks rendered as transparent
+   * zero-background divs and the drawer read as "just blank" between
+   * click and bans.detail response — exactly the symptom the user
+   * reported. The CSS rule the markup was meant to ride has always
+   * been `.skel`, not `.skeleton`; rename the markup to match.
+   *
+   * `[data-testid="drawer-loading"]` is the E2E hook; `aria-busy="true"`
+   * + `aria-label="Loading player details"` carry the screen-reader
+   * announcement without needing a `.sr-only` CSS rule (none exists
+   * in the theme).
+   *
    * @returns {string}
    */
   function renderDrawerLoading() {
-    return '<header class="drawer__header" style="display:flex;justify-content:space-between;align-items:center;padding:1rem 1.25rem;border-bottom:1px solid var(--border)">'
-      + '<div class="skeleton" style="width:8rem;height:1.25rem"></div>'
+    return '<header class="drawer__header" data-testid="drawer-loading" aria-busy="true" aria-label="Loading player details" style="display:flex;justify-content:space-between;align-items:center;padding:1rem 1.25rem;border-bottom:1px solid var(--border)">'
+      + '<div class="skel" data-skeleton style="width:8rem;height:1.25rem"></div>'
       + '<button class="btn btn--ghost btn--icon" type="button" data-drawer-close aria-label="Close">'
       + '<i data-lucide="x"></i>'
       + '</button>'
       + '</header>'
       + '<div class="drawer__body" style="padding:1.25rem;display:flex;flex-direction:column;gap:0.75rem">'
-      +   '<div class="skeleton" style="height:0.875rem"></div>'
-      +   '<div class="skeleton" style="height:0.875rem;width:60%"></div>'
-      +   '<div class="skeleton" style="height:0.875rem;width:80%"></div>'
+      +   '<div class="skel" data-skeleton style="height:0.875rem"></div>'
+      +   '<div class="skel" data-skeleton style="height:0.875rem;width:60%"></div>'
+      +   '<div class="skel" data-skeleton style="height:0.875rem;width:80%"></div>'
       + '</div>';
   }
 
@@ -1023,7 +1087,7 @@
       const nid = parseInt(delBtn.dataset.notesDelete || '0', 10);
       if (nid > 0) {
         e.preventDefault();
-        void deleteNote(nid);
+        void deleteNote(nid, delBtn);
         return;
       }
     }
@@ -1094,30 +1158,48 @@
       return;
     }
 
-    const env = await sb.api.call(Actions.NotesAdd, { steam_id: steamId, body: body });
-    if (env && env.ok) {
-      if (textarea) textarea.value = '';
-      await refreshNotesPane();
-      showToast({ kind: 'success', title: 'Note added' });
-    } else {
-      const msg = (env && env.error && env.error.message) || 'Couldn\u2019t add note.';
-      showToast({ kind: 'error', title: 'Note not saved', body: msg });
+    // Surface the busy state on the form's submit button so the operator
+    // sees that the click registered while notes.add is in flight.
+    const submitBtn = /** @type {HTMLButtonElement | null} */ (form.querySelector('button[type="submit"]'));
+    setBusy(submitBtn, true);
+    try {
+      const env = await sb.api.call(Actions.NotesAdd, { steam_id: steamId, body: body });
+      if (env && env.ok) {
+        if (textarea) textarea.value = '';
+        await refreshNotesPane();
+        showToast({ kind: 'success', title: 'Note added' });
+      } else {
+        const msg = (env && env.error && env.error.message) || 'Couldn\u2019t add note.';
+        showToast({ kind: 'error', title: 'Note not saved', body: msg });
+      }
+    } finally {
+      // The pane re-renders on success which replaces the form node, so
+      // `submitBtn` may already be detached — `setBusy` no-ops when the
+      // ref is missing, but the explicit release guards the failure path
+      // (and any future early-return) without leaving the button busy.
+      setBusy(submitBtn, false);
     }
   }
 
   /**
    * POST `notes.delete` and refresh the Notes pane.
    * @param {number} nid
+   * @param {HTMLElement | null} [triggerBtn]
    * @returns {Promise<void>}
    */
-  async function deleteNote(nid) {
-    const env = await sb.api.call(Actions.NotesDelete, { nid: nid });
-    if (env && env.ok) {
-      await refreshNotesPane();
-      showToast({ kind: 'success', title: 'Note deleted' });
-    } else {
-      const msg = (env && env.error && env.error.message) || 'Couldn\u2019t delete note.';
-      showToast({ kind: 'error', title: 'Note not deleted', body: msg });
+  async function deleteNote(nid, triggerBtn) {
+    setBusy(triggerBtn || null, true);
+    try {
+      const env = await sb.api.call(Actions.NotesDelete, { nid: nid });
+      if (env && env.ok) {
+        await refreshNotesPane();
+        showToast({ kind: 'success', title: 'Note deleted' });
+      } else {
+        const msg = (env && env.error && env.error.message) || 'Couldn\u2019t delete note.';
+        showToast({ kind: 'error', title: 'Note not deleted', body: msg });
+      }
+    } finally {
+      setBusy(triggerBtn || null, false);
     }
   }
 
@@ -1268,7 +1350,46 @@
     }
   });
 
-  /** @type {any} */ (window).SBPP = { showToast: showToast, openDrawer: openDrawer, closeDrawer: closeDrawer };
+  // ---- ACTION-BUTTON BUSY STATE ----------------------------
+  // Inline page-tail scripts that fire `sb.api.call(…)` from a click
+  // handler call this on submit and again from the .then tail to
+  // release. Without it every Confirm modal looked frozen between
+  // the click and the API response — `btn.disabled = true` is a
+  // load-bearing gate against double-clicks but invisible on its
+  // own; the paired `.btn[data-loading="true"]` CSS rule in
+  // theme.css owns the visual spinner.
+  //
+  // Idempotent in both directions: calling with `busy=true` twice
+  // leaves the button in its busy state; calling with `busy=false`
+  // when it isn't busy is a no-op.
+  //
+  // The `disabled` flip stays even on third-party themes that
+  // strip the CSS rule, so the gate against double-clicks is
+  // preserved regardless of whether the spinner ever paints.
+  // Per-file fallback helpers (`setBusy(btn, busy)` in each
+  // inline IIFE) further fall back to bare `btn.disabled = busy`
+  // when `window.SBPP` itself isn't defined.
+  /**
+   * @param {HTMLElement | null} btn
+   * @param {boolean} [busy] defaults to true
+   * @returns {void}
+   */
+  function setBusy(btn, busy) {
+    if (!btn) return;
+    const isBusy = busy === undefined ? true : !!busy;
+    const b = /** @type {HTMLButtonElement} */ (btn);
+    if (isBusy) {
+      btn.setAttribute('data-loading', 'true');
+      btn.setAttribute('aria-busy', 'true');
+      b.disabled = true;
+    } else {
+      btn.removeAttribute('data-loading');
+      btn.removeAttribute('aria-busy');
+      b.disabled = false;
+    }
+  }
+
+  /** @type {any} */ (window).SBPP = { showToast: showToast, openDrawer: openDrawer, closeDrawer: closeDrawer, setBusy: setBusy };
 
   // ---- HELPERS ---------------------------------------------
   /**

--- a/web/themes/default/page_admin_admins_list.tpl
+++ b/web/themes/default/page_admin_admins_list.tpl
@@ -265,6 +265,20 @@
                 sbpp.showToast({ kind: kind, title: title, body: body || '' });
             }
         }
+        /**
+         * Flip the busy / loading state on a triggered action button. Calls
+         * window.SBPP.setBusy when present (theme.js owns the spinner CSS
+         * contract) and falls back to plain `disabled` so third-party themes
+         * that strip theme.js still gate against double-clicks.
+         * @param {Element|null} btn
+         * @param {boolean} [busy] defaults to true
+         */
+        function setBusy(btn, busy) {
+            if (!btn) return;
+            var S = /** @type {any} */ (window).SBPP;
+            if (S && typeof S.setBusy === 'function') S.setBusy(btn, busy);
+            else /** @type {HTMLButtonElement} */ (btn).disabled = busy === undefined ? true : !!busy;
+        }
 
         /**
          * @param {string} aid
@@ -386,11 +400,11 @@
 
             var ctx = pending;
             var submitBtn = /** @type {HTMLButtonElement|null} */ (form.querySelector('[data-testid="admins-delete-submit"]'));
-            if (submitBtn) submitBtn.disabled = true;
+            setBusy(submitBtn, true);
 
             var a = api(), A = actions();
             if (!a || !A) {
-                if (submitBtn) submitBtn.disabled = false;
+                setBusy(submitBtn, false);
                 if (ctx.fallback) window.location.href = ctx.fallback;
                 return;
             }
@@ -400,7 +414,7 @@
             if (reason !== '') params.ureason = reason;
 
             a.call(A.AdminsRemove, params).then(function (r) {
-                if (submitBtn) submitBtn.disabled = false;
+                setBusy(submitBtn, false);
                 if (!r || r.ok === false) {
                     var msg = (r && r.error && r.error.message) || 'Unknown error';
                     showError(msg);

--- a/web/themes/default/page_admin_bans_add.tpl
+++ b/web/themes/default/page_admin_bans_add.tpl
@@ -251,6 +251,18 @@
             window.sb.message[kind](title, body || '');
         }
     }
+    /**
+     * Flip the busy / loading state on a triggered action button. Calls
+     * window.SBPP.setBusy when present (theme.js owns the spinner CSS
+     * contract) and falls back to plain `disabled` so third-party themes
+     * that strip theme.js still gate against double-clicks.
+     */
+    function setBusy(btn, busy) {
+        if (!btn) return;
+        var S = window.SBPP;
+        if (S && typeof S.setBusy === 'function') S.setBusy(btn, busy);
+        else btn.disabled = busy === undefined ? true : !!busy;
+    }
     function validate(type) {
         var err = 0;
         var reason = '';
@@ -307,7 +319,7 @@
         if (reason === null) return;
         var a = api(), A = actions();
         if (!a || !A) return;
-        btn.disabled = true;
+        setBusy(btn, true);
         a.call(A.BansAdd, {
             nickname: $id('nickname').value,
             type: type,
@@ -319,7 +331,7 @@
             reason: reason,
             fromsub: Number(($id('fromsub') && $id('fromsub').value) || 0)
         }).then(function (r) {
-            btn.disabled = false;
+            setBusy(btn, false);
             if (!r || r.ok === false) {
                 toast('error', 'Add ban failed', (r && r.error && r.error.message) || 'Unknown error');
                 return;

--- a/web/themes/default/page_admin_bans_email.tpl
+++ b/web/themes/default/page_admin_bans_email.tpl
@@ -99,6 +99,18 @@
             window.sb.message[kind](title, body || '');
         }
     }
+    /**
+     * Flip the busy / loading state on a triggered action button. Calls
+     * window.SBPP.setBusy when present (theme.js owns the spinner CSS
+     * contract) and falls back to plain `disabled` so third-party themes
+     * that strip theme.js still gate against double-clicks.
+     */
+    function setBusy(btn, busy) {
+        if (!btn) return;
+        var S = window.SBPP;
+        if (S && typeof S.setBusy === 'function') S.setBusy(btn, busy);
+        else btn.disabled = busy === undefined ? true : !!busy;
+    }
     /** @param {string} type @param {number} id */
     window.CheckEmail = function (type, id) {
         var err = 0;
@@ -110,12 +122,15 @@
         if (err > 0) return;
         var a = api(), A = actions();
         if (!a || !A) return;
+        var submitBtn = $id('aemail');
+        setBusy(submitBtn, true);
         a.call(A.SystemSendMail, {
             subject: subject.value,
             message: message.value,
             type: type,
             id: id
         }).then(function (r) {
+            setBusy(submitBtn, false);
             if (!r || r.ok === false) {
                 toast('error', 'Email failed', (r && r.error && r.error.message) || 'Unknown error');
                 return;

--- a/web/themes/default/page_admin_bans_protests.tpl
+++ b/web/themes/default/page_admin_bans_protests.tpl
@@ -239,6 +239,20 @@
             window.sb.message[kind](title, body || '');
         }
     }
+    /**
+     * Flip the busy / loading state on a triggered action button. Calls
+     * window.SBPP.setBusy when present (theme.js owns the spinner CSS
+     * contract) and falls back to plain `disabled` so third-party themes
+     * that strip theme.js still gate against double-clicks.
+     * @param {Element|null} btn
+     * @param {boolean} [busy] defaults to true
+     */
+    function setBusy(btn, busy) {
+        if (!btn) return;
+        var S = /** @type {any} */ (window).SBPP;
+        if (S && typeof S.setBusy === 'function') S.setBusy(btn, busy);
+        else /** @type {HTMLButtonElement} */ (btn).disabled = busy === undefined ? true : !!busy;
+    }
 
     /** @type {WeakMap<HTMLElement, number>} */
     var pendingTimers = new WeakMap();
@@ -318,10 +332,10 @@
         // those values here have been removed.
         var a = api(), A = actions();
         if (!a || !A || !Number.isFinite(pid)) return;
-        /** @type {HTMLButtonElement} */ (btn).disabled = true;
+        setBusy(btn, true);
         a.call(A.ProtestsRemove, { pid: pid, archiv: '1' }).then(function (r) {
             if (!r || r.ok === false) {
-                /** @type {HTMLButtonElement} */ (btn).disabled = false;
+                setBusy(btn, false);
                 toast('error', 'Action failed', (r && r.error && r.error.message) || 'Unknown error');
                 return;
             }

--- a/web/themes/default/page_admin_bans_protests_archiv.tpl
+++ b/web/themes/default/page_admin_bans_protests_archiv.tpl
@@ -227,6 +227,18 @@
             window.sb.message[kind](title, body || '');
         }
     }
+    /**
+     * Flip the busy / loading state on a triggered action button. Calls
+     * window.SBPP.setBusy when present (theme.js owns the spinner CSS
+     * contract) and falls back to plain `disabled` so third-party themes
+     * that strip theme.js still gate against double-clicks.
+     */
+    function setBusy(btn, busy) {
+        if (!btn) return;
+        var S = window.SBPP;
+        if (S && typeof S.setBusy === 'function') S.setBusy(btn, busy);
+        else btn.disabled = busy === undefined ? true : !!busy;
+    }
     document.addEventListener('click', function (e) {
         var t = e.target;
         if (!t || !t.closest) return;
@@ -243,10 +255,10 @@
         if (!window.confirm(msg)) return;
         var a = api(), A = actions();
         if (!a || !A || !Number.isFinite(pid)) return;
-        btn.disabled = true;
+        setBusy(btn, true);
         a.call(A.ProtestsRemove, { pid: pid, archiv: archiv }).then(function (r) {
             if (!r || r.ok === false) {
-                btn.disabled = false;
+                setBusy(btn, false);
                 toast('error', 'Action failed', (r && r.error && r.error.message) || 'Unknown error');
                 return;
             }

--- a/web/themes/default/page_admin_bans_submissions.tpl
+++ b/web/themes/default/page_admin_bans_submissions.tpl
@@ -258,6 +258,20 @@
             window.sb.message[kind](title, body || '');
         }
     }
+    /**
+     * Flip the busy / loading state on a triggered action button. Calls
+     * window.SBPP.setBusy when present (theme.js owns the spinner CSS
+     * contract) and falls back to plain `disabled` so third-party themes
+     * that strip theme.js still gate against double-clicks.
+     * @param {Element|null} btn
+     * @param {boolean} [busy] defaults to true
+     */
+    function setBusy(btn, busy) {
+        if (!btn) return;
+        var S = /** @type {any} */ (window).SBPP;
+        if (S && typeof S.setBusy === 'function') S.setBusy(btn, busy);
+        else /** @type {HTMLButtonElement} */ (btn).disabled = busy === undefined ? true : !!busy;
+    }
 
     /** @type {WeakMap<HTMLElement, number>} */
     var pendingTimers = new WeakMap();
@@ -344,10 +358,10 @@
             // removed.
             var a2 = api(), A2 = actions();
             if (!a2 || !A2 || !Number.isFinite(sid)) return;
-            /** @type {HTMLButtonElement} */ (btn).disabled = true;
+            setBusy(btn, true);
             a2.call(A2.SubmissionsRemove, { sid: sid, archiv: '1' }).then(function (r) {
                 if (!r || r.ok === false) {
-                    /** @type {HTMLButtonElement} */ (btn).disabled = false;
+                    setBusy(btn, false);
                     toast('error', 'Action failed', (r && r.error && r.error.message) || 'Unknown error');
                     return;
                 }

--- a/web/themes/default/page_admin_bans_submissions_archiv.tpl
+++ b/web/themes/default/page_admin_bans_submissions_archiv.tpl
@@ -238,6 +238,18 @@
             window.sb.message[kind](title, body || '');
         }
     }
+    /**
+     * Flip the busy / loading state on a triggered action button. Calls
+     * window.SBPP.setBusy when present (theme.js owns the spinner CSS
+     * contract) and falls back to plain `disabled` so third-party themes
+     * that strip theme.js still gate against double-clicks.
+     */
+    function setBusy(btn, busy) {
+        if (!btn) return;
+        var S = window.SBPP;
+        if (S && typeof S.setBusy === 'function') S.setBusy(btn, busy);
+        else btn.disabled = busy === undefined ? true : !!busy;
+    }
     document.addEventListener('click', function (e) {
         var t = e.target;
         if (!t || !t.closest) return;
@@ -254,10 +266,10 @@
         if (!window.confirm(msg)) return;
         var a = api(), A = actions();
         if (!a || !A || !Number.isFinite(sid)) return;
-        btn.disabled = true;
+        setBusy(btn, true);
         a.call(A.SubmissionsRemove, { sid: sid, archiv: archiv }).then(function (r) {
             if (!r || r.ok === false) {
-                btn.disabled = false;
+                setBusy(btn, false);
                 toast('error', 'Action failed', (r && r.error && r.error.message) || 'Unknown error');
                 return;
             }

--- a/web/themes/default/page_admin_groups_add.tpl
+++ b/web/themes/default/page_admin_groups_add.tpl
@@ -86,6 +86,15 @@ function SbppGroupsAddTypeChanged(sel) {
     srvBlock.style.display = (sel.value === '2') ? 'block' : 'none';
 }
 
+// Local wrapper around window.SBPP.setBusy with a `disabled`-only fallback
+// so a third-party theme that strips theme.js still gates against double-clicks.
+function SbppGroupsAddSetBusy(btn, busy) {
+    if (!btn) return;
+    var S = window.SBPP;
+    if (S && typeof S.setBusy === 'function') S.setBusy(btn, busy);
+    else btn.disabled = busy === undefined ? true : !!busy;
+}
+
 function SbppGroupsAdd(event) {
     event.preventDefault();
     var form = event.target;
@@ -93,6 +102,8 @@ function SbppGroupsAdd(event) {
     var type = form.querySelector('select[name="type"]').value;
     var srvflagsEl = form.querySelector('input[name="srvflags"]');
     var srvflags = srvflagsEl ? srvflagsEl.value : '';
+    var submitBtn = form.querySelector('[data-testid="add-group-submit"]');
+    SbppGroupsAddSetBusy(submitBtn, true);
     sb.api.call(Actions.GroupsAdd, {
         name: name,
         type: type,
@@ -105,8 +116,9 @@ function SbppGroupsAdd(event) {
         // sb.message is the legacy fallback (no-ops under sbpp2026 since #dialog-* is
         // legacy-default-only, but kept so a third-party theme that never wired SBPP
         // still gets some signal).
-        if (!r) return;
+        if (!r) { SbppGroupsAddSetBusy(submitBtn, false); return; }
         if (r.redirect) return;
+        SbppGroupsAddSetBusy(submitBtn, false);
         if (r.ok === false) {
             var em = (r.error && r.error.message) || 'Unknown error';
             if (window.SBPP && typeof window.SBPP.showToast === 'function') {
@@ -125,6 +137,9 @@ function SbppGroupsAdd(event) {
             sb.message.success(title, body, data.message ? data.message.redir : '');
         }
         if (data.reload) {
+            // Re-arm before the reload so a stale render briefly shows the
+            // disabled state, then leaves the form re-enabled if reload fails.
+            SbppGroupsAddSetBusy(submitBtn, true);
             setTimeout(function () { window.location.reload(); }, 2000);
         }
     });

--- a/web/themes/default/page_admin_groups_list.tpl
+++ b/web/themes/default/page_admin_groups_list.tpl
@@ -111,7 +111,7 @@
                             <button type="button"
                                     class="btn btn--ghost btn--sm"
                                     data-testid="group-delete"
-                                    onclick="SbppGroupsDelete({$selected_group.gid}, '{$selected_group.name|escape:'javascript'}');">Delete group</button>
+                                    onclick="SbppGroupsDelete({$selected_group.gid}, '{$selected_group.name|escape:'javascript'}', this);">Delete group</button>
                         {/if}
                     </div>
                     <div class="card__body space-y-4">
@@ -232,7 +232,7 @@
                                     <a class="btn btn--ghost btn--sm" href="index.php?p=admin&c=groups&o=edit&type=srv&id={$group.id|escape:'url'}">Edit</a>
                                 {/if}
                                 {if $permission_deletegroup}
-                                    <button type="button" class="btn btn--ghost btn--sm" onclick="SbppServerGroupsDelete({$group.id}, '{$group.name|escape:'javascript'}', 'srv');">Delete</button>
+                                    <button type="button" class="btn btn--ghost btn--sm" onclick="SbppServerGroupsDelete({$group.id}, '{$group.name|escape:'javascript'}', 'srv', this);">Delete</button>
                                 {/if}
                             </div>
                         </div>
@@ -334,7 +334,7 @@
                                     <a class="btn btn--ghost btn--sm" href="index.php?p=admin&c=groups&o=edit&type=server&id={$group.gid|escape:'url'}">Edit</a>
                                 {/if}
                                 {if $permission_deletegroup}
-                                    <button type="button" class="btn btn--ghost btn--sm" onclick="SbppServerGroupsDelete({$group.gid}, '{$group.name|escape:'javascript'}', 'server');">Delete</button>
+                                    <button type="button" class="btn btn--ghost btn--sm" onclick="SbppServerGroupsDelete({$group.gid}, '{$group.name|escape:'javascript'}', 'server', this);">Delete</button>
                                 {/if}
                             </div>
                         </div>
@@ -438,32 +438,65 @@ function SbppGroupsApplyResponse(r, opts) {
     }
 }
 
+// Local wrapper around window.SBPP.setBusy that falls back to `disabled`
+// so a stripped-down theme still gates against double-clicks.
+function SbppGroupsSetBusy(btn, busy) {
+    if (!btn) return;
+    var S = window.SBPP;
+    if (S && typeof S.setBusy === 'function') S.setBusy(btn, busy);
+    else btn.disabled = busy === undefined ? true : !!busy;
+}
+
 function SbppGroupsSave(event) {
     event.preventDefault();
     var form = event.target;
     var gid = Number(form.querySelector('input[name="gid"]').value);
     var name = form.querySelector('input[name="name"]').value;
     var bitmask = SbppFoldFlags(form);
+    var submitBtn = form.querySelector('[data-testid="group-save"]');
+    SbppGroupsSetBusy(submitBtn, true);
     sb.api.call(Actions.GroupsEdit, {
         gid: gid,
         name: name,
         web_flags: bitmask,
         srv_flags: '',
         type: 'web'
-    }).then(function (r) { SbppGroupsApplyResponse(r, { defaultTitle: 'Group updated' }); });
+    }).then(function (r) {
+        SbppGroupsSetBusy(submitBtn, false);
+        SbppGroupsApplyResponse(r, { defaultTitle: 'Group updated' });
+    });
     return false;
 }
 
-function SbppGroupsDelete(gid, name) {
+function SbppGroupsDelete(gid, name, btn) {
     if (!confirm('Delete group "' + name + '"?')) return;
+    SbppGroupsSetBusy(btn, true);
     sb.api.call(Actions.GroupsRemove, { gid: Number(gid), type: 'web' })
-        .then(function (r) { SbppGroupsApplyResponse(r, { defaultTitle: 'Group deleted' }); });
+        .then(function (r) {
+            // Leave the button busy on success — the apply handler reloads /
+            // navigates within 1.5s and re-enabling it would let the operator
+            // queue a second delete on the now-stale row.
+            if (r && r.ok && (r.data && (r.data.reload || (r.data.message && r.data.message.redir)))) {
+                SbppGroupsApplyResponse(r, { defaultTitle: 'Group deleted' });
+                return;
+            }
+            SbppGroupsSetBusy(btn, false);
+            SbppGroupsApplyResponse(r, { defaultTitle: 'Group deleted' });
+        });
 }
 
-function SbppServerGroupsDelete(gid, name, type) {
+function SbppServerGroupsDelete(gid, name, type, btn) {
     if (!confirm('Delete group "' + name + '"?')) return;
+    SbppGroupsSetBusy(btn, true);
     sb.api.call(Actions.GroupsRemove, { gid: Number(gid), type: String(type) })
-        .then(function (r) { SbppGroupsApplyResponse(r, { defaultTitle: 'Group deleted' }); });
+        .then(function (r) {
+            if (r && r.ok && (r.data && (r.data.reload || (r.data.message && r.data.message.redir)))) {
+                SbppGroupsApplyResponse(r, { defaultTitle: 'Group deleted' });
+                return;
+            }
+            SbppGroupsSetBusy(btn, false);
+            SbppGroupsApplyResponse(r, { defaultTitle: 'Group deleted' });
+        });
 }
 
 // --- Live bitmask preview (#1258) ---

--- a/web/themes/default/page_admin_servers_list.tpl
+++ b/web/themes/default/page_admin_servers_list.tpl
@@ -244,6 +244,18 @@
 <script>
 (function () {
     'use strict';
+    /**
+     * Flip the busy / loading state on a triggered action button. Calls
+     * window.SBPP.setBusy when present (theme.js owns the spinner CSS
+     * contract) and falls back to plain `disabled` so third-party themes
+     * that strip theme.js still gate against double-clicks.
+     */
+    function setBusy(btn, busy) {
+        if (!btn) return;
+        var S = window.SBPP;
+        if (S && typeof S.setBusy === 'function') S.setBusy(btn, busy);
+        else btn.disabled = busy === undefined ? true : !!busy;
+    }
     document.addEventListener('click', function (e) {
         var t = e.target;
         if (!t || !t.closest) return;
@@ -258,10 +270,10 @@
         }
         var api = window.sb && window.sb.api;
         if (!api || !window.Actions) return;
-        btn.disabled = true;
+        setBusy(btn, true);
         api.call(window.Actions.ServersRemove, { sid: sid }).then(function (r) {
             if (!r || r.ok === false) {
-                btn.disabled = false;
+                setBusy(btn, false);
                 if (r && r.error && window.SBPP && window.SBPP.showToast) {
                     window.SBPP.showToast({ kind: 'error', title: 'Delete failed', body: r.error.message || 'Unknown error' });
                 }

--- a/web/themes/default/page_bans.tpl
+++ b/web/themes/default/page_bans.tpl
@@ -913,6 +913,20 @@
             sbpp.showToast({ kind: kind, title: title, body: body || '' });
         }
     }
+    /**
+     * Flip the busy / loading state on a triggered action button. Calls
+     * window.SBPP.setBusy when present (theme.js owns the spinner CSS
+     * contract) and falls back to plain `disabled` so third-party themes
+     * that strip theme.js still gate against double-clicks.
+     * @param {Element|null} btn
+     * @param {boolean} [busy] defaults to true
+     */
+    function setBusy(btn, busy) {
+        if (!btn) return;
+        var S = /** @type {any} */ (window).SBPP;
+        if (S && typeof S.setBusy === 'function') S.setBusy(btn, busy);
+        else /** @type {HTMLButtonElement} */ (btn).disabled = busy === undefined ? true : !!busy;
+    }
 
     /**
      * Find every DOM node that mirrors the same ban id. The desktop
@@ -1108,11 +1122,11 @@
 
         var ctx = pending;
         var submitBtn = /** @type {HTMLButtonElement|null} */ (form.querySelector('[data-testid="bans-unban-submit"]'));
-        if (submitBtn) submitBtn.disabled = true;
+        setBusy(submitBtn, true);
 
         var a = api(), A = actions();
         if (!a || !A) {
-            if (submitBtn) submitBtn.disabled = false;
+            setBusy(submitBtn, false);
             if (ctx.fallback) {
                 // Encode the reason into the legacy GET URL so the no-JS
                 // path lands with the typed reason populated.
@@ -1123,7 +1137,7 @@
         }
 
         a.call(A.BansUnban, { bid: Number(ctx.bid), ureason: reason }).then(function (r) {
-            if (submitBtn) submitBtn.disabled = false;
+            setBusy(submitBtn, false);
             if (!r || r.ok === false) {
                 var msg = (r && r.error && r.error.message) || 'Unknown error';
                 showError(msg);

--- a/web/themes/default/page_comms.tpl
+++ b/web/themes/default/page_comms.tpl
@@ -720,6 +720,20 @@
             sbpp.showToast({ kind: kind, title: title, body: body || '' });
         }
     }
+    /**
+     * Flip the busy / loading state on a triggered action button. Calls
+     * window.SBPP.setBusy when present (theme.js owns the spinner CSS
+     * contract) and falls back to plain `disabled` so third-party themes
+     * that strip theme.js still gate against double-clicks.
+     * @param {Element|null} btn
+     * @param {boolean} [busy] defaults to true
+     */
+    function setBusy(btn, busy) {
+        if (!btn) return;
+        var S = /** @type {any} */ (window).SBPP;
+        if (S && typeof S.setBusy === 'function') S.setBusy(btn, busy);
+        else /** @type {HTMLButtonElement} */ (btn).disabled = busy === undefined ? true : !!busy;
+    }
 
     /**
      * Find every DOM node that mirrors the same comm-block id — the
@@ -886,9 +900,13 @@
         d.setAttribute('hidden', '');
         // Re-enable any unblock buttons we disabled before showing the
         // dialog so a Cancel click leaves the row clickable again.
+        // Includes the `data-loading="true"` selector branch so a
+        // SetBusy-flipped trigger releases too (the row-action button
+        // never gets flipped through this code path today, but the
+        // pairing keeps the contract symmetric).
         Array.prototype.forEach.call(
-            document.querySelectorAll('[data-action="comms-unblock"][disabled]'),
-            function (btn) { /** @type {HTMLButtonElement} */ (btn).disabled = false; }
+            document.querySelectorAll('[data-action="comms-unblock"][disabled], [data-action="comms-unblock"][data-loading="true"]'),
+            function (btn) { setBusy(btn, false); }
         );
         pending = null;
     }
@@ -925,10 +943,10 @@
 
         if (act === 'comms-delete') {
             if (!window.confirm('Delete the block for "' + name + '"?')) return;
-            /** @type {HTMLButtonElement} */ (btn).disabled = true;
+            setBusy(btn, true);
             a.call(A.CommsDelete, { bid: Number(bid) }).then(function (r) {
                 if (!r || r.ok === false) {
-                    /** @type {HTMLButtonElement} */ (btn).disabled = false;
+                    setBusy(btn, false);
                     var msg = (r && r.error && r.error.message) || 'Unknown error';
                     toast('error', 'Delete failed', msg);
                     return;
@@ -973,11 +991,11 @@
 
         var ctx = pending;
         var submitBtn = /** @type {HTMLButtonElement|null} */ (form.querySelector('[data-testid="comms-unblock-submit"]'));
-        if (submitBtn) submitBtn.disabled = true;
+        setBusy(submitBtn, true);
 
         var a = api(), A = actions();
         if (!a || !A) {
-            if (submitBtn) submitBtn.disabled = false;
+            setBusy(submitBtn, false);
             if (ctx.fallback) {
                 var sep = ctx.fallback.indexOf('?') === -1 ? '?' : '&';
                 window.location.href = ctx.fallback + sep + 'ureason=' + encodeURIComponent(reason);
@@ -986,7 +1004,7 @@
         }
 
         a.call(A.CommsUnblock, { bid: Number(ctx.bid), ureason: reason }).then(function (r) {
-            if (submitBtn) submitBtn.disabled = false;
+            setBusy(submitBtn, false);
             if (!r || r.ok === false) {
                 var msg = (r && r.error && r.error.message) || 'Unknown error';
                 showError(msg);

--- a/web/themes/default/page_login.tpl
+++ b/web/themes/default/page_login.tpl
@@ -209,6 +209,19 @@
 (function () {
     'use strict';
 
+    /**
+     * Flip the busy / loading state on a triggered action button. Calls
+     * window.SBPP.setBusy when present (theme.js owns the spinner CSS
+     * contract) and falls back to plain `disabled` so third-party themes
+     * that strip theme.js still gate against double-clicks.
+     */
+    function setBusy(btn, busy) {
+        if (!btn) return;
+        var S = window.SBPP;
+        if (S && typeof S.setBusy === 'function') S.setBusy(btn, busy);
+        else btn.disabled = busy === undefined ? true : !!busy;
+    }
+
     // ----- form submit -> sb.api.call(Actions.AuthLogin, ...) ---------
     // `redirect` is the post-login destination passed to the JSON API
     // (`web/api/handlers/auth.php` → `Api::redirect('?' . <redir-param>)`).
@@ -223,11 +236,30 @@
             var u = document.getElementById('loginUsername');
             var p = document.getElementById('loginPassword');
             var r = document.getElementById('loginRememberMe');
+            // Flip the Sign in button into the busy state immediately —
+            // sb.api.call honours the `redirect` envelope automatically
+            // (window.location.href = …) on success, so we don't need
+            // to release on the success path; on failure the server's
+            // redirect envelope (back to ?p=login&m=…) navigates away
+            // too. The setBusy is purely the in-flight cue between
+            // click and navigation, which is otherwise invisible on a
+            // slow network (#XXXX).
+            var submitBtn = form.querySelector('[data-testid="login-submit"]');
+            setBusy(submitBtn, true);
             sb.api.call(Actions.AuthLogin, {
                 username: u ? u.value : '',
                 password: p ? p.value : '',
                 remember: !!(r && r.checked),
                 redirect: ''
+            }).then(function (res) {
+                // Defensive release: if the dispatcher returned a non-
+                // redirect envelope (e.g. an unexpected error shape that
+                // didn't navigate), restore the button so the user can
+                // retry without a hard reload. The success / standard-
+                // failure paths navigate before this fires.
+                if (!res || !res.redirect) setBusy(submitBtn, false);
+            }, function () {
+                setBusy(submitBtn, false);
             });
         });
     }

--- a/web/themes/default/page_lostpassword.tpl
+++ b/web/themes/default/page_lostpassword.tpl
@@ -84,6 +84,18 @@
             window.SBPP.showToast({ kind: kind, title: title, body: body || '' });
         }
     }
+    /**
+     * Flip the busy / loading state on a triggered action button. Calls
+     * window.SBPP.setBusy when present (theme.js owns the spinner CSS
+     * contract) and falls back to plain `disabled` so third-party themes
+     * that strip theme.js still gate against double-clicks.
+     */
+    function setBusy(btn, busy) {
+        if (!btn) return;
+        var S = window.SBPP;
+        if (S && typeof S.setBusy === 'function') S.setBusy(btn, busy);
+        else btn.disabled = busy === undefined ? true : !!busy;
+    }
 
     function mapKind(k) {
         if (k === 'red') return 'error';
@@ -98,9 +110,9 @@
             toast('warn', 'Email required', 'Please enter your email address.');
             return;
         }
-        submitEl.disabled = true;
+        setBusy(submitEl, true);
         sb.api.call(Actions.AuthLostPassword, { email: emailEl.value }).then(function (res) {
-            submitEl.disabled = false;
+            setBusy(submitEl, false);
             if (!res || res.redirect) return;
             if (res.ok === false) {
                 var emsg = (res.error && res.error.message) || 'Unknown error';

--- a/web/themes/default/page_youraccount.tpl
+++ b/web/themes/default/page_youraccount.tpl
@@ -391,6 +391,19 @@
         showToast('error', 'Error', msg);
     }
 
+    /**
+     * Flip the busy / loading state on a triggered action button. Calls
+     * window.SBPP.setBusy when present (theme.js owns the spinner CSS
+     * contract) and falls back to plain `disabled` so third-party themes
+     * that strip theme.js still gate against double-clicks.
+     */
+    function setBusy(btn, busy) {
+        if (!btn) return;
+        var S = window.SBPP;
+        if (S && typeof S.setBusy === 'function') S.setBusy(btn, busy);
+        else btn.disabled = busy === undefined ? true : !!busy;
+    }
+
     // -- Change password ------------------------------------------------
     var pwForm = document.getElementById('account-password-form');
     if (pwForm) {
@@ -419,6 +432,8 @@
             }
             if (bad) return;
 
+            var pwBtn = pwForm.querySelector('[data-testid="account-save"]');
+            setBusy(pwBtn, true);
             sb.api.call(Actions.AccountChangePassword, {
                 aid: aid,
                 old_password: current,
@@ -428,8 +443,11 @@
                 // api.js translates into `window.location.href = …`. The
                 // .then still fires before navigation; bail before the
                 // failure path mistakes the redirect envelope for an error.
+                // Release the busy state on every non-navigating branch so
+                // the operator can retry without a hard reload.
                 if (env && env.ok) return;
                 if (env && env.redirect) return;
+                setBusy(pwBtn, false);
                 if (showFieldError('account-', env && env.error, { current: 'current-password' })) return;
                 flashFailure(env);
             });
@@ -452,11 +470,15 @@
             var removeEl = document.getElementById('account-remove-srv-password');
             var remove   = !!(removeEl && 'checked' in removeEl && removeEl.checked);
 
+            var srvBtn = srvForm.querySelector('[data-testid="account-srv-save"]');
+
             if (remove) {
+                setBusy(srvBtn, true);
                 sb.api.call(Actions.AccountChangeSrvPassword, {
                     aid: aid,
                     srv_password: 'NULL'
                 }).then(function (env) {
+                    setBusy(srvBtn, false);
                     if (env && env.ok) { flashSuccess(env); return; }
                     if (env && env.redirect) return;
                     flashFailure(env);
@@ -484,22 +506,26 @@
                     aid: aid,
                     srv_password: next
                 }).then(function (env) {
+                    setBusy(srvBtn, false);
                     if (env && env.ok) { flashSuccess(env); return; }
                     if (env && env.redirect) return;
                     flashFailure(env);
                 });
             }
 
+            setBusy(srvBtn, true);
             if (hasExisting) {
                 sb.api.call(Actions.AccountCheckSrvPassword, {
                     aid: aid,
                     password: current
                 }).then(function (env) {
                     if (!env || !env.ok || !env.data) {
+                        setBusy(srvBtn, false);
                         flashFailure(env);
                         return;
                     }
                     if (!env.data.matches) {
+                        setBusy(srvBtn, false);
                         setMsg('account-current-srv-password-msg', 'Incorrect server password.');
                         return;
                     }
@@ -542,11 +568,14 @@
             }
             if (bad) return;
 
+            var emailBtn = emailForm.querySelector('[data-testid="account-email-save"]');
+            setBusy(emailBtn, true);
             sb.api.call(Actions.AccountChangeEmail, {
                 aid: aid,
                 email: email,
                 password: pw
             }).then(function (env) {
+                setBusy(emailBtn, false);
                 if (env && env.ok) { flashSuccess(env); return; }
                 if (env && env.redirect) return;
                 if (showFieldError(


### PR DESCRIPTION
## Summary

Two surfaces that fire `sb.api.call(...)` without a page refresh had **no visible loading indicator** — users clicked Confirm / opened the drawer and saw nothing happen for the 100–1000 ms the JSON action took to resolve, then instinctively double-clicked "to make it work" and queued duplicate requests.

### Action buttons (Comms unblock, ban unban, admin delete, group save, comment edit, login form, password reset, etc.)

- New single-source helper `window.SBPP.setBusy(btn, busy)` in `web/themes/default/js/theme.js` atomically flips three attributes on the button: `data-loading="true"` (drives the spinner), `aria-busy="true"` (announces to AT users), and the native `disabled` flag (the load-bearing double-click gate).
- CSS spinner lives in `web/themes/default/css/theme.css` (`.btn[data-loading="true"]` + `::after` donut + `sbpp-btn-spin` keyframe). Content hides via `color: transparent !important` / `visibility: hidden` so the button width stays locked — no layout shift.
- Inline page-tail `<script>` blocks in every `.tpl` that fires the action wrap the global via a local `setBusy(btn, busy)` helper that **delegates to `window.SBPP.setBusy` when present** and **falls back to bare `btn.disabled = busy`** so third-party themes that strip `theme.js` still gate against double-clicks (the spinner naturally degrades; the disabled state is what matters).
- `prefers-reduced-motion: reduce` is handled by the global reset in `theme.css` (pins every `animation-duration` to ~0 ms). The spinner sits still for reduced-motion users; they still see the donut shape, `cursor: progress`, and the disabled state.

### Player drawer + lazy panes (History / Comms / Notes)

- The drawer's `renderDrawerLoading()` already emitted skeleton blocks but with `class="skeleton"` (singular), and **no matching CSS rule existed**. The blocks rendered transparent and the drawer read as **literally blank** for the entire `bans.detail` window — exactly the "just blank with no loading indicator" symptom the user reported.
- Rename `class="skeleton"` → `class="skel"` (the class the banlist skeleton hook has always used). The existing linear-gradient + shimmer animation now actually paints.
- New sibling helper `renderPaneSkeleton()` so the lazy panes swap from a bare "Loading…" text node to the same shimmer vocabulary as the drawer header.
- Drawer header skeletons carry `[data-skeleton]` (terminal marker under `#drawer-root[data-loading="true"]`); lazy-pane skeletons deliberately **omit** `[data-skeleton]` because the panel parent's \`hidden\` attribute doesn't compose with `[data-skeleton]:not([hidden])` — a nested marker would stall every page-load waiter that runs after the drawer opens.

## Regression guards

- ${ } `web/tests/e2e/specs/flows/action-loading-indicator.spec.ts` — stalls `Actions.CommsUnblock` via `page.route`, asserts the `data-loading="true"` + `aria-busy="true"` + `disabled` triple while in-flight, releases the route, and confirms the row flips in-place. A second test counts requests to prove the disabled gate blocks a double-click.
- ${ } `web/tests/e2e/specs/flows/drawer-loading-indicator.spec.ts` — stalls `bans.detail` then `bans.player_history`, asserts the `.skel` block paints a `linear-gradient` background via `getComputedStyle(el).backgroundImage` (the regression catch for the `class="skeleton"` typo — the missing rule leaves \`background-image: none\`), releases the routes, and confirms the drawer flips to `renderDrawerBody` / the pane fills with content.

## Quality gates

- ${ } PHPStan (level 5 + dba)
- ${ } PHPUnit (508 tests / 2233 assertions)
- ${ } ts-check (\`tsc --noEmit --checkJs\`)
- ${ } api-contract (no drift)
- ${ } Playwright E2E suite — drawer + palette + banlist + responsive + a11y axe scans all green locally

## Docs

`AGENTS.md` carries:

- Two new **Convention** blocks: *Loading state on action buttons* and *Loading state on drawers + lazy panes*.
- Four new **Anti-patterns**: manual `btn.disabled = true` on `sb.api.call` sites; splitting the data-loading / aria-busy / disabled triple; reaching for `.skeleton` instead of `.skel`; nesting `[data-skeleton]` inside a hidden ancestor.
- Two new **Where to find what** rows pointing at the canonical reference shapes and regression guards for both surfaces.

## Test plan

- [x] PHPStan clean
- [x] PHPUnit clean
- [x] ts-check clean
- [x] api-contract no diff
- [x] new drawer-loading-indicator spec passes
- [x] new action-loading-indicator spec passes (both cases — happy path + double-click gate)
- [x] existing drawer / palette / banlist / responsive / a11y specs unaffected