### PR TITLE
docs: paint the topbar sponsor heart brand-orange to match the footer

### DIFF
--- a/docs/src/styles/sbpp.css
+++ b/docs/src/styles/sbpp.css
@@ -244,6 +244,24 @@
   letter-spacing: -0.02em;
 }
 
+/* ---- Topbar sponsor heart ----
+   The heart icon in the topbar social row (added via
+   `social: [{ icon: 'heart', href: 'https://github.com/sponsors/rumblefrog', ... }]`
+   in astro.config.mjs) lights up brand orange instead of the default
+   neutral, matching the heart inside Footer.astro's
+   `.sbpp-sponsor-link`. The two surfaces read as a unified sponsor
+   pair across the chrome.
+
+   The href-attribute selector keeps the rule surgical — GitHub +
+   Discord icons keep Starlight's default neutral hover colours. */
+.social-icons a[href*="sponsors/rumblefrog"] {
+  color: var(--sl-color-orange);
+}
+.social-icons a[href*="sponsors/rumblefrog"]:hover,
+.social-icons a[href*="sponsors/rumblefrog"]:focus-visible {
+  color: var(--sl-color-orange-high);
+}
+
 /* ---- Selection ---- */
 ::selection {
   background-color: var(--sbpp-brand-200);


### PR DESCRIPTION
## Summary

Visual polish on top of #1366 + #1368.

Pre-fix, the heart icon in the topbar social row (added in #1366) inherited Starlight's default neutral grey, while the heart inside `Footer.astro`'s `.sbpp-sponsor-link` (added in #1368) was painted in brand orange (`var(--sl-color-orange)`). The two sponsor surfaces looked unrelated and the colour mismatch broke the "unified sponsor affordance across the chrome" pairing — the topbar heart needs to read as a peer of the footer heart, not as just another social icon.

One rule added to `docs/src/styles/sbpp.css`:

```css
.social-icons a[href*="sponsors/rumblefrog"] {
  color: var(--sl-color-orange);
}
.social-icons a[href*="sponsors/rumblefrog"]:hover,
.social-icons a[href*="sponsors/rumblefrog"]:focus-visible {
  color: var(--sl-color-orange-high);
}
```

Both halves resolve via the same `--sl-color-orange` token the `Footer.astro` icon uses, so the colour matches byte-for-byte across light and dark mode:
- Light: `#d97706` (rest) → `#b45309` (hover, darker)
- Dark:  `#fbbf24` (rest) → `#fcd34d` (hover, lighter — the gold)

The href-attribute selector keeps the rule surgical — GitHub + Discord icons in the same social row keep Starlight's default neutral hover colours.

## Test plan

- [x] `npm run build` in `docs/` — clean, 20 pages.
- [x] CSS rule lands in the bundled stylesheet (`rg 'sponsors/rumblefrog' docs/dist/_astro/common.*.css` returns both the rest-state and the hover-state rule).
- [x] Single-file diff (`docs/src/styles/sbpp.css`, +18 lines).
- [ ] After merge: visual check on the deployed sbpp.github.io site (topbar heart vs footer heart match in both light + dark mode).