### PR TITLE
docs: add Cloudflare Web Analytics beacon

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -60,6 +60,21 @@ export default defineConfig({
           tag: 'meta',
           attrs: { name: 'theme-color', content: '#ea580c' },
         },
+        // Cloudflare Web Analytics — privacy-friendly traffic stats
+        // for sbpp.github.io. No cookies, no fingerprinting, no
+        // cross-site tracking; the beacon just POSTs an anonymised
+        // page-view ping per navigation. The `data-cf-beacon` token
+        // is a public site identifier (it has to ship in the HTML
+        // for the beacon to work) — it's not a credential and can't
+        // be used to read the analytics dashboard.
+        {
+          tag: 'script',
+          attrs: {
+            defer: true,
+            src: 'https://static.cloudflareinsights.com/beacon.min.js',
+            'data-cf-beacon': '{"token": "900ab004c40747e099a22fa226b7fb29"}',
+          },
+        },
       ],
       // Starlight 0.33 changed `social` from a `Record<KnownPlatform, url>`
       // map to a `[{icon, label, href}]` array (see the changelog at


### PR DESCRIPTION
## Summary

- Wires the Cloudflare Web Analytics beacon into the Astro/Starlight head config (`docs/astro.config.mjs`) so traffic to <https://sbpp.github.io/> shows up in the analytics dashboard.
- Cloudflare Web Analytics is privacy-friendly by design: no cookies, no fingerprinting, no cross-site tracking — just an anonymised page-view ping per navigation. No consent banner needed under GDPR/CCPA, and nothing leaves the visitor's browser beyond the beacon URL.
- The `data-cf-beacon` token is a public site identifier (it ships in the page HTML for the beacon to work); it's not a credential and can't be used to read the dashboard. Hardcoding it is the canonical Cloudflare-documented integration pattern.

## Test plan

- [x] `npm run build` in `docs/` succeeds.
- [x] Grepped the `dist/` output: all 20 content pages + `404.html` carry exactly one `<script defer src="https://static.cloudflareinsights.com/beacon.min.js" data-cf-beacon='{"token": "…"}'>` in `<head>`.
- [x] No other files touched — single-line site-config change, picked up by `docs-build.yml` CI on PR.
- [ ] After merge: confirm the beacon reports pageviews in the Cloudflare dashboard (allow ~15 min for the first sample to land).