### PR TITLE
chore(cleanup): drop dead PHP fields rendering unreferenced JS calls (#1404)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2138,7 +2138,22 @@ contacting every contributor individually.
   → removed at v2.0.0 (#1123 D1). Page-tail helpers are inlined as
   self-contained vanilla JS per page (see `web/pages/admin.edit.ban.php`
   / `admin.edit.comms.php` for canonical examples); toasts go through
-  `window.SBPP.showToast` from the theme JS.
+  `window.SBPP.showToast` from the theme JS. The trailing per-row
+  `<script>LoadServerHost('SID', …)</script>` echo on the Add Admin
+  form (`admin.admins.php`) and the per-group
+  `<script>LoadServerHostPlayersList('<sids>', …)</script>` echo on
+  the Server Groups list (`admin.groups.php`) survived the v2.0
+  cutover and raised one `ReferenceError` per server / per server
+  group on every page load with no visible effect (the static `<span
+  id="saSID">IP:port</span>` fallback / the literal "Servers populate
+  via the legacy LoadServerHostPlayersList hook." placeholder masked
+  the symptom). Both went at #1404 along with the orphan
+  `AdminAdminsAddView::server_script` ctor param and the
+  `<div id="servers_{gid}">` hydration slot; `DeadJsCallSitesTest` is
+  the per-file forbidden-substring gate so a fork pasting back the
+  v1.x shape gets caught at PR time. Hydration follow-ups tracked at
+  #1405 (Add Admin per-server access list) / #1406 (Server Groups
+  per-group server cards).
 - `onclick="if (typeof <Helper> === 'function') <Helper>(...)"`
   legacy-helper presence guards in templates (the v1.x sourcebans.js
   defensiveness pattern that survived the #1123 D1 deletion of the
@@ -2825,6 +2840,7 @@ contacting every contributor individually.
 | Action -> permission lock              | `web/tests/api/PermissionMatrixTest.php`                 |
 | Trap PHP 8.1 null-into-scalar deprecations at runtime (the bits PHPStan can't see) | `web/tests/integration/Php82DeprecationsTest.php` (#1273) — process-isolated render harness with a stub Smarty + `set_error_handler` that promotes `E_DEPRECATED` / `E_USER_DEPRECATED` to `\ErrorException`. Mirrors the LostPasswordChromeTest stub-Smarty pattern; each test method runs in a separate process because the page handlers declare top-level helpers (`setPostKey()` etc.) that PHP can't redeclare in one process. Add a marquee route here whenever a new high-traffic page handler ships, especially if it reads nullable `:prefix_*` columns or `$_POST` / `$_GET` lookups. |
 | Pin the "every `:name` PDO placeholder needs as many `bind()` calls as occurrences" contract under native prepares | `web/tests/integration/SrvAdminsPdoParamTest.php` (#1314) — two methods. `testReusedNamedPlaceholderUnderNativePreparesIsRejected` issues a tiny `SELECT 1 ... WHERE aid = :sid OR aid = :sid` against `Sbpp\Db\Database` with one `bind()` and asserts it throws `HY093`; this is the contract pin (also a regression guard if anyone re-flips `EMULATE_PREPARES` back to `true`). `testAdminSrvadminsPageRendersWithoutPdoException` is the page-level regression guard for the actual #1314 fatal — process-isolated `require` of `pages/admin.srvadmins.php` with `?id=0` asserting no `PDOException` escapes. Mirrors the Php82DeprecationsTest stub-Smarty + process-isolation shape. |
+| Pin "dead v1.x JS call sites + their server-side feeders stay deleted" (the `<script>LoadServerHost(...)</script>` / `$data['unban_link']` / `$info['popup']` shapes the v2.0.0 `sourcebans.js` cutover left without a JS landing site) | `web/tests/integration/DeadJsCallSitesTest.php` (#1404) — three methods, 12 assertions. Per-file forbidden-substring map (`page.banlist.php` / `page.commslist.php` / `page.home.php` / `admin.admins.php` / `admin.groups.php`) scanned against the **comment-stripped** source of each handler via `php_strip_whitespace()`, so the cleanup's own `// #1404 — ...` explanatory comments (and pre-existing historical-context comments that name the dead helpers in passing) don't false-fire the gate. The Smarty half (`{$server_script nofilter}`, the `<div id="servers_{$group.gid}">` hydration slot, the "Servers populate via the legacy LoadServerHostPlayersList hook." placeholder copy) is pinned by `testDeadTemplateSidesStayDropped` (also comment-stripped via `{* *}`-regex). The View-DTO side (`Sbpp\View\AdminAdminsAddView::server_script` orphan property) is pinned independently by `testAdminAdminsAddViewDoesNotCarryServerScriptProperty` so the failure points at the View directly instead of cascading through SmartyTemplateRule. Pure file scanning — extends `PHPUnit\Framework\TestCase` (no DB / session / Smarty bring-up). Sister #1402 (rewire dead JS handlers) and #1403 (ShowBox→`window.SBPP.showToast` rewrite) extend the per-file forbidden-substring map as their PRs land. |
 | Add an E2E spec                        | `web/tests/e2e/specs/<smoke|flows|a11y|responsive>/...` + `web/tests/e2e/pages/...` |
 | Add a route to the screenshot gallery  | `web/tests/e2e/specs/_screenshots.spec.ts` (`ROUTES` array) |
 | Tweak mobile (<=768px) chrome layout   | `web/themes/default/css/theme.css` — see the `#1207` `@media (max-width: 768px)` blocks for the canonical shapes (icon-only topbar search, full-width drawer + scroll lock). Sub-paged admin routes (servers / mods / groups / comms / settings / admins / bans) use the `<details open>` accordion in the `#1259` `@media (min-width: 1024px)` block (sidebar inline at `<1024px`, sticky 14rem rail at `>=1024px`); see "Sub-paged admin routes" in Conventions. |

--- a/web/includes/View/AdminAdminsAddView.php
+++ b/web/includes/View/AdminAdminsAddView.php
@@ -32,7 +32,6 @@ final class AdminAdminsAddView extends View
         public readonly array $server_list,
         public readonly array $server_admin_group_list,
         public readonly array $server_group_list,
-        public readonly string $server_script,
     ) {
     }
 }

--- a/web/pages/admin.admins.php
+++ b/web/pages/admin.admins.php
@@ -128,16 +128,24 @@ if ($section === 'add-admin') {
     $servers                 = $GLOBALS['PDO']->query("SELECT * FROM `:prefix_servers`")->resultset();
     $server_admin_group_list = $GLOBALS['PDO']->query("SELECT * FROM `:prefix_srvgroups`")->resultset();
     $server_group_list       = $GLOBALS['PDO']->query("SELECT * FROM `:prefix_groups` WHERE type != 3")->resultset();
-    $server_list             = [];
-    $serverscript            = "<script type=\"text/javascript\">";
+    // #1404 — the pre-fix loop also built a `$serverscript` `<script>`
+    // blob that emitted `LoadServerHost('sid', 'id', 'saSID');` per
+    // server. The `LoadServerHost` helper was deleted with
+    // `sourcebans.js` at #1123 D1, so every page load raised
+    // `ReferenceError: LoadServerHost is not defined` once per
+    // configured server with no visible effect (the `sa<SID>` <span>
+    // already renders bare `IP:port` text from `$server_list`).
+    // Hydration to per-server hostnames is the next step — tracked as
+    // a follow-up ticket; see AGENTS.md "Anti-patterns" for the
+    // matching `LoadServerHost` entry.
+    $server_list = [];
     foreach ($servers as $server) {
-        $serverscript .= "LoadServerHost('" . $server['sid'] . "', 'id', 'sa" . $server['sid'] . "');";
+        $info         = [];
         $info['sid']  = $server['sid'];
         $info['ip']   = $server['ip'];
         $info['port'] = $server['port'];
         array_push($server_list, $info);
     }
-    $serverscript .= "</script>";
 
     \Sbpp\View\Renderer::render($theme, new \Sbpp\View\AdminAdminsAddView(
         // See AdminAdminsListView for why we don't splat Perms::for().
@@ -146,7 +154,6 @@ if ($section === 'add-admin') {
         server_list: $server_list,
         server_admin_group_list: $server_admin_group_list,
         server_group_list: $server_group_list,
-        server_script: $serverscript,
     ));
     echo '</div></div><!-- /.admin-sidebar-content + /.admin-sidebar-shell — opened by new AdminTabs(...) above -->';
     return;

--- a/web/pages/admin.admins.php
+++ b/web/pages/admin.admins.php
@@ -140,7 +140,6 @@ if ($section === 'add-admin') {
     // matching `LoadServerHost` entry.
     $server_list = [];
     foreach ($servers as $server) {
-        $info         = [];
         $info['sid']  = $server['sid'];
         $info['ip']   = $server['ip'];
         $info['port'] = $server['port'];

--- a/web/pages/admin.groups.php
+++ b/web/pages/admin.groups.php
@@ -137,12 +137,20 @@ $server_admin_group_count = count($server_group_list);
 // ------------------------------------------------------------------
 // Server groups (`:prefix_groups` WHERE type = 3).
 //
-// `LoadServerHostPlayersList(...)` inline scripts are still emitted
-// for any third-party theme that forked the pre-v2.0.0 default and
-// renders an accordion-revealed server list per row. The shipped
-// template omits the accordion entirely (the marquee surface is the
-// master-detail flag grid above, not these server-of-servers
-// groupings) and ignores the script tags.
+// #1404 — the pre-fix loop also echoed a per-row
+// `<script>LoadServerHostPlayersList('<sids>', 'id', 'servers_<gid>')</script>`
+// blob meant to async-hydrate the per-group server list into the
+// matching `<div id="servers_{gid}">` slot. The helper was deleted
+// with `sourcebans.js` at #1123 D1, so every page load raised
+// `ReferenceError: LoadServerHostPlayersList is not defined` once
+// per server group AND left the slot showing the literal "Servers
+// populate via the legacy LoadServerHostPlayersList hook." copy
+// admin-facing forever. The echo + the slot + the placeholder copy
+// all went together; the `:prefix_servers_groups` lookup that fed
+// the SID list went too (nothing else read it). Hydration to per-
+// group server cards is the next step — tracked as a follow-up
+// ticket; see AGENTS.md "Anti-patterns" for the matching
+// `LoadServerHostPlayersList` entry.
 // ------------------------------------------------------------------
 $server_group_rows = $GLOBALS['PDO']->query("SELECT * FROM `:prefix_groups` WHERE type = '3'")->resultset();
 $server_list   = [];
@@ -154,18 +162,6 @@ foreach ($server_group_rows as $row) {
     $GLOBALS['PDO']->bind(':gid', $row['gid']);
     $cnt = $GLOBALS['PDO']->single();
     $row['server_count'] = (int) $cnt['cnt'];
-
-    $GLOBALS['PDO']->query("SELECT server_id FROM `:prefix_servers_groups` WHERE group_id = :gid");
-    $GLOBALS['PDO']->bind(':gid', $row['gid']);
-    $servers_in_group = $GLOBALS['PDO']->resultset();
-
-    $server_arr = "";
-    foreach ($servers_in_group as $server) {
-        $server_arr .= $server['server_id'] . ";";
-    }
-    echo "<script>";
-    echo "LoadServerHostPlayersList('" . $server_arr . "', 'id', 'servers_" . $row['gid'] . "');";
-    echo "</script>";
 
     $server_list[]   = $row;
     $server_counts[] = $row['server_count'];

--- a/web/pages/page.banlist.php
+++ b/web/pages/page.banlist.php
@@ -855,11 +855,14 @@ foreach ($res as $row) {
     // automatically (see the smarter-default block in admin.bans.php),
     // but we make it explicit + drop the dead fragment.
     $data['groups_link']     = CreateLinkR('<i class="fas fa-users fa-lg"></i> Show Groups', "index.php?p=admin&c=bans&section=group-ban&fid=" . urlencode($data['communityid']));
-    $data['friend_ban_link'] = CreateLinkR('<i class="fas fa-trash fa-lg"></i> Ban Friends', '#', '', '_self', false, "BanFriendsProcess('" . $data['communityid'] . "','" . $data['player'] . "');return false;");
+    // #1404 — `friend_ban_link`, `unban_link`, and `delete_link` were
+    // v1.x `CreateLinkR`-built `BanFriendsProcess` / `UnbanBan` /
+    // `RemoveBan` `<a onclick=…>` blobs; the helpers were deleted with
+    // `sourcebans.js` at #1123 D1 and no v2.0+ template ever consumed
+    // the fields. Modern unban / delete affordances live on the
+    // `.row-actions` cell in `page_bans.tpl` (`data-action="bans-unban"`
+    // / `data-action="bans-delete"`). Pinned by `DeadJsCallSitesTest`.
     $data['edit_link']       = CreateLinkR('<i class="fas fa-edit fa-lg"></i> Edit Details', "index.php?p=admin&c=bans&o=edit" . $pagelink . "&id=" . $row['ban_id'] . "&key=" . $_SESSION['banlist_postkey']);
-
-    $data['unban_link']  = CreateLinkR('<i class="fas fa-undo fa-lg"></i> Unban', "#", "", "_self", false, "UnbanBan('" . $row['ban_id'] . "', '" . $_SESSION['banlist_postkey'] . "', '" . $pagelink . "', '" . $data['player'] . "', 1, false);return false;");
-    $data['delete_link'] = CreateLinkR('<i class="fas fa-trash fa-lg"></i> Delete Ban', "#", "", "_self", false, "RemoveBan('" . $row['ban_id'] . "', '" . $_SESSION['banlist_postkey'] . "', '" . $pagelink . "', '" . $data['player'] . "', 0, false);return false;");
 
 
     $data['server_id'] = $row['ban_server'];

--- a/web/pages/page.commslist.php
+++ b/web/pages/page.commslist.php
@@ -674,18 +674,14 @@ foreach ($res as $row) {
 
     $data['edit_link'] = CreateLinkR('<i class="fas fa-edit fa-lg"></i> Edit Details', "index.php?p=admin&c=comms&o=edit" . $pagelink . "&id=" . $row['ban_id'] . "&key=" . $_SESSION['banlist_postkey']);
 
-    switch ($data['type']) {
-        case 2:
-            $data['unban_link'] = CreateLinkR('<i class="fas fa-undo fa-lg"></i> UnGag', "#", "", "_self", false, "UnGag('" . $row['ban_id'] . "', '" . $_SESSION['banlist_postkey'] . "', '" . $pagelink . "', '" . $data['player'] . "', 1);return false;");
-            break;
-        case 1:
-            $data['unban_link'] = CreateLinkR('<i class="fas fa-undo fa-lg"></i> UnMute', "#", "", "_self", false, "UnMute('" . $row['ban_id'] . "', '" . $_SESSION['banlist_postkey'] . "', '" . $pagelink . "', '" . $data['player'] . "', 1);return false;");
-            break;
-        default:
-            break;
-    }
-
-    $data['delete_link'] = CreateLinkR('<i class="fas fa-trash fa-lg"></i> Delete Block', "#", "", "_self", false, "RemoveBlock('" . $row['ban_id'] . "', '" . $_SESSION['banlist_postkey'] . "', '" . $pagelink . "', '" . $data['player'] . "', 0);return false;");
+    // #1404 — the `unban_link` (UnGag/UnMute switch arms) and
+    // `delete_link` fields were `CreateLinkR`-built `UnGag` / `UnMute`
+    // / `RemoveBlock` `<a onclick=…>` blobs; the helpers were deleted
+    // with `sourcebans.js` at #1123 D1 and no v2.0+ template ever
+    // consumed the fields. Modern unmute / delete affordances live on
+    // the `.row-actions` cell in `page_comms.tpl`
+    // (`data-action="comms-unblock"` / `data-action="comms-delete"`).
+    // Pinned by `DeadJsCallSitesTest`.
 
     $data['server_id'] = $row['ban_server'];
 

--- a/web/pages/page.home.php
+++ b/web/pages/page.home.php
@@ -66,11 +66,16 @@ foreach ($rows as $row) {
     }
     $info['link_url'] = "window.location = '" . $info['search_link'] . "';";
 
-    // To print a name in the popup instead an empty string
-    if (empty($cleaned_name)) {
-        $cleaned_name = "<i>No nickname present</i>";
-    }
-    $info['popup']    = "ShowBox('Blocked player: " . $cleaned_name . "', '" . $cleaned_name . " tried to enter<br />' + document.getElementById('" . $info['server'] . "').title + '<br />at " . $info['date'] . "<br /><div align=middle><a href=" . $info['search_link'] . ">Click here for ban details.</a></div>', 'red', '', true);";
+    // #1404 — `$info['popup']` carried a `ShowBox(...)` `<script>`
+    // blob that v1.x stitched into each row's onclick. `ShowBox`
+    // was deleted with `sourcebans.js` at #1123 D1 and no v2.0+
+    // template ever consumed `{$player.popup}` (the dashboard
+    // reads `short_name` / `search_link` / `bid` / `sname` /
+    // `blocked_human` instead). The no-nickname placeholder
+    // (`<i>No nickname present</i>`) that fed the popup string
+    // went with it; the dashboard's `{if $p.short_name}…{else}no
+    // nickname{/if}` arm renders the empty-name fallback. Pinned
+    // by `DeadJsCallSitesTest`.
 
     $GLOBALS['server_qry'] .= "__sbppLoadServerHostProperty(" . (int) $row['sid'] . ", 'block_" . (int) $row['sid'] . "_$blcount', 'title');";
 

--- a/web/tests/integration/DeadJsCallSitesTest.php
+++ b/web/tests/integration/DeadJsCallSitesTest.php
@@ -1,0 +1,300 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sbpp\Tests\Integration;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Issue #1404: grep-guard against the dead PHP-side data fields +
+ * `<script>` blobs that survived the v2.0 `sourcebans.js` deletion
+ * (#1123 D1). Five files carried two cleanup shapes:
+ *
+ *   - **Inert dead fields** (`web/pages/page.banlist.php`,
+ *     `page.commslist.php`, `page.home.php`) — built `$data['friend_ban_link']`
+ *     / `$data['unban_link']` / `$data['delete_link']` / `$info['popup']`
+ *     for templates that no longer consume them. Modern row-action
+ *     buttons (`.row-actions` cells with `data-action="bans-unban"`
+ *     / `data-action="bans-delete"` / `data-action="comms-unblock"` /
+ *     `data-action="comms-delete"`) replace the legacy
+ *     `CreateLinkR`-built `<a onclick=…>` blobs entirely; the dashboard
+ *     reads `short_name` / `search_link` / `bid` / `sname` /
+ *     `blocked_human` instead of `popup`.
+ *   - **Live dead `<script>` blobs** (`admin.admins.php`,
+ *     `admin.groups.php`) — emitted `<script>LoadServerHost(...)</script>`
+ *     / `<script>LoadServerHostPlayersList(...)</script>` per row into
+ *     the live DOM. The helpers were deleted with `sourcebans.js` at
+ *     #1123 D1, so every Add Admin / Groups List page load raised
+ *     `ReferenceError: LoadServerHost… is not defined` once per
+ *     server / server group. Admin.groups.php also left a literal
+ *     "Servers populate via the legacy LoadServerHostPlayersList
+ *     hook." placeholder copy admin-facing forever.
+ *
+ * AGENTS.md's "Anti-patterns" block already flags the legacy 1.4.11
+ * JS handler names (`LoadServerHost`, `LoadServerHostPlayersList`,
+ * `BanFriendsProcess`, `UnbanBan`, `RemoveBan`, `UnGag`, `UnMute`,
+ * `RemoveBlock`, `ShowBox`) as forbidden. This test pins the
+ * cleanup so a future "convenient" reintroduction (a fork pasting
+ * back the v1.x row-action shape) is caught at PR time rather than
+ * landing as another silent `ReferenceError` flood.
+ *
+ * Comment-stripping discipline
+ * ----------------------------
+ *
+ * The grep runs against the **comment-stripped** source of each PHP
+ * file (`php_strip_whitespace()`) and the **`{* … *}`-stripped**
+ * source of each Smarty template. Without this step the gate
+ * false-fires on:
+ *
+ *   - The cleanup `// #1404 — ...` markers this PR itself added next
+ *     to each deletion, which name the dead helpers in passing
+ *     ("...the helpers `BanFriendsProcess` / `UnbanBan` /
+ *     `RemoveBan` were deleted with sourcebans.js at #1123 D1...").
+ *   - Pre-existing legitimate references to the legacy helper names
+ *     inside historical-context comments (e.g. `page.banlist.php`
+ *     line 45 explains the `?a=unban&id=…` GET fallback that
+ *     superseded `UnbanBan()`).
+ *
+ * Stripping comments rather than line-matching by leading `//` lets
+ * the gate stay file-level and survive future code re-flow without
+ * tweaking the test.
+ *
+ * Scope notes (intentional non-matches)
+ * -------------------------------------
+ *
+ * The guard scans only the five page handlers the issue listed —
+ * not the whole repo — so legitimate sister-site references stay
+ * unaffected:
+ *
+ *   - `admin.bans.search.php` / `admin.admins.search.php` /
+ *     `admin.comms.search.php` legitimately use `$serverscript`
+ *     to build a MODERN `sb.api.call(Actions.ServersHostPlayers,…)`
+ *     blob — same variable name, completely different shape (no
+ *     `LoadServerHost(` call literal). Those files are out of scope.
+ *   - `page.servers.php` legitimately calls `__sbppLoadServerHost(`
+ *     (the double-underscored vanilla replacement helper). The
+ *     forbidden form is the BARE `LoadServerHost(` (no `__sbpp` prefix);
+ *     `str_contains` would match the prefixed form too, so the
+ *     handler isn't in the per-file map.
+ *
+ * No DB / session / Smarty bring-up needed; pure file scanning.
+ * Extends `PHPUnit\Framework\TestCase` directly (no `ApiTestCase`)
+ * so test discovery + CI scheduling stay cheap.
+ */
+final class DeadJsCallSitesTest extends TestCase
+{
+    /**
+     * Map of forbidden substrings, keyed by the page handler that
+     * carried them pre-#1404. Each entry pins one specific dead
+     * pollution shape — assignment literal, embedded JS call form, or
+     * (for the wizard-side `LoadServerHostPlayersList` echo) the
+     * `<script>...` blob fragment that landed in the live DOM.
+     *
+     * Values are arrays so a single file can pin multiple patterns
+     * (`page.banlist.php` and `page.commslist.php` both carried
+     * two-or-three sibling assignments). The literals are deliberately
+     * specific so the test never false-matches code-shaped
+     * structures elsewhere in the file: `$data['…']` and `$info['…']`
+     * assignments are the unambiguous v1.x `CreateLinkR` shape.
+     *
+     * @return array<string, list<string>>
+     */
+    private static function forbiddenPatternsByFile(): array
+    {
+        return [
+            'page.banlist.php' => [
+                "\$data['friend_ban_link']",
+                "\$data['unban_link']",
+                "\$data['delete_link']",
+                'BanFriendsProcess(',
+                'UnbanBan(',
+                // Bare `RemoveBan(` (not `Sb`-prefixed). Pre-#1404
+                // page.banlist.php emitted `RemoveBan('<bid>', ...)` as
+                // the `<a onclick=…>` payload; sister #1402 may
+                // reintroduce a Smarty helper that calls
+                // `SbppRemoveBan` or similar — those wouldn't false-match.
+                "RemoveBan('",
+            ],
+            'page.commslist.php' => [
+                "\$data['unban_link']",
+                "\$data['delete_link']",
+                "UnGag('",
+                "UnMute('",
+                "RemoveBlock('",
+            ],
+            'page.home.php' => [
+                "\$info['popup']",
+                // `ShowBox(` was the toast helper the popup string
+                // called into. Sister #1403 covers the broader
+                // ShowBox-to-window.SBPP.showToast rewrite across
+                // OTHER files in `web/pages/`; #1404's scope is just
+                // this one assignment in `page.home.php`. The
+                // forbidden-list is per-file (not repo-wide), so this
+                // pattern only gates the home dashboard.
+                'ShowBox(',
+            ],
+            'admin.admins.php' => [
+                // The bare `<script>` blob tag that wrapped the dead
+                // `LoadServerHost(...)` per-server emission. Modern
+                // sister code (`admin.admins.search.php`) builds
+                // `'<script>(function(){…})();</script>'` instead;
+                // pinning the exact `"<script type=\"text/javascript\">"`
+                // prelude scopes the gate to the deleted shape only.
+                '<script type="text/javascript">',
+                // The bare JS call literal. The modern replacement is
+                // `__sbppLoadServerHost(` (the vanilla helper in
+                // `page.servers.php` / `page.home.php`); the bare form
+                // is what sourcebans.js used to provide.
+                "LoadServerHost('",
+            ],
+            'admin.groups.php' => [
+                'LoadServerHostPlayersList(',
+                // The `echo "<script>";` opening tag for the
+                // per-group blob. Scoped to this exact shape so the
+                // gate doesn't false-match the (legitimate) inline
+                // `<script>` block at the end of the file.
+                'echo "<script>";',
+            ],
+        ];
+    }
+
+    /**
+     * Strip every PHP comment + whitespace via the engine's own
+     * tokenizer so my own `// #1404 — ...` explanatory comments (and
+     * pre-existing historical-context comments like
+     * page.banlist.php's "v1.x prompted via sourcebans.js's
+     * UnbanBan() helper" note at line 45) don't false-match the
+     * forbidden literals. `php_strip_whitespace` is the canonical
+     * way to do this — it tokenises with the engine and drops
+     * `T_COMMENT` / `T_DOC_COMMENT` / `T_WHITESPACE`. Anything that
+     * survives is actual executable code.
+     */
+    private static function stripPhpComments(string $path): string
+    {
+        return php_strip_whitespace($path);
+    }
+
+    /**
+     * Strip Smarty `{* ... *}` comments (greedy, multiline) before
+     * grepping. Same defensiveness reason as `stripPhpComments` — my
+     * own cleanup markers shouldn't false-match. Inline HTML
+     * `<!-- ... -->` comments are NOT stripped (Smarty doesn't treat
+     * them as comments; they survive the render and reach the
+     * browser); the forbidden patterns here aren't HTML-comment-shaped
+     * so this is fine.
+     */
+    private static function stripSmartyComments(string $contents): string
+    {
+        return (string) preg_replace('/\{\*.*?\*\}/s', '', $contents);
+    }
+
+    /**
+     * Single-method pin. Each forbidden substring is checked against
+     * the comment-stripped file contents with `str_contains` and the
+     * assertion message names the exact file + pattern that fired,
+     * so a regression reads as a single `assertSame(0, $hits, …)`
+     * instead of cascading per-pattern failures.
+     *
+     * The literal expected hit count is `0` per the issue body.
+     */
+    public function testDeadJsCallSitesStayDeleted(): void
+    {
+        $pagesDir = ROOT . 'pages';
+        $this->assertDirectoryExists($pagesDir, 'pages/ must live next to tests/ for the scan to find it');
+
+        $hits = [];
+        foreach (self::forbiddenPatternsByFile() as $relativePath => $patterns) {
+            $fullPath = $pagesDir . '/' . $relativePath;
+            $this->assertFileExists(
+                $fullPath,
+                "$relativePath must exist — if it was renamed/deleted, update DeadJsCallSitesTest::forbiddenPatternsByFile() in the same PR.",
+            );
+            $stripped = self::stripPhpComments($fullPath);
+
+            foreach ($patterns as $pattern) {
+                if (str_contains($stripped, $pattern)) {
+                    $hits[] = "$relativePath contains forbidden literal " . var_export($pattern, true);
+                }
+            }
+        }
+
+        $this->assertSame(
+            0,
+            count($hits),
+            "Dead JS call sites resurrected in web/pages/. See AGENTS.md \"Anti-patterns\" (legacy 1.4.11 JS handler names) + #1404 for the cleanup rationale.\n\nOffending lines:\n - "
+                . implode("\n - ", $hits),
+        );
+    }
+
+    /**
+     * Sibling cross-check: the template halves of the two live
+     * regressions stay dropped. `admin.admins.php`'s `$serverscript`
+     * fed a `{$server_script nofilter}` echo at the tail of
+     * `page_admin_admins_add.tpl`; `admin.groups.php`'s echoed
+     * `<script>` blobs targeted a per-row `<div id="servers_{gid}">`
+     * with a literal "Servers populate via the legacy
+     * LoadServerHostPlayersList hook." placeholder above it. The PHP
+     * half going dead without the template half going with it would
+     * leave SmartyTemplateRule's "unused property" check unhappy
+     * (admin.admins side) and the operator-facing placeholder copy
+     * stranded (admin.groups side). Pin both.
+     */
+    public function testDeadTemplateSidesStayDropped(): void
+    {
+        $hits = [];
+
+        $addTpl = ROOT . 'themes/default/page_admin_admins_add.tpl';
+        $this->assertFileExists($addTpl);
+        $addContents = self::stripSmartyComments((string) file_get_contents($addTpl));
+        // `{$server_script}` / `{$server_script nofilter}` — the View
+        // no longer declares this property; reintroducing the echo
+        // would fail SmartyTemplateRule, but the rule's verdict only
+        // surfaces under PHPStan and this gate catches the literal
+        // shape immediately.
+        if (preg_match('/\{\s*\$server_script\b/', $addContents)) {
+            $hits[] = 'themes/default/page_admin_admins_add.tpl re-emits {$server_script}';
+        }
+
+        $groupsTpl = ROOT . 'themes/default/page_admin_groups_list.tpl';
+        $this->assertFileExists($groupsTpl);
+        $groupsContents = self::stripSmartyComments((string) file_get_contents($groupsTpl));
+        // The literal hydration-target slot.
+        if (preg_match('/<div\s+id\s*=\s*"servers_\{\$group\.gid\}"/', $groupsContents)) {
+            $hits[] = 'themes/default/page_admin_groups_list.tpl re-introduces <div id="servers_{$group.gid}"> hydration slot';
+        }
+        // The operator-facing placeholder copy.
+        if (str_contains($groupsContents, 'Servers populate via the legacy')) {
+            $hits[] = 'themes/default/page_admin_groups_list.tpl re-introduces the "Servers populate via the legacy ..." placeholder copy';
+        }
+
+        $this->assertSame(
+            0,
+            count($hits),
+            "Dead template halves resurrected. The PHP + template halves of #1404 ship together:\n - "
+                . implode("\n - ", $hits),
+        );
+    }
+
+    /**
+     * View-DTO cross-check: `Sbpp\View\AdminAdminsAddView` no longer
+     * declares a `server_script` constructor parameter. If a future
+     * PR reintroduces the property without restoring the template
+     * echo, SmartyTemplateRule fails on "unused public property"; if
+     * it reintroduces BOTH halves, the previous two tests fire. This
+     * one pins the View-side independently so the failure message
+     * points at the View directly instead of cascading.
+     */
+    public function testAdminAdminsAddViewDoesNotCarryServerScriptProperty(): void
+    {
+        $viewPath = ROOT . 'includes/View/AdminAdminsAddView.php';
+        $this->assertFileExists($viewPath);
+        $stripped = self::stripPhpComments($viewPath);
+
+        $this->assertDoesNotMatchRegularExpression(
+            '/\$server_script\b/',
+            $stripped,
+            'AdminAdminsAddView must not declare a `server_script` property — the per-server LoadServerHost(...) hydration echo it fed was deleted at #1404 (see AGENTS.md "Anti-patterns" for the LoadServerHost entry).',
+        );
+    }
+}

--- a/web/themes/default/page_admin_admins_add.tpl
+++ b/web/themes/default/page_admin_admins_add.tpl
@@ -220,7 +220,13 @@
             </div>
         </form>
 
-        {* nofilter: server-built `<script>LoadServerHost('SID', 'id', 'saSID');…</script>` from `:prefix_servers.sid` integer column, no user input — see admin.admins.php. *}
-        {$server_script nofilter}
+        {* #1404 — the `{$server_script nofilter}` tail used to emit a
+            server-built `<script>LoadServerHost('SID', 'id', 'saSID');…</script>`
+            blob; the helper was deleted with `sourcebans.js` at #1123 D1
+            so every page load raised `ReferenceError: LoadServerHost is
+            not defined` once per server. Each `#sa<SID>` <span> renders
+            bare `{$server.ip}:{$server.port}` per row above. Hydration to
+            the live hostname is the next step — see the follow-up ticket
+            tracked off #1404. *}
     {/if}
 </div>

--- a/web/themes/default/page_admin_groups_list.tpl
+++ b/web/themes/default/page_admin_groups_list.tpl
@@ -338,10 +338,18 @@
                                 {/if}
                             </div>
                         </div>
-                        <div class="card__body">
-                            <div class="text-xs text-muted">Servers populate via the legacy <code>LoadServerHostPlayersList</code> hook.</div>
-                            <div id="servers_{$group.gid}" class="text-xs mt-2"></div>
-                        </div>
+                        {* #1404 — pre-fix this card body carried a
+                           "Servers populate via the legacy
+                           LoadServerHostPlayersList hook." placeholder
+                           plus a sibling `<div id="servers_{gid}">`
+                           that admin.groups.php tried to async-hydrate.
+                           The helper was deleted with sourcebans.js at
+                           #1123 D1, so the placeholder copy was
+                           admin-facing forever. The body now collapses
+                           to the master-detail flag grid + member count
+                           up top — per-group server-card hydration is
+                           the next step (follow-up ticket tracked off
+                           #1404). *}
                     </article>
                 {/foreach}
             </div>


### PR DESCRIPTION
## Summary

Closes #1404.

Five PHP page handlers built server-side data fields containing dead JS function calls that survived the v2.0 `sourcebans.js` deletion (#1123 D1). Three built dead fields that no template ever rendered (pure dead pollution). Two (`admin.admins.php` + `admin.groups.php`) actually emitted dead `<script>` blobs into the live DOM, throwing `ReferenceError` per row on every page load (scaling with install size).

Cleanup scope:

- **Inert dead fields dropped** (no template consumer):
  - `page.banlist.php`: `$data['friend_ban_link']` / `$data['unban_link']` / `$data['delete_link']` (lines 858, 861, 862)
  - `page.commslist.php`: `$data['unban_link']` (UnGag/UnMute switch arms) + `$data['delete_link']` (lines 679, 682, 688)
  - `page.home.php`: `$info['popup']` (line 73) + the redundant `<i>No nickname present</i>` placeholder (`page_dashboard.tpl:332` already has the `{if $p.short_name}{else}<span class="text-faint">no nickname</span>{/if}` fallback)
- **Live dead `<script>` blobs dropped**:
  - `admin.admins.php`: `$serverscript` (`LoadServerHost('SID')` per-server emission) + the `{$server_script nofilter}` echo in `page_admin_admins_add.tpl` + the orphan `server_script` ctor param on `AdminAdminsAddView`
  - `admin.groups.php`: per-row `<script>LoadServerHostPlayersList(...)</script>` echo + the `:prefix_servers_groups` SQL lookup that fed it (free perf win — one fewer DB roundtrip per server group per page load) + the placeholder copy + the `<div id="servers_{gid}">` slot in `page_admin_groups_list.tpl`

Regression guard: new `web/tests/integration/DeadJsCallSitesTest.php` (3 methods, 12 assertions) grep-asserts that none of the dead fields/blobs return. The helpers strip PHP + Smarty comments before grepping so the cleanup's own explanatory comments don't false-fire the gate.

Follow-up issues filed for the proper hydration features that the dropped placeholders pointed at:
- #1405 — Hydrate Add Admin page's per-server access list with live hostname/status (`Sbpp\Servers\SourceQueryCache` + `server-tile-hydrate.js`)
- #1406 — Hydrate Server Groups list with per-group server cards (`Actions.GroupsServersList`)

AGENTS.md anti-pattern entries amended to cite #1404 as the precedent for the `LoadServerHost` / `LoadServerHostPlayersList` removals.

## Test plan

- [x] PHPStan green (240 files, 0 errors — the `SmartyTemplateRule` cross-check passes after the `server_script` View property removal)
- [x] PHPUnit green (680 tests, 2710 assertions, including the new 3-test/12-assertion `DeadJsCallSitesTest`)
- [x] ts-check green
- [x] API contract clean
- [x] E2E green at `CI=1` (267 passed / 279 skipped / 0 failed)
- [x] Adversarial review pass

## Related

- Closes #1404
- Sister #1402 (rewire dead JS handlers) and #1403 (silent ShowBox toasts) shipping separately
- #1405 / #1406 follow-up feature tickets filed
- #1123 D1 — the v2.0 cutover that deleted `sourcebans.js`