### PR TITLE
ci(plugins): compile SourceMod plugins on every PR

### DIFF
--- a/.github/workflows/plugin-build.yml
+++ b/.github/workflows/plugin-build.yml
@@ -1,0 +1,57 @@
+name: Plugin build
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'game/addons/sourcemod/scripting/**'
+      - '.github/workflows/plugin-build.yml'
+  pull_request:
+    paths:
+      - 'game/addons/sourcemod/scripting/**'
+      - '.github/workflows/plugin-build.yml'
+
+# Compile every top-level `.sp` plugin with `spcomp` so a PR that breaks a
+# plugin (#1378's auto-DB-reconnection rewrite of sbpp_sleuth.sp /
+# sbpp_checker.sp is the canonical motivating example) fails the gate
+# instead of waiting for a release tag to surface the breakage. Mirrors
+# `release.yml`'s build-plugin step exactly — same compiler version, same
+# `-i include` invocation, same shallow `*.sp` glob (nested sub-files like
+# sbpp_admcfg/sbpp_admin_groups.sp are `#include`d by their parent and
+# don't compile standalone).
+jobs:
+  plugin-build:
+    name: Compile SourceMod plugins
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup SourcePawn compiler
+        uses: rumblefrog/setup-sp@master
+        with:
+          version: '1.12.x'
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      # Loop continues on individual failures so a PR that breaks more than
+      # one plugin sees every error in one CI run instead of having to fix-
+      # push-fix-push for each. The `::error file=…::` annotation surfaces
+      # each failure inline on the PR's Files Changed view; `::group::`
+      # collapses per-plugin spcomp output so the log stays scannable.
+      - name: Compile plugins
+        working-directory: game/addons/sourcemod/scripting
+        run: |
+          mkdir -p ../plugins
+          failed=0
+          for src in *.sp; do
+            echo "::group::Compiling $src"
+            if ! spcomp -i include -o "../plugins/${src%.sp}.smx" "$src"; then
+              echo "::error file=game/addons/sourcemod/scripting/$src::Failed to compile $src"
+              failed=$((failed + 1))
+            fi
+            echo "::endgroup::"
+          done
+          if [ "$failed" -gt 0 ]; then
+            echo "::error::$failed plugin(s) failed to compile"
+            exit 1
+          fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -179,7 +179,7 @@ services:
 
 ## Quality gates
 
-CI runs five gates on every PR. Match them locally before opening one.
+CI runs six gates on every PR. Match them locally before opening one.
 
 | Gate           | Local                                | CI workflow            |
 | -------------- | ------------------------------------ | ---------------------- |
@@ -188,6 +188,7 @@ CI runs five gates on every PR. Match them locally before opening one.
 | ts-check       | `./sbpp.sh ts-check`                 | `ts-check.yml`         |
 | API contract   | `./sbpp.sh composer api-contract`    | `api-contract.yml`     |
 | Playwright E2E | `./sbpp.sh e2e`                      | `e2e.yml`              |
+| Plugin build   | `(cd game/addons/sourcemod/scripting && spcomp -i include sbpp_*.sp)` | `plugin-build.yml`     |
 
 PHPStan specifics:
 
@@ -305,6 +306,34 @@ Playwright E2E specifics:
   `web/tests/e2e/scripts/upload-screenshots.sh` wrapper pushes the
   PNGs to the `screenshots-archive` orphan branch under a per-PR
   subdirectory and prints the markdown table to comment on the PR.
+
+Plugin build specifics:
+
+- Path-filtered to `game/addons/sourcemod/scripting/**` plus the
+  workflow file itself, so a PR that only touches `web/` or docs
+  doesn't pay for a SourcePawn round-trip. PRs that touch a plugin
+  source — `.sp`, `.inc`, or anything nested like
+  `sbpp_admcfg/sbpp_admin_groups.sp` — fire the gate.
+- Compiles **only the top-level `.sp` files** (shallow `*.sp` glob
+  in `scripting/`). Sub-files like `sbpp_admcfg/sbpp_admin_groups.sp`
+  and `sbpp_admcfg/sbpp_admin_users.sp` are `#include`d by their
+  parent (`sbpp_admcfg.sp` line 49-50) and don't compile standalone;
+  using a recursive `**/*.sp` glob would surface phantom failures.
+- Pinned to SourcePawn `1.12.x` via `rumblefrog/setup-sp@master` —
+  same compiler version `release.yml`'s build-plugin step uses, so
+  the gate exercises exactly what the next release tag will
+  compile. Bumping the floor (e.g. to 1.13.x) requires updating
+  `release.yml` in the same PR; the two must stay in lockstep.
+- Loop continues on individual failures and emits one
+  `::error file=…::` annotation per broken plugin so a PR that
+  breaks more than one (#1378's auto-DB-reconnection rewrite of
+  `sbpp_sleuth.sp` AND `sbpp_checker.sp` together is the canonical
+  multi-file shape) sees every error in one CI run instead of
+  fix-push-fix-push round-trips.
+- No local `./sbpp.sh` wrapper. The dev stack doesn't ship spcomp
+  (it's not relevant to panel work), so plugin contributors install
+  spcomp themselves and run the literal command from the table
+  above. Untouched-plugin PRs: trust the gate.
 
 ## Conventions
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -968,7 +968,7 @@ dev-only and documented as such in `docker-compose.yml`.
 
 ## Quality gates
 
-Five CI jobs run on every PR (`.github/workflows/`):
+Six CI jobs run on every PR (`.github/workflows/`):
 
 | Gate           | Workflow              | Local command                | What it covers                                |
 | -------------- | --------------------- | ---------------------------- | --------------------------------------------- |
@@ -977,6 +977,7 @@ Five CI jobs run on every PR (`.github/workflows/`):
 | ts-check       | `ts-check.yml`        | `./sbpp.sh ts-check`         | `tsc --checkJs` over `web/scripts/`.          |
 | API contract   | `api-contract.yml`    | `./sbpp.sh composer api-contract` | Regenerates `scripts/api-contract.js` and fails on diff. |
 | Playwright E2E | `e2e.yml`             | `./sbpp.sh e2e`              | Browser-level smoke / flows / a11y against the dev stack (chromium + mobile-chromium). |
+| Plugin build   | `plugin-build.yml`    | `(cd game/addons/sourcemod/scripting && spcomp -i include sbpp_*.sp)` | Compiles every top-level `.sp` plugin with `spcomp` (1.12.x, mirroring `release.yml`). Path-filtered to `game/addons/sourcemod/scripting/**` — only fires when a PR touches plugin sources. |
 
 PHPStan is at level 5 (bumped from 4 in #1101); raise one step at a
 time, never jump 5→7. The baseline at `web/phpstan-baseline.neon`

--- a/docker/README.md
+++ b/docker/README.md
@@ -99,7 +99,9 @@ again with `admin` / `admin`.
 
 ## Quality gates
 
-Five gates run in CI on every PR; each has a one-shot wrapper for local runs.
+Six gates run in CI on every PR; the first five each have a one-shot
+wrapper for local runs. The sixth (plugin compile) is CI-only — the
+dev stack ships no spcomp, and panel-only PRs never trigger it.
 
 ```sh
 ./sbpp.sh phpstan                 # static analysis (web/phpstan.neon, baseline at web/phpstan-baseline.neon)
@@ -107,6 +109,9 @@ Five gates run in CI on every PR; each has a one-shot wrapper for local runs.
 ./sbpp.sh ts-check                # tsc --checkJs over web/scripts (#1098)
 ./sbpp.sh composer api-contract   # regenerate web/scripts/api-contract.js (#1112)
 ./sbpp.sh e2e                     # Playwright + axe against the dev stack (#1124)
+
+# Plugin compile (no sbpp.sh wrapper — install spcomp locally if you want to mirror it)
+(cd game/addons/sourcemod/scripting && spcomp -i include sbpp_*.sp)
 ```
 
 `ts-check` runs the TypeScript compiler in `--checkJs` mode against the


### PR DESCRIPTION
## Summary

- Adds a sixth quality gate (`plugin-build.yml`) that runs `spcomp` against every top-level `.sp` plugin on PRs that touch `game/addons/sourcemod/scripting/**`. PRs that break a plugin — like #1378's auto-DB-reconnection rewrite of `sbpp_sleuth.sp` and `sbpp_checker.sp` — fail the gate instead of waiting for a release tag to surface the breakage.
- Mirrors `release.yml`'s build-plugin step exactly (same `rumblefrog/setup-sp@master`, same `1.12.x` floor, same `-i include`, same shallow `*.sp` glob so nested sub-files like `sbpp_admcfg/sbpp_admin_groups.sp` that are `#include`d by their parent don't compile standalone). The two **must stay in lockstep** — a future bump to 1.13.x updates both files in the same PR.
- Loop continues on per-plugin failure with `::error file=…::` annotations + `::group::` per-plugin output, then fails at the end with a count. A PR that breaks more than one plugin sees every error in one CI run instead of fix-push-fix-push round-trips.
- Paired doc updates per AGENTS.md's "Add or remove a quality gate / CI workflow" rule: `ARCHITECTURE.md` + `AGENTS.md` + `docker/README.md` quality-gate sections all bumped 5 → 6, AGENTS.md gets a new "Plugin build specifics" subsection mirroring the per-gate explanation pattern of the other gates.

No `./sbpp.sh` wrapper: the dev stack doesn't ship spcomp (it's not relevant to panel work), so plugin contributors install it themselves and run the literal `(cd game/addons/sourcemod/scripting && spcomp -i include sbpp_*.sp)` command. Untouched-plugin PRs trust the gate.

## Test plan

- [ ] Open this PR — `Plugin build` workflow should NOT fire (path filter excludes the workflow's own `.github/workflows/plugin-build.yml` AND the panel-only doc edits — wait, actually the workflow file IS in its own paths filter, so it *will* fire on this PR; the gate exercises itself, which is the right shape for the meta-PR).
- [ ] Confirm `Plugin build` job passes against current `main` plugin sources (sanity check that the workflow's spcomp invocation matches what `release.yml` does at tag time).
- [ ] Open a follow-up PR that intentionally breaks `sbpp_sleuth.sp` (e.g. introduces a syntax error) — confirm the gate fails, the failure surfaces as an inline `::error file=…::` annotation on the PR's Files Changed view, and the per-plugin output is wrapped in a collapsible `::group::`.
- [ ] Open a follow-up PR that breaks both `sbpp_sleuth.sp` AND `sbpp_checker.sp` — confirm the loop continues on the first failure and surfaces both errors in a single run.
- [ ] Verify a panel-only PR (web/ edit, no plugin touched) does NOT trigger the workflow.