### PR TITLE
feat(cla): gate web/ PRs on a signed Contributor License Agreement

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -26,4 +26,12 @@
 - [ ] My code follows the code style of this project.
 - [ ] My change requires a change to the documentation.
 - [ ] I have updated the documentation accordingly.
-- [ ] I have read the **CONTRIBUTING** document.
+- [ ] I have read the [**CONTRIBUTING**](CONTRIBUTING.md) document.
+
+---
+
+**Note:** If your PR touches `web/**` and this is your first
+contribution to the web panel, the CLA bot will comment within
+~30 seconds with one-line sign instructions. You only need to sign
+once per repo. See [`CLA.md`](CLA.md) for the full text and
+[`CONTRIBUTING.md`](CONTRIBUTING.md) for the rationale.

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,0 +1,72 @@
+name: CLA Assistant
+
+# Gates PRs that touch the dual-licensable web panel (web/**) on a signed
+# Contributor License Agreement. The CLA itself lives at CLA.md; the
+# rationale and how-to-sign instructions live in CONTRIBUTING.md.
+#
+# Scope: only PRs touching `web/**` trigger the check. Plugin-only PRs
+# under `game/addons/sourcemod/**` are GPLv3 and intentionally not gated.
+#
+# Allowlist: the maintainer (rumblefrog) plus all GitHub App bots.
+# Update the `allowlist:` field below to onboard additional maintainers.
+#
+# Storage: signatures land in `signatures/cla.json` on an orphan branch
+# `cla-signatures` that the action creates on its first successful run.
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_target:
+    types: [opened, closed, synchronize, reopened]
+    paths:
+      - 'web/**'
+      - 'CLA.md'
+      - '.github/workflows/cla.yml'
+
+# `pull_request_target` runs in the base-repo context, which is required so
+# the action can write to the `cla-signatures` branch in this repo. Never
+# switch this to `pull_request` — the fork-context token can't push.
+permissions:
+  actions: write
+  contents: write
+  pull-requests: write
+  statuses: write
+
+jobs:
+  cla:
+    name: CLA signature check
+    # Gate execution so non-signing comments on PRs (and `pull_request_target`
+    # events that already passed the paths filter) don't burn action minutes.
+    # `recheck` is the documented manual re-trigger for maintainers.
+    if: |
+      (github.event_name == 'issue_comment' &&
+        (github.event.comment.body == 'recheck' ||
+         github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA')) ||
+      github.event_name == 'pull_request_target'
+    runs-on: ubuntu-24.04
+    steps:
+      - name: CLA Assistant
+        uses: contributor-assistant/github-action@v2.6.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          path-to-signatures: 'signatures/cla.json'
+          path-to-document: 'https://github.com/sbpp/sourcebans-pp/blob/main/CLA.md'
+          branch: 'cla-signatures'
+          allowlist: 'rumblefrog,dependabot[bot],*[bot]'
+          lock-pullrequest-aftermerge: true
+          custom-pr-sign-comment: 'I have read the CLA Document and I hereby sign the CLA'
+          custom-notsigned-prcomment: |
+            Thanks for the PR! This change touches `web/**` (the SourceBans++ web panel),
+            which is covered by the project's [Contributor License Agreement](https://github.com/sbpp/sourcebans-pp/blob/main/CLA.md).
+
+            To sign, comment exactly the following line on this PR:
+
+            > I have read the CLA Document and I hereby sign the CLA
+
+            You only need to sign once — your signature applies to every future
+            web-panel PR you open against this repo. Plugin-only PRs
+            (`game/addons/sourcemod/**`) don't need a signature.
+
+            See [`CONTRIBUTING.md`](https://github.com/sbpp/sourcebans-pp/blob/main/CONTRIBUTING.md)
+            for the rationale.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,6 +48,7 @@ code change — never as a follow-up. CI doesn't gate this; it's on you.
 | Add or rename a DB table, or change the schema substantively | `ARCHITECTURE.md` (Database schema table) + ensure `install/includes/sql/struc.sql` is the source of truth + paired `web/updater/data/<N>.php` registered in `store.json` |
 | Add or change a row in `install/includes/sql/data.sql` (e.g. new `sb_settings` key) | Paired migration in `web/updater/data/<N>.php` + register in `web/updater/store.json` (see "Updater migrations") |
 | Add or remove a quality gate / CI workflow                  | `ARCHITECTURE.md` (Quality gates) **and** `AGENTS.md` (Quality gates) |
+| Change the CLA text, the `web/**` paths filter on the CLA workflow, the allowlist, or the sign-comment phrase | `CLA.md` + `.github/workflows/cla.yml` + `CONTRIBUTING.md` (rationale / how-to-sign) + the "Contributor License Agreement gate" Conventions block in `AGENTS.md`. Sign-comment phrase is duplicated in three places (workflow `if:`, `custom-pr-sign-comment`, CLA.md §10) — keep them byte-identical. |
 | Change a `./sbpp.sh` command surface                        | `AGENTS.md` (Dev commands) + `docker/README.md`       |
 | Introduce a new convention or pattern (e.g. View DTOs)      | `AGENTS.md` (Conventions) + `ARCHITECTURE.md` if it's an architectural shift |
 | Remove a legacy pattern                                     | `AGENTS.md` (Anti-patterns) + `ARCHITECTURE.md` (Legacy patterns being phased out) |
@@ -1557,6 +1558,58 @@ at 1920px so the IP column — tier-3 — is visible). When you add a
 new tier-3 column to either list and it relies on visibility for
 the spec, target a 1920px viewport, not 1440px.
 
+### Contributor License Agreement gate (`web/**`)
+
+Pull requests that touch `web/**` are gated on a signed Contributor
+License Agreement. The web panel is dual-licensable (free for hobby /
+community use under CC BY-SA 4.0; separate commercial licence for
+production use by hosting providers), and the CLA is the mechanism
+that lets the maintainer relicense future contributions without
+contacting every contributor individually.
+
+- Agreement text: [`CLA.md`](CLA.md). Ten sections, ~1 page. Contributor
+  keeps copyright; maintainer gets a perpetual, irrevocable, worldwide,
+  royalty-free, sublicensable licence with the **explicit right to
+  relicense under any terms, including proprietary or commercial**
+  (§3(b)). Same legal shape as GitLab / Discourse / Plex.
+- Workflow: [`.github/workflows/cla.yml`](.github/workflows/cla.yml).
+  Uses `contributor-assistant/github-action@v2.6.1`. Triggers:
+  `pull_request_target` with `paths: ['web/**', 'CLA.md',
+  '.github/workflows/cla.yml']`, plus `issue_comment` for the
+  "I have read the CLA Document and I hereby sign the CLA" sign flow.
+  Job-level `if:` gates execution so unrelated comments / non-web PRs
+  don't burn action minutes. Permissions: `actions: write`,
+  `contents: write`, `pull-requests: write`, `statuses: write` — all
+  load-bearing for writing to the signatures branch and posting the
+  PR comment / status check.
+- Signature storage: orphan branch `cla-signatures` in this repo at
+  `signatures/cla.json`. The action creates the branch on its first
+  successful run; do NOT precreate it manually. Each entry pins the
+  contributor's GitHub login, ID, the PR that recorded the signature,
+  and a timestamp.
+- Allowlist: the maintainer (`rumblefrog`) plus `*[bot]` (covers
+  Dependabot and any future GitHub App bot). The allowlist lives in
+  the workflow file's `allowlist:` field — single source of truth.
+  Onboarding an additional maintainer means adding their login there
+  in the same PR as any docs update naming them.
+- Scope is `web/**`. Plugin-only PRs (`game/addons/sourcemod/**`)
+  stay GPLv3 and intentionally skip the gate — copyleft already
+  blocks quiet relicensing, so layering a CLA on top would only add
+  friction. Mixed PRs (web/ + plugins) trigger the gate because of
+  the web/ half; one signature unblocks both.
+- The sign phrase ("I have read the CLA Document and I hereby sign
+  the CLA") is duplicated in three places: the workflow's job-level
+  `if:`, the workflow's `custom-pr-sign-comment:` field, and the
+  CLA.md §10 acceptance section. Keep all three byte-identical — the
+  action matches the contributor's comment against
+  `custom-pr-sign-comment`, the `if:` matches against the same string
+  to gate execution, and CLA.md §10 is what the contributor is told
+  to type. Drift between any two silently breaks the signing flow.
+- Historical contributors haven't signed; their pre-CLA web-panel
+  contributions aren't covered by the new grant. Retroactive sign-off
+  is a separate piece of work (opt-in follow-up) and isn't blocked
+  by the workflow being in place.
+
 ## Anti-patterns (do NOT reintroduce)
 
 - `btn.disabled = true` (or any other manual `disabled` flip) inside
@@ -2391,3 +2444,4 @@ the spec, target a 1920px viewport, not 1440px.
 | Translate raw `PDOException` connect errors into operator-friendly messages on the wizard's database step | `sbpp_install_translate_pdo_error()` in `web/install/includes/helpers.php` (#1335 m4). Pattern-matches the four error codes a non-technical operator is most likely to hit — 1045 (access denied), 2002 (host unreachable), 1049 (unknown database), 1044 (denied for user on database) — and emits a friendlier translation; falls back to the raw message for unrecognised codes so debugging stays possible. Pre-fix the wizard surfaced `SQLSTATE[HY000] [1045] Access denied for user 'sourcebans'@'192.168.96.5' (using password: YES)` verbatim, which is gibberish to non-DBAs and includes the panel-as-seen-by-DB internal IP (minor information disclosure). Regression test: `web/tests/integration/InstallGuardTest.php::testPdoErrorTranslationCoversCommonCodes`. |
 | Run a stack in parallel with another worktree | Worktree-local `docker-compose.override.yml` (see "Parallel stacks") |
 | Local dev stack details                | `docker/README.md`                                       |
+| Change the Contributor License Agreement (text, scope, allowlist) or how the CLA bot gates `web/**` PRs | `CLA.md` (the agreement text — 10 sections, web/-scoped, explicit relicensing right in §3(b)) + `.github/workflows/cla.yml` (the `contributor-assistant/github-action` workflow — paths filter, allowlist, sign-comment text, custom not-signed PR comment) + `CONTRIBUTING.md` (rationale + how-to-sign for contributors). Signatures land on the orphan branch `cla-signatures` under `signatures/cla.json`; the action creates the branch on its first successful run. The maintainer plus all `*[bot]` accounts are allowlisted by default. See "Contributor License Agreement gate" in Conventions. |

--- a/CLA.md
+++ b/CLA.md
@@ -1,0 +1,149 @@
+# SourceBans++ Web Panel Contributor License Agreement
+
+Thank you for your interest in contributing to the SourceBans++ web panel.
+To clarify the intellectual property licence granted with contributions
+from any person or entity, the project must have a Contributor Licence
+Agreement ("Agreement") on file that has been signed by each Contributor,
+indicating agreement to the licence terms below.
+
+This Agreement is for your protection as a Contributor as well as the
+protection of the Project and its users; it does not change your rights
+to use your own Contributions for any other purpose.
+
+This Agreement is entered into between you ("Contributor", "you",
+"your") and rumblefrog, the maintainer of the SourceBans++ project
+("Maintainer", "we", "our"), and governs Contributions you make to the
+web panel portion of the Project (defined below).
+
+## 1. Definitions
+
+- **"Project"** means the contents of the `web/` directory of the
+  `sbpp/sourcebans-pp` repository on GitHub, including any branches,
+  forks, successors, and future locations of the same code under the
+  Maintainer's control.
+
+- **"Contribution"** means any work of authorship — including code,
+  documentation, configuration, design assets, or other material — that
+  you intentionally submit to the Project for inclusion in `web/`.
+  Submission includes, without limitation, opening a pull request,
+  sending a patch, or any equivalent act of transmitting the work to
+  the Maintainer through any communication channel (issue tracker,
+  mailing list, chat, etc.). For the avoidance of doubt, communication
+  that is conspicuously marked or otherwise designated in writing by
+  you as "Not a Contribution" is excluded.
+
+## 2. Copyright
+
+You retain ownership of the copyright in your Contributions. Nothing in
+this Agreement transfers copyright to the Maintainer.
+
+## 3. Licence Grant
+
+Subject to the terms of this Agreement, you grant to the Maintainer,
+and to recipients of the Project distributed by the Maintainer, a
+perpetual, irrevocable, worldwide, royalty-free, non-exclusive,
+sublicensable, and transferable licence to:
+
+(a) reproduce, prepare derivative works of, publicly display, publicly
+perform, and distribute your Contribution and such derivative works,
+in source or object form;
+
+(b) include your Contribution in the Project under any licence terms
+the Maintainer chooses, **including licence terms different from the
+licence then in effect for the Project, and including proprietary or
+commercial licence terms**; and
+
+(c) sublicense the rights granted in this Section through multiple
+tiers of sublicensees.
+
+For clarity, the licence granted in Section 3(b) is the practical
+mechanism by which the Maintainer may dual-license the Project (for
+example, offering it under both a community open-source licence and a
+separate commercial licence) and by which the Maintainer may relicense
+the Project under different terms in the future without seeking your
+further permission.
+
+## 4. Patent Grant
+
+Subject to the terms of this Agreement, you grant to the Maintainer and
+to recipients of the Project distributed by the Maintainer a perpetual,
+irrevocable (except as stated in this Section), worldwide, royalty-free,
+non-exclusive licence under any patent claims that you can license that
+are necessarily infringed by your Contribution alone, or by combination
+of your Contribution with the Project to which the Contribution was
+submitted.
+
+If any entity institutes patent litigation against you or any other
+entity (including a cross-claim or counterclaim in a lawsuit) alleging
+that your Contribution, or the Project to which you have contributed,
+constitutes direct or contributory patent infringement, then any patent
+licences granted to that entity under this Agreement for that
+Contribution or Project shall terminate as of the date such litigation
+is filed.
+
+## 5. Representations
+
+You represent that:
+
+(a) each Contribution is your original creation, or you have sufficient
+rights to submit the Contribution under the terms of this Agreement;
+
+(b) you are not aware of any third-party rights, restrictions, or
+claims (including patents, copyrights, trademarks, or trade secrets)
+that would prevent the Maintainer from exercising the rights granted in
+Sections 3 and 4;
+
+(c) if your employer or another entity has rights to intellectual
+property that you create that includes your Contribution, you have
+received written permission to make Contributions on its behalf, or
+your employer has waived such rights for your Contributions to the
+Project; and
+
+(d) you are legally entitled to enter into this Agreement. If you are
+an individual, you represent that you are of legal age in your
+jurisdiction.
+
+If any representation in this Section ceases to be true, you agree to
+notify the Maintainer in writing as soon as you become aware.
+
+## 6. No Obligation
+
+This Agreement does not obligate the Maintainer to use, accept, or
+distribute any Contribution. The Maintainer may accept or reject any
+Contribution at its sole discretion.
+
+## 7. No Warranty
+
+You provide your Contributions "AS IS", without warranty of any kind,
+express or implied, including but not limited to warranties of
+merchantability, fitness for a particular purpose, title, and
+non-infringement. You are not required to provide support for your
+Contributions, except to the extent you choose to.
+
+## 8. Scope
+
+This Agreement applies **only** to Contributions to the `web/`
+directory of the Project. Contributions to other parts of the
+SourceBans++ repository, including the SourceMod plugins under
+`game/addons/sourcemod/`, are governed by the licence terms of those
+subprojects (currently GPLv3 for the SourceMod plugins) and are not
+covered by this Agreement.
+
+## 9. Miscellaneous
+
+This Agreement is the entire agreement between you and the Maintainer
+regarding Contributions, and supersedes any prior or contemporaneous
+understanding regarding the subject matter of this Agreement. If any
+provision of this Agreement is held to be unenforceable, the remaining
+provisions shall remain in full force and effect.
+
+## 10. Acceptance
+
+You accept this Agreement by commenting the exact phrase below on any
+pull request that the project's CLA bot has flagged:
+
+> I have read the CLA Document and I hereby sign the CLA
+
+Your signature is recorded automatically by the bot, applies to all
+future Contributions you make to the Project, and is effective as of
+the date the bot records it.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,93 @@
+# Contributing to SourceBans++
+
+Thanks for considering a contribution. Pull requests are welcome.
+Before opening one, please take a few minutes to read this document and
+the project's developer guides.
+
+## Where to start
+
+- **[`AGENTS.md`](AGENTS.md)** — conventions, the local Docker dev
+  stack (`./sbpp.sh`), the six quality gates CI runs on every PR, and
+  the cheat-sheet for common changes.
+- **[`ARCHITECTURE.md`](ARCHITECTURE.md)** — codebase tour: how the
+  web panel boots, request lifecycle, database access patterns, and
+  how the SourceMod plugins fit in.
+- **[Docs site](https://sbpp.github.io/)** (sources under
+  [`docs/`](docs/)) — self-hoster documentation (install, upgrade,
+  configure, FAQ). Self-hoster-visible changes ship docs updates in
+  the same PR.
+
+## Contributor License Agreement (web panel only)
+
+The SourceBans++ **web panel** (everything under
+[`web/`](web/)) is offered under a dual-licence model: free for hobby
+and community use under [CC BY-SA 4.0](LICENSE.md), and under a
+separate commercial licence for production use by game-server hosting
+companies that bundle SourceBans++ as a paid feature (see
+[README.md](README.md#license) for the commercial-licence contact).
+
+To make that arrangement workable, contributions to `web/**` from
+anyone other than the project maintainer are accepted under a
+Contributor Licence Agreement ("CLA") that grants the maintainer the
+right to relicense the web panel under different terms in the future,
+**including the commercial terms above**. You retain copyright in
+everything you contribute — the CLA is a licence grant, not a
+copyright assignment.
+
+The full text lives in [`CLA.md`](CLA.md). It's about a page long.
+
+### How to sign
+
+1. Open a pull request that touches `web/**`.
+2. Wait ~30 seconds for the CLA bot to comment with the sign
+   instructions. (First-time PRs occasionally take a minute — that's
+   normal; the bot is a GitHub Action, not a hosted service.)
+3. Reply on the PR with exactly:
+
+   > I have read the CLA Document and I hereby sign the CLA
+
+4. The bot updates the CLA status check to green within a few seconds.
+   You're done.
+
+You only need to sign once — your signature applies to every future
+PR you open against this repo, and is recorded on the
+`cla-signatures` branch of the repository.
+
+### Who doesn't need to sign
+
+- **The maintainer** (`rumblefrog`) — covered by ownership.
+- **GitHub App bots** (e.g. `dependabot[bot]`) — covered by ownership
+  of the configuration that opens those PRs. The allowlist in
+  [`.github/workflows/cla.yml`](.github/workflows/cla.yml) is the
+  source of truth.
+- **PRs that only touch SourceMod plugins** under
+  `game/addons/sourcemod/**` — those stay under GPLv3 (strong
+  copyleft) and aren't part of the dual-licence arrangement. If your
+  PR mixes `web/**` and plugin files, the CLA check fires because of
+  the `web/**` half; signing once unblocks both.
+
+### Why a CLA
+
+The web panel is offered free for hobby and community use, and under
+a separate commercial licence for production use. The CLA gives the
+maintainer the right to offer both — without it, every contributor
+would need to be contacted individually for every future relicensing
+decision, which doesn't scale.
+
+If you have legal questions about the CLA, please open an issue or
+reach out via the [Discord](https://discord.gg/tzqYqmAtF5) before
+signing.
+
+## Quality gates
+
+CI runs six gates on every PR (PHPStan, PHPUnit, ts-check, API
+contract, Playwright E2E, plugin build). Mirror them locally with
+`./sbpp.sh` before opening — see the
+[Quality gates](AGENTS.md#quality-gates) section of `AGENTS.md` for
+the full list and which subset applies to plugin-only changes.
+
+## Reporting security issues
+
+Please open an issue with reproduction details. If the report needs
+to be private, contact a maintainer on
+[Discord](https://discord.gg/tzqYqmAtF5) first.

--- a/README.md
+++ b/README.md
@@ -40,14 +40,44 @@ the upgrade path for each major version boundary.
 
 ## Contributing
 
-Pull requests welcome. Conventions and the local Docker dev stack
-live in [`AGENTS.md`](AGENTS.md); the codebase tour is in
-[`ARCHITECTURE.md`](ARCHITECTURE.md).
+Pull requests welcome. See [`CONTRIBUTING.md`](CONTRIBUTING.md) for the
+guide, [`AGENTS.md`](AGENTS.md) for conventions and the local Docker
+dev stack, and [`ARCHITECTURE.md`](ARCHITECTURE.md) for the codebase
+tour.
+
+PRs that touch the web panel (`web/**`) are covered by a Contributor
+License Agreement — see [`CLA.md`](CLA.md). The CLA bot leaves
+one-line sign instructions on your first such PR; you only need to
+sign once. Plugin-only PRs (`game/addons/sourcemod/**`) stay under
+GPLv3 and don't need a signature.
 
 Security issues: please open an issue with reproduction details, or
 contact a maintainer on Discord if the report needs to be private.
+
+## Sponsors
+
+SourceBans++ is built and maintained on volunteer time. If your
+community, server network, or hosting business depends on it,
+sponsoring development helps keep the panel healthy &mdash; and
+funds the modernization work that's been landing across v2.x.
+
+[![Sponsor on GitHub](https://img.shields.io/github/sponsors/rumblefrog?style=flat-square&logo=github&label=Sponsor%20on%20GitHub)](https://github.com/sponsors/rumblefrog)
+
+**Game-server hosts and SourceBans++-as-a-feature providers** &mdash;
+production / commercial use of the web panel is covered by a
+separate commercial license; see **License** below.
+
+<!-- sponsors:start -->
+<!-- Corporate sponsor logos land here once the corporate tier ships. -->
+<!-- sponsors:end -->
 
 ## License
 
 - **SourceMod plugins:** [GPLv3](https://raw.githubusercontent.com/sbpp/sourcebans-pp/v1.x/.github/GPLv3).
 - **Web panel:** [CC BY-NC-SA 3.0](LICENSE.md).
+  Hobby / community use is free under the linked terms; for
+  production / commercial use (e.g. game-server hosting companies
+  bundling SourceBans++ as a paid feature), a separate commercial
+  license is available &mdash; reach out via the contact link on
+  [GitHub Sponsors](https://github.com/sponsors/rumblefrog) or
+  Discord.


### PR DESCRIPTION
## Summary

Set up dual-licensing infrastructure for the web panel so the maintainer
can keep offering it under CC BY-SA (community / hobby use) while also
offering a separate commercial license (production / hosting providers)
without having to track down every contributor for every future
relicensing decision.

The CLA is the standard mechanism for this — same legal shape GitLab,
Discourse, and Plex use. Contributors keep copyright in their work
(§2); the maintainer gets a perpetual, irrevocable, worldwide,
royalty-free, sublicensable licence with the **explicit right to
relicense under any terms, including proprietary or commercial** (§3(b)).

## Scope

- **`web/**` only.** Plugin contributions under `game/addons/sourcemod/**`
  stay pure GPLv3 — strong copyleft already blocks quiet relicensing,
  so layering a CLA on top would only add friction without unlocking
  anything.
- **Allowlisted from the gate**: the maintainer (`rumblefrog`) plus
  all GitHub App bots (`*[bot]`, which covers Dependabot today and any
  future GitHub App).
- **Mixed PRs** (web/ + plugins) fire the gate via the web/ half; one
  signature unblocks both.

## What's in this PR

- `CLA.md` (new) — 10-section agreement, ~1 page. The load-bearing
  clauses are §3 (licence grant with sublicense + relicense rights),
  §4 (Apache-2.0-shape patent grant with the standard litigation
  termination), §8 (scope-limited to `web/**`).
- `.github/workflows/cla.yml` (new) — uses
  [`contributor-assistant/github-action@v2.6.1`](https://github.com/contributor-assistant/github-action).
  Triggers on `pull_request_target` with `paths: ['web/**', 'CLA.md', '.github/workflows/cla.yml']`
  plus `issue_comment` for the sign flow. Job-level `if:` filter so
  unrelated comments don't burn action minutes. Signatures land on an
  auto-created orphan branch `cla-signatures` under
  `signatures/cla.json`.
- `CONTRIBUTING.md` (new) — pointers to `AGENTS.md` / `ARCHITECTURE.md`
  plus the rationale and how-to-sign for contributors. Also fixes the
  long-dangling reference from `.github/PULL_REQUEST_TEMPLATE.md`
  line 29 (which already mentioned "the **CONTRIBUTING** document"
  even though it didn't exist).
- `README.md` — Contributing section links the new `CONTRIBUTING.md`
  and notes the CLA. **Also bundles in-progress edits** from before
  this work (Sponsors section + License commercial-license callout)
  since they document the model the CLA actually enables — splitting
  them would create dangling references from the new `CONTRIBUTING.md`.
- `.github/PULL_REQUEST_TEMPLATE.md` — CONTRIBUTING checkbox now
  links to the new file; bottom-of-template note about the CLA bot's
  sign flow. No new checkbox (bot enforces via status check, a
  self-checked box would be redundant + falsifiable).
- `AGENTS.md` — three additions: new row in "Keep the docs in sync"
  table, new row in "Where to find what" table, and a new Conventions
  subsection "Contributor License Agreement gate (`web/**`)" with the
  load-bearing rule that the sign phrase is byte-identical in three
  places (CLA.md §10 / workflow `if:` / `custom-pr-sign-comment`).

## What happens on merge

1. First PR after merge that touches `web/**` from a non-allowlisted
   contributor:
   - The action creates the `cla-signatures` orphan branch with an
     empty `signatures/cla.json`.
   - Posts a comment with one-line sign instructions.
   - Sets a `license/cla` status check (red until signed).
2. Contributor comments the exact sign phrase; bot records signature
   and flips status check to green within seconds.
3. Future PRs from the same contributor pass the gate automatically.

## Known follow-ups (deliberately out of scope)

- **Historical contributors haven't signed.** Their pre-CLA web-panel
  contributions aren't covered by the new grant, so strictly speaking
  the relicense applies "from this point forward". GitLab / Discourse
  / Plex either (a) get retroactive sign-off from material historical
  contributors, or (b) note the relicense applies from version X.Y
  onward. Separate piece of work, not blocked by this PR.
- **No corporate (CCLA) variant** yet — defer until a company actually
  contributes. Adding a second document is easy then.

## Test plan

- [ ] CI passes on this PR (the new CLA workflow won't fire on this
      branch since I'm in the allowlist; other gates should be
      unaffected — the workflow is path-filtered to `web/**` and this
      PR touches it via paired docs only).
- [ ] After merge: open a draft test PR from a second account touching
      `web/**`, verify the bot comments with sign instructions, sign,
      verify status check flips green. Close the draft PR.
- [ ] Verify `cla-signatures` orphan branch was auto-created with the
      test signature.
- [ ] Check that a plugin-only PR (`game/addons/sourcemod/**` change)
      does not trigger the CLA workflow.