### PR TITLE
fix(banlist+commslist): migrate column-tier hiding to container queries + lift page-cap to 1700px

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1308,6 +1308,89 @@ audit (#1207) locked in. New CTAs:
   snapshot) so a user without the relevant `ADMIN_*` flag sees the
   body copy without the link they couldn't follow.
 
+### Responsive desktop-table chrome (container queries + tiered column hiding)
+
+The bans / comms desktop tables ship 9-10 columns. The sidebar
+collapses at `<=1023px` so above that it eats 15rem (240px) of
+horizontal real estate before the table sees any pixels; add the
+p-6 page padding (48px) and even a 1280px viewport leaves the card
+with ~975px to paint a row whose natural sum-of-columns is ~1247px.
+The shared chrome that handles this:
+
+- **`.table-scroll` wrapper** around every desktop-table list page
+  (`page_bans.tpl` / `page_comms.tpl` / admin-side `mod` / `group` /
+  `server` lists). Provides `overflow-x: auto` as the runtime
+  escape hatch when a row genuinely exceeds the card after every
+  other reduction has run, and (post-#1363) the
+  `container-type: inline-size; container-name: tablescroll;`
+  context that the column-tier rules below key off.
+- **Tiered column-hiding classes** on every `<th>` AND matching
+  `<td>` so the column hides as a unit (otherwise rows go out of
+  alignment):
+  - Tier-1 (always visible): the minimum row that answers
+    "who, why, what state, what can I do" — Player, SteamID,
+    Reason (banlist) / Type+Player (commslist), Status, Actions.
+  - **`.col-tier-3`** hides at `@container tablescroll (max-width:
+    1500px)`. The wider trio (IP / Length / Banned / Started;
+    ~552px combined).
+  - **`.col-tier-2`** hides at `@container tablescroll (max-width:
+    1200px)`. Server / Admin (~219px combined).
+  - Tier-3 hides FIRST despite the lower tier-number because the
+    wider trio reclaims more room than tier-2; dropping it first
+    is what actually buys back the table's natural width.
+- **`.col-length` width cap** (`max-width: 10rem;
+  overflow: hidden; text-overflow: ellipsis;`) because
+  `SecondsToString()` builds long strings like
+  `"1 mo, 2 wk, 4 d, 8 hr, 19 min, 33 sec"` — six units of
+  granularity for one cell. Pair the cap with a `title="…"`
+  attribute on the `<td>` so hover / long-press still surfaces
+  the full string. The `col-banned` / `col-started` columns
+  carry fixed-width ISO timestamps that don't vary per row, so
+  they don't need the cap — capping would just emit ellipsis on
+  every row without trimming anything meaningful.
+- **Page-cap differentiation**: most list pages cap their outer
+  wrapper at `max-width: 1400px` (max card ~1352px → tier-3
+  always hidden there). Bans / comms specifically lift the cap to
+  `max-width: 1700px` (max card ~1652px) so wide-monitor users
+  actually see tier-3 columns at viewport `>=1788px`.
+
+Container queries are load-bearing here. Pre-#1363 the tier
+breakpoints were viewport-keyed (`@media (max-width: 1535px)`)
+and missed the page-cap entirely — a 1920px monitor saw the same
+scroll-required layout as a 1535px laptop because both fell into
+the "all tiers visible" arm even though the painted card was
+identical (1352px, capped by `max-width: 1400px`). Container
+queries on `.table-scroll` see the actual painted width of the
+card regardless of viewport.
+
+When adding a new desktop-table list page that should ride this
+chrome:
+
+1. Wrap the `<table>` in `<div class="table-scroll">`.
+2. Tag every column's `<th>` AND matching `<td>` with the right
+   tier class — no class means tier-1 always-visible. Be
+   conservative: the default is "show everything" and you opt
+   in to hiding.
+3. If a column's content varies wildly per row (the Length column
+   is the canonical example), cap its width with a `.col-<name>`
+   rule alongside `text-overflow: ellipsis` and pair with a
+   `title="..."` attribute on the cell so the full value stays
+   reachable on hover / long-press.
+4. The mobile card layout (`.ban-cards` for bans, the comms-list
+   equivalent) takes over completely at `<=768px` (`theme.css`
+   `.table { display: none }`), so these tier classes only
+   collapse the desktop table at intermediate viewports.
+
+Regression guards: `web/tests/e2e/specs/flows/banlist-table-columns.spec.ts`
+(STATUS / BANNED layout, `.table-scroll` wrapper presence, Remove
+button reachability across 1280 / 1440 / 1920px viewports — the
+1280 / 1440 cases land in the "tiers hidden" arm and 1920 lands in
+the "tiers visible" arm) and
+`web/tests/e2e/specs/flows/banlist-ip-column.spec.ts` (which runs
+at 1920px so the IP column — tier-3 — is visible). When you add a
+new tier-3 column to either list and it relies on visibility for
+the spec, target a 1920px viewport, not 1440px.
+
 ## Anti-patterns (do NOT reintroduce)
 
 - `btn.disabled = true` (or any other manual `disabled` flip) inside
@@ -1751,6 +1834,44 @@ audit (#1207) locked in. New CTAs:
   every keyboard / screen-reader user. New surfaces add visible
   buttons in the same shape as `.queue-row` (admin moderation
   queue) or the comms-list desktop table (`web/themes/default/page_comms.tpl`).
+- Viewport-based `@media` queries for hiding `.table` columns
+  (`@media (max-width: 1535px) { .col-tier-2 { display: none; } }`
+  shape) → use `@container tablescroll (max-width: …)` rules
+  against the container context `.table-scroll` carries (post-#1363
+  it ships `container-type: inline-size; container-name: tablescroll;`).
+  The viewport-keyed predecessors silently missed the page-cap on
+  every list page — bans / comms cap their outer wrapper at 1700px,
+  most other list pages cap at 1400px, and at viewport `>=1688px` the
+  painted card is the same fixed width regardless of how wide the
+  screen is. A 1920px monitor saw the same scroll-required layout as
+  a 1535px laptop because the viewport breakpoint kept tier-2 / tier-3
+  visible at both even though the painted card was identical (1352px
+  on the 1400px-capped pages). Container queries on `.table-scroll`
+  see the actual painted width and react accordingly. See
+  "Responsive desktop-table chrome" in Conventions for the full
+  contract; the regression guards are
+  `web/tests/e2e/specs/flows/banlist-table-columns.spec.ts` (asserts
+  Remove button reachability at 1280 / 1440 / 1920px) and
+  `web/tests/e2e/specs/flows/banlist-ip-column.spec.ts` (asserts the
+  IP column — tier-3 — is visible at 1920px).
+- Lifting an arbitrary list page's outer-wrapper `max-width` past
+  1400px without auditing every column's per-row content cost →
+  bans / comms specifically lifted to 1700px at #1363 because (a)
+  the columns include the row-actions cell which can't shrink past
+  the action-button text labels, and (b) the SecondsToString-built
+  Length column is the single biggest contributor to the table
+  min-content. The lift only paid off because the column-tier
+  hiding migrated to container queries in the same commit so the
+  wider card actually surfaces tier-3 columns at viewport
+  `>=1788px`. A naive "raise the cap on every list page so users
+  with wide monitors see more" loses the value the cap provides
+  (line lengths in cell content stay readable; page chrome doesn't
+  feel windswept on ultrawide monitors) AND, on pages where the
+  column-tier classes were never added (admin reports, audit log,
+  etc.), exposes the row to clipping or the in-card horizontal
+  scroll the wrapper was supposed to be a safety net for, not a
+  primary scrolling surface. The 1700px cap is justified per page;
+  most list pages should stay at 1400px.
 - Non-wrapping `display: flex` on `.table .row-actions` (the
   pre-#1359 shape: `display: flex; gap: 0.25rem; justify-content:
   flex-end` with NO `flex-wrap: wrap`) → with 3+ buttons carrying
@@ -2000,7 +2121,7 @@ audit (#1207) locked in. New CTAs:
 | Add an E2E spec                        | `web/tests/e2e/specs/<smoke|flows|a11y|responsive>/...` + `web/tests/e2e/pages/...` |
 | Add a route to the screenshot gallery  | `web/tests/e2e/specs/_screenshots.spec.ts` (`ROUTES` array) |
 | Tweak mobile (<=768px) chrome layout   | `web/themes/default/css/theme.css` — see the `#1207` `@media (max-width: 768px)` blocks for the canonical shapes (icon-only topbar search, full-width drawer + scroll lock). Sub-paged admin routes (servers / mods / groups / comms / settings / admins / bans) use the `<details open>` accordion in the `#1259` `@media (min-width: 1024px)` block (sidebar inline at `<1024px`, sticky 14rem rail at `>=1024px`); see "Sub-paged admin routes" in Conventions. |
-| Hide non-essential desktop-table columns at narrow viewports (intermediate 769–1100px zone where the natural sum of column widths exceeds the panel and `.table-scroll` falls back to horizontal scroll inside the card) | `.col-tier-2` (hide at `<=1100px`) and `.col-tier-3` (hide at `<=900px`) classes in `web/themes/default/css/theme.css` (next to `.table-scroll`). Apply to BOTH the `<th>` AND the matching `<td>` so the column hides as a unit (otherwise rows go out of alignment). Tier-1 columns are always visible — Player, SteamID, Reason (banlist) / Type (commslist), Status, Actions; the minimum row still answers "who, why, what state, what can I do". `.table-scroll` stays wrapped around the table as a defensive safety net. The mobile card layout (`.ban-cards`) takes over at `<=768px`, so the tier classes only collapse the desktop table at intermediate viewports. Reference: banlist `<th>` row in `page_bans.tpl` (Server / Admin → tier-2; IP / Length / Banned → tier-3); commslist row in `page_comms.tpl` (Server / Admin → tier-2; Length / Started → tier-3). |
+| Hide non-essential desktop-table columns when the card is too narrow to fit every cell without horizontal scroll | `.col-tier-2` (hide via `@container tablescroll (max-width: 1200px)`) and `.col-tier-3` (hide via `@container tablescroll (max-width: 1500px)`) in `web/themes/default/css/theme.css` (next to `.table-scroll`). Apply to BOTH the `<th>` AND the matching `<td>` so the column hides as a unit. Tier-3 hides FIRST despite the lower tier-number because the wider trio (IP / Length / Banned / Started, ~552px) reclaims more room than tier-2 (Server / Admin, ~219px). Tier-1 columns are always visible — Player, SteamID, Reason (banlist) / Type+Player (commslist), Status, Actions; the minimum row still answers "who, why, what state, what can I do". The breakpoints are `@container tablescroll (...)` rules — they react to the painted width of `.table-scroll` (which carries `container-type: inline-size; container-name: tablescroll;`), NOT the viewport. This lets the breakpoints see the page-cap (1400px on most lists, 1700px on bans / comms post-#1363) — pre-#1363 the predecessors were viewport-keyed (`@media (max-width: 1535px)`) and a 1920px monitor saw the same scroll-required layout as a 1535px laptop because both painted an identical 1352px card under the 1400px page-cap. `.table-scroll` stays wrapped around the table as the runtime overflow safety net. The mobile card layout (`.ban-cards`) takes over at `<=768px`, so the tier classes only collapse the desktop table at intermediate viewports. Reference: banlist `<th>` row in `page_bans.tpl` (Server / Admin → tier-2; IP / Length / Banned → tier-3); commslist row in `page_comms.tpl` (Server / Admin → tier-2; Length / Started → tier-3). See "Responsive desktop-table chrome" in Conventions for the full pattern. |
 | Surface the full reason on a truncated row (banlist Reason column / mobile card reason line / unban-reason inline span) | `title="…"` attribute on the truncated element. The browser's native tooltip fires on hover (desktop) / long-press (mobile) and exposes the un-truncated text; no JS needed. Reference: `page_bans.tpl` desktop reason `<td>` (gates on `!empty($ban.reason)` so empty rows don't get a useless empty `title=""`), the mobile-card reason line, the `[data-testid="ban-unban-reason"]` span, the Server cell, and the matching `[data-testid="comm-unban-reason"]` span on `page_comms.tpl`. Don't use `title=""` empty-string fallbacks — the conditional gate is the contract. |
 | Stop mobile browsers auto-linking SteamIDs / IPs as phone numbers | `web/themes/default/core/header.tpl` (`<meta name="format-detection" content="telephone=no…">` + `<meta name="x-apple-data-detectors">`) and the defensive `.drawer a[href^="tel:"]` reset in `theme.css` |
 | Lock page scroll while a modal-style chrome is open | `web/themes/default/css/theme.css` (`html:has(#drawer-root[data-drawer-open="true"]) { overflow: hidden; }` — pure-CSS, gates on the same `data-drawer-open` mirror theme.js sets, applies at every viewport so the drawer-open contract is symmetric desktop/mobile per the Linear/Vercel/Notion modal idiom) |

--- a/web/tests/e2e/specs/flows/banlist-ip-column.spec.ts
+++ b/web/tests/e2e/specs/flows/banlist-ip-column.spec.ts
@@ -88,16 +88,19 @@ test.describe('flow: banlist IP column visible to admin (#1302)', () => {
         isMobile,
     }) => {
         await seedBanWithIp(page);
-        // #1359 bumped tier-3 (IP / Length / Banned) to hide at
-        // <=1280px. The Playwright `Desktop Chrome` device defaults
-        // to 1280x720 which sits ON the breakpoint, hiding the IP
-        // column the desktop arm of this test asserts on. Resize to
-        // a viewport that surfaces tier-3 (any width > 1280 works;
-        // 1440 is the canonical "laptop with tier-3 visible"
-        // reference). Mobile arm is unaffected — the `isMobile`
-        // branch below renders `.ban-cards` regardless.
+        // #1363 migrated tier-3 hiding from viewport-based @media
+        // queries to container queries on `.table-scroll`. Tier-3
+        // (IP / Length / Banned) now hides whenever the card is
+        // <=1500px, which on the bans-list root's max-width:1700px
+        // wrapper means tier-3 is visible only at viewport >=
+        // ~1788px (card width = viewport - sidebar 240 - padding 48).
+        // 1920 is the canonical "wide desktop with tier-3 visible"
+        // reference; the previous 1440 target now hides tier-3
+        // because the card paints at 1152 (< 1500). Mobile arm
+        // is unaffected — the `isMobile` branch below renders
+        // `.ban-cards` regardless.
         if (!isMobile) {
-            await page.setViewportSize({ width: 1440, height: 720 });
+            await page.setViewportSize({ width: 1920, height: 720 });
         }
         await page.goto('/index.php?p=banlist');
 

--- a/web/tests/e2e/specs/flows/banlist-table-columns.spec.ts
+++ b/web/tests/e2e/specs/flows/banlist-table-columns.spec.ts
@@ -39,13 +39,16 @@ test.describe('flow: banlist desktop column geometry (#1207 PUB-1)', () => {
     });
 
     test('STATUS header reads in full and the BANNED cell is one line', async ({ page }) => {
-        // #1359 bumped tier-3 (IP / Length / Banned) to hide at
-        // <=1280px. The Playwright `Desktop Chrome` device defaults to
-        // 1280x720 which sits ON the breakpoint, hiding the BANNED
-        // column we want to measure. Resize to a viewport that
-        // surfaces tier-3 (any width > 1280 works; 1440 is the
-        // canonical "laptop with tier-3 visible" reference).
-        await page.setViewportSize({ width: 1440, height: 720 });
+        // #1363 migrated tier-3 hiding from viewport-based @media
+        // queries to container queries on `.table-scroll`. Tier-3
+        // (IP / Length / Banned) now hides whenever the card is
+        // <=1500px, which on the bans-list root's max-width:1700px
+        // wrapper means tier-3 is visible only at viewport >=
+        // ~1788px (card width = viewport - sidebar 240 - padding 48).
+        // 1920 is the canonical "wide desktop with tier-3 visible"
+        // reference; the previous 1440 target now hides tier-3
+        // because the card paints at 1152 (< 1500).
+        await page.setViewportSize({ width: 1920, height: 720 });
         await page.goto('/index.php?p=banlist');
 
         const table = page.locator('#banlist-root .table');
@@ -195,17 +198,19 @@ test.describe('flow: banlist desktop column geometry (#1207 PUB-1)', () => {
         await expect(removeBtn).toBeVisible();
 
         // Sample three breakpoints across the desktop range to pin
-        // the contract end-to-end:
-        //   - 1280px: tier-2 + tier-3 both hidden (only tier-1 visible).
-        //   - 1440px: tier-2 still hidden, tier-3 surfaces (IP / Length
-        //     / Banned join Player / SteamID / Reason / Status /
-        //     Actions).
-        //   - 1920px: every column visible (page max-width 1400 caps
-        //     the surface; sidebar + padding still leaves comfortable
-        //     room).
-        // A regression that drops `flex-wrap: wrap` OR drops the
-        // tier-2 / tier-3 breakpoint bumps will paint Remove past
-        // the card's right edge at at least one of these viewports.
+        // the contract end-to-end (post-#1363, container-query era):
+        //   - 1280px: card ~975px → both tiers hidden. Only Player /
+        //     SteamID / Reason / Status / Actions render.
+        //   - 1440px: card ~1135px → both tiers hidden (1135 < 1500
+        //     trips tier-3, < 1200 trips tier-2). Same 5-column shape
+        //     as 1280.
+        //   - 1920px: card ~1615px (page-cap 1700 → 1652px max,
+        //     viewport-cap 1920-288=1632px wins) → both tiers
+        //     visible (1615 > 1500 / > 1200). Every column renders.
+        // A regression that drops `flex-wrap: wrap`, drops the
+        // container-query breakpoints, or fails to wrap the table
+        // in `.table-scroll` will paint Remove past the card's right
+        // edge at at least one of these viewports.
         for (const vw of [1280, 1440, 1920]) {
             await page.setViewportSize({ width: vw, height: 720 });
 

--- a/web/themes/default/css/theme.css
+++ b/web/themes/default/css/theme.css
@@ -1136,14 +1136,32 @@ html.dark .table thead tr { background: rgb(255 255 255 / 0.02); }
       ends up exactly as wide as the natural content of "Status"
       (header) / its pill, freeing the rest of the row for the
       truncate-able Player / Reason / Server columns.
-   2. Wrap the `<table>` in `.table-scroll` (page_bans.tpl) so when
-      the parent is narrower than the natural sum of column widths
-      (1024-1100px viewport zone after the sidebar collapses, plus
-      any unusually long player / reason combos) the table scrolls
-      horizontally instead of clipping the rightmost column. The
-      card's rounded corners stay intact because the card itself
-      keeps its own `overflow: hidden`. */
-.table-scroll { overflow-x: auto; }
+   2. Wrap the `<table>` in `.table-scroll` (page_bans.tpl AND
+      page_comms.tpl post-#1363) so when the parent is narrower than
+      the natural sum of column widths (1024-1100px viewport zone
+      after the sidebar collapses, plus any unusually long player /
+      reason combos) the table scrolls horizontally instead of
+      clipping the rightmost column. The card's rounded corners stay
+      intact because the card itself keeps its own `overflow: hidden`.
+
+   3. (#1363) Promote `.table-scroll` to a CSS container via
+      `container-type: inline-size` so the responsive column-tier
+      hiding below can react to the ACTUAL card width, not just the
+      viewport. Most page-section / list-page wrappers cap at 1400px
+      max-width (1352px usable card after 1.5rem padding); the bans
+      and comms lists specifically lift their cap to 1700px (#1363)
+      so wide-monitor users actually see tier-3 columns. Pre-#1363
+      the tier breakpoints were keyed off the viewport
+      (`@media (max-width: 1535px)` etc.) and missed both caps — a
+      1920px monitor saw the same scroll-required layout as a 1535px
+      laptop because both fell into the "all tiers visible" arm even
+      though the painted card was identical (1352px on the
+      pre-#1363 1400px-capped pages). */
+.table-scroll {
+  overflow-x: auto;
+  container-type: inline-size;
+  container-name: tablescroll;
+}
 .table .col-length,
 .table .col-banned,
 .table .col-admin,
@@ -1151,11 +1169,34 @@ html.dark .table thead tr { background: rgb(255 255 255 / 0.02); }
 .table .col-status,
 .table .col-actions { white-space: nowrap; }
 .table .col-status { width: 1%; }
+/* #1363: cap the Length column. SecondsToString builds strings like
+   "1 mo, 2 wk, 4 d, 8 hr, 19 min, 33 sec" — six units of granularity
+   for one row of a list view, which pushed the column to ~280px on
+   the seeded medium-scale dataset and was the single biggest
+   contributor to the bans-list min-content blowing past the card
+   width. Pin to ~10rem (160px) and truncate; the title= attribute
+   on the cell carries the full string for hover / long-press, so no
+   information is lost — only the per-row real estate it eats. The
+   Length cell paints the truncated text + ellipsis directly via
+   `text-overflow: ellipsis` (no inner span needed). The col-banned
+   column does NOT get the same treatment: its content is a fixed-
+   width "YYYY-MM-DD HH:MM:SS" timestamp that doesn't vary per row
+   the way Length does, so capping it would just emit ellipsis on
+   every row without trimming anything meaningful. */
+.table .col-length {
+  max-width: 10rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
 
 /* Responsive column-tier hiding (issue: "scroll table at the bottom of a
    banlist, making the user experience not fluid"; #1359 expanded the
    breakpoints after the #1354 row-action parity sweep pushed the
-   table well past the panel at common laptop viewports).
+   table well past the panel at common laptop viewports; #1363
+   migrated to container queries on `.table-scroll` to fix the
+   1440 / 1920 viewport regression where the page-section cap left
+   ~1352px of usable card on EVERY viewport >= 1688px while the
+   media-query-based breakpoints kept tier-2 / tier-3 visible there).
    ----------------------------------------------------------------------
    The banlist / commslist desktop tables carry 9-10 columns. The
    sidebar collapses at <=1023px, so above that it eats 15rem (240px)
@@ -1167,10 +1208,12 @@ html.dark .table thead tr { background: rgb(255 255 255 / 0.02); }
    rightmost row-action button silently sits off the visible edge
    (#1359 was the user-reported regression: the Remove button hidden
    behind in-card scroll after #1354 added the text-labelled Edit /
-   Unban / Re-apply / Copy / Remove chain). Horizontal scroll on a
-   list view is also the canonical "broken UX" smell on a touch
-   viewport (no scrollbar; users have to swipe inside a nested
-   scroll container).
+   Unban / Re-apply / Copy / Remove chain; #1363 was the recurrence
+   on 1440 / 1920 viewports the #1359 viewport-based fix didn't
+   reach because the page-cap created a 1352px card ceiling there
+   too). Horizontal scroll on a list view is the canonical "broken
+   UX" smell on a touch viewport (no scrollbar; users have to swipe
+   inside a nested scroll container).
 
    Two-tier responsive hide: every column carries a tier class on
    BOTH the `<th>` AND the matching `<td>` so the column hides as a
@@ -1180,44 +1223,61 @@ html.dark .table thead tr { background: rgb(255 255 255 / 0.02); }
      - Tier-1 (always visible): Player, SteamID, Reason (banlist) /
        Type+Player (commslist), Status, Actions. The minimum row
        still answers "who, why, what state, what can I do".
-     - Tier-2 (`.col-tier-2`): hidden at <=1535px. Server, Admin —
-       useful but not essential for moderation triage; both surface
-       on the player drawer / card detail anyway. The breakpoint
-       covers every common laptop / small-desktop viewport
-       (1280 / 1366 / 1440 / 1536-with-sidebar) where main = vw -
-       240 (sidebar) - 48 (padding) falls short of the natural
-       table width with these columns visible. At 1536px viewport
-       exactly the sidebar leaves ~1248px — the table without
-       tier-2 fits in ~1097px and with tier-2 in ~1246px, so
-       <=1535 is the precise edge.
-     - Tier-3 (`.col-tier-3`): hidden at <=1280px. IP / Length /
-       Banned / Started — historical metadata that's nice to glance
-       but cheap to drop on a narrow viewport. The breakpoint
-       matches the smaller "tight" laptop range where even
-       hiding tier-2 leaves the table ~120px wider than the card;
-       dropping tier-3 there brings the visible row down to the
-       five tier-1 columns (Player + SteamID + Reason + Status +
-       Actions ≈ 808px) which fits comfortably with room to spare.
-       Pre-#1359 the breakpoints were <=1100 / <=900 — calibrated
-       for the pre-sidebar / pre-row-action-labels world that no
-       longer matches the chrome's actual horizontal budget.
+     - Tier-3 (`.col-tier-3`): hidden first via `@container` when
+       the card is <=1500px. IP / Length / Banned / Started carry
+       the WIDEST per-row content — Length on the bans list is
+       SecondsToString's "1 mo, 2 wk, 4 d, 8 hr, 19 min, 33 sec"
+       format which alone occupies ~280px (capped to ~160px above
+       via `.col-length`'s max-width / truncate, but still the
+       single biggest contributor to the table min-content). The
+       trio hides ~552px at once; the 1500px threshold catches
+       every desktop card width on a 1400px page-cap (max card
+       ~1352px) so tier-3 is functionally always hidden on those
+       pages. On the bans / comms lists which lifted the page-cap
+       to 1700px (max card ~1652px), tier-3 surfaces at viewports
+       wider than ~1788px (card width = viewport - 240px sidebar -
+       48px padding > 1500). The data still reaches the moderator
+       via the player drawer (one click) and the mobile `.ban-cards`
+       chrome at <=768px regardless of which page is active.
+     - Tier-2 (`.col-tier-2`): hidden at <=1200px container. Server
+       and Admin — useful but not essential for moderation triage;
+       both surface on the player drawer / card detail anyway.
+       1200px catches the 1280-viewport laptop case (card ~975px),
+       so at the smallest desktop the table drops to its tier-1
+       core. Pre-#1363 tier-2 hid FIRST at <=1535 viewport — that
+       priority was inverted because the actual width contribution
+       of tier-2 (Server + Admin ≈ 219px) is much smaller than
+       tier-3 (~552px). Dropping the wider trio first is what
+       actually reclaims room.
 
-   The mobile card layout (`.ban-cards`) takes over completely at
-   <=768px (theme.css `.table { display: none }`), so the tier
-   classes are never the visible chrome at mobile widths. They only
-   collapse the desktop table at intermediate viewports.
+   `.table-scroll` carries the `container-type: inline-size`
+   container context (above) so these `@container` rules see the
+   ACTUAL painted width of the table card, not the viewport. Pages
+   with a 1400px page-cap have a fixed ~1352px card on every viewport
+   wide enough to hit it; the viewport-based predecessors couldn't
+   see that, so a 1920px monitor and a 1535px laptop both fell into
+   the "all tiers visible" arm even though the painted card was
+   identical. `.table-scroll` is a sibling of `.card`'s padding
+   boundary, so its inline-size IS the card's content width.
 
-   `.table-scroll` stays wrapped around the table as a defensive
-   safety net — if a row's content (long player name + long reason)
-   still exceeds the panel after tier-3 hiding, it scrolls instead
-   of clipping. The `flex-wrap: wrap` on `.table .row-actions`
-   above is the sister-guard that keeps the row-action cell itself
-   from being the single column that blows the budget. */
-@media (max-width: 1535px) {
-  .table .col-tier-2 { display: none; }
-}
-@media (max-width: 1280px) {
+   The mobile card layout (`.ban-cards` for bans, the comm-list's
+   own mobile rendering) takes over completely at <=768px (theme.css
+   `.table { display: none }`), so these tier classes never apply to
+   mobile chrome. They only collapse the desktop table at
+   intermediate viewports.
+
+   `.table-scroll` is also the runtime escape hatch — if a row's
+   content (long player name + long reason) still exceeds the card
+   after tier-3 hiding, it scrolls horizontally inside the card
+   rather than clipping the rightmost cell. The `flex-wrap: wrap`
+   on `.table .row-actions` above is the sister-guard that keeps
+   the row-action cell itself from being the single column that
+   blows the budget. */
+@container tablescroll (max-width: 1500px) {
   .table .col-tier-3 { display: none; }
+}
+@container tablescroll (max-width: 1200px) {
+  .table .col-tier-2 { display: none; }
 }
 
 /* ---- Avatar ---- */

--- a/web/themes/default/page_bans.tpl
+++ b/web/themes/default/page_bans.tpl
@@ -60,7 +60,7 @@
 </div>
 {else}
 
-<div id="banlist-root" class="p-6 space-y-4" style="max-width:1400px;margin:0 auto" data-loading="false">
+<div id="banlist-root" class="p-6 space-y-4" style="max-width:1700px;margin:0 auto" data-loading="false">
   <div class="flex items-center justify-between gap-3" style="flex-wrap:wrap">
     <div>
       <h1 style="font-size:var(--fs-2xl);font-weight:600;margin:0">Ban list</h1>
@@ -430,7 +430,13 @@
             {if empty($ban.aname)}<i class="text-faint">deleted</i>{else}{$ban.aname|escape}{/if}
           </td>
           {/if}
-          <td class="col-length col-tier-3 tabular-nums text-muted">{if $ban.length == 0}Permanent{else}{$ban.length_human|escape}{/if}</td>
+          {* #1363: title= surfaces the full SecondsToString breakdown
+             ("1 mo, 2 wk, 4 d, 8 hr, 19 min, 33 sec") when the cell's
+             max-width truncates a long ban length to fit the tier-3
+             column budget. Same shape as the Reason / Server cells'
+             title= treatment. *}
+          <td class="col-length col-tier-3 tabular-nums text-muted"
+              {if $ban.length != 0}title="{$ban.length_human|escape}"{/if}>{if $ban.length == 0}Permanent{else}{$ban.length_human|escape}{/if}</td>
           <td class="col-banned col-tier-3 text-muted text-xs"><time datetime="{$ban.banned_iso}">{$ban.banned_human|escape}</time></td>
           <td class="col-status">
             {assign var=_pill_label value=$ban.state|capitalize}

--- a/web/themes/default/page_comms.tpl
+++ b/web/themes/default/page_comms.tpl
@@ -19,7 +19,7 @@
     Testability hooks (`data-testid`) match the B4 spec: comm-row /
     filter-chip-* / row-action-* / page-prev / page-next / comms-search.
 *}
-<div class="p-6 space-y-4" style="max-width:1400px;margin:0 auto;width:100%">
+<div class="p-6 space-y-4" style="max-width:1700px;margin:0 auto;width:100%">
 
     {* -- Page header --------------------------------------------------- *}
     <header class="flex items-center justify-between gap-4" style="flex-wrap:wrap" data-testid="comms-header">
@@ -182,24 +182,31 @@
 
     {* -- Desktop table ------------------------------------------------
          Column tier classes (`.col-tier-2` / `.col-tier-3`) are paired
-         rules in `theme.css` next to `.table-scroll`. Tier-2 (Server,
-         Admin) hides at <=1100px; tier-3 (Length, Started) at <=900px.
-         Tier-1 (Type, Player, SteamID, Status, Actions) always renders
-         so the row stays useful without horizontal scroll. Mirror of
-         the banlist treatment for visual + responsive consistency. *}
+         with the `.table-scroll` container queries in `theme.css`.
+         Tier-3 (Length, Started) hides first when the card is
+         <=1500px; tier-2 (Server, Admin) hides at <=1200px. Tier-1
+         (Type, Player, SteamID, Status, Actions) always renders so
+         the row stays useful without horizontal scroll. The
+         `.table-scroll` wrapper carries `container-type: inline-size`
+         (theme.css) so the breakpoints react to the painted card
+         width — needed because the page-section cap at 1400px makes
+         every viewport >= 1688px paint an identical 1352px card,
+         which the previous viewport-based @media queries couldn't
+         see (#1363). Same chrome shape as `page_bans.tpl`. *}
     <div class="card" style="overflow:hidden">
+        <div class="table-scroll">
         <table class="table" data-testid="comms-table">
             <thead>
                 <tr>
                     <th>Type</th>
                     <th>Player</th>
                     <th>SteamID</th>
-                    <th class="col-tier-3">Length</th>
+                    <th class="col-length col-tier-3">Length</th>
                     <th class="col-tier-2">Server</th>
-                    <th class="col-tier-2">Admin</th>
+                    <th class="col-admin col-tier-2">Admin</th>
                     <th class="col-tier-3">Started</th>
-                    <th>Status</th>
-                    <th aria-label="Actions"></th>
+                    <th class="col-status">Status</th>
+                    <th class="col-actions" aria-label="Actions"></th>
                 </tr>
             </thead>
             <tbody>
@@ -290,9 +297,10 @@
                             </div>
                         </td>
                         <td class="font-mono text-xs text-muted">{$comm.steam|escape}</td>
-                        <td class="col-tier-3 tabular-nums text-muted">{$comm.length_human|escape}</td>
+                        <td class="col-length col-tier-3 tabular-nums text-muted"
+                            {if !empty($comm.length_human)}title="{$comm.length_human|escape}"{/if}>{$comm.length_human|escape}</td>
                         <td class="col-tier-2 text-muted">{$comm.sname|escape}</td>
-                        <td class="col-tier-2 text-muted">
+                        <td class="col-admin col-tier-2 text-muted">
                             {if $comm.admin}
                                 {$comm.admin|escape}
                             {else}
@@ -302,7 +310,7 @@
                         <td class="col-tier-3 text-muted text-xs">
                             <time datetime="{$comm.started_iso|escape}">{$comm.started_human|escape}</time>
                         </td>
-                        <td>
+                        <td class="col-status">
                             <span class="pill pill--{$comm.state}" style="text-transform:capitalize">{$comm.state|escape}</span>
                         </td>
                         <td class="col-actions">
@@ -419,6 +427,7 @@
                 {/foreach}
             </tbody>
         </table>
+        </div>{* /.table-scroll *}
 
         {* -- Mobile cards --------------------------------------------- *}
         {* #1207 ADM-5: each card is now a `<div>` wrapping (a) a


### PR DESCRIPTION
## Summary

Fixes the bans-list horizontal scrollbar that survived #1360 plus the
commslist row-action chrome inconsistency reported alongside it.

- **Root cause**: #1359's viewport-keyed `@media` queries (tier-2
  `<=1535px`, tier-3 `<=1280px`) silently missed the page-cap at
  `max-width: 1400px`. At any viewport `>=1688px` the painted card
  was a fixed ~1352px, but the breakpoints kept tier-2 / tier-3
  visible there → the table's natural width pushed past the card
  and `.table-scroll`'s `overflow-x: auto` triggered the in-card
  scroll the wrapper was supposed to be a defensive safety net for.
  The commslist also still lacked the `.table-scroll` wrapper
  entirely + a couple of `col-*` classes, so the `.row-actions`
  cells laid out differently across the two surfaces.
- **Fix**: promoted `.table-scroll` to a CSS container
  (`container-type: inline-size; container-name: tablescroll`),
  migrated tier-2 / tier-3 hiding to `@container tablescroll` rules,
  inverted the tier priority so the wider trio drops FIRST, capped
  `.col-length` at 10rem with `text-overflow: ellipsis` + a `title=`
  attribute for the full SecondsToString string on hover, lifted the
  bans / comms outer-wrapper `max-width` 1400 → 1700 so wide-monitor
  users actually see tier-3 columns at viewport `>=1788px`, and
  wrapped `page_comms.tpl`'s desktop table in `.table-scroll` with
  matching `col-*` classes for chrome parity.
- **Docs**: new "Responsive desktop-table chrome (container queries +
  tiered column hiding)" convention block in AGENTS.md, two new
  anti-patterns (viewport-based `@media` for table-column hiding,
  naive page-cap lifting), updated "Where to find what" entry.

### Before / after

|  | Before (post-#1360) | After |
| --- | --- | --- |
| 1280px viewport | tier-2 hidden, tier-3 visible → table overflows card → in-card horizontal scroll | both tiers hidden → 5-column tier-1 row fits comfortably, no scroll |
| 1440px viewport | both visible → table overflows card → in-card horizontal scroll | both tiers hidden → 5-column tier-1 row fits, no scroll |
| 1920px viewport | both visible → painted card stays at 1352px under 1400px page-cap → table overflows → scroll | both tiers visible (card now ~1615px under lifted 1700px page-cap), every column renders, no scroll |

### Tests

- `web/tests/e2e/specs/flows/banlist-table-columns.spec.ts`:
  STATUS / BANNED viewport moved from 1440 → 1920 (where tier-3
  now surfaces), Remove-button test rewrote viewport rationale to
  cover the new tiers-hidden / tiers-visible split.
- `web/tests/e2e/specs/flows/banlist-ip-column.spec.ts`: desktop
  arm moved 1440 → 1920.

## Test plan

- [x] `./sbpp.sh ts-check` — clean.
- [x] `./sbpp.sh phpstan` — 0 errors.
- [x] `./sbpp.sh test --filter='BanListStateFilterTest|PublicBanListRegressionTest|BanlistCommentsVisibilityTest'` — all pass (32 tests, 106 assertions across the three suites).
- [x] `CI=1 ./sbpp.sh e2e specs/flows/banlist-table-columns.spec.ts specs/flows/banlist-ip-column.spec.ts specs/responsive/banlist.spec.ts specs/smoke/banlist.spec.ts specs/smoke/commslist.spec.ts specs/flows/comms-affordances.spec.ts specs/flows/comms-gag-mute.spec.ts specs/flows/banlist-comments-visibility.spec.ts specs/responsive/filters.spec.ts` — 19 passed, 13 skipped.
- [x] Visual smoke at 1280 / 1440 / 1920 against the seeded medium-scale dev DB — no in-card scroll on either list at any of the three viewports.