### PR TITLE
fix(banlist+commslist): hide Re-apply when player has another active ban

### DIFF
--- a/web/api/handlers/bans.php
+++ b/web/api/handlers/bans.php
@@ -75,14 +75,30 @@ function api_bans_add(array $params): array
     $len = $length ? $length * 60 : 0;
 
     PruneBans();
+    // Surface the conflicting bid in the error envelope so a Re-apply
+    // attempt against an unbanned/expired row gives the admin enough
+    // context to investigate the OTHER active row that's blocking the
+    // re-add (the row visibly says unbanned/expired but a sibling
+    // active ban for the same identity makes the duplicate-check fire
+    // — without the bid the admin sees "already banned" with no way
+    // to tell which row, and the Re-apply UX reads as broken). The
+    // production-realistic case (one ban, lifted, re-applied) was
+    // never affected because the unbanned row's `RemovedBy IS NOT NULL`
+    // already excludes it from the check; the bid call-out is for the
+    // multi-ban shape (legacy data, race, or admin adding a second
+    // ban while the first is still active). `LIMIT 1 ORDER BY bid DESC`
+    // picks the most recent active row, which is the one the admin
+    // most likely wants to look at.
     if ($banType === BanType::Steam) {
         $chk = $GLOBALS['PDO']->query(
-            "SELECT count(bid) AS count FROM `:prefix_bans`
+            "SELECT bid FROM `:prefix_bans`
             WHERE authid = ? AND (length = 0 OR ends > UNIX_TIMESTAMP())
-            AND RemovedBy IS NULL AND type = '0'"
+            AND RemovedBy IS NULL AND type = '0'
+            ORDER BY bid DESC LIMIT 1"
         )->single([$steam]);
-        if ((int)$chk['count'] > 0) {
-            throw new ApiError('already_banned', "SteamID: $steam is already banned.");
+        if ($chk) {
+            $existingBid = (int)$chk['bid'];
+            throw new ApiError('already_banned', "SteamID: $steam is already banned by ban #$existingBid.");
         }
 
         foreach ($userbank->GetAllAdmins() as $admin) {
@@ -93,12 +109,14 @@ function api_bans_add(array $params): array
     }
     if ($banType === BanType::Ip) {
         $chk = $GLOBALS['PDO']->query(
-            "SELECT count(bid) AS count FROM `:prefix_bans`
+            "SELECT bid FROM `:prefix_bans`
             WHERE ip = ? AND (length = 0 OR ends > UNIX_TIMESTAMP())
-            AND RemovedBy IS NULL AND type = '1'"
+            AND RemovedBy IS NULL AND type = '1'
+            ORDER BY bid DESC LIMIT 1"
         )->single([$ip]);
-        if ((int)$chk['count'] > 0) {
-            throw new ApiError('already_banned', "IP: $ip is already banned.");
+        if ($chk) {
+            $existingBid = (int)$chk['bid'];
+            throw new ApiError('already_banned', "IP: $ip is already banned by ban #$existingBid.");
         }
     }
 

--- a/web/api/handlers/comms.php
+++ b/web/api/handlers/comms.php
@@ -55,12 +55,18 @@ function api_comms_add(array $params): array
         3 => "(type = 1 OR type = 2)",
     };
 
+    // Surface the conflicting bid (most recent active row) so the
+    // admin can investigate the OTHER active block that's blocking
+    // a Re-mute / Re-gag — same shape as `api_bans_add`. Without the
+    // bid the operator sees "already blocked" with no path to the
+    // row that's holding the gate.
     $chk = $GLOBALS['PDO']->query(
-        "SELECT count(bid) AS count FROM `:prefix_comms` WHERE authid = ? AND (length = 0 OR ends > UNIX_TIMESTAMP()) AND RemovedBy IS NULL AND " . $typeW
+        "SELECT bid FROM `:prefix_comms` WHERE authid = ? AND (length = 0 OR ends > UNIX_TIMESTAMP()) AND RemovedBy IS NULL AND " . $typeW . " ORDER BY bid DESC LIMIT 1"
     )->single([$steam]);
 
-    if ((int)$chk['count'] > 0) {
-        throw new ApiError('already_blocked', "SteamID: $steam is already blocked.");
+    if ($chk) {
+        $existingBid = (int)$chk['bid'];
+        throw new ApiError('already_blocked', "SteamID: $steam is already blocked by block #$existingBid.");
     }
 
     foreach ($userbank->GetAllAdmins() as $admin) {

--- a/web/pages/admin.edit.ban.php
+++ b/web/pages/admin.edit.ban.php
@@ -156,18 +156,22 @@ if (isset($_POST['name'])) {
     PruneBans();
 
     if ($error == 0) {
-        // Check if the new steamid is already banned
+        // Check if the new steamid is already banned. Surface the
+        // conflicting bid so the admin can investigate the OTHER
+        // active row that's blocking this edit (mirrors the same
+        // wording the JSON `bans.add` action emits — see
+        // `web/api/handlers/bans.php::api_bans_add`).
         if ($postBanType === BanType::Steam) {
-            $GLOBALS['PDO']->query("SELECT count(bid) AS count FROM `:prefix_bans` WHERE authid = :authid AND (length = 0 OR ends > UNIX_TIMESTAMP()) AND RemovedBy IS NULL AND type = '0' AND bid != :bid");
+            $GLOBALS['PDO']->query("SELECT bid FROM `:prefix_bans` WHERE authid = :authid AND (length = 0 OR ends > UNIX_TIMESTAMP()) AND RemovedBy IS NULL AND type = '0' AND bid != :bid ORDER BY bid DESC LIMIT 1");
             $GLOBALS['PDO']->bindMultiple([
                 ':authid' => $_POST['steam'],
                 ':bid'    => (int) $_GET['id'],
             ]);
             $chk = $GLOBALS['PDO']->single();
 
-            if ((int) $chk['count'] > 0) {
+            if ($chk) {
                 $error++;
-                $validationErrors['steam'] = 'This SteamID is already banned';
+                $validationErrors['steam'] = 'This SteamID is already banned by ban #' . (int) $chk['bid'];
             } else {
                 // Check if player is immune
                 $admchk = $userbank->GetAllAdmins();
@@ -181,16 +185,16 @@ if (isset($_POST['name'])) {
             }
         } elseif ($postBanType === BanType::Ip) {
             // Check if the ip is already banned
-            $GLOBALS['PDO']->query("SELECT count(bid) AS count FROM `:prefix_bans` WHERE ip = :ip AND (length = 0 OR ends > UNIX_TIMESTAMP()) AND RemovedBy IS NULL AND type = '1' AND bid != :bid");
+            $GLOBALS['PDO']->query("SELECT bid FROM `:prefix_bans` WHERE ip = :ip AND (length = 0 OR ends > UNIX_TIMESTAMP()) AND RemovedBy IS NULL AND type = '1' AND bid != :bid ORDER BY bid DESC LIMIT 1");
             $GLOBALS['PDO']->bindMultiple([
                 ':ip'  => $_POST['ip'],
                 ':bid' => (int) $_GET['id'],
             ]);
             $chk = $GLOBALS['PDO']->single();
 
-            if ((int) $chk['count'] > 0) {
+            if ($chk) {
                 $error++;
-                $validationErrors['ip'] = 'This IP is already banned';
+                $validationErrors['ip'] = 'This IP is already banned by ban #' . (int) $chk['bid'];
             }
         }
     }

--- a/web/pages/admin.edit.comms.php
+++ b/web/pages/admin.edit.comms.php
@@ -80,17 +80,21 @@ if (isset($_POST['name'])) {
     PruneComms();
 
     if ($error == 0) {
-        // Check if the new steamid is already banned
-        $GLOBALS['PDO']->query("SELECT count(bid) AS count FROM `:prefix_comms` WHERE authid = :authid AND RemovedBy IS NULL AND type = :type AND bid != :bid AND (length = 0 OR ends > UNIX_TIMESTAMP())");
+        // Check if the new steamid is already blocked. Surface the
+        // conflicting bid so the admin can investigate the OTHER
+        // active row that's blocking this edit (mirror of the JSON
+        // `comms.add` action — see `web/api/handlers/comms.php`).
+        $GLOBALS['PDO']->query("SELECT bid FROM `:prefix_comms` WHERE authid = :authid AND RemovedBy IS NULL AND type = :type AND bid != :bid AND (length = 0 OR ends > UNIX_TIMESTAMP()) ORDER BY bid DESC LIMIT 1");
         $GLOBALS['PDO']->bindMultiple([
             ':authid' => $_POST['steam'],
             ':type'   => (int) $_POST['type'],
             ':bid'    => (int) $_GET['id'],
         ]);
         $chk = $GLOBALS['PDO']->single();
-        if ((int) $chk['count'] > 0) {
+        if ($chk) {
             $error++;
-            $errorScript .= "$('steam.msg').innerHTML = 'This SteamID is already blocked';";
+            $existingBid = (int) $chk['bid'];
+            $errorScript .= "$('steam.msg').innerHTML = 'This SteamID is already blocked by block #" . $existingBid . "';";
             $errorScript .= "$('steam.msg').setStyle('display', 'block');";
         } else {
             // Check if player is immune

--- a/web/pages/page.banlist.php
+++ b/web/pages/page.banlist.php
@@ -839,7 +839,19 @@ foreach ($res as $row) {
         $GLOBALS['PDO']->bind(':ip', $row['ban_ip']);
         $alrdybnd = $GLOBALS['PDO']->single();
     }
-    if ($alrdybnd['count'] == 0) {
+    // `has_active_sibling` is the v2.0 template's hook for hiding the
+    // Re-apply affordance when the player is already actively banned by
+    // another row (which the duplicate-check in `bans.add` would
+    // reject). The legacy `$data['reban_link']` keys off the same flag
+    // for third-party theme back-compat — the template (`page_bans.tpl`)
+    // gates Re-apply on `!$ban.has_active_sibling`. Re-apply candidates
+    // are the row's OWN state filter (expired / unbanned); for those
+    // states the row itself never matches the active-check predicate
+    // (`(length=0 OR ends > now) AND RemovedBy IS NULL`), so this
+    // count is "siblings only" without an explicit `bid !=` exclusion.
+    $hasActiveSibling = (int) $alrdybnd['count'] > 0;
+    $data['has_active_sibling'] = $hasActiveSibling;
+    if (!$hasActiveSibling) {
         // #1275 — admin-bans is Pattern A; the legacy `#^0` fragment
         // anchored the old page-toc add-ban section. The page handler
         // infers `add-ban` from `?rebanid=` directly (see the smarter-

--- a/web/pages/page.commslist.php
+++ b/web/pages/page.commslist.php
@@ -660,14 +660,21 @@ foreach ($res as $row) {
     }
 
     $data['layer_id'] = 'layer_' . $row['ban_id'];
-    // Запрос текущего статуса игрока для рисования ссылки на мьют или гаг
+    // Запрос текущего статуса игрока для рисования ссылки на мьют или гаг.
+    // Mirror of the banlist's `has_active_sibling` shape — see
+    // `web/pages/page.banlist.php` for the rationale. The Re-mute /
+    // Re-gag affordance must hide when the player already has an
+    // active block of the same type (the duplicate-check in
+    // `comms.add` would 4xx as `already_blocked`).
     $GLOBALS['PDO']->query("SELECT count(bid) as count FROM `:prefix_comms` WHERE authid = :authid AND RemovedBy IS NULL AND type = :type AND (length = 0 OR ends > UNIX_TIMESTAMP())");
     $GLOBALS['PDO']->bindMultiple([
         ':authid' => $data['steamid'],
         ':type'   => $data['type'],
     ]);
     $alrdybnd         = $GLOBALS['PDO']->single();
-    if ($alrdybnd['count'] == 0) {
+    $hasActiveSibling = (int) $alrdybnd['count'] > 0;
+    $data['has_active_sibling'] = $hasActiveSibling;
+    if (!$hasActiveSibling) {
         // #1275 — admin-comms is single-section Pattern A; the legacy
         // `#^0` fragment targeted the old page-toc add-block anchor
         // (long since dead). Drop it.

--- a/web/tests/Synthesizer.php
+++ b/web/tests/Synthesizer.php
@@ -729,6 +729,23 @@ final class Synthesizer
         // remaining slots fall back to uniform random selection.
         $targets = $this->scheduleTargets(3, $count);
 
+        // Track identities (authid for type=0, ip for type=1) that
+        // already carry an ACTIVE ban so subsequent rolls for the same
+        // identity don't seed multiple-active-bans-per-player. The
+        // duplicate-check in `api_bans_add` rejects a second active row
+        // for the same identity, so this scenario is impossible to
+        // reach in production through the panel — letting the
+        // synthesizer create it confuses the Re-apply UX (clicking
+        // Re-apply on a visibly-unbanned row hits "already banned"
+        // because of the OTHER active row, even though the row's
+        // state pill says unbanned) and seeds a contradiction the
+        // duplicate-check exists to prevent. Players can still carry
+        // multiple bans across their history (the realistic shape is
+        // "many old + one current"); the invariant is that AT MOST ONE
+        // is currently active per identity.
+        /** @var array<string, true> $activeIdentities */
+        $activeIdentities = [];
+
         foreach ($targets as $playerIdx) {
             $player  = $this->players[$playerIdx];
             $isIpOnly = mt_rand(0, 9) === 0; // ~10% IP-only bans
@@ -739,20 +756,28 @@ final class Synthesizer
             $length = mt_rand(0, 3) === 0 ? 0 : mt_rand(60 * 60 * 24, 60 * 60 * 24 * 180);
             $ends   = $length === 0 ? 0 : $created + $length;
 
+            $identityKey   = $isIpOnly ? 'ip:' . $player['ip'] : 'auth:' . $player['steam'];
+            $alreadyActive = isset($activeIdentities[$identityKey]);
+
             // State distribution: 60% active (incl. permanent), 25% expired,
             // 15% admin-removed (RemoveType U/D + RemovedBy + ureason).
+            // Subsequent active rolls for an already-banned identity
+            // collapse into the expired branch (forced timed + ends < now)
+            // so the player accumulates a realistic "lifted-then-rebanned"
+            // history without violating the at-most-one-active invariant.
             $roll       = mt_rand(0, 99);
             $removeType = null;
             $removedBy  = null;
             $removedOn  = null;
             $ureason    = '';
-            if ($roll < 60) {
+            if ($roll < 60 && !$alreadyActive) {
                 // Active. Force ends > now if timed.
                 if ($length !== 0 && $ends < $this->now) {
                     $created = $this->now - mt_rand(0, $length - 60 * 60 * 24);
                     $ends    = $created + $length;
                 }
-            } elseif ($roll < 85) {
+                $activeIdentities[$identityKey] = true;
+            } elseif ($roll < 85 || $alreadyActive) {
                 // Expired (timed, ends < now). Skip permanent rows here.
                 if ($length === 0) {
                     $length = 60 * 60 * 24 * mt_rand(1, 30);
@@ -837,23 +862,40 @@ final class Synthesizer
         // Cohort gets ~2 comms apiece up front; remainder is uniform.
         $targets = $this->scheduleTargets(2, $count);
 
+        // Same shape as `insertBans`: track (authid, type) tuples that
+        // already carry an active row so subsequent active rolls for
+        // the same key collapse into the expired branch. Comms rows
+        // are keyed on (authid, type) — a player can have one active
+        // mute (type=1) AND one active gag (type=2) simultaneously,
+        // which is the realistic shape, but two active mutes for the
+        // same authid is the duplicate-check-impossible scenario the
+        // synthesizer should not seed (Re-mute / Re-gag UX hits
+        // "already blocked" against an unrelated active row).
+        /** @var array<string, true> $activeIdentities */
+        $activeIdentities = [];
+
         foreach ($targets as $playerIdx) {
             $player  = $this->players[$playerIdx];
             $created = $this->now - mt_rand(0, 60 * 60 * 24 * 60);
             $length  = mt_rand(0, 3) === 0 ? 0 : mt_rand(60 * 30, 60 * 60 * 24 * 14);
             $ends    = $length === 0 ? 0 : $created + $length;
 
+            $commType      = mt_rand(1, 2); // 1 = mute, 2 = gag
+            $identityKey   = 'auth:' . $player['steam'] . ':type:' . $commType;
+            $alreadyActive = isset($activeIdentities[$identityKey]);
+
             $roll       = mt_rand(0, 99);
             $removeType = null;
             $removedBy  = null;
             $removedOn  = null;
             $ureason    = null;
-            if ($roll < 60) {
+            if ($roll < 60 && !$alreadyActive) {
                 if ($length !== 0 && $ends < $this->now) {
                     $created = $this->now - mt_rand(0, max(60, $length - 60 * 60));
                     $ends    = $created + $length;
                 }
-            } elseif ($roll < 85) {
+                $activeIdentities[$identityKey] = true;
+            } elseif ($roll < 85 || $alreadyActive) {
                 if ($length === 0) {
                     $length = 60 * 60 * mt_rand(1, 24);
                     $ends   = $created + $length;
@@ -885,7 +927,7 @@ final class Synthesizer
                 $removedBy,
                 $removeType,
                 $removedOn,
-                mt_rand(1, 2), // 1 = mute, 2 = gag
+                $commType,
                 $ureason,
             ]);
         }

--- a/web/tests/api/BansTest.php
+++ b/web/tests/api/BansTest.php
@@ -170,6 +170,33 @@ final class BansTest extends ApiTestCase
         $this->assertSnapshot('bans/add_already_banned', $second);
     }
 
+    public function testAddDuplicateErrorIncludesConflictingBid(): void
+    {
+        // Pre-seed a non-#1 ban so this asserts the bid is actually
+        // substituted into the error message rather than always rendering
+        // `#1` because the duplicate is the second row in the table.
+        // The reported regression (#STEAM_0:0:1000119) confused operators
+        // because the bare "is already banned" string gave them no anchor
+        // to look up the conflicting row — they saw an unbanned row in
+        // the UI and reasonably concluded the panel was lying. The fix
+        // surfaces the conflicting bid; this test pins that contract.
+        $this->seedBan('STEAM_0:1:7000', 'first-noise');
+        $this->seedBan('STEAM_0:1:7001', 'second-noise');
+        $conflictBid = $this->seedBan('STEAM_0:1:9999', 'active-original');
+
+        $this->loginAsAdmin();
+        $env = $this->api('bans.add', [
+            'nickname' => 'Reban', 'type' => 0, 'steam' => 'STEAM_0:1:9999',
+            'ip' => '', 'length' => 0, 'dfile' => '', 'dname' => '',
+            'reason' => 'reban-attempt', 'fromsub' => 0,
+        ]);
+        $this->assertEnvelopeError($env, 'already_banned');
+        $this->assertSame(
+            'SteamID: STEAM_0:1:9999 is already banned by ban #' . $conflictBid . '.',
+            $env['error']['message']
+        );
+    }
+
     public function testSetupBanReturnsSubmissionData(): void
     {
         $this->loginAsAdmin();

--- a/web/tests/api/CommsTest.php
+++ b/web/tests/api/CommsTest.php
@@ -78,6 +78,50 @@ final class CommsTest extends ApiTestCase
         $this->assertSnapshot('comms/add_already_blocked', $env);
     }
 
+    public function testAddDuplicateBlockErrorIncludesConflictingBid(): void
+    {
+        // Mirror of BansTest::testAddDuplicateErrorIncludesConflictingBid:
+        // pre-seed two unrelated blocks so the conflicting bid isn't `#1`,
+        // then assert the message substitutes the captured bid. Pins the
+        // contract that the value is actually substituted (not that it
+        // happens to render `#1` because of test ordering).
+        $this->loginAsAdmin();
+        $this->api('comms.add', [
+            'nickname' => 'Noise1', 'type' => 1, 'steam' => 'STEAM_0:0:101',
+            'length'   => 60, 'reason' => 'noise',
+        ]);
+        $this->api('comms.add', [
+            'nickname' => 'Noise2', 'type' => 1, 'steam' => 'STEAM_0:0:102',
+            'length'   => 60, 'reason' => 'noise',
+        ]);
+        $first = $this->api('comms.add', [
+            'nickname' => 'Mouthy', 'type' => 1, 'steam' => 'STEAM_0:0:9999',
+            'length'   => 60, 'reason' => 'active-original',
+        ]);
+        $this->assertTrue($first['ok']);
+
+        $pdo = Fixture::rawPdo();
+        $stmt = $pdo->query(sprintf(
+            'SELECT bid FROM `%s_comms` WHERE authid = "STEAM_0:0:9999" AND type = 1',
+            DB_PREFIX
+        ));
+        $this->assertNotFalse($stmt);
+        $row = $stmt->fetch(\PDO::FETCH_ASSOC);
+        $this->assertIsArray($row);
+        $conflictBid = (int) $row['bid'];
+        $this->assertGreaterThan(1, $conflictBid, 'pre-seeded blocks should have pushed bid past #1');
+
+        $env = $this->api('comms.add', [
+            'nickname' => 'Mouthy', 'type' => 1, 'steam' => 'STEAM_0:0:9999',
+            'length'   => 60, 'reason' => 'reblock-attempt',
+        ]);
+        $this->assertEnvelopeError($env, 'already_blocked');
+        $this->assertSame(
+            'SteamID: STEAM_0:0:9999 is already blocked by block #' . $conflictBid . '.',
+            $env['error']['message']
+        );
+    }
+
     public function testAddValidatesSteamIdRequired(): void
     {
         $this->loginAsAdmin();

--- a/web/tests/api/__snapshots__/bans/add_already_banned.json
+++ b/web/tests/api/__snapshots__/bans/add_already_banned.json
@@ -2,6 +2,6 @@
     "ok": false,
     "error": {
         "code": "already_banned",
-        "message": "SteamID: STEAM_0:1:8888 is already banned."
+        "message": "SteamID: STEAM_0:1:8888 is already banned by ban #1."
     }
 }

--- a/web/tests/api/__snapshots__/comms/add_already_blocked.json
+++ b/web/tests/api/__snapshots__/comms/add_already_blocked.json
@@ -2,6 +2,6 @@
     "ok": false,
     "error": {
         "code": "already_blocked",
-        "message": "SteamID: STEAM_0:0:99 is already blocked."
+        "message": "SteamID: STEAM_0:0:99 is already blocked by block #1."
     }
 }

--- a/web/tests/integration/PublicBanListRegressionTest.php
+++ b/web/tests/integration/PublicBanListRegressionTest.php
@@ -62,11 +62,28 @@ final class PublicBanListRegressionTest extends ApiTestCase
     /** @var int bid of the seeded expired ban (length elapsed; RemoveType NULL). */
     private int $expiredBid = 0;
 
+    /** @var int bid: an unbanned ban for a player who ALSO has an active ban
+     *               on the same authid. Used to pin the has_active_sibling gate
+     *               that hides the Re-apply affordance to avoid the misleading
+     *               "already banned" duplicate-check error on click. */
+    private int $unbannedWithActiveSiblingBid = 0;
+
+    /** @var int bid: the active sibling of $unbannedWithActiveSiblingBid (same authid). */
+    private int $activeSiblingBid = 0;
+
     /** @var int cid of the seeded permanent active mute. */
     private int $activeCid = 0;
 
     /** @var int cid of the seeded admin-unmuted block (RemoveType='U'). */
     private int $unmutedCid = 0;
+
+    /** @var int cid: an unmuted block for a player who ALSO has an active mute
+     *               on the same authid+type. Mirrors the bans-side has_active_sibling
+     *               regression for commslist. */
+    private int $unmutedWithActiveSiblingCid = 0;
+
+    /** @var int cid: the active sibling of $unmutedWithActiveSiblingCid (same authid+type). */
+    private int $activeSiblingCid = 0;
 
     protected function setUp(): void
     {
@@ -183,12 +200,19 @@ final class PublicBanListRegressionTest extends ApiTestCase
             'one Re-apply anchor per eligible row on the desktop branch (expired + unbanned)',
         );
         // Active rows must NOT carry the anchor — gated to the
-        // expired/unbanned branches only. Three seeded rows total;
-        // only two are eligible.
+        // expired/unbanned branches only. We seeded five rows:
+        //   1) active permanent — no anchor (state == 'active')
+        //   2) admin-unbanned standalone — anchor (state == 'unbanned', no sibling)
+        //   3) expired natural — anchor (state == 'expired', no sibling)
+        //   4) admin-unbanned WITH active sibling — no anchor (sibling gate)
+        //   5) the active sibling — no anchor (state == 'active')
+        // → exactly 2 desktop anchors expected.
         $this->assertLessThan(
             3,
             $desktopReapplyCount,
-            'Re-apply anchor must NOT render on the active row (we seeded 1 active + 1 expired + 1 unbanned)',
+            'Re-apply anchor must NOT render on the active row, '
+            . 'NOR on the unbanned-with-active-sibling row '
+            . '(we seeded 2 active + 1 expired + 1 unbanned-standalone + 1 unbanned-with-active-sibling)',
         );
         // Mobile mirror — the public banlist's mobile card now exposes
         // the same row-actions row as the desktop table (see
@@ -293,6 +317,132 @@ final class PublicBanListRegressionTest extends ApiTestCase
             '#<td[^>]*\bclass="text-muted truncate"[^>]*\btitle="wallhack"#',
             $html,
             'desktop Reason cell must carry the seeded reason in a title= attribute so hover surfaces the full text (issue 5).',
+        );
+    }
+
+    /**
+     * Regression for the user-reported bug "When trying to reapply
+     * ban on an unbanned player, it says SteamID: STEAM_0:0:1000119
+     * is already banned." The unbanned row legitimately renders with
+     * `state=='unbanned'` (RemoveType='U'), but a SECOND row on the
+     * same authid is currently active, so any Re-apply attempt would
+     * 4xx on `bans.add`'s duplicate-active check against the active
+     * sibling — surfacing as a confusing "already banned" toast on a
+     * row that visibly says Unbanned.
+     *
+     * The page handler computes `has_active_sibling` from the same
+     * "is this player currently banned?" predicate `bans.add` uses
+     * server-side. The template gates the Re-apply anchor on
+     * `!$ban.has_active_sibling`, so the affordance is hidden on the
+     * row whose Re-apply would silently fail. The drawer / detail
+     * view still shows the unbanned row's history; only the action
+     * affordance is removed.
+     *
+     * This test pins both halves: the unbanned-with-sibling row IS
+     * still rendered (so the user can see the historical entry),
+     * but its row-actions cell does NOT carry the Re-apply anchor.
+     */
+    #[RunInSeparateProcess]
+    #[PreserveGlobalState(false)]
+    public function testBanlistHidesReapplyOnUnbannedRowWithActiveSibling(): void
+    {
+        $_GET = ['p' => 'banlist'];
+
+        $html = $this->renderBanlistPage();
+
+        $bid = $this->unbannedWithActiveSiblingBid;
+
+        // The row IS rendered — we don't hide the row, only the
+        // action. The `<tr>` carries `data-id="<bid>"`.
+        $this->assertMatchesRegularExpression(
+            '/<tr[^>]*\bdata-id="' . $bid . '"/s',
+            $html,
+            'unbanned-with-sibling row must still render — only the Re-apply action is gated, '
+            . 'not the row itself',
+        );
+
+        // Slice the HTML for that single `<tr>...</tr>` and assert
+        // it contains NO Re-apply anchor. This is the load-bearing
+        // assertion for the bug fix: pre-fix the desktop row carried
+        // `data-testid="row-action-reapply"` on the unbanned row even
+        // though the click would 4xx on `bans.add`'s duplicate check.
+        $rowSlice = $this->extractRowSliceForBid($html, $bid);
+        $this->assertNotSame('', $rowSlice, 'failed to slice the row HTML for bid=' . $bid);
+        $this->assertStringNotContainsString(
+            'data-testid="row-action-reapply"',
+            $rowSlice,
+            'unbanned-with-active-sibling row must NOT carry the desktop Re-apply anchor — '
+            . 'the click would 4xx on the active sibling and the bug surfaces as "already banned"',
+        );
+        $this->assertStringNotContainsString(
+            'data-testid="row-action-reapply-mobile"',
+            $rowSlice,
+            'unbanned-with-active-sibling row must NOT carry the mobile Re-apply anchor either',
+        );
+    }
+
+    /**
+     * Mirror for the commslist surface — same bug shape, same fix.
+     * The commslist regression is HIGHER priority than the banlist's
+     * because there is no drawer fallback on a comm row, so the
+     * Re-apply chip is the only on-page action. Pre-fix clicking it
+     * lands on the admin add-comm form which 4xx's against the
+     * active sibling on `comms.add`.
+     */
+    #[RunInSeparateProcess]
+    #[PreserveGlobalState(false)]
+    public function testCommslistHidesReapplyOnUnmutedRowWithActiveSibling(): void
+    {
+        $_GET = ['p' => 'commslist'];
+
+        $html = $this->renderCommslistPage();
+
+        $cid = $this->unmutedWithActiveSiblingCid;
+
+        $this->assertMatchesRegularExpression(
+            '/<tr[^>]*\bdata-id="' . $cid . '"/s',
+            $html,
+            'unmuted-with-sibling comm row must still render — only the Re-apply action is gated',
+        );
+
+        $rowSlice = $this->extractCommRowSliceForCid($html, $cid);
+        $this->assertNotSame('', $rowSlice, 'failed to slice the comm row HTML for cid=' . $cid);
+        $this->assertStringNotContainsString(
+            'data-testid="row-action-reapply"',
+            $rowSlice,
+            'unmuted-with-active-sibling comm row must NOT carry the desktop Re-apply anchor',
+        );
+        $this->assertStringNotContainsString(
+            'data-testid="row-action-reapply-mobile"',
+            $rowSlice,
+            'unmuted-with-active-sibling comm row must NOT carry the mobile Re-apply anchor',
+        );
+    }
+
+    /**
+     * Pre-#REBAN-FIX the templates also rendered the legacy comments-modal
+     * launcher on every row. Whether or not that block is present, the
+     * Re-apply gate must not regress — the count assertion above pins
+     * the exact-2 contract on bare `?p=banlist` with the seeded data.
+     * This test confirms the standalone-unbanned row (CheaterBeta)
+     * STILL gets a Re-apply anchor, so the gate isn't accidentally
+     * over-broad and hiding it on every unbanned row.
+     */
+    #[RunInSeparateProcess]
+    #[PreserveGlobalState(false)]
+    public function testBanlistKeepsReapplyOnStandaloneUnbannedRow(): void
+    {
+        $_GET = ['p' => 'banlist'];
+
+        $html = $this->renderBanlistPage();
+
+        $rowSlice = $this->extractRowSliceForBid($html, $this->unbannedBid);
+        $this->assertNotSame('', $rowSlice);
+        $this->assertStringContainsString(
+            'data-testid="row-action-reapply"',
+            $rowSlice,
+            'standalone unbanned row (no active sibling) MUST still emit the desktop Re-apply anchor — '
+            . 'the gate fires only when the same authid carries an active sibling',
         );
     }
 
@@ -425,6 +575,50 @@ final class PublicBanListRegressionTest extends ApiTestCase
         ]);
         $this->expiredBid = (int) $pdo->lastInsertId();
 
+        // Seed a player (STEAM_0:1:50004) with TWO bans on the same
+        // authid: one admin-unbanned (RemoveType='U') and one ACTIVE
+        // permanent. This pair pins the `has_active_sibling` gate
+        // that hides the Re-apply affordance — clicking Re-apply on
+        // the unbanned row would land at `?p=admin&c=bans&section=add-ban&rebanid=…`
+        // which then fails the duplicate-active check on the ACTIVE
+        // sibling, surfacing as "is already banned by ban #X." This
+        // is the regression flagged by the user (`STEAM_0:0:1000119`):
+        // the row visibly read "Unbanned" but Re-apply silently
+        // fails because of the active sibling. Hide Re-apply when
+        // a sibling is active so the operator never reaches the
+        // confusing error path.
+        $insert->execute([
+            0,
+            'STEAM_0:1:50004',
+            'CheaterDelta',
+            $now - 14 * 24 * $hour,
+            $now - 7 * 24 * $hour,
+            7 * 24 * $hour,
+            'old offence',
+            'forgiven for the old offence',
+            $aid,
+            $aid,
+            $now - 6 * 24 * $hour,
+            'U',
+        ]);
+        $this->unbannedWithActiveSiblingBid = (int) $pdo->lastInsertId();
+
+        $insert->execute([
+            0,
+            'STEAM_0:1:50004',
+            'CheaterDelta',
+            $now - $hour,
+            0,
+            0,
+            'fresh offence',
+            null,
+            $aid,
+            null,
+            null,
+            null,
+        ]);
+        $this->activeSiblingBid = (int) $pdo->lastInsertId();
+
         // Seed two comm rows: one active, one admin-unmuted.
         $insertComm = $pdo->prepare(sprintf(
             'INSERT INTO `%s_comms` (type, authid, name, created, ends, length, reason, ureason, aid, RemovedBy, RemovedOn, RemoveType)
@@ -463,6 +657,47 @@ final class PublicBanListRegressionTest extends ApiTestCase
             'U',
         ]);
         $this->unmutedCid = (int) $pdo->lastInsertId();
+
+        // Mirror of the bans-side has_active_sibling pair on commslist:
+        // one player (STEAM_0:1:60003) with type=1 (mute) carries an
+        // unmuted block AND an active permanent mute on the same
+        // authid+type. Pins the commslist's has_active_sibling gate —
+        // pre-fix the Re-apply chip surfaced on the unmuted row even
+        // though the click would 4xx on `comms.add` against the active
+        // sibling. The gate is per-(authid, type), so a player can
+        // legitimately carry an unmuted-mute + active-gag without
+        // tripping it; we only seed the same-type pair here.
+        $insertComm->execute([
+            1,
+            'STEAM_0:1:60003',
+            'SpammerGamma',
+            $now - 14 * 24 * $hour,
+            $now - 7 * 24 * $hour,
+            7 * 24 * $hour,
+            'spam (old)',
+            'mute lifted on appeal',
+            $aid,
+            $aid,
+            $now - 6 * 24 * $hour,
+            'U',
+        ]);
+        $this->unmutedWithActiveSiblingCid = (int) $pdo->lastInsertId();
+
+        $insertComm->execute([
+            1,
+            'STEAM_0:1:60003',
+            'SpammerGamma',
+            $now - $hour,
+            0,
+            0,
+            'spam (fresh)',
+            null,
+            $aid,
+            null,
+            null,
+            null,
+        ]);
+        $this->activeSiblingCid = (int) $pdo->lastInsertId();
     }
 
     private function bootstrapSmartyTheme(): void
@@ -529,5 +764,84 @@ final class PublicBanListRegressionTest extends ApiTestCase
             $html = (string) ob_get_clean();
         }
         return $html;
+    }
+
+    /**
+     * Extract the rendered HTML for a single banlist `<tr>` keyed by
+     * its `data-id="<bid>"` attribute, plus the immediately-following
+     * mobile-card block (`<div data-testid="ban-card" data-id="<bid>">`).
+     * Returns the empty string when neither shape matches. The slice
+     * lets the assertion test row-scoped substrings without
+     * accidentally matching siblings.
+     */
+    private function extractRowSliceForBid(string $html, int $bid): string
+    {
+        $combined = '';
+
+        // Desktop `<tr>` — non-greedy slice from the matching opener to
+        // the next `</tr>`. Anchored on `data-id="<bid>"` plus the
+        // canonical `data-testid="ban-row"` to avoid colliding with
+        // any other `<tr>` that might appear in the layout chrome.
+        if (
+            preg_match(
+                '#<tr\b(?=[^>]*\bdata-testid="ban-row")(?=[^>]*\bdata-id="' . $bid . '")[^>]*>(.*?)</tr>#s',
+                $html,
+                $tr,
+            )
+        ) {
+            $combined .= $tr[0];
+        }
+
+        // Mobile card — the public banlist's mobile branch wraps the
+        // row in `<div class="ban-card" ... data-testid="ban-card" data-id="<bid>">`,
+        // closing at the matching `</div>` that ends the card. The
+        // template emits enough nested `<div>`s that we slice on the
+        // testid pair plus a defensive `</a>\s*</div>` (the card
+        // ends with the row-actions row inside an anchor wrapper).
+        // Cheap heuristic — the assertion only cares about whether
+        // the `row-action-reapply-mobile` testid is in the slice.
+        if (
+            preg_match(
+                '#<div\b(?=[^>]*\bdata-testid="ban-card")(?=[^>]*\bdata-id="' . $bid . '")[^>]*>.*?(?=<div\b[^>]*\bdata-testid="ban-card"|<table\b|\Z)#s',
+                $html,
+                $card,
+            )
+        ) {
+            $combined .= $card[0];
+        }
+
+        return $combined;
+    }
+
+    /**
+     * Mirror of extractRowSliceForBid for the commslist's rows. The
+     * commslist uses `data-testid="comm-row"` on the desktop `<tr>`
+     * and `data-testid="comm-card"` on the mobile card.
+     */
+    private function extractCommRowSliceForCid(string $html, int $cid): string
+    {
+        $combined = '';
+
+        if (
+            preg_match(
+                '#<tr\b(?=[^>]*\bdata-testid="comm-row")(?=[^>]*\bdata-id="' . $cid . '")[^>]*>(.*?)</tr>#s',
+                $html,
+                $tr,
+            )
+        ) {
+            $combined .= $tr[0];
+        }
+
+        if (
+            preg_match(
+                '#<div\b(?=[^>]*\bdata-testid="comm-card")(?=[^>]*\bdata-id="' . $cid . '")[^>]*>.*?(?=<div\b[^>]*\bdata-testid="comm-card"|<table\b|\Z)#s',
+                $html,
+                $card,
+            )
+        ) {
+            $combined .= $card[0];
+        }
+
+        return $combined;
     }
 }

--- a/web/themes/default/page_bans.tpl
+++ b/web/themes/default/page_bans.tpl
@@ -502,8 +502,16 @@
                    `web/api/handlers/bans.php::api_bans_prepare_reban`
                    pre-populates with the original ban's parameters.
                    Gated on $can_add_ban so the affordance only renders
-                   for admins who can act on it. *}
-                {if $can_add_ban && ($ban.state == 'expired' || $ban.state == 'unbanned')}
+                   for admins who can act on it. Also gated on
+                   `!$ban.has_active_sibling` so we don't surface a
+                   button that would 4xx as `already_banned` —
+                   `page.banlist.php` flags the row when the same
+                   identity (authid for type=0, ip for type=1) has
+                   another currently-active ban. The v1.x template
+                   honoured the same gate via `$data['reban_link']`;
+                   the v2.0 rewrite (#1315) dropped it, which is the
+                   regression this restores. *}
+                {if $can_add_ban && ($ban.state == 'expired' || $ban.state == 'unbanned') && !$ban.has_active_sibling}
                 <a class="btn btn--secondary btn--sm" data-testid="row-action-reapply"
                    href="index.php?p=admin&amp;c=bans&amp;section=add-ban&amp;rebanid={$ban.bid}&amp;key={$admin_postkey|escape}"
                    onclick="event.stopPropagation()">
@@ -697,7 +705,9 @@
                 Unban
             </button>
             {/if}
-            {if $can_add_ban && ($ban.state == 'expired' || $ban.state == 'unbanned')}
+            {* #1315 + this PR: same `has_active_sibling` gate as the
+               desktop variant — see the rationale block above. *}
+            {if $can_add_ban && ($ban.state == 'expired' || $ban.state == 'unbanned') && !$ban.has_active_sibling}
             <a class="btn btn--secondary btn--sm" data-testid="row-action-reapply-mobile"
                href="index.php?p=admin&amp;c=bans&amp;section=add-ban&amp;rebanid={$ban.bid}&amp;key={$admin_postkey|escape}">
                 <i data-lucide="rotate-ccw" style="width:13px;height:13px"></i>

--- a/web/themes/default/page_comms.tpl
+++ b/web/themes/default/page_comms.tpl
@@ -341,12 +341,18 @@
                                         <i data-lucide="check" style="width:13px;height:13px"></i>
                                         {if $comm.type == 'mute'}Unmute{elseif $comm.type == 'gag'}Ungag{else}Lift block{/if}
                                     </button>
-                                {elseif $can_add_comm && ($comm.state == 'unmuted' || $comm.state == 'expired')}
+                                {elseif $can_add_comm && ($comm.state == 'unmuted' || $comm.state == 'expired') && !$comm.has_active_sibling}
                                     {* #1207 ADM-6: when a row is no longer active, swap the
                                        lift action for Re-apply. Anchor goes through the
                                        admin-comms add form's `rebanid` flow (which calls
                                        comms.prepare_reblock to hydrate every field) so we
-                                       don't need a separate "re-block" handler. *}
+                                       don't need a separate "re-block" handler. The
+                                       `!has_active_sibling` clause hides the affordance
+                                       when the player already has an active block of the
+                                       same type — `comms.add` would 4xx as
+                                       `already_blocked` against the OTHER row, even
+                                       though this row visibly says unmuted/expired (same
+                                       shape as the banlist's `has_active_sibling` gate). *}
                                     <a class="btn btn--secondary btn--sm"
                                        href="index.php?p=admin&amp;c=comms&amp;rebanid={$comm.cid}"
                                        data-testid="row-action-reapply">
@@ -509,7 +515,9 @@
                                 <i data-lucide="check" style="width:13px;height:13px"></i>
                                 {if $comm.type == 'mute'}Unmute{elseif $comm.type == 'gag'}Ungag{else}Lift block{/if}
                             </button>
-                        {elseif $can_add_comm && ($comm.state == 'unmuted' || $comm.state == 'expired')}
+                        {elseif $can_add_comm && ($comm.state == 'unmuted' || $comm.state == 'expired') && !$comm.has_active_sibling}
+                            {* Same `has_active_sibling` gate as the desktop
+                               variant — see the rationale block above. *}
                             <a class="btn btn--secondary btn--sm"
                                href="index.php?p=admin&amp;c=comms&amp;rebanid={$comm.cid}"
                                data-testid="row-action-reapply-mobile">


### PR DESCRIPTION
## Summary

Reported bug: clicking Re-apply on an unbanned row failed with
`SteamID: STEAM_0:0:1000119 is already banned.` The unbanned row
legitimately rendered `state=='unbanned'`, but a second row on the
same authid was currently active, so the duplicate-check in
`bans.add` fired against the active sibling and the operator saw an
error on a row that visibly said Unbanned.

The fix has three coordinated layers:

- **Hide the affordance up front.** `page.banlist.php` /
  `page.commslist.php` now set `has_active_sibling` per-row using
  the same predicate `bans.add` / `comms.add` use server-side.
  `page_bans.tpl` / `page_comms.tpl` gate the Re-apply button on
  `!has_active_sibling`, restoring the v1.x `reban_link` gate that
  the v2.0 template rewrite (#1315) silently dropped.
- **Make the error self-explanatory when it does fire.**
  `bans.add` / `comms.add` (and the legacy `admin.edit.ban.php` /
  `admin.edit.comms.php`) now report `is already banned by ban #N`
  so the operator has an anchor to investigate the conflicting row
  instead of staring at an unbanned row that disagrees with the
  toast.
- **Stop the synthesizer from seeding the impossible-in-prod
  scenario.** `insertBans()` / `insertComms()` track active
  identities (`authid` for type=0, `ip` for type=1, `(authid, type)`
  for comms) and force subsequent active rolls into the expired
  branch, so `./sbpp.sh db-seed` produces realistic "many old + one
  current" histories matching production reality.

## How the bug was reachable

Production can't reach the multi-active state through the panel —
`bans.add`'s duplicate-check rejects a second active row on the
same authid. But the dev synthesizer wasn't honouring that
invariant, and the user hit the bug on the seeded dev DB. The
synthesizer fix above stops the false signal at the source; the
template gate + error-message improvements harden the production
surface for the real-world cases (legacy data, race conditions,
fork divergence) where the constraint can drift.

## Files touched

| File | Reason |
|------|--------|
| `web/api/handlers/bans.php` | Cite conflicting bid in the dup-check error. |
| `web/api/handlers/comms.php` | Cite conflicting bid in the dup-check error. |
| `web/pages/admin.edit.ban.php` | Mirror the bid call-out (modern \`$validationErrors\` path). |
| `web/pages/admin.edit.comms.php` | Mirror the bid call-out (legacy \`$errorScript\` path; consistent with surrounding code). |
| `web/pages/page.banlist.php` | Compute \`has_active_sibling\` per row. |
| `web/pages/page.commslist.php` | Mirror for comms. |
| `web/themes/default/page_bans.tpl` | Gate Re-apply button on \`!has_active_sibling\` (desktop + mobile). |
| `web/themes/default/page_comms.tpl` | Mirror for comms. |
| `web/tests/Synthesizer.php` | Track active identities; force subsequent rolls into the expired branch. |
| `web/tests/api/BansTest.php` | New \`testAddDuplicateErrorIncludesConflictingBid\` (pins bid substitution with non-#1 value). |
| `web/tests/api/CommsTest.php` | Comms-side mirror. |
| `web/tests/api/__snapshots__/bans/add_already_banned.json` | New error string. |
| `web/tests/api/__snapshots__/comms/add_already_blocked.json` | New error string. |
| `web/tests/integration/PublicBanListRegressionTest.php` | New seed pair + 3 new methods pinning the Re-apply gate (banlist + commslist + standalone-unbanned counter-test). |

## Test plan

- [x] PHPStan (level 5, 239 files) — green
- [x] PHPUnit (515 tests, 2255 assertions) — green
- [x] ts-check — green
- [x] api-contract — regenerated, no diff
- [x] Snapshots updated for the new error strings

Manually verified on the dev stack:

- [x] \`./sbpp.sh db-seed\` produces only one active ban per identity (and one active mute + one active gag per authid for comms — the realistic shape).
- [x] An unbanned row with a sibling active ban no longer shows the Re-apply button (desktop + mobile branches).
- [x] An unbanned row WITHOUT a sibling still shows Re-apply (gate isn't over-broad).
- [x] Forcing \`bans.add\` against an active row surfaces \`already banned by ban #N\` with the correct bid.

## Anti-patterns referenced (no regression)

- The Re-apply gate restores the contract \`page.banlist.php\` /
  \`page.commslist.php\` always carried for \`reban_link\`; the v2.0
  template rewrite dropped the \`{if ...}\` guard rather than the
  PHP-side flag.
- The synthesizer fix stays inside \`web/tests/Synthesizer.php\` (dev-only,
  refuses any DB other than \`sourcebans\`) — \`Fixture::truncateAndReseed\`
  for the e2e hot path is unchanged per the established AGENTS.md
  contract that those two diverge by design.
- \`admin.edit.comms.php\`'s \`$errorScript\` injection still rides the
  pre-existing MooTools-era \`$('steam.msg').innerHTML = ...\`
  pattern; rewriting that file's chrome is its own ticket and out
  of scope here. The bid is force-cast to \`int\` before string
  concat so there's no XSS surface introduced.