### PR TITLE
fix(theme): apply persisted dark mode before first paint (#1367)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -870,6 +870,87 @@ drawer flips to `renderDrawerBody`. The second test stalls
 `bans.player_history` and asserts the History pane's
 `renderPaneSkeleton()` paints the same shimmer rows.
 
+### Anti-FOUC theme bootloader (`core/header.tpl` `<head>` script)
+
+Light/dark theme is keyed off the `dark` class on `<html>`, with
+`:root` declaring the light tokens and `html.dark` overriding to the
+dark tokens. The persisted preference lives in
+`localStorage['sbpp-theme']` (the `THEME_KEY` in `theme.js`); values
+are `'light'` / `'dark'` / `'system'`, and `'system'` resolves
+against `prefers-color-scheme: dark` at boot.
+
+`theme.js` (loaded from the document tail via `core/footer.tpl`) is
+the load-bearing path for user interactions — the toggle click and
+the matchMedia listener for OS-preference changes mid-session. But
+its boot-time `applyTheme(currentTheme())` is NOT what should land
+the dark class on first paint: by the time `theme.js` executes, the
+parser has finished `<body>` and the browser has already painted the
+entire body in light mode (the `:root` defaults). The class flip
+then triggers a full repaint the user perceives as a white flash +
+content flicker on every page navigation (#1367).
+
+The fix is a tiny inline blocking `<script>` in `<head>` of
+`core/header.tpl`, ABOVE the `<link rel="stylesheet">`, that mirrors
+`applyTheme(currentTheme())`'s dark-resolution logic: same
+`THEME_KEY`, same default (`'system'`), same `mode === 'dark' || (mode
+=== 'system' && matchMedia(...).matches)` predicate, and only ADDS
+the class (light is the `:root` default, so removing would be a no-op
+anyway). It runs synchronously before the body parses, so the very
+first paint lands in the user's chosen mode.
+
+The contract:
+
+- The bootloader lives in `web/themes/default/core/header.tpl`
+  inside `<head>`, immediately above the stylesheet link. The
+  script is parser-blocking + synchronous, so the class is
+  guaranteed to be set before `<body>` parses regardless of where
+  in `<head>` it lives, but pinning it just above the stylesheet
+  makes the "this resolves the CSS cascade" intent obvious.
+- The script is a self-contained IIFE wrapped in `try/catch`:
+  `localStorage` throws on private-mode iframes / SecurityError,
+  and `matchMedia` is missing on very old browsers. In either
+  failure mode the bootloader silently falls through to light
+  (matching `theme.js`'s defensiveness).
+- The bootloader does NOT write to `localStorage` — `theme.js`
+  still owns persistence (its boot-time `applyTheme()` writes the
+  resolved mode back). The bootloader is read-only on the
+  persisted state.
+- The bootloader uses `var` (not `let`/`const`) and avoids
+  optional chaining / nullish coalescing. The script runs in the
+  earliest realm setup phase; any syntax error means the whole
+  body would paint in light first. Strict ES5 keeps the surface
+  area defensive (theme.js itself uses ES6+, but theme.js failing
+  is recoverable — the bootloader failing is the FOUC bug).
+- Logic must stay byte-equivalent to `applyTheme(currentTheme())`
+  in `theme.js` minus the `localStorage.setItem(...)` write. If
+  `theme.js` ever changes the resolution rule (e.g., adds a
+  `'high-contrast'` mode), the bootloader has to mirror the
+  change in the same PR or the first paint silently desyncs from
+  the user's persisted preference.
+
+Regression guard: `web/tests/e2e/specs/flows/theme-fouc.spec.ts`.
+The spec uses `page.route` to intercept and STALL the `theme.js`
+network request, then asserts the state of `<html>`'s class list
+WHILE theme.js is held — i.e. the bootloader is the only thing
+that could have set the class. The contract: dark-pinned mode
+must read `class="dark"`, light-pinned mode must NOT, and system
++ emulated OS-dark (via `colorScheme: 'dark'` on a fresh
+`chromium.newContext()`) must read `class="dark"` via the
+matchMedia branch. Releasing the route then lets theme.js boot
+normally so the post-load shape is asserted too. This is the
+only Playwright-tractable way to prove "the bootloader did it,
+not theme.js" — checking `readyState === 'loading'` was tried
+and fails because `addInitScript` runs before
+`document.documentElement` exists.
+
+The install wizard (`web/install/_chrome.tpl`) does NOT carry the
+bootloader. It runs against an unconfigured panel with no
+logged-in user and no `theme.js` chrome at all — there's no theme
+toggle to gate, so `localStorage['sbpp-theme']` is never set
+during install. The wizard inherits the `:root` light defaults,
+which is the documented behavior; do NOT add the bootloader there
+without a paired theme toggle in the wizard chrome.
+
 ### Templates + View DTOs
 
 - Pages are rendered via typed view-model DTOs in `Sbpp\View\*`
@@ -1519,6 +1600,53 @@ the spec, target a 1920px viewport, not 1440px.
  default `none`). Same shape applies to any new skeleton surface:
  reuse the `.skel` class from `theme.css`; don't roll a new
  `.skeleton-*` rule.
+- Removing the inline anti-FOUC bootloader from `<head>` of
+ `web/themes/default/core/header.tpl` ("theme.js already does this
+ on boot, why does it have to be inline?") → theme.js loads from
+ `core/footer.tpl` (the document tail), so its boot-time
+ `applyTheme(currentTheme())` runs AFTER the parser reaches `</body>`.
+ By that point the browser has already painted the entire body in
+ light mode (the `:root` tokens default to light), and theme.js's
+ class flip triggers a full repaint the user perceives as a white
+ flash + content flicker on every page navigation (#1367 — the
+ reporter's exact symptom: "the page briefly renders in light mode
+ for a split second before switching back to dark"). The bootloader
+ is the inline-script-in-`<head>` pattern every modern theme-toggle
+ implementation uses (Tailwind docs, Next.js docs, GitHub, Vercel)
+ — it has to run BEFORE the body parses, which means it has to be
+ inline (no external `<script src=…>` because the network round-trip
+ would defeat the point) and it has to be in `<head>` (so the parser
+ reaches it before the body tags). Regression guard:
+ `web/tests/e2e/specs/flows/theme-fouc.spec.ts` uses `page.route`
+ to stall the `theme.js` network request, then asserts the `dark`
+ class is present (or absent, in light mode) on `<html>` WHILE
+ theme.js is held — proving the bootloader, not theme.js, did
+ the class flip. Pre-fix the dark / system arms read `false` (no
+ class because theme.js was stalled and was the only path); post-fix
+ they read `true` because the inline bootloader runs in `<head>`
+ long before the parser reaches `<script src="theme.js">`.
+- Letting the inline bootloader's resolution logic drift from
+ `theme.js`'s `applyTheme(currentTheme())` (e.g., adding a new
+ `'high-contrast'` mode to theme.js without mirroring in the
+ bootloader, or vice versa) → the first paint resolves to one
+ mode, theme.js's boot-time call resolves to a different mode,
+ the user sees a flicker on every navigation. The bootloader is
+ the read-only mirror of `applyTheme()`'s resolution rule — same
+ `THEME_KEY` ('sbpp-theme'), same default ('system'), same
+ dark-resolution predicate. The bootloader's only difference is
+ it doesn't `localStorage.setItem(...)` (theme.js still owns
+ persistence). Any change to theme.js's resolution logic has
+ to land a paired bootloader update in the same PR.
+- Moving the bootloader to an external `<script src="…">` ("inline
+ scripts are smelly, let's externalize") → an external script adds
+ a network round-trip BEFORE the bootloader can run, and the
+ browser will paint in light mode in the meantime. The whole point
+ of the inline shape is that the script's execution is bound to
+ parse time, not to network completion. Same reason `<head>` is
+ the load-bearing location: a `<script>` at the bottom of `<body>`
+ (or `defer`/`async`) wouldn't help. The script is ~10 lines of
+ ES5 — well under any "inline scripts are bad for caching"
+ threshold.
 - `[data-skeleton]` on a placeholder block nested inside a `hidden`
  ancestor (lazy tabpanels, off-screen drawers, collapsed
  `<details>`) → the `_base.ts` page-load waiter blocks until
@@ -2226,6 +2354,7 @@ the spec, target a 1920px viewport, not 1440px.
 | Keep the main sidebar sticky-pinned across the full document scroll (`<aside class="sidebar">`) | The structural half of #1271 lives in `web/themes/default/core/footer.tpl`: `<footer class="app-footer">` is rendered as the LAST flex column item of `<div class="main">`, INSIDE `<div class="app">`. `.sidebar`'s sticky containing block is `.app`; if the footer were a body-level sibling of `.app` (the pre-fix shape), `.app`'s height would fall short of the document by `footerHeight` and the sidebar would release at the bottom — brand cut off, on barely-tall pages (`docHeight - viewport ≤ footerHeight`, e.g. `?p=admin&c=audit` on the bare e2e seed) the entire scroll range would be in the release phase and the sidebar would track the scroll. Keeping the footer inside `.app` makes the sticky CB extend to the full document. The CSS half (`.sidebar { align-self: flex-start; }` from #1278) is defensive parity with `.admin-sidebar` and is RETAINED but not load-bearing on its own. The footer's `margin-top: auto` (`.app-footer` rule in `theme.css`) is the classic "sticky footer" pattern — pushes the footer to the bottom of `.main`'s flex column on short pages so the credit doesn't float halfway up the viewport. Regression guard: `web/tests/e2e/specs/responsive/sidebar-sticky.spec.ts` asserts strict `top===0` at scroll=`document.scrollHeight` on `?p=admin&c=bans` (the canonical tall page) AND on `?p=admin&c=audit` (the barely-tall page that historically presented the bug most visibly). |
 | Disable the chrome's slide-in / fade animations for `prefers-reduced-motion` users | `web/themes/default/css/theme.css` (`@media (prefers-reduced-motion: reduce)` global block — see the matching note in "Playwright E2E specifics" / Conventions). The block applies universally to `*, *::before, *::after` and is the right shape for *motion-of-state* (drawer slide-in, toast slide-in, chevron rotation). Two documented exceptions live next to their rules: the busy-button spinner (`.btn[data-loading="true"]::after`) and the skeleton shimmer (`.skel`), both essential feedback per WCAG 2.3.3 — without rotation the donut reads as a decorative ring, without sliding the gradient reads as a permanent placeholder. Each rule carries its own per-rule `@media (prefers-reduced-motion: reduce)` override that re-enables the animation with `!important` longhands so specificity wins over the universal `*::after` / `*` reset (#1362). If you ship a new animation, default to honouring the global reset; the per-rule exception only applies to motion that is itself the load-bearing feedback (without it, the affordance is silently broken — not just less lively). Regression guard for both exceptions: `web/tests/e2e/specs/flows/loading-animations.spec.ts`. |
 | Tell the browser to paint native UA surfaces (`<select>` dropdown panels, native scrollbars, `<input type="date|time|color">` pickers, autofill highlighting) in the matching scheme | `web/themes/default/css/theme.css` — the two `color-scheme` declarations on `:root` (`light`) and `html.dark` (`dark`) (#1309). Without these the chrome's dark tokens swap correctly for DOM-rendered surfaces, but anything painted in the browser's top-layer system UI ignores `html.dark` and renders light — most jarring on mobile where the native `<select>` picker full-screens. Regression guard: `web/tests/e2e/specs/a11y/color-scheme.spec.ts`. |
+| Apply the persisted theme to `<html>` BEFORE first paint (no FOUC on every page navigation) | `web/themes/default/core/header.tpl` — the inline `<script>` block in `<head>`, immediately above `<link rel="stylesheet">` (#1367). Reads `localStorage['sbpp-theme']` (mirror of `THEME_KEY` in `theme.js`), resolves dark via the same predicate as `applyTheme(currentTheme())`, adds `class="dark"` to `<html>` synchronously before `<body>` parses. Pre-fix theme.js (loaded from the document tail via `core/footer.tpl`) was the only thing flipping the class — by then the body had already painted in light mode and the class flip triggered a full repaint the user perceived as a white flash + content flicker on every page navigation (the reporter's exact symptom on #1367). The bootloader's resolution logic must stay byte-equivalent to `theme.js`'s `applyTheme(currentTheme())` minus the `localStorage.setItem(...)` write — drift between the two means the first paint resolves to one theme, theme.js's boot-time call resolves to another, and the user sees flicker even with the bootloader present. See "Anti-FOUC theme bootloader" in Conventions. Regression guard: `web/tests/e2e/specs/flows/theme-fouc.spec.ts` uses `page.route` to stall the `theme.js` network request and asserts the state of `<html>`'s class list WHILE theme.js is held — proving the bootloader, not theme.js, did the class flip. Three arms cover the three branches of the resolution logic (dark-pinned must read `class="dark"`, light-pinned must NOT, system + emulated OS-dark via `colorScheme: 'dark'` on a fresh `chromium.newContext()` must read `class="dark"` via the matchMedia branch). Releasing the route then lets theme.js boot normally so the post-load shape is asserted too. |
 | Edit a step of the install wizard (chrome, form, schema-apply, admin-create, AMXBans import) | Page handlers under `web/install/pages/page.<N>.php` (1=license, 2=DB details, 3=requirements, 4=schema apply, 5=admin form + final config write, 6=optional AMXBans import). Each handler builds a `Sbpp\View\Install\Install*View` DTO from `web/includes/View/Install/` and renders the matching template under `web/themes/default/install/`. Shared step-handler helpers (prefix validation, raw-PDO probe before instantiating `\Database`, KeyValues quoting, friendly PDO error translation, filesystem-check detail strings) live in `web/install/includes/helpers.php` (`sbpp_install_validate_prefix` / `sbpp_install_open_db` / `sbpp_install_kv_escape` / `sbpp_install_translate_pdo_error` / `sbpp_install_describe_filesystem_check`) — required eagerly from `web/install/bootstrap.php` so every step page has them in scope without its own require. Every step (3-6) re-runs `sbpp_install_validate_prefix` at the top of its handler before any SQL substitution; step 6 also validates `amx_prefix` (operator input on that page itself). The `_chrome.tpl` / `_chrome_close.tpl` partials wrap every step (header + progress stepper + footer); they own the install-only inline CSS (`.install-shell`, `.install-alert`, `.install-pill`, `.install-grid`) since the wizard reuses the panel's `theme.css` design tokens but doesn't pull in the panel's chrome JS (`theme.js`, `lucide.min.js`, command palette, etc. — the wizard has no logged-in user / no Config / no `$userbank`). Steps with per-page tail scripts: step 1 (vanilla JS validating the license-accept checkbox), step 5 (#1335 M3: client-side validation for SteamID format + email shape + password match — saves the round-trip-with-wiped-passwords path on the common form-error case); the handoff template carries an inline auto-submit script. Navigation is plain HTML `<form action="?step=N">` everywhere else. Test-IDs follow `install-<step>-<field>` consistently (#1335 m3 standardised step 2's `install-db-*` shape onto the wider `install-database-*` pattern). Anti-pattern: reintroducing MooTools / `web/install/scripts/sourcebans.js` / `ShowBox()` / `$E()` / inline `onclick="next()"` — every legacy hook is dead post-#1123 D1, the rewrite at #1332 dropped them all (#1332). |
 | Recover from a missing `web/includes/vendor/` at install time | `web/install/recovery.php` is the self-contained "vendor/ missing" surface — pure inline HTML + CSS, NO Composer / Smarty / `Sbpp\…` dependency (#1332 C3). `web/install/index.php`'s lifecycle is paths-init (`init.php`) → C2 already-installed guard (`already-installed.php`, #1335) → vendor/-check (short-circuit to `recovery.php` if missing) → composer + Smarty bootstrap (`bootstrap.php`) → step dispatch (`includes/routing.php` → `pages/page.<N>.php`). The recovery surface is gated by `file_exists(PANEL_INCLUDES_PATH . '/vendor/autoload.php')` BEFORE any namespaced class is referenced. Direct visits with vendor present 302 to `/install/` instead of always emitting the 503 page (#1335 m1). The release artifact (post-#1332 Workstream A) bundles `vendor/` so this surface is the safety net for git checkouts and partial uploads, never the happy path. |
 | Display a friendly error page when the panel boots with `install/` still present, `updater/` still present, or `vendor/` missing | `web/init-recovery.php` (`sbpp_check_install_guard()` + `sbpp_render_install_blocked_page()`, #1335 M1). Pure inline HTML + CSS like `recovery.php`, runs upstream of Composer / Smarty. `web/init.php` calls the helper for all three scenarios; the missing-`config.php` case redirects to `/install/` instead of dying. Pre-#1335 these were three bare `die('plain text')` calls that read like a server crash to a non-technical operator who clicked the wizard's "Open the panel" CTA before completing post-install cleanup. Regression test: `web/tests/integration/InstallGuardTest.php`. |

--- a/web/tests/e2e/specs/a11y/color-scheme.spec.ts
+++ b/web/tests/e2e/specs/a11y/color-scheme.spec.ts
@@ -19,17 +19,24 @@
  *   html.dark  → color-scheme: dark;
  *
  * We assert via `expect(locator).toHaveCSS('color-scheme', …)` rather
- * than a one-shot `getComputedStyle()` read because theme.js applies
- * `<html class="dark">` after the first paint (the script loads from
- * the document tail, not <head>) and the resolved color-scheme value
- * follows. `toHaveCSS` polls so we land on the settled value without
- * a hand-rolled `setTimeout` (forbidden by AGENTS.md).
+ * than a one-shot `getComputedStyle()` read for robustness against
+ * any pre-paint resolution noise — `toHaveCSS` polls so we land on
+ * the settled value without a hand-rolled `setTimeout` (forbidden by
+ * AGENTS.md).
+ *
+ * Note (#1367): post-fix, `<html class="dark">` is set by an inline
+ * bootloader in `<head>` BEFORE the body parses (regression-guarded
+ * by `flows/theme-fouc.spec.ts`), so the dark class — and therefore
+ * the resolved `color-scheme` — is settled on the very first paint.
+ * Pre-fix the class was only set after theme.js (loaded from the
+ * document tail) ran, so the resolved color-scheme value transitioned
+ * through light → dark on every navigation. Either shape passes this
+ * spec; the polling assertion stays as defensive shape, not because
+ * it's load-bearing here.
  *
  * Theme pinning mirrors `a11y/dark-theme-contrast.spec.ts` /
  * `_screenshots.spec.ts`: write `localStorage['sbpp-theme']` on `/`,
- * then navigate to the target route, then wait on `<html class="dark">`
- * so theme.js's boot-time `applyTheme()` has resolved before the
- * assertion runs.
+ * then navigate to the target route, then wait on `<html class="dark">`.
  *
  * Project filter: chromium-only. The fix is a token-block change in
  * `theme.css`; the computed value of `color-scheme` does not depend on

--- a/web/tests/e2e/specs/flows/theme-fouc.spec.ts
+++ b/web/tests/e2e/specs/flows/theme-fouc.spec.ts
@@ -1,0 +1,274 @@
+/**
+ * Anti-FOUC regression guard (#1367).
+ *
+ * The reported symptom: "When navigating between pages while using
+ * dark mode, the page briefly renders in light mode for a split
+ * second before switching back to dark, causing an uncomfortable
+ * flash" + a sister "content elements disappear and reappear" on
+ * every page navigation.
+ *
+ * Root cause
+ * ----------
+ * Pre-fix `web/themes/default/core/header.tpl` rendered a bare
+ * `<html lang="en">` and `theme.js` (loaded from the document tail
+ * via `core/footer.tpl`) was the only thing that flipped the
+ * `class="dark"` toggle. With the script at the tail, the browser
+ * paints the entire body in light mode (the `:root` tokens default
+ * to light) BEFORE theme.js runs `applyTheme(currentTheme())` —
+ * the user perceives that as a white flash + content flicker on
+ * every page navigation. The existing color-scheme.spec.ts even
+ * acknowledged this in its preamble: *"theme.js applies <html
+ * class='dark'> after the first paint (the script loads from the
+ * document tail, not <head>) and the resolved color-scheme value
+ * follows."*
+ *
+ * The fix
+ * -------
+ * `core/header.tpl` now ships a tiny inline blocking script in
+ * `<head>` (above `<link rel="stylesheet">`) that reads the same
+ * `localStorage['sbpp-theme']` key theme.js owns and adds
+ * `class="dark"` to `<html>` synchronously, before the body parses.
+ * The first paint lands in the user's persisted theme — no flash.
+ * theme.js is unchanged; its boot-time `applyTheme(currentTheme())`
+ * is now a no-op when the class is already correct (toggle(true)
+ * on a set class is a no-op), and it stays the load-bearing path
+ * for the click handler + the matchMedia listener.
+ *
+ * What this spec proves
+ * ---------------------
+ * The straightforward "open a dark page and assert <html class='dark'>"
+ * can't distinguish between the bootloader and theme.js — by the time
+ * Playwright reads the DOM, theme.js has long since run too. The
+ * regression-catch we want is specifically: *"the dark class is set
+ * BEFORE theme.js executes"*. We `page.route('**\/theme.js')` the
+ * network request and stall the response; while theme.js is in flight,
+ * the parser has paused at the `<script src="theme.js">` tag at the
+ * tail of `<body>`, but the inline bootloader in `<head>` has already
+ * run. We then read `<html>` and assert the `dark` class is present.
+ *
+ * Pre-fix this assertion would fail (only theme.js sets the class, and
+ * theme.js is stalled) — exactly the regression we want to catch.
+ * Post-fix the class is set by the inline bootloader well before
+ * the parser reaches theme.js, so the assertion passes.
+ *
+ * Three tests cover the three branches of the bootloader's resolution
+ * logic (mirrors theme.js's `applyTheme(currentTheme())`):
+ *
+ *   1. mode = 'dark'             → bootloader adds class
+ *   2. mode = 'light'            → bootloader does NOT add class
+ *   3. mode = 'system' + OS-dark → bootloader resolves to dark, adds class
+ *
+ * No DB reset, no login state — the bootloader is pure HTML/JS in
+ * the chrome and doesn't depend on the page body.
+ *
+ * Why we don't use page.addInitScript + MutationObserver
+ * -------------------------------------------------------
+ * The "natural" Playwright shape — install a MutationObserver via
+ * `addInitScript` and record `document.readyState` when the `dark`
+ * class first appears — runs into a known timing trap:
+ * `addInitScript` runs in the freshly-created document context BEFORE
+ * the parser has consumed the implicit `<html>` start tag, so
+ * `document.documentElement` is `null` at attachment time. The
+ * MutationObserver can't attach to a null target, and a deferred
+ * "wait for documentElement" chain is racy enough to miss the actual
+ * mutation in some chromium builds. The network-stall approach above
+ * is direct: it proves the contract the user actually cares about
+ * (the class is set before theme.js runs) without depending on the
+ * parser's microtask scheduling.
+ */
+
+import { expect, test, chromium } from '@playwright/test';
+
+const TARGET_ROUTE = '/index.php?p=banlist';
+const THEME_JS_PATTERN = '**/theme.js';
+
+/**
+ * Stall the theme.js network request until released. Returns a
+ * promise that resolves when theme.js is intercepted (i.e., the
+ * parser has reached the `<script src="theme.js">` tag in `<body>`'s
+ * tail), plus a release function to call when the assertions finish.
+ *
+ * Other API requests pass through normally — only theme.js is
+ * stalled. This keeps the test scoped to "what happens BEFORE
+ * theme.js runs".
+ */
+function setupThemeJsStall(page: import('@playwright/test').Page): {
+    waitForStall: Promise<void>;
+    release: () => void;
+} {
+    let resolveRelease: (() => void) | null = null;
+    let resolveStall: (() => void) | null = null;
+    const waitForStall = new Promise<void>((resolve) => {
+        resolveStall = resolve;
+    });
+    const releasePromise = new Promise<void>((resolve) => {
+        resolveRelease = resolve;
+    });
+
+    void page.route(THEME_JS_PATTERN, async (route) => {
+        if (resolveStall) {
+            resolveStall();
+            resolveStall = null; // first hit only
+        }
+        await releasePromise;
+        await route.continue();
+    });
+
+    return {
+        waitForStall,
+        release: () => {
+            if (resolveRelease) resolveRelease();
+        },
+    };
+}
+
+test.describe('flow: anti-FOUC bootloader (#1367)', () => {
+    test('mode=dark → html.dark is set BEFORE theme.js executes (bootloader contract)', async ({
+        page,
+    }) => {
+        // Establish the origin + persist 'dark' BEFORE installing the
+        // network stall. This first navigation lands in light mode (no
+        // localStorage entry → 'system' default → matches the
+        // project-level `colorScheme: 'light'` from playwright.config.ts).
+        await page.goto('/');
+        await page.evaluate(() => localStorage.setItem('sbpp-theme', 'dark'));
+
+        const { waitForStall, release } = setupThemeJsStall(page);
+
+        // Fire the navigation in the background. We can't `await` it
+        // because the parser will block at `<script src="theme.js">` in
+        // `<body>`'s tail (theme.js is stalled), and `page.goto`'s
+        // default `waitUntil: 'load'` would hang indefinitely. Catching
+        // any rejection guards against a teardown race in the rare case
+        // the browser closes before we resolve the stall.
+        const navigation = page
+            .goto(TARGET_ROUTE)
+            .catch((err: Error) => {
+                // page.route can leak through navigation aborts; the
+                // catch keeps the test from failing on tear-down noise.
+                if (!/(closed|aborted)/i.test(err.message)) throw err;
+            });
+
+        // Wait until the parser reaches the theme.js tag and our route
+        // handler intercepts it. At this exact moment, the inline
+        // bootloader in `<head>` has long since run (it's higher up in
+        // the document), but theme.js itself has not — its execution
+        // depends on the response body, which we're holding.
+        await waitForStall;
+
+        // The contract: the inline bootloader has already added `dark`
+        // to <html> by the time the parser even reached theme.js. If
+        // this fails, the bootloader is missing or broken — theme.js
+        // (the only other path that adds the class) hasn't executed
+        // yet, so there's nothing else to set it.
+        const isDark = await page.evaluate(() =>
+            document.documentElement.classList.contains('dark'),
+        );
+        expect(
+            isDark,
+            'pre-fix theme.js was the only path that set html.dark; with theme.js ' +
+                'stalled, this read `false` and the body painted in light mode for the ' +
+                "duration of the in-flight window — exactly the white flash the user " +
+                'reported. Post-fix the inline bootloader in <head> sets the class long ' +
+                'before the parser reaches theme.js, so this reads `true` regardless of ' +
+                "theme.js's load timing.",
+        ).toBe(true);
+
+        // Release theme.js so the page finishes loading cleanly and
+        // any subsequent test reuses the same page context safely.
+        release();
+        await navigation;
+
+        // Sanity check: the class is still on <html> after the
+        // navigation completes — guards against a future regression
+        // where the bootloader adds the class but theme.js immediately
+        // removes it.
+        await expect(page.locator('html')).toHaveClass(/dark/);
+    });
+
+    test('mode=light → html.dark is NOT set BEFORE theme.js executes (bootloader respects light)', async ({
+        page,
+    }) => {
+        await page.goto('/');
+        await page.evaluate(() => localStorage.setItem('sbpp-theme', 'light'));
+
+        const { waitForStall, release } = setupThemeJsStall(page);
+        const navigation = page
+            .goto(TARGET_ROUTE)
+            .catch((err: Error) => {
+                if (!/(closed|aborted)/i.test(err.message)) throw err;
+            });
+
+        await waitForStall;
+
+        const isDark = await page.evaluate(() =>
+            document.documentElement.classList.contains('dark'),
+        );
+        expect(
+            isDark,
+            'when the user has pinned light, the bootloader must not add html.dark — ' +
+                'doing so would resolve the wrong theme on first paint and produce the ' +
+                "inverse FOUC (briefly dark, then light). theme.js's boot-time " +
+                "applyTheme('light') would then remove the class on the second paint, " +
+                'producing the same flicker the bootloader is supposed to prevent.',
+        ).toBe(false);
+
+        release();
+        await navigation;
+
+        await expect(page.locator('html')).not.toHaveClass(/dark/);
+    });
+});
+
+test.describe('flow: anti-FOUC bootloader — system mode resolution (#1367)', () => {
+    test('mode=system + OS-dark → bootloader resolves to dark BEFORE theme.js executes', async () => {
+        // The project-level config pins `colorScheme: 'light'`, and
+        // `test.use({ colorScheme: 'dark' })` only flips the context
+        // option for the whole describe — but we want to scope the
+        // colorScheme override tightly to this one test. A fresh
+        // `chromium.launch()` is the canonical way to do that
+        // (loading-animations.spec.ts uses the same pattern). Skip
+        // mobile-chromium since the matchMedia resolution is
+        // viewport-independent — the second project run would burn
+        // cycles without revealing different findings.
+        const browser = await chromium.launch();
+        try {
+            const ctx = await browser.newContext({
+                colorScheme: 'dark',
+                baseURL: process.env.E2E_BASE_URL ?? 'http://localhost:8080',
+            });
+            const page = await ctx.newPage();
+
+            await page.goto('/');
+            await page.evaluate(() => localStorage.setItem('sbpp-theme', 'system'));
+
+            const { waitForStall, release } = setupThemeJsStall(page);
+            const navigation = page
+                .goto(TARGET_ROUTE)
+                .catch((err: Error) => {
+                    if (!/(closed|aborted)/i.test(err.message)) throw err;
+                });
+
+            await waitForStall;
+
+            const isDark = await page.evaluate(() =>
+                document.documentElement.classList.contains('dark'),
+            );
+            expect(
+                isDark,
+                'system mode + OS-dark must resolve to dark on first paint — the bootloader ' +
+                    'reads `matchMedia("(prefers-color-scheme: dark)").matches` against the ' +
+                    "context's emulated colorScheme and adds html.dark before the parser " +
+                    'reaches theme.js. If this fails, the bootloader is missing the matchMedia ' +
+                    'branch or the context override is being ignored.',
+            ).toBe(true);
+
+            release();
+            await navigation;
+
+            await expect(page.locator('html')).toHaveClass(/dark/);
+        } finally {
+            await browser.close();
+        }
+    });
+});

--- a/web/themes/default/core/header.tpl
+++ b/web/themes/default/core/header.tpl
@@ -62,6 +62,55 @@
     <link rel="manifest" href="{$theme_url}/images/site.webmanifest">
     <meta name="theme-color" content="#ea580c">
     <meta name="theme-color" content="#09090b" media="(prefers-color-scheme: dark)">
+    {*
+        Anti-FOUC bootloader (#1367). theme.js (loaded from footer.tpl,
+        the document tail) runs `applyTheme(currentTheme())` on boot to
+        flip <html> into the user's persisted theme — but by then the
+        body has already painted in light mode (the :root tokens default
+        to light), and theme.js's class flip triggers a full repaint
+        the user perceives as a white flash + content flicker on every
+        page navigation. The reporter's exact symptom: "When navigating
+        between pages while using dark mode, the page briefly renders in
+        light mode for a split second before switching back to dark."
+
+        The inline script below is byte-equivalent to theme.js's
+        `applyTheme(currentTheme())` minus the localStorage write
+        (theme.js still owns persistence): same THEME_KEY ('sbpp-theme'),
+        same default ('system'), same dark-resolution logic. It runs
+        synchronously before <body> parses, so the very first paint
+        lands in the user's chosen mode. theme.js still runs on boot —
+        its `applyTheme(currentTheme())` is now a no-op when the class
+        is already correct (toggle(true) on a set class, toggle(false)
+        on an unset class — both no-ops), and it stays the load-bearing
+        path for the click + matchMedia handlers below it.
+
+        Wrapped in IIFE + try/catch because `localStorage` throws on
+        private-mode iframes / SecurityError, and `matchMedia` is
+        missing on very old browsers; in either failure mode we
+        silently fall through to light, matching theme.js's
+        defensiveness. The logic also only ADDS the dark class — never
+        removes — because :root defaults to light, so removing would
+        be a no-op anyway, and not removing means we don't have to
+        repeatedly clear before-checking.
+
+        Placement: BEFORE the <link rel="stylesheet"> below. The script
+        is parser-blocking + synchronous, so anywhere in <head> works
+        in principle, but pinning it just above the stylesheet makes
+        the "this resolves the CSS cascade for dark vs light tokens"
+        intent obvious to future readers. Regression guard:
+        web/tests/e2e/specs/flows/theme-fouc.spec.ts (stalls theme.js
+        via page.route, asserts <html class="dark"> is present anyway).
+    *}
+    <script>
+    (function () {
+        try {
+            var m = localStorage.getItem('sbpp-theme') || 'system';
+            var d = m === 'dark' || (m === 'system' && window.matchMedia
+                && matchMedia('(prefers-color-scheme: dark)').matches);
+            if (d) document.documentElement.classList.add('dark');
+        } catch (e) { /* localStorage / matchMedia unavailable; default to light */ }
+    })();
+    </script>
     <link rel="stylesheet" href="{$theme_url}/css/theme.css">
     <script src="./scripts/api-contract.js"></script>
     <script src="./scripts/sb.js"></script>


### PR DESCRIPTION
## Summary

Closes #1367 — *White flash and content flicker when navigating between pages in dark mode.*

The chrome's light/dark theme is keyed off `class="dark"` on `<html>`, with `:root` tokens defaulting to light. `theme.js` is the only thing that toggles the class — but it loads from the document tail (`core/footer.tpl`), so by the time it runs `applyTheme(currentTheme())` on boot, the browser has **already painted the entire body in light mode**. The class flip then triggers a full repaint the user perceives as a white flash + content flicker on every page navigation. The reporter's exact symptom: *"the page briefly renders in light mode for a split second before switching back to dark."*

The fix is a tiny inline blocking `<script>` in `<head>` of `core/header.tpl` (immediately above the stylesheet link) that mirrors theme.js's resolution logic — same `THEME_KEY` (`'sbpp-theme'`), same `'system'` default, same `mode === 'dark' || (mode === 'system' && matchMedia(...).matches)` predicate — minus the `localStorage.setItem(...)` write. It runs synchronously before `<body>` parses, so the very first paint lands in the user's chosen mode. theme.js still runs on boot — its `applyTheme(currentTheme())` is now a no-op when the class is already correct, and it stays the load-bearing path for the toggle-click handler + the OS-preference matchMedia listener.

This is the same inline-script-in-`<head>` pattern every modern theme-toggle implementation uses (Tailwind docs, Next.js docs, GitHub, Vercel) — has to run BEFORE the body parses, which means inline (no external `<script src=…>` because the network round-trip would defeat the point) and in `<head>` (so the parser reaches it before the body tags).

## Defensiveness

- Wrapped in IIFE + try/catch because `localStorage` throws on private-mode iframes / SecurityError, and `matchMedia` is missing on very old browsers; in either failure mode we silently fall through to light, matching theme.js's defensiveness.
- Uses `var` and avoids ES6+ syntax — the bootloader failing IS the FOUC bug, so the surface area stays defensive (theme.js itself uses ES6+, but theme.js failing is recoverable, the bootloader failing isn't).
- Only **adds** the dark class — never removes — because `:root` defaults to light, so removing would be a no-op.

## Documentation

- `AGENTS.md` gets a new "Anti-FOUC theme bootloader" section under Conventions, three new entries under Anti-patterns (don't remove the bootloader, don't let resolution drift from theme.js, don't externalize the script), and a new "Where to find what" row.
- `color-scheme.spec.ts` preamble updated to clarify that `<html class="dark">` is now set BEFORE first paint via the bootloader, so the `toHaveCSS` polling assertion is defensive shape rather than load-bearing.

## Regression guard

`web/tests/e2e/specs/flows/theme-fouc.spec.ts` (new) uses `page.route` to intercept and STALL the `theme.js` network request, then asserts the state of `<html>`'s class list WHILE theme.js is held — i.e. the bootloader is the **only** thing that could have set the class. Three arms:

| Mode | Expected `<html class="dark">` | Branch under test |
| ---- | ------------------------------ | ----------------- |
| `'dark'` | yes | direct match |
| `'light'` | no | bootloader respects pinned light |
| `'system'` + emulated OS-dark | yes | matchMedia branch |

Each test then releases the route, waits for navigation to complete, and re-asserts the class — guards against a future regression where the bootloader adds the class but theme.js immediately removes it.

**Verified:** with the bootloader removed, the dark + system arms fail with `Expected: true, Received: false`. With the bootloader in place, all three arms pass on both `chromium` and `mobile-chromium` projects.

## Test plan

- [x] `./sbpp.sh phpstan` — no new errors
- [x] `./sbpp.sh ts-check` — passes (errors in other spec files are pre-existing)
- [x] `./sbpp.sh test` — PHPUnit unaffected
- [x] `./sbpp.sh e2e specs/flows/theme-fouc.spec.ts` — 6/6 pass on chromium + mobile-chromium
- [x] `./sbpp.sh e2e specs/a11y/color-scheme.spec.ts` — 4/4 pass (no regression)
- [x] `./sbpp.sh e2e specs/flows/ui/theme-toggle.spec.ts specs/a11y/dark-theme-contrast.spec.ts` — 13/13 pass (no regression)
- [x] Regression-guard sanity check: removed the bootloader, ran `theme-fouc.spec.ts`, confirmed dark + system arms fail with `Expected: true, Received: false`. Restored, all 6 pass again.

## Manual verification (reviewer-friendly)

1. `./sbpp.sh up` (or your worktree-scoped equivalent), open `http://localhost:8080`.
2. Toggle theme to dark via the topbar moon icon.
3. Navigate Dashboard → Bans → Servers → Comm blocks → Audit log a few times.
4. **Expected:** smooth transitions, body stays dark on every paint.
5. **Pre-fix (compare against `main`):** brief white flash + element flicker on every navigation.