### PR TITLE
docs: add GitHub Sponsors link (topbar + landing page)

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -69,6 +69,11 @@ export default defineConfig({
           label: 'Discord',
           href: 'https://discord.gg/tzqYqmAtF5',
         },
+        {
+          icon: 'heart',
+          label: 'Sponsor rumblefrog on GitHub',
+          href: 'https://github.com/sponsors/rumblefrog',
+        },
       ],
       editLink: {
         // Source of truth lives in sourcebans-pp; the deploy shell is

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -72,3 +72,11 @@ day-to-day moderation work.
     most often.
   </Card>
 </CardGrid>
+
+---
+
+SourceBans++ is maintained by
+[@rumblefrog](https://github.com/rumblefrog) and community
+contributors in their spare time. If the project helps run your
+community and you'd like to chip in, you can
+[support it on GitHub Sponsors](https://github.com/sponsors/rumblefrog).


### PR DESCRIPTION
## Summary

The repo's `.github/FUNDING.yml` already wires `rumblefrog` for the GitHub repo's Sponsor button, but the docs site at sbpp.github.io carried no equivalent surface — anyone who only ever reads docs has no path to support the project.

Two unobtrusive placements:

- **Topbar heart icon** (`docs/astro.config.mjs` `social` array). Sits next to the existing GitHub + Discord entries; positioned last so the order reads "look at the code, join the community, support if you like." The `heart` icon is built into Starlight's icon set (verified against the bundled `@astrojs/starlight ^0.39` — `node_modules/@astrojs/starlight/components-internals/Icons.ts` ships it; no custom-icon plumbing needed).
- **Landing-page attribution + sponsor line** (`docs/src/content/docs/index.mdx`) below the navigation CardGrid. Plain prose, separated from the install / upgrade / connect / troubleshoot cards by a horizontal rule so it doesn't compete with the primary CTAs. Friendly framing ("maintained by [@rumblefrog](https://github.com/rumblefrog) and community contributors in their spare time. If the project helps run your community and you'd like to chip in…").

Sponsor URL: <https://github.com/sponsors/rumblefrog>.

No new pages, no sidebar changes, no new dependencies — pure config + content edit.

## Test plan

- [x] `npm run build` in `docs/` — clean, 20 pages, no warnings.
- [x] Topbar heart icon renders on the landing page (`dist/index.html` carries the heart SVG path + `Sponsor rumblefrog on GitHub` aria-label).
- [x] Topbar heart icon renders on inner pages (`dist/getting-started/quickstart/index.html` has 2 `sponsors/rumblefrog` references — desktop topbar + mobile menu).
- [x] Landing-page bottom line renders cleanly under the CardGrid with the `<a>` pointing at the sponsors URL.
- [ ] After merge: visual check on the deployed sbpp.github.io site (topbar icon color, hover state, mobile menu position).