### PR TITLE
docs: drop inline landing-page sponsor line

### DIFF
--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -72,11 +72,3 @@ day-to-day moderation work.
     most often.
   </Card>
 </CardGrid>
-
----
-
-SourceBans++ is maintained by
-[@rumblefrog](https://github.com/rumblefrog) and community
-contributors in their spare time. If the project helps run your
-community and you'd like to chip in, you can
-[support it on GitHub Sponsors](https://github.com/sponsors/rumblefrog).


### PR DESCRIPTION
## Summary

Follow-up to #1366 + #1368.

#1366 (already merged) added the sponsor link in two places:
1. A heart icon in the topbar (every page).
2. An inline paragraph below the landing page's CardGrid (landing only).

#1368 (open) wires a "Support SourceBans++ on GitHub Sponsors" affordance into the per-page footer via a `Footer.astro` override. Verified locally that Starlight's `splash` template DOES render the `Footer` component slot (`rg sbpp-sponsor-link docs/dist/index.html` returns a match), so once #1368 lands the inline paragraph becomes the third sponsor surface on the landing page — redundant with the footer affordance and the topbar icon.

Drop the inline paragraph. Net result on the landing page after both #1368 and this PR merge:

- Topbar heart icon (chrome, every page)
- Footer affordance (chrome, every page)

Two chrome surfaces, no content-area duplication. The right shape for "prominent but not annoying" — the user observation that triggered the cleanup.

Restores the landing page body to its post-#1364 shape (no sponsor line in the content area).

## Test plan

- [x] `npm run build` in `docs/` — clean, 20 pages, no warnings.
- [x] Single-file diff (`docs/src/content/docs/index.mdx`, 8 deletions only).
- [x] Branch is single-commit on top of `main` (after rebase to drop the duplicate of the merged #1366 commit).