### PR TITLE
feat(toast): add optional $duration_ms parameter for persistent error toasts (#1409)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -929,8 +929,10 @@ coalescing" and "Duration semantics" below for the contract on each):
   testid and Playwright's `getByTestId(...)` strict mode rejects
   multi-match. E2E specs anchor on the painted
   `[data-testid="toast"]` element (set by `showToast` after the
-  chrome JS picks up the blob) or `[role="status"]`; wire-layer
-  specs probe the response body directly for
+  chrome JS picks up the blob) or the painted role attribute
+  (`[role="alert"]` for `kind === 'error'`, `[role="status"]`
+  otherwise — see "ARIA role contract" below); wire-layer specs
+  probe the response body directly for
   `class="sbpp-pending-toast"`.
 - `body` is plain text — `theme.js`'s `escapeHtml` escapes it
   before inserting into the DOM. HTML tags surface as visible
@@ -1066,6 +1068,41 @@ The typeof gate keeps the chrome's behaviour deterministic
 regardless of upstream noise; the encoder side already
 enforces an `int|null` PHP type so the only way a non-number
 lands on the wire is a hand-rolled malformed payload.
+
+ARIA role contract (#1409 review):
+
+The painted `[data-testid="toast"]` element carries a
+kind-aware `role` attribute:
+
+- `role="alert"` for `kind === 'error'` (assertive — screen
+  readers INTERRUPT the current announcement to surface the
+  toast).
+- `role="status"` for every other kind (`info` / `success` /
+  `warn` — polite; the announcement waits for the user to
+  finish what they're listening to).
+
+The distinction matters most for the persistent error toasts
+(`duration_ms: 0`): a polite `role="status"` announcement on
+a "destructive action FAILED, you MUST acknowledge before
+moving on" toast can be silently missed by a screen-reader
+user who's focused elsewhere — exactly the population least
+likely to notice the visual chrome change. `role="alert"`
+maps to the W3C ARIA spec's `aria-live="assertive"`
+semantic, which is the canonical answer for "this is
+serious and the user needs to know NOW". Apple HIG,
+Material Design, and Bootstrap all converge on the same
+error/non-error split.
+
+The role is set on the painted DOM element by `showToast`
+in `theme.js` — `el.setAttribute('role', kind === 'error'
+? 'alert' : 'status')`. The wire-format `<script>` block
+deliberately carries no role attribute (it's not a live
+region; the chrome's painted element is the announcement
+target). E2E specs that anchor on `role="status"` would
+miss error toasts under the kind-aware shape; use
+`[data-testid="toast"]` as the kind-independent anchor and
+filter by `data-kind="error"` if the spec specifically
+wants the error variant.
 
 PHP-side call site:
 
@@ -2463,8 +2500,12 @@ contacting every contributor individually.
   collide across emit calls and Playwright's `getByTestId(...)`
   strict mode rejects multi-match. E2E specs anchor on the
   *painted* `[data-testid="toast"]` element (chrome-rendered by
-  `showToast` after picking up the blob) or `[role="status"]`;
-  wire-layer specs probe the response body directly for
+  `showToast` after picking up the blob); for a kind-specific
+  anchor use `[data-testid="toast"][data-kind="error"]` (the
+  CSS class + dataset attribute the chrome stamps regardless
+  of ARIA role) rather than `[role="status"]` (which won't
+  match error toasts post-#1409 — they carry `role="alert"`).
+  Wire-layer specs probe the response body directly for
   `class="sbpp-pending-toast"`. The class is the consumer
   selector; no additional hooks needed. Regression guard:
   `ToastEmitRegressionTest::testToastEmitWireFormatStaysStable`
@@ -2566,6 +2607,47 @@ contacting every contributor individually.
   `null`) and exercised end-to-end by
   `web/tests/e2e/specs/flows/toast-persistent-duration.spec.ts`
   (the toast outlasts SHOWTOAST_DEFAULT_DURATION).
+- Uniform `role="status"` on every painted toast regardless of
+  kind (the pre-#1409-review shape) → `role="status"` is the
+  POLITE live-region role (`aria-live="polite"`) — screen
+  readers wait for the user to finish what they're listening
+  to before announcing. For routine `info` / `success` / `warn`
+  toasts that's the right shape (interrupting a screen-reader
+  user for "Settings saved" is rude and disruptive). For ERROR
+  toasts — especially the persistent `duration_ms: 0` shape —
+  it's wrong: the operator MUST acknowledge before moving on,
+  and a polite announcement that's quietly queued behind the
+  current task can be missed entirely. Screen-reader users are
+  the population least likely to notice a visual change without
+  an auditory cue; "the destructive operation failed" hitting
+  the speech queue silently doesn't help them. The contract
+  (#1409 review Suggested #3) is `role="alert"` for
+  `kind === 'error'` (assertive, interrupts), `role="status"`
+  for every other kind. Apple HIG / Material Design /
+  Bootstrap all converge on the same split; the W3C ARIA
+  spec is explicit that `role="alert"` is the answer for
+  "interrupt the user with critical info". E2E specs that
+  anchor on `[role="status"]` to find error toasts would miss
+  them under the kind-aware shape; reach for
+  `[data-testid="toast"][data-kind="error"]` as the
+  kind-specific anchor instead. The role attribute writes are
+  centralised in `showToast` in `web/themes/default/js/theme.js`
+  — one branch, single source.
+- Hand-rolling a `role="status"` / `role="alert"` attribute on
+  a custom toast / banner / live region surface without
+  matching the chrome's kind-aware contract → the broader
+  rule: assertive (`alert`) is for "user MUST acknowledge
+  before moving on" (destructive-operation-failed,
+  unrecoverable error, security-relevant event); polite
+  (`status`) is for everything else (background status
+  updates, routine confirmations, ambient information).
+  Choosing the wrong role isn't a visual bug — it's a
+  screen-reader user accessibility bug, which is the worst
+  kind of regression because the people affected are the
+  least likely to be running the test suite. When in doubt,
+  follow the chrome's `showToast` shape (error → alert; rest
+  → status) for consistency across the panel surfaces a
+  screen-reader user navigates.
 - `onclick="if (typeof <Helper> === 'function') <Helper>(...)"`
   legacy-helper presence guards in templates (the v1.x sourcebans.js
   defensiveness pattern that survived the #1123 D1 deletion of the
@@ -3251,7 +3333,7 @@ contacting every contributor individually.
 | Add visible row actions to a table-rendered admin list (Edit / Unmute / Remove buttons + responsive mobile-card mirror) | `web/themes/default/page_comms.tpl` (#1207 ADM-5) is the canonical reference: `<button class="btn btn--secondary btn--sm">` / `<a class="btn btn--ghost btn--sm">` inside a `.row-actions` cell, plus `.ban-card__actions` row of identical-data-action buttons in the mobile card. Wire destructive / state-changing buttons via `data-action="…"` + `data-bid` + `data-fallback-href`; the inline page-tail JS calls `sb.api.call(Actions.PascalName)` and falls back to the GET URL if the JSON dispatcher is absent. The public banlist (`web/themes/default/page_bans.tpl`) follows the same shape — same chrome (Lucide icon + visible text label inside `.btn--ghost` / `.btn--secondary btn--sm`), same `.ban-card__actions` mobile row, same `data-action` / `data-fallback-href` wiring (`bans-unban` / `bans-delete`). The Remove affordance points at the legacy GET handler (`?p=banlist&a=delete&id=…&key=…` at the top of `page.banlist.php`) because no JSON `bans.delete` action exists yet — the inline JS `confirm()`-prompts then navigates, mirroring commslist's flow without adding a new handler / snapshot / permission-matrix entry. |
 | Wire a comment-delete trash icon on any of the four comment-rendering surfaces (banlist, commslist, admin.bans protests, admin.bans submissions) | `web/scripts/comment-actions.js` (#1402). Single document-level dispatcher loaded from `core/footer.tpl` (`<script src="./scripts/comment-actions.js" defer>`) that picks up every `[data-action="comment-delete"]` click, `window.confirm`s the destructive intent, then `sb.api.call(Actions.BansRemoveComment, { cid, ctype, page })`. The four call sites emit the trigger with `data-cid="<int>"` + `data-ctype="<B|C|S|P>"` + `data-page="<int>"` (the page number for client-side row-hide / paginator-aware redirect; `data-page="-1"` is the sentinel for unpaginated moderation queues). The `ctype` letter matches `:prefix_comments.type` (B=ban, C=comm-block, S=submission, P=protest); `api_bans_remove_comment`'s `ctype` arm consumes all four. Don't duplicate the dispatcher inline per page — the single mount point is the contract, otherwise a future bug-fix has to land in four places. |
 | Add a confirm + reason modal for an irreversible row-level action (unban, lift comm block, delete admin, delete mod, …) | `web/themes/default/page_bans.tpl` (`#bans-unban-dialog`, `Actions.BansUnban`) and `web/themes/default/page_comms.tpl` (`#comms-unblock-dialog`, `Actions.CommsUnblock`) are the canonical reference (#1301), with `web/themes/default/page_admin_admins_list.tpl` (`#admins-delete-dialog`, `Actions.AdminsRemove`, #1352) and `web/themes/default/page_admin_mods_list.tpl` (`#mod-delete-dialog`, `Actions.ModsRemove`, #1397) as the third and fourth references for the optional-reason variant. Shape: a `<dialog hidden>` with a `<form method="dialog">` carrying a `<textarea aria-required="true">` (or `aria-required="false"` for the optional-reason variant — see admins-delete / mod-delete) (NOT the native `required` — that lets the browser block the form submit before our handler runs, swallowing the inline-error UX), a Cancel button, and a Confirm submit button. The page-tail JS opens the dialog via `showModal()` on `[data-action]` clicks, validates the trimmed reason on submit (load-bearing gate is server-side), forwards `ureason` to the JSON action, and on success flips the row in place via the same `flipRowToUnbanned`/`flipRowToUnmuted` helper the legacy single-click flow used (or removes the row outright + decrements the count badge for the admins-delete / mod-delete variants where there's no "now-unbanned" state to render). The legacy GET fallback (`?p=banlist&a=unban&id=…&key=…&ureason=…` / `?p=commslist&a=ungag…&ureason=…`) is the no-JS / hand-edited-URL path; both halves now reject empty `ureason` server-side so the audit log carries the *why*. The admins-delete and mod-delete variants have no legacy GET handler — `RemoveAdmin()` / `RemoveMod()` always went through the JSON dispatcher pre-#1123 D1 — so their `data-fallback-href` lands the operator back at the list page as a graceful no-op when the JSON dispatcher is missing entirely (third-party theme stripping `api.js`); the audit-log "Reason: …" suffix is only emitted when `ureason` is non-empty (vs always-emitted on the bans / comms variants where reason is required). **Do not** put `onclick="event.stopPropagation()"` on the trigger button — `document.addEventListener('click')` is how the dialog opener picks the click up, and stopPropagation would silently swallow it (the action button isn't inside any `[data-drawer-href]` ancestor anyway, so the defensiveness was a copy-paste from the row-name anchor that doesn't apply here). The submit button MUST flip through `setBusy(submitBtn, true)` BEFORE `sb.api.call(...)` leaves the page and clear via `setBusy(submitBtn, false)` on every non-navigating response branch — see "Loading state on action buttons" in Conventions for the contract, the inline-script local wrapper shape, and the regression guard. |
-| Emit a toast from a server-side branch (lostpassword reset success, banlist GET-fallback unban result, admin.edit.* not-found guard, …) | `\Sbpp\View\Toast::emit($kind, $title, $body, ?$redirect, ?$duration_ms)` (`web/includes/View/Toast.php`). Stashes the payload in a `<script type="application/json" class="sbpp-pending-toast">…</script>` block that `theme.js`'s `flushPendingToasts` picks up on `DOMContentLoaded`. Always FQN at call sites (no `use Sbpp\View\Toast;` shim). The chrome JS renders the body through `escapeHtml`; the PHP JSON encoder uses `JSON_HEX_TAG \| JSON_HEX_AMP \| JSON_HEX_APOS \| JSON_HEX_QUOT \| JSON_INVALID_UTF8_SUBSTITUTE \| JSON_THROW_ON_ERROR` so a `</script>` in body cannot break out AND malformed UTF-8 in player names (the #1108 / #765 Latin-1-on-utf8 shape) substitutes to U+FFFD instead of throwing. Multi-toast safe: emit calls stack cleanly; the first non-empty `$redirect` wins (chrome navigates ~1500ms after the toast paints so the user can read it). The optional 5th arg `$duration_ms` (#1409) overrides the chrome's `SHOWTOAST_DEFAULT_DURATION` (~4000ms) — `null` (default) keeps the chrome timing, `0` makes the toast persistent (no auto-dismiss; user must click the X button), `> 0` is an explicit ms override. The 5 NOT-* destructive-action-failed branches in `page.banlist.php` / `page.commslist.php` ("Player NOT Unbanned", "Ban NOT Deleted", "Player NOT UnGagged" × 2, "Ban NOT Deleted") pass `0` so severe-error confirmations don't auto-dismiss before the operator finishes reading. Negative `$duration_ms` throws `\InvalidArgumentException` (Fail closed; see "Duration semantics" in Conventions). Persistent + redirect are mutually exclusive (#1409): pass `null` for `$redirect` when emitting `duration_ms: 0` — the chrome's auto-redirect would otherwise navigate ~1500ms after paint, tearing down the persistent toast before the operator can acknowledge it. The chrome ALSO carries a whole-drain inhibit (`flushPendingToasts` skips the redirect setTimeout entirely when any block had `duration_ms: 0`) as defence-in-depth, but the call-site half (`$redirect=null`) is the primary contract pinned by `testNotStarBranchesPassPersistentDurationMs`'s strict regex. Pair with `PageDie()` (or `exit`) whenever the handler's "render the page body" path is no longer meaningful — pre-#1403 the legacy `<script>ShowBox(...)</script>` shape carried its own `window.location` and beat the page render to the user; the lifted helper relies on the explicit redirect + the 1500ms settle. See "Server-side toast emission" in Conventions for the full contract. Pinned by `web/tests/integration/ToastEmitRegressionTest.php` (static grep + wire-format + JSON-escape + UTF-8-substitute + FIRST-wins-redirect + `duration_ms` omitted/set/negative/escape contracts + the 5 NOT-* call sites pass `duration_ms: 0` AND `$redirect=null` + call-site contract) and the six marquee E2E specs (`lostpassword-toast.spec.ts`, `protest-toast.spec.ts`, `banlist-getfallback-toast.spec.ts`, `commslist-getfallback-toast.spec.ts`, `admin-edit-comms-toast.spec.ts`, `toast-persistent-duration.spec.ts`). The lostpassword spec seeds the dev stack's mailpit and asserts the password-reset email lands at the right address — the marquee user-reported regression from the audit. The persistent-duration spec (#1409) drives a NOT-* branch payload and asserts the toast is STILL visible past the default ~4000ms window. |
+| Emit a toast from a server-side branch (lostpassword reset success, banlist GET-fallback unban result, admin.edit.* not-found guard, …) | `\Sbpp\View\Toast::emit($kind, $title, $body, ?$redirect, ?$duration_ms)` (`web/includes/View/Toast.php`). Stashes the payload in a `<script type="application/json" class="sbpp-pending-toast">…</script>` block that `theme.js`'s `flushPendingToasts` picks up on `DOMContentLoaded`. Always FQN at call sites (no `use Sbpp\View\Toast;` shim). The chrome JS renders the body through `escapeHtml`; the PHP JSON encoder uses `JSON_HEX_TAG \| JSON_HEX_AMP \| JSON_HEX_APOS \| JSON_HEX_QUOT \| JSON_INVALID_UTF8_SUBSTITUTE \| JSON_THROW_ON_ERROR` so a `</script>` in body cannot break out AND malformed UTF-8 in player names (the #1108 / #765 Latin-1-on-utf8 shape) substitutes to U+FFFD instead of throwing. Multi-toast safe: emit calls stack cleanly; the first non-empty `$redirect` wins (chrome navigates ~1500ms after the toast paints so the user can read it). The optional 5th arg `$duration_ms` (#1409) overrides the chrome's `SHOWTOAST_DEFAULT_DURATION` (~4000ms) — `null` (default) keeps the chrome timing, `0` makes the toast persistent (no auto-dismiss; user must click the X button), `> 0` is an explicit ms override. The 5 NOT-* destructive-action-failed branches in `page.banlist.php` / `page.commslist.php` ("Player NOT Unbanned", "Ban NOT Deleted", "Player NOT UnGagged" × 2, "Ban NOT Deleted") pass `0` so severe-error confirmations don't auto-dismiss before the operator finishes reading. Negative `$duration_ms` throws `\InvalidArgumentException` (Fail closed; see "Duration semantics" in Conventions). Persistent + redirect are mutually exclusive (#1409): pass `null` for `$redirect` when emitting `duration_ms: 0` — the chrome's auto-redirect would otherwise navigate ~1500ms after paint, tearing down the persistent toast before the operator can acknowledge it. The chrome ALSO carries a whole-drain inhibit (`flushPendingToasts` skips the redirect setTimeout entirely when any block had `duration_ms: 0`) as defence-in-depth, but the call-site half (`$redirect=null`) is the primary contract pinned by `testNotStarBranchesPassPersistentDurationMs`'s strict regex (which disambiguates the two `Player NOT UnGagged` sites in `page.commslist.php` by body substring + asserts each site's call shape with `assertSame($expected_count, …)`). Painted ARIA role is kind-aware (#1409 review): `role="alert"` for `kind === 'error'` (assertive — screen readers interrupt to surface), `role="status"` for every other kind (polite). Persistent error toasts especially benefit from `alert` because the screen-reader user is the population least likely to notice a visual change without an auditory cue. Pair with `PageDie()` (or `exit`) whenever the handler's "render the page body" path is no longer meaningful — pre-#1403 the legacy `<script>ShowBox(...)</script>` shape carried its own `window.location` and beat the page render to the user; the lifted helper relies on the explicit redirect + the 1500ms settle. See "Server-side toast emission" in Conventions for the full contract (the "ARIA role contract" subsection covers the kind-aware role rationale). Pinned by `web/tests/integration/ToastEmitRegressionTest.php` (static grep + wire-format + JSON-escape + UTF-8-substitute + FIRST-wins-redirect + `duration_ms` omitted/set/negative/escape contracts + the 5 NOT-* call sites pass `duration_ms: 0` AND `$redirect=null` + call-site contract) and the six marquee E2E specs (`lostpassword-toast.spec.ts`, `protest-toast.spec.ts`, `banlist-getfallback-toast.spec.ts`, `commslist-getfallback-toast.spec.ts`, `admin-edit-comms-toast.spec.ts`, `toast-persistent-duration.spec.ts`). The lostpassword spec seeds the dev stack's mailpit and asserts the password-reset email lands at the right address — the marquee user-reported regression from the audit. The persistent-duration spec (#1409) drives a NOT-* branch payload and asserts the toast is STILL visible past the default ~4000ms window; its sister regression-guard test drives `window.SBPP.showToast(...)` directly (no page-flow / redirect dependency, post-review reshape) and asserts a routine toast auto-dismisses inside the ~4000-5000ms window so a regression bumping or zeroing the default duration fails loudly. |
 | Add a loading indicator to an action button that fires `sb.api.call(...)` without a page refresh | `window.SBPP.setBusy(btn, busy)` (`web/themes/default/js/theme.js`) writes the `data-loading="true"` + `aria-busy="true"` + `disabled` triple atomically; the CSS spinner lives in `web/themes/default/css/theme.css` under `.btn[data-loading="true"]` + the `sbpp-btn-spin` keyframe. Inline page-tail scripts inside `.tpl` files define a local `setBusy(btn, busy)` wrapper that delegates to `window.SBPP.setBusy` when present and falls back to `btn.disabled = busy` so third-party themes that strip `theme.js` still gate against double-clicks. Canonical reference shapes: the three confirm-dialog flows (`page_comms.tpl` / `page_bans.tpl` / `page_admin_admins_list.tpl`), the form-submit flows (`page_admin_groups_list.tpl` / `page_admin_groups_add.tpl` / `page_admin_bans_add.tpl` / `page_admin_bans_email.tpl` / `page_youraccount.tpl` / `page_lostpassword.tpl` / `page_login.tpl`), the row-action flows (`page_admin_servers_list.tpl` / `page_admin_bans_protests.tpl` / `page_admin_bans_protests_archiv.tpl` / `page_admin_bans_submissions.tpl` / `page_admin_bans_submissions_archiv.tpl`), and the drawer Notes paths (`theme.js`'s `submitNoteForm` / `deleteNote`). Comment edit on the banlist (`web/scripts/banlist.js`) carries the same pattern for the `sb.api.call(BansEditComment)` round-trip. Regression guards: `web/tests/e2e/specs/flows/action-loading-indicator.spec.ts` (stalls `Actions.CommsUnblock` via `page.route`, asserts the busy-attribute triple on the submit button while in flight, releases the route, and confirms the row flips in-place; the second test counts requests to prove the disabled gate blocks a double-click) **plus** `web/tests/e2e/specs/flows/loading-animations.spec.ts` (#1362 — samples `getComputedStyle(::after).transform` at multiple frame boundaries under both `reducedMotion: 'reduce'` AND `'no-preference'`, asserts the matrix values change across samples; catches the v2.0 RC1 regression where the global `prefers-reduced-motion: reduce` reset froze the spinner under reduced motion). |
 | Add a loading indicator to the player drawer or one of its lazy panes (so the chrome doesn't read as blank while the JSON action is in flight) | `renderDrawerLoading()` (header skeleton for the in-flight `bans.detail`) and `renderPaneSkeleton()` (placeholder for History / Comms / Notes activation) in `web/themes/default/js/theme.js`. Both lean on the `.skel` CSS rule in `theme.css` (linear-gradient + `shimmer` keyframe + dark-mode override + the `@media (prefers-reduced-motion: reduce)` per-rule override that keeps the shimmer sliding even under reduced motion, #1362). The header skeleton carries `[data-testid="drawer-loading"]` + `aria-busy="true"` + per-block `[data-skeleton]` (terminal markers under `#drawer-root[data-loading="true"]`); the lazy-pane skeleton carries `[data-pane-empty]` + `aria-busy="true"` and deliberately omits `[data-skeleton]` because the panel parent's `hidden` attribute doesn't compose into `[data-skeleton]:not([hidden])` and a nested marker would stall every page-load waiter that runs after the drawer opens. Class name is `.skel` (singular) — NOT `.skeleton`; the pre-fix `class="skeleton"` typo had no matching rule and the shimmer rows rendered as transparent zero-background divs (the user-visible "drawer is blank" regression). Regression guards: `web/tests/e2e/specs/flows/drawer-loading-indicator.spec.ts` (stalls `bans.detail` then `bans.player_history` via `page.route`, asserts the skeleton header is visible + the `.skel` block paints a `linear-gradient` background via `getComputedStyle(el).backgroundImage`, releases the routes, and confirms the drawer flips to `renderDrawerBody` / the pane fills with content) **plus** `web/tests/e2e/specs/flows/loading-animations.spec.ts` (#1362 — samples `getComputedStyle(.skel).backgroundPositionX` at multiple frame boundaries under both `reducedMotion: 'reduce'` AND `'no-preference'`, asserts the values change across samples; catches the v2.0 RC1 regression where the global reset froze the shimmer alongside the spinner). |
 | Surface unban-reason / removed-by inline on a public-list row (admin-lifted bans / comms — banlist-ureason or commslist-ureason inline) | `web/themes/default/page_bans.tpl` + `web/themes/default/page_comms.tpl` (#1315). Reason cell on the desktop table emits a `<div class="text-xs text-faint mt-1" data-testid="ban-unban-meta">` (or `comm-unban-meta` for comms) with "Unbanned by `<admin>`: `<reason>`" when `$ban.state == 'unbanned'` (or `$comm.state == 'unmuted'`); mobile cards mirror with the `-mobile` testid suffix. Always gated on `!$hideadminname` so anonymous viewers under a hidden-admins config don't get the admin name leaked. The `ureason` / `removedby` row fields come from the page handler's existing data path (`page.banlist.php` lines 635-643, `page.commslist.php` lines 626-635) — read-only render, no write-side overlap with #1301 / #1323's unban-reason flow. The commslist surface is higher-priority than the banlist (no drawer fallback on `<tr data-testid="comm-row">`); banlist users have the drawer as the canonical detail view. |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -885,9 +885,9 @@ PHP page handlers that need to surface a toast (success / error
 confirmation) to the user — either as the only signal on a
 GET-fallback path or alongside a `PageDie()`-rendered chrome
 footer — emit through `Sbpp\View\Toast::emit($kind, $title, $body,
-?$redirect)`. Single source for the wire format the chrome's
-`flushPendingToasts` consumer in `web/themes/default/js/theme.js`
-reads on `DOMContentLoaded`.
+?$redirect, ?$duration_ms)`. Single source for the wire format the
+chrome's `flushPendingToasts` consumer in
+`web/themes/default/js/theme.js` reads on `DOMContentLoaded`.
 
 Lifted at #1403 from the inline `emitSubmitToast()` helper in
 `page.submit.php` after an audit found six PHP page handlers
@@ -903,11 +903,16 @@ user, leading to "I clicked Reset Password three times because
 nothing happened" double-submits that burned three validation
 tokens. See the matching Anti-patterns entry for the full repro.
 
-Wire format (`$kind` ∈ `'info' | 'success' | 'warn' | 'error'`):
+Wire format (`$kind` ∈ `'info' | 'success' | 'warn' | 'error'`;
+`redirect` and `duration_ms` are both optional — see "Redirect
+coalescing" and "Duration semantics" below for the contract on each):
 
 ```html
 <script type="application/json" class="sbpp-pending-toast">
 {"kind":"success","title":"Password reset","body":"...","redirect":"?p=login"}
+</script>
+<script type="application/json" class="sbpp-pending-toast">
+{"kind":"error","title":"Ban NOT Deleted","body":"...","duration_ms":0}
 </script>
 ```
 
@@ -968,7 +973,7 @@ JSON_THROW_ON_ERROR
   instead of silently emitting `false` (which `echo` would
   render as the empty string — invisible regression vector).
 
-Redirect coalescing (FIRST wins):
+Redirect coalescing (FIRST wins; suppressed by persistent toasts):
 
 `$redirect` is optional. When passed, `theme.js`'s
 `flushPendingToasts` honours it AFTER the toasts paint, with a
@@ -988,11 +993,99 @@ time should NOT carry a redirect (the user is leaving the page
 anyway, the post-redirect surface can re-surface the same toast
 if persistent).
 
+Persistent + redirect mutual exclusion (#1409): when ANY toast in
+the drained queue carries `duration_ms: 0` (persistent), the
+chrome SUPPRESSES the redirect setTimeout entirely — the
+auto-navigation would otherwise tear down the toast ~1500ms after
+paint, defeating the whole point of the persistent semantic
+(operator never gets to read or dismiss it). The call-site
+contract is to pass `null` for `$redirect` when emitting
+`duration_ms: 0`; the chrome's whole-drain inhibit is
+defence-in-depth so a future caller forgetting that rule
+doesn't silently regress to broken UX. Both halves of the
+contract ship together (the static gate in
+`ToastEmitRegressionTest::testNotStarBranchesPassPersistentDurationMs`
+asserts the call-site half; the chrome-side inhibit is exercised
+end-to-end by `toast-persistent-duration.spec.ts`); neither half
+is sufficient on its own. Whole-drain (not per-block) inhibit:
+if a mixed queue carries persistent + non-persistent toasts, the
+non-persistent toasts still paint with their auto-dismiss
+timers, but the redirect is gated on the user's explicit X-click
+on the persistent toast. (No in-tree caller emits a mixed queue
+today; the contract is conservative for future surfaces.)
+
+Duration semantics (#1409):
+
+`$duration_ms` is optional and OMITTED from the wire format when
+the caller didn't pass an override — the chrome's `showToast`
+falls through to its `SHOWTOAST_DEFAULT_DURATION` constant
+(`4000` in `theme.js`). Three values are meaningful:
+
+- `null` (default) — omit the field. The toast auto-dismisses
+  after `SHOWTOAST_DEFAULT_DURATION` (~4000ms). The right
+  choice for every routine info / success / warn confirmation.
+- `0` — persistent. The chrome does NOT schedule an auto-dismiss
+  timer at all; the only way the toast disappears is the user
+  clicking the X button. Reserved for severe-error
+  "this destructive operation FAILED and the operator must
+  acknowledge before moving on" branches. The five canonical
+  call sites are the NOT-* (capital NOT) branches in
+  `page.banlist.php` / `page.commslist.php`:
+  - `page.banlist.php` — "Player NOT Unbanned", "Ban NOT Deleted"
+  - `page.commslist.php` — "Player NOT UnGagged" (ungag failure),
+    "Player NOT UnGagged" (unmute failure), "Ban NOT Deleted"
+- `> 0` — explicit override in milliseconds. Currently no in-tree
+  caller uses this; the contract exists so a future surface
+  (e.g. a long-form Markdown-rendered toast) can lengthen the
+  read window without resorting to persistent display.
+
+Negative values are programmer error — the helper throws
+`\InvalidArgumentException` rather than silently coercing.
+The "Fail closed" instinct applies: a negative arrival means
+the caller's arithmetic is broken; coercion would mask the
+bug AND silently flip the toast to persistent (the
+worst-of-both outcome).
+
+`SHOWTOAST_DEFAULT_DURATION` lives in `theme.js`'s TOASTS
+block — single source for the chrome-side default. Don't
+mirror the literal `4000` into other tests or call sites;
+reference the PHP-side `null` default and trust the chrome.
+The 4000ms default is itself a constant the project doesn't
+tune lightly — see the "Passing duration_ms = 0 for routine
+info / success toasts" Anti-patterns entry for the
+counter-direction (don't reach for `0` to dodge the timer
+on casual confirmations).
+
+The consumer-side gate in `flushPendingToasts` is
+`typeof data.duration_ms === 'number'`. A hostile / malformed
+payload sending a string or boolean must NOT pass through
+unchecked — `showToast` would then schedule
+`setTimeout(..., "0")` (Number-coerced to 0, auto-dismisses
+immediately) or `setTimeout(..., true)` (coerced to 1ms).
+The typeof gate keeps the chrome's behaviour deterministic
+regardless of upstream noise; the encoder side already
+enforces an `int|null` PHP type so the only way a non-number
+lands on the wire is a hand-rolled malformed payload.
+
 PHP-side call site:
 
 ```php
 \Sbpp\View\Toast::emit('success', 'Password reset', 'Email sent.', '?p=login');
 PageDie();
+
+// Severe-error: persistent toast (`duration_ms: 0`) so the
+// operator has to acknowledge before it disappears. `$redirect`
+// MUST be `null` — persistent + redirect are mutually exclusive
+// per "Redirect coalescing" above. The page handler continues
+// rendering the underlying surface (no PageDie() here) so the
+// operator stays on a valid page while reading the toast.
+\Sbpp\View\Toast::emit(
+    'error',
+    'Ban NOT Deleted',
+    "The ban for '" . $name . "' had an error while being removed.",
+    null,
+    0,
+);
 ```
 
 Always FQN — no `use Sbpp\View\Toast;` shim per call site, no
@@ -1020,6 +1113,10 @@ Regression guards:
   template-side `<script>ShowBox(...)` regression is sister
   #1402's surface), wire-format contract, JSON-escape contract,
   UTF-8-substitute contract, FIRST-wins-redirect contract,
+  `duration_ms` contract (omitted by default, included when set,
+  rejects negatives, JSON-escape guarantees preserved when
+  present, the 5 NOT-* call sites in `page.banlist.php` /
+  `page.commslist.php` still pass `duration_ms: 0`),
   "every audited page still calls Toast::emit" call-site
   contract.
 - `web/tests/e2e/specs/flows/lostpassword-toast.spec.ts` (the
@@ -1027,7 +1124,11 @@ Regression guards:
   error branches end-to-end, asserts the password-reset email
   lands in mailpit AND the chrome footer renders AND the toast
   paints), `protest-toast.spec.ts`, `banlist-getfallback-toast.spec.ts`,
-  `commslist-getfallback-toast.spec.ts`, `admin-edit-comms-toast.spec.ts`.
+  `commslist-getfallback-toast.spec.ts`, `admin-edit-comms-toast.spec.ts`,
+  `toast-persistent-duration.spec.ts` (#1409 — drives a NOT-*
+  branch's wire-format payload through the chrome and asserts
+  the toast is STILL visible past the default ~4000ms window;
+  the X-button dismiss is the only way out).
 
 ### Loading state on drawers + lazy panes (`.skel` shimmer)
 
@@ -2369,6 +2470,102 @@ contacting every contributor individually.
   `ToastEmitRegressionTest::testToastEmitWireFormatStaysStable`
   explicitly asserts the wire-format block carries NO
   `data-testid` attribute.
+- Passing `duration_ms = 0` to `\Sbpp\View\Toast::emit` for routine
+  info / success toasts → the persistent flag is for severe-error
+  "this destructive operation FAILED and the operator MUST
+  acknowledge before moving on" branches (the 5 NOT-* sites in
+  `page.banlist.php` / `page.commslist.php` are the canonical
+  reference shape). Using it for casual confirmations
+  ("Password reset email sent", "Ban added", "Settings saved",
+  etc.) creates UI clutter — the user has to click the X button
+  on every toast — and trains operators to dismiss reflexively
+  without reading, which DEFEATS the purpose of the persistent
+  flag the next time it actually matters (operator hits
+  "Ban NOT Deleted", reflex-dismisses without reading, and the
+  audit-log search five minutes later for "what just happened?"
+  comes up empty because the read-the-message-first contract
+  was burned through routine overuse). The contract:
+  - **Default** (no 5th arg): chrome's `SHOWTOAST_DEFAULT_DURATION`
+    (~4000ms). The right choice for every routine path.
+  - `0`: severe-error branches ONLY. The five NOT-* sites today
+    are the entire set; adding a sixth requires the same
+    "destructive operation failed mid-flight, audit log already
+    committed, operator needs the *why* before the toast
+    disappears" justification.
+  - `> 0`: explicit override (no in-tree caller today).
+  Negative values throw `\InvalidArgumentException` — the
+  "Fail closed" pattern AGENTS.md applies elsewhere. Don't
+  silently coerce; surface the programmer error.
+  Pinned by `ToastEmitRegressionTest::testToastEmitOmitsDurationMsByDefault`
+  / `testToastEmitIncludesDurationMsWhenSet`
+  / `testToastEmitRejectsNegativeDuration`
+  / `testNotStarBranchesPassPersistentDurationMs` plus the
+  `toast-persistent-duration.spec.ts` E2E that asserts the
+  NOT-* toast survives past `SHOWTOAST_DEFAULT_DURATION`.
+- Mirroring the literal `4000` into a new caller or test
+  ("the default is 4 seconds, let me hard-code it") → the
+  default lives in `theme.js`'s `SHOWTOAST_DEFAULT_DURATION`
+  constant — single source. Reference it as `null` on the
+  PHP side (`Toast::emit(...)` with no 5th arg) and trust the
+  chrome to fill in the value. The 4000ms number is one
+  reduce-this-to-3000ms tweak away from desynchronising every
+  hard-coded mirror; the chrome's constant + omission-on-wire
+  is what keeps the contract single-source. The matching
+  consumer-side gate
+  (`if (typeof data.duration_ms === 'number') opts.durationMs = data.duration_ms;`)
+  is what makes "field absent → use default" work — a future
+  refactor that always serialises `duration_ms` (even when
+  null) would silently disable the default fall-through path
+  on every install whose chrome is still on the typeof-number
+  gate.
+- Reading `data.duration_ms` from a `<script class="sbpp-pending-toast">`
+  block without the `typeof data.duration_ms === 'number'`
+  gate (e.g. truthy check `if (data.duration_ms)` or
+  unconditional assignment `opts.durationMs = data.duration_ms`)
+  → a hostile / malformed payload sending a string or boolean
+  must NOT pass through unchecked. `showToast` would then
+  schedule `setTimeout(..., "0")` (Number-coerced to 0,
+  auto-dismisses immediately) or `setTimeout(..., true)`
+  (coerced to 1ms). The typeof gate keeps the chrome's
+  behaviour deterministic regardless of upstream noise. The
+  encoder side already enforces an `int|null` PHP type, but
+  the chrome can't trust the server in this defence-in-depth
+  sense; the gate is the contract.
+- `setTimeout(() => el.remove(), 0)` instead of skipping the
+  timer entirely when `durationMs === 0` → `setTimeout(fn, 0)`
+  schedules the callback for the NEXT tick of the event loop,
+  not "never". The persistent toast would auto-dismiss after
+  ~4ms (the browser-clamped minimum), which is the OPPOSITE
+  of what `0` means in this contract. The chrome-side guard
+  is `if (durationMs > 0) setTimeout(...)` — `=== undefined`
+  arms have already been resolved to `SHOWTOAST_DEFAULT_DURATION`
+  by the time the guard runs, so the only path that hits
+  `setTimeout` is the explicit positive case.
+- Pairing `duration_ms: 0` with a non-null `$redirect` on a
+  `\Sbpp\View\Toast::emit(...)` call → persistent + redirect
+  are mutually exclusive (#1409). The chrome's
+  `flushPendingToasts` honours the redirect ~1500ms after
+  paint; that auto-navigation tears down the persistent toast
+  before the operator can read or dismiss it, defeating the
+  whole "needs acknowledgement" semantic the persistent flag
+  exists for. The call-site contract is to pass `null` for
+  `$redirect` when emitting `duration_ms: 0`; the page
+  handler's normal "render the body after the foreach loop"
+  flow keeps the operator on a valid surface (no `PageDie()`
+  before the toast persists). The chrome ALSO carries a
+  defence-in-depth inhibit (`flushPendingToasts` skips the
+  redirect setTimeout entirely if any drained block had
+  `duration_ms: 0`) so a future caller forgetting the rule
+  doesn't silently regress, but the call-site half is the
+  primary contract — relying on the chrome inhibit alone
+  leaves the wire payload carrying a redirect URL the chrome
+  silently throws away, which a code reader would flag as a
+  bug (and rightly so). Pinned by
+  `ToastEmitRegressionTest::testNotStarBranchesPassPersistentDurationMs`
+  (strict regex requires the 4th arg to be the literal
+  `null`) and exercised end-to-end by
+  `web/tests/e2e/specs/flows/toast-persistent-duration.spec.ts`
+  (the toast outlasts SHOWTOAST_DEFAULT_DURATION).
 - `onclick="if (typeof <Helper> === 'function') <Helper>(...)"`
   legacy-helper presence guards in templates (the v1.x sourcebans.js
   defensiveness pattern that survived the #1123 D1 deletion of the
@@ -3054,7 +3251,7 @@ contacting every contributor individually.
 | Add visible row actions to a table-rendered admin list (Edit / Unmute / Remove buttons + responsive mobile-card mirror) | `web/themes/default/page_comms.tpl` (#1207 ADM-5) is the canonical reference: `<button class="btn btn--secondary btn--sm">` / `<a class="btn btn--ghost btn--sm">` inside a `.row-actions` cell, plus `.ban-card__actions` row of identical-data-action buttons in the mobile card. Wire destructive / state-changing buttons via `data-action="…"` + `data-bid` + `data-fallback-href`; the inline page-tail JS calls `sb.api.call(Actions.PascalName)` and falls back to the GET URL if the JSON dispatcher is absent. The public banlist (`web/themes/default/page_bans.tpl`) follows the same shape — same chrome (Lucide icon + visible text label inside `.btn--ghost` / `.btn--secondary btn--sm`), same `.ban-card__actions` mobile row, same `data-action` / `data-fallback-href` wiring (`bans-unban` / `bans-delete`). The Remove affordance points at the legacy GET handler (`?p=banlist&a=delete&id=…&key=…` at the top of `page.banlist.php`) because no JSON `bans.delete` action exists yet — the inline JS `confirm()`-prompts then navigates, mirroring commslist's flow without adding a new handler / snapshot / permission-matrix entry. |
 | Wire a comment-delete trash icon on any of the four comment-rendering surfaces (banlist, commslist, admin.bans protests, admin.bans submissions) | `web/scripts/comment-actions.js` (#1402). Single document-level dispatcher loaded from `core/footer.tpl` (`<script src="./scripts/comment-actions.js" defer>`) that picks up every `[data-action="comment-delete"]` click, `window.confirm`s the destructive intent, then `sb.api.call(Actions.BansRemoveComment, { cid, ctype, page })`. The four call sites emit the trigger with `data-cid="<int>"` + `data-ctype="<B|C|S|P>"` + `data-page="<int>"` (the page number for client-side row-hide / paginator-aware redirect; `data-page="-1"` is the sentinel for unpaginated moderation queues). The `ctype` letter matches `:prefix_comments.type` (B=ban, C=comm-block, S=submission, P=protest); `api_bans_remove_comment`'s `ctype` arm consumes all four. Don't duplicate the dispatcher inline per page — the single mount point is the contract, otherwise a future bug-fix has to land in four places. |
 | Add a confirm + reason modal for an irreversible row-level action (unban, lift comm block, delete admin, delete mod, …) | `web/themes/default/page_bans.tpl` (`#bans-unban-dialog`, `Actions.BansUnban`) and `web/themes/default/page_comms.tpl` (`#comms-unblock-dialog`, `Actions.CommsUnblock`) are the canonical reference (#1301), with `web/themes/default/page_admin_admins_list.tpl` (`#admins-delete-dialog`, `Actions.AdminsRemove`, #1352) and `web/themes/default/page_admin_mods_list.tpl` (`#mod-delete-dialog`, `Actions.ModsRemove`, #1397) as the third and fourth references for the optional-reason variant. Shape: a `<dialog hidden>` with a `<form method="dialog">` carrying a `<textarea aria-required="true">` (or `aria-required="false"` for the optional-reason variant — see admins-delete / mod-delete) (NOT the native `required` — that lets the browser block the form submit before our handler runs, swallowing the inline-error UX), a Cancel button, and a Confirm submit button. The page-tail JS opens the dialog via `showModal()` on `[data-action]` clicks, validates the trimmed reason on submit (load-bearing gate is server-side), forwards `ureason` to the JSON action, and on success flips the row in place via the same `flipRowToUnbanned`/`flipRowToUnmuted` helper the legacy single-click flow used (or removes the row outright + decrements the count badge for the admins-delete / mod-delete variants where there's no "now-unbanned" state to render). The legacy GET fallback (`?p=banlist&a=unban&id=…&key=…&ureason=…` / `?p=commslist&a=ungag…&ureason=…`) is the no-JS / hand-edited-URL path; both halves now reject empty `ureason` server-side so the audit log carries the *why*. The admins-delete and mod-delete variants have no legacy GET handler — `RemoveAdmin()` / `RemoveMod()` always went through the JSON dispatcher pre-#1123 D1 — so their `data-fallback-href` lands the operator back at the list page as a graceful no-op when the JSON dispatcher is missing entirely (third-party theme stripping `api.js`); the audit-log "Reason: …" suffix is only emitted when `ureason` is non-empty (vs always-emitted on the bans / comms variants where reason is required). **Do not** put `onclick="event.stopPropagation()"` on the trigger button — `document.addEventListener('click')` is how the dialog opener picks the click up, and stopPropagation would silently swallow it (the action button isn't inside any `[data-drawer-href]` ancestor anyway, so the defensiveness was a copy-paste from the row-name anchor that doesn't apply here). The submit button MUST flip through `setBusy(submitBtn, true)` BEFORE `sb.api.call(...)` leaves the page and clear via `setBusy(submitBtn, false)` on every non-navigating response branch — see "Loading state on action buttons" in Conventions for the contract, the inline-script local wrapper shape, and the regression guard. |
-| Emit a toast from a server-side branch (lostpassword reset success, banlist GET-fallback unban result, admin.edit.* not-found guard, …) | `\Sbpp\View\Toast::emit($kind, $title, $body, ?$redirect)` (`web/includes/View/Toast.php`). Stashes the payload in a `<script type="application/json" class="sbpp-pending-toast">…</script>` block that `theme.js`'s `flushPendingToasts` picks up on `DOMContentLoaded`. Always FQN at call sites (no `use Sbpp\View\Toast;` shim). The chrome JS renders the body through `escapeHtml`; the PHP JSON encoder uses `JSON_HEX_TAG \| JSON_HEX_AMP \| JSON_HEX_APOS \| JSON_HEX_QUOT \| JSON_INVALID_UTF8_SUBSTITUTE \| JSON_THROW_ON_ERROR` so a `</script>` in body cannot break out AND malformed UTF-8 in player names (the #1108 / #765 Latin-1-on-utf8 shape) substitutes to U+FFFD instead of throwing. Multi-toast safe: emit calls stack cleanly; the first non-empty `$redirect` wins (chrome navigates ~1500ms after the toast paints so the user can read it). Pair with `PageDie()` (or `exit`) whenever the handler's "render the page body" path is no longer meaningful — pre-#1403 the legacy `<script>ShowBox(...)</script>` shape carried its own `window.location` and beat the page render to the user; the lifted helper relies on the explicit redirect + the 1500ms settle. See "Server-side toast emission" in Conventions for the full contract. Pinned by `web/tests/integration/ToastEmitRegressionTest.php` (static grep + wire-format + JSON-escape + UTF-8-substitute + FIRST-wins-redirect + call-site contract) and the five marquee E2E specs (`lostpassword-toast.spec.ts`, `protest-toast.spec.ts`, `banlist-getfallback-toast.spec.ts`, `commslist-getfallback-toast.spec.ts`, `admin-edit-comms-toast.spec.ts`). The lostpassword spec seeds the dev stack's mailpit and asserts the password-reset email lands at the right address — the marquee user-reported regression from the audit. |
+| Emit a toast from a server-side branch (lostpassword reset success, banlist GET-fallback unban result, admin.edit.* not-found guard, …) | `\Sbpp\View\Toast::emit($kind, $title, $body, ?$redirect, ?$duration_ms)` (`web/includes/View/Toast.php`). Stashes the payload in a `<script type="application/json" class="sbpp-pending-toast">…</script>` block that `theme.js`'s `flushPendingToasts` picks up on `DOMContentLoaded`. Always FQN at call sites (no `use Sbpp\View\Toast;` shim). The chrome JS renders the body through `escapeHtml`; the PHP JSON encoder uses `JSON_HEX_TAG \| JSON_HEX_AMP \| JSON_HEX_APOS \| JSON_HEX_QUOT \| JSON_INVALID_UTF8_SUBSTITUTE \| JSON_THROW_ON_ERROR` so a `</script>` in body cannot break out AND malformed UTF-8 in player names (the #1108 / #765 Latin-1-on-utf8 shape) substitutes to U+FFFD instead of throwing. Multi-toast safe: emit calls stack cleanly; the first non-empty `$redirect` wins (chrome navigates ~1500ms after the toast paints so the user can read it). The optional 5th arg `$duration_ms` (#1409) overrides the chrome's `SHOWTOAST_DEFAULT_DURATION` (~4000ms) — `null` (default) keeps the chrome timing, `0` makes the toast persistent (no auto-dismiss; user must click the X button), `> 0` is an explicit ms override. The 5 NOT-* destructive-action-failed branches in `page.banlist.php` / `page.commslist.php` ("Player NOT Unbanned", "Ban NOT Deleted", "Player NOT UnGagged" × 2, "Ban NOT Deleted") pass `0` so severe-error confirmations don't auto-dismiss before the operator finishes reading. Negative `$duration_ms` throws `\InvalidArgumentException` (Fail closed; see "Duration semantics" in Conventions). Persistent + redirect are mutually exclusive (#1409): pass `null` for `$redirect` when emitting `duration_ms: 0` — the chrome's auto-redirect would otherwise navigate ~1500ms after paint, tearing down the persistent toast before the operator can acknowledge it. The chrome ALSO carries a whole-drain inhibit (`flushPendingToasts` skips the redirect setTimeout entirely when any block had `duration_ms: 0`) as defence-in-depth, but the call-site half (`$redirect=null`) is the primary contract pinned by `testNotStarBranchesPassPersistentDurationMs`'s strict regex. Pair with `PageDie()` (or `exit`) whenever the handler's "render the page body" path is no longer meaningful — pre-#1403 the legacy `<script>ShowBox(...)</script>` shape carried its own `window.location` and beat the page render to the user; the lifted helper relies on the explicit redirect + the 1500ms settle. See "Server-side toast emission" in Conventions for the full contract. Pinned by `web/tests/integration/ToastEmitRegressionTest.php` (static grep + wire-format + JSON-escape + UTF-8-substitute + FIRST-wins-redirect + `duration_ms` omitted/set/negative/escape contracts + the 5 NOT-* call sites pass `duration_ms: 0` AND `$redirect=null` + call-site contract) and the six marquee E2E specs (`lostpassword-toast.spec.ts`, `protest-toast.spec.ts`, `banlist-getfallback-toast.spec.ts`, `commslist-getfallback-toast.spec.ts`, `admin-edit-comms-toast.spec.ts`, `toast-persistent-duration.spec.ts`). The lostpassword spec seeds the dev stack's mailpit and asserts the password-reset email lands at the right address — the marquee user-reported regression from the audit. The persistent-duration spec (#1409) drives a NOT-* branch payload and asserts the toast is STILL visible past the default ~4000ms window. |
 | Add a loading indicator to an action button that fires `sb.api.call(...)` without a page refresh | `window.SBPP.setBusy(btn, busy)` (`web/themes/default/js/theme.js`) writes the `data-loading="true"` + `aria-busy="true"` + `disabled` triple atomically; the CSS spinner lives in `web/themes/default/css/theme.css` under `.btn[data-loading="true"]` + the `sbpp-btn-spin` keyframe. Inline page-tail scripts inside `.tpl` files define a local `setBusy(btn, busy)` wrapper that delegates to `window.SBPP.setBusy` when present and falls back to `btn.disabled = busy` so third-party themes that strip `theme.js` still gate against double-clicks. Canonical reference shapes: the three confirm-dialog flows (`page_comms.tpl` / `page_bans.tpl` / `page_admin_admins_list.tpl`), the form-submit flows (`page_admin_groups_list.tpl` / `page_admin_groups_add.tpl` / `page_admin_bans_add.tpl` / `page_admin_bans_email.tpl` / `page_youraccount.tpl` / `page_lostpassword.tpl` / `page_login.tpl`), the row-action flows (`page_admin_servers_list.tpl` / `page_admin_bans_protests.tpl` / `page_admin_bans_protests_archiv.tpl` / `page_admin_bans_submissions.tpl` / `page_admin_bans_submissions_archiv.tpl`), and the drawer Notes paths (`theme.js`'s `submitNoteForm` / `deleteNote`). Comment edit on the banlist (`web/scripts/banlist.js`) carries the same pattern for the `sb.api.call(BansEditComment)` round-trip. Regression guards: `web/tests/e2e/specs/flows/action-loading-indicator.spec.ts` (stalls `Actions.CommsUnblock` via `page.route`, asserts the busy-attribute triple on the submit button while in flight, releases the route, and confirms the row flips in-place; the second test counts requests to prove the disabled gate blocks a double-click) **plus** `web/tests/e2e/specs/flows/loading-animations.spec.ts` (#1362 — samples `getComputedStyle(::after).transform` at multiple frame boundaries under both `reducedMotion: 'reduce'` AND `'no-preference'`, asserts the matrix values change across samples; catches the v2.0 RC1 regression where the global `prefers-reduced-motion: reduce` reset froze the spinner under reduced motion). |
 | Add a loading indicator to the player drawer or one of its lazy panes (so the chrome doesn't read as blank while the JSON action is in flight) | `renderDrawerLoading()` (header skeleton for the in-flight `bans.detail`) and `renderPaneSkeleton()` (placeholder for History / Comms / Notes activation) in `web/themes/default/js/theme.js`. Both lean on the `.skel` CSS rule in `theme.css` (linear-gradient + `shimmer` keyframe + dark-mode override + the `@media (prefers-reduced-motion: reduce)` per-rule override that keeps the shimmer sliding even under reduced motion, #1362). The header skeleton carries `[data-testid="drawer-loading"]` + `aria-busy="true"` + per-block `[data-skeleton]` (terminal markers under `#drawer-root[data-loading="true"]`); the lazy-pane skeleton carries `[data-pane-empty]` + `aria-busy="true"` and deliberately omits `[data-skeleton]` because the panel parent's `hidden` attribute doesn't compose into `[data-skeleton]:not([hidden])` and a nested marker would stall every page-load waiter that runs after the drawer opens. Class name is `.skel` (singular) — NOT `.skeleton`; the pre-fix `class="skeleton"` typo had no matching rule and the shimmer rows rendered as transparent zero-background divs (the user-visible "drawer is blank" regression). Regression guards: `web/tests/e2e/specs/flows/drawer-loading-indicator.spec.ts` (stalls `bans.detail` then `bans.player_history` via `page.route`, asserts the skeleton header is visible + the `.skel` block paints a `linear-gradient` background via `getComputedStyle(el).backgroundImage`, releases the routes, and confirms the drawer flips to `renderDrawerBody` / the pane fills with content) **plus** `web/tests/e2e/specs/flows/loading-animations.spec.ts` (#1362 — samples `getComputedStyle(.skel).backgroundPositionX` at multiple frame boundaries under both `reducedMotion: 'reduce'` AND `'no-preference'`, asserts the values change across samples; catches the v2.0 RC1 regression where the global reset froze the shimmer alongside the spinner). |
 | Surface unban-reason / removed-by inline on a public-list row (admin-lifted bans / comms — banlist-ureason or commslist-ureason inline) | `web/themes/default/page_bans.tpl` + `web/themes/default/page_comms.tpl` (#1315). Reason cell on the desktop table emits a `<div class="text-xs text-faint mt-1" data-testid="ban-unban-meta">` (or `comm-unban-meta` for comms) with "Unbanned by `<admin>`: `<reason>`" when `$ban.state == 'unbanned'` (or `$comm.state == 'unmuted'`); mobile cards mirror with the `-mobile` testid suffix. Always gated on `!$hideadminname` so anonymous viewers under a hidden-admins config don't get the admin name leaked. The `ureason` / `removedby` row fields come from the page handler's existing data path (`page.banlist.php` lines 635-643, `page.commslist.php` lines 626-635) — read-only render, no write-side overlap with #1301 / #1323's unban-reason flow. The commslist surface is higher-priority than the banlist (no drawer fallback on `<tr data-testid="comm-row">`); banlist users have the drawer as the canonical detail view. |

--- a/web/includes/View/Toast.php
+++ b/web/includes/View/Toast.php
@@ -71,7 +71,8 @@ namespace Sbpp\View;
  *     "kind":  "info" | "success" | "warn" | "error",
  *     "title": "Title text",
  *     "body":  "Body text (plain text — escapeHtml'd at render)",
- *     "redirect": "?p=banlist&page=2"   // optional
+ *     "redirect":    "?p=banlist&page=2",   // optional
+ *     "duration_ms": 0                       // optional
  * }
  * ```
  *
@@ -83,6 +84,26 @@ namespace Sbpp\View;
  * fallback paths in `page.banlist.php` / `page.commslist.php` /
  * `admin.edit.comms.php` all bounce back to the same list page
  * regardless of the success/error branch).
+ *
+ * `duration_ms` is also optional and OMITTED from the payload when
+ * the caller didn't pass an override — the chrome consumer's
+ * `flushPendingToasts` reads `data.duration_ms` only when present
+ * and otherwise falls through to `showToast`'s
+ * `SHOWTOAST_DEFAULT_DURATION` (~4000ms). Three values are
+ * meaningful: `null` (omit the field, default chrome timing — the
+ * common case for routine info / success / warn toasts), `0`
+ * (persistent — the toast does NOT auto-dismiss; the user has to
+ * click the X button), and `> 0` (explicit override in
+ * milliseconds). The persistent shape is for severe-error
+ * confirmations the operator MUST acknowledge — the v1.x
+ * `ShowBox(text, title, redirect, bg, sticky=true)` 5-arg helper
+ * carried the same semantic for the destructive-action-failed
+ * branches (Ban NOT Deleted / Player NOT Unbanned / Player NOT
+ * UnGagged); the lift in #1403 dropped it for fidelity and #1409
+ * restored it under a cleaner contract. Don't reach for `0` on
+ * routine confirmations — see the "Passing duration_ms = 0 for
+ * routine info / success toasts" Anti-patterns entry in AGENTS.md
+ * for the rationale.
  *
  * # Encoding
  *
@@ -156,6 +177,39 @@ final class Toast
      * re-renders its own form on the same URL — the toast then fires
      * inline on whichever response the browser is already loading.
      *
+     * `$duration_ms` is the optional auto-dismiss duration in
+     * milliseconds. Three values are meaningful:
+     *
+     *   - `null` (default) — omit the field from the wire format;
+     *     the chrome consumer falls through to
+     *     `SHOWTOAST_DEFAULT_DURATION` in `theme.js` (~4000ms).
+     *     The right choice for every routine info / success / warn
+     *     confirmation.
+     *   - `0` — persistent. The chrome does NOT schedule an
+     *     auto-dismiss timer; the only way the toast disappears is
+     *     the user clicking the X button. Reserve for severe-error
+     *     "this destructive operation FAILED and the operator must
+     *     acknowledge before moving on" branches (the
+     *     `Ban NOT Deleted` / `Player NOT Unbanned` /
+     *     `Player NOT UnGagged` shapes in `page.banlist.php` /
+     *     `page.commslist.php`; #1409 restored the v1.x
+     *     `ShowBox(..., sticky=true)` semantic the #1403 lift
+     *     dropped). Don't reach for `0` on casual confirmations —
+     *     persistent toasts create UI clutter and train users to
+     *     dismiss without reading; see the matching anti-pattern
+     *     entry in AGENTS.md.
+     *   - `> 0` — explicit override. Currently no in-tree caller
+     *     uses this; the contract exists so a future surface (e.g.
+     *     a long-form Markdown-rendered toast) can lengthen the
+     *     read window without resorting to persistent display.
+     *
+     * Negative values are programmer error — the helper throws
+     * `\InvalidArgumentException` rather than silently coercing to
+     * `max(0, $duration_ms)`. A negative arrival means the caller's
+     * own arithmetic is broken; coercion would mask the bug and
+     * silently flip the toast to persistent (the worst-of-both
+     * outcome). Fail closed.
+     *
      * Echoes the JSON blob directly to the response. No return
      * value — the meaningful output IS the side effect, mirroring
      * the pre-#1403 `emitSubmitToast` shape.
@@ -165,7 +219,20 @@ final class Toast
         string $title,
         string $body,
         ?string $redirect = null,
+        ?int $duration_ms = null,
     ): void {
+        if ($duration_ms !== null && $duration_ms < 0) {
+            throw new \InvalidArgumentException(
+                sprintf(
+                    'Toast::emit: $duration_ms must be null, 0, or a positive integer; got %d. '
+                    . 'Pass null for the chrome\'s default ~4000ms timer, 0 for a persistent '
+                    . 'toast (user must dismiss via the X button), or a positive ms count for '
+                    . 'an explicit override.',
+                    $duration_ms,
+                ),
+            );
+        }
+
         $payload = [
             'kind'  => $kind,
             'title' => $title,
@@ -173,6 +240,9 @@ final class Toast
         ];
         if ($redirect !== null && $redirect !== '') {
             $payload['redirect'] = $redirect;
+        }
+        if ($duration_ms !== null) {
+            $payload['duration_ms'] = $duration_ms;
         }
 
         $json = json_encode(

--- a/web/pages/page.banlist.php
+++ b/web/pages/page.banlist.php
@@ -145,11 +145,33 @@ if (isset($_GET['a']) && $_GET['a'] == "unban" && isset($_GET['id'])) {
             $ucount++;
         } else {
             if (!isset($_GET['bulk'])) {
+                // #1409: persistent toast (`duration_ms: 0`) on the
+                // severe-error "destructive action FAILED" branch.
+                // The unban operation didn't complete; the operator
+                // needs to read this before it auto-dismisses. v1.x
+                // shipped the same semantic via
+                // `ShowBox(..., sticky=true)`; the #1403 mechanical
+                // lift dropped it for fidelity and this restores it.
+                //
+                // The 4th `$redirect` argument is `null` (not the
+                // sibling success branch's `"index.php?p=banlist"`)
+                // because persistent + redirect are mutually
+                // exclusive: the chrome's `flushPendingToasts` would
+                // otherwise navigate ~1500ms after paint, tearing
+                // the toast down before the operator can read or
+                // dismiss it — exactly the regression #1409 closes.
+                // The page handler continues rendering the banlist
+                // body after this branch (no `PageDie()` here), so
+                // the operator stays on a valid surface; the toast
+                // persists until the user clicks the X button. See
+                // AGENTS.md "Server-side toast emission" →
+                // "Duration semantics" for the full contract.
                 \Sbpp\View\Toast::emit(
                     'error',
                     'Player NOT Unbanned',
                     'There was an error unbanning ' . $row['name'],
-                    "index.php?p=banlist$pagelink",
+                    null,
+                    0,
                 );
             }
             $fail++;
@@ -233,11 +255,22 @@ if (isset($_GET['a']) && $_GET['a'] == "unban" && isset($_GET['id'])) {
             $dcount++;
         } else {
             if (!isset($_GET['bulk'])) {
+                // #1409: persistent toast (`duration_ms: 0`) — same
+                // contract as the sibling "Player NOT Unbanned"
+                // branch above. The DELETE didn't complete; the
+                // operator needs to see this and acknowledge before
+                // it disappears. Redirect is intentionally `null` —
+                // see the sibling branch above for the rationale
+                // (chrome's auto-redirect would tear down the toast
+                // before the user can read it). AGENTS.md
+                // "Server-side toast emission" → "Duration
+                // semantics" carries the full contract.
                 \Sbpp\View\Toast::emit(
                     'error',
                     'Ban NOT Deleted',
                     "The ban for '" . $steam['name'] . "' had an error while being removed.",
-                    "index.php?p=banlist$pagelink",
+                    null,
+                    0,
                 );
             }
             $fail++;

--- a/web/pages/page.commslist.php
+++ b/web/pages/page.commslist.php
@@ -112,11 +112,26 @@ if (isset($_GET['a']) && $_GET['a'] == "ungag" && isset($_GET['id'])) {
         );
         Log::add(LogType::Message, "Player UnGagged", "$row[name] ($row[authid]) has been ungagged. Reason: $unbanReason");
     } else {
+        // #1409: persistent toast (`duration_ms: 0`) on the severe-
+        // error "destructive action FAILED" branch. The ungag SQL
+        // didn't complete; the operator needs to read this before
+        // it disappears. Mirrors the sibling banlist NOT-* branches.
+        //
+        // Redirect is intentionally `null`: persistent + redirect
+        // are mutually exclusive (the chrome's `flushPendingToasts`
+        // would otherwise navigate ~1500ms after paint, tearing the
+        // toast down before the operator can read or dismiss it).
+        // The page handler continues rendering the commslist body
+        // after this branch (no `PageDie()`), so the operator stays
+        // on a valid surface; the toast persists until the user
+        // clicks the X button. See AGENTS.md "Server-side toast
+        // emission" → "Duration semantics" for the full contract.
         \Sbpp\View\Toast::emit(
             'error',
             'Player NOT UnGagged',
             'There was an error ungagging ' . $row['name'],
-            "index.php?p=commslist$pagelink",
+            null,
+            0,
         );
     }
 } else if (isset($_GET['a']) && $_GET['a'] == "unmute" && isset($_GET['id'])) {
@@ -200,11 +215,19 @@ if (isset($_GET['a']) && $_GET['a'] == "ungag" && isset($_GET['id'])) {
         // the original "?p=commsist" redirect typo (now corrected to
         // "?p=commslist" since landing the user on a 404 made the
         // toast pointless) are separate UX bugs worth a follow-up.
+        //
+        // #1409: persistent toast (`duration_ms: 0`) — same severe-
+        // error "destructive action FAILED" semantic as the sibling
+        // ungag NOT-* branch above and the banlist NOT-* branches.
+        // Redirect is intentionally `null` — see the ungag branch
+        // above for the rationale. AGENTS.md "Server-side toast
+        // emission" → "Duration semantics" carries the contract.
         \Sbpp\View\Toast::emit(
             'error',
             'Player NOT UnGagged',
             'There was an error unmuted ' . $row['name'],
-            "index.php?p=commslist$pagelink",
+            null,
+            0,
         );
     }
 } else if (isset($_GET['a']) && $_GET['a'] == "delete") {
@@ -265,11 +288,20 @@ if (isset($_GET['a']) && $_GET['a'] == "ungag" && isset($_GET['id'])) {
         );
         Log::add(LogType::Message, "Block Deleted", "Block $steam[name] ($steam[authid]) has been deleted.");
     } else {
+        // #1409: persistent toast (`duration_ms: 0`) — same severe-
+        // error "destructive action FAILED" semantic as the sibling
+        // banlist "Ban NOT Deleted" branch. The DELETE didn't
+        // complete; the operator needs to see this and acknowledge
+        // before it disappears. Redirect is intentionally `null` —
+        // see the sibling ungag branch above for the rationale.
+        // AGENTS.md "Server-side toast emission" → "Duration
+        // semantics" carries the contract.
         \Sbpp\View\Toast::emit(
             'error',
             'Ban NOT Deleted',
             "The ban for '" . $steam['name'] . "' had an error while being removed.",
-            "index.php?p=commslist$pagelink",
+            null,
+            0,
         );
     }
 }

--- a/web/scripts/globals.d.ts
+++ b/web/scripts/globals.d.ts
@@ -180,7 +180,22 @@ interface Window {
      * narrow with `if (window.SBPP && window.SBPP.foo) …`.
      */
     SBPP?: {
-        showToast?: (msg: string, kind?: string) => void;
+        /**
+         * Render a toast in the chrome's toast stack. Accepts the
+         * `ToastOpts` object documented inline in `theme.js`:
+         * `{kind?, title, body?, durationMs?}`. `durationMs` is the
+         * #1409 follow-up to `Sbpp\View\Toast::emit`'s `duration_ms`
+         * wire-format field — `undefined` falls through to
+         * `SHOWTOAST_DEFAULT_DURATION` (~4000ms), `0` is persistent
+         * (user must click the X button), `> 0` is an explicit
+         * override in milliseconds.
+         */
+        showToast?: (opts: {
+            kind?: 'info' | 'success' | 'warn' | 'error';
+            title: string;
+            body?: string;
+            durationMs?: number;
+        }) => void;
         openDrawer?: (bid: number | string) => void;
         /**
          * Hydrate every `[data-testid="server-tile"]` inside a

--- a/web/tests/e2e/fixtures/db.ts
+++ b/web/tests/e2e/fixtures/db.ts
@@ -37,6 +37,8 @@ const SEED_LOSTPASSWORD_INSIDE_CONTAINER =
     '/var/www/html/web/tests/e2e/scripts/seed-lostpassword-e2e.php';
 const SET_SETTING_INSIDE_CONTAINER =
     '/var/www/html/web/tests/e2e/scripts/set-setting-e2e.php';
+const ORPHAN_BAN_AID_INSIDE_CONTAINER =
+    '/var/www/html/web/tests/e2e/scripts/orphan-ban-aid-e2e.php';
 
 /**
  * Run the PHP shim that drives `Sbpp\Tests\Fixture` against
@@ -336,6 +338,61 @@ export async function setSettingE2e(setting: string, value: string): Promise<voi
             }
             reject(new Error(
                 `set-setting-e2e.php exited ${code}\n`
+                + `stdout:\n${stdout}\nstderr:\n${stderr}`,
+            ));
+        });
+    });
+}
+
+/**
+ * Orphan a `:prefix_bans` row by UPDATE-ing its `aid` to a value that
+ * doesn't exist in `:prefix_admins`. Triggers the `page.banlist.php`
+ * capital-NOT branch (`'Player NOT Unbanned'`, L159 post-#1409) which
+ * fires when the admin INNER JOIN at L72 returns empty even though the
+ * bans row itself still exists — the documented "destructive action
+ * FAILED" branch the #1409 follow-up converts to a persistent toast
+ * (`duration_ms: 0`).
+ *
+ * Caller responsibility: pass a `bid` returned from `seedBanViaApi` so
+ * the underlying bans row has the right shape for the L83 SELECT to
+ * resolve; `new_aid` defaults to 99999 (well outside any realistic
+ * admin-id sequence — matches the `NONEXISTENT_BID` convention in
+ * `banlist-getfallback-toast.spec.ts`). The shim refuses to overwrite
+ * with an aid that DOES exist in `:prefix_admins` so a future change
+ * to the seed admin layout doesn't silently degrade the scenario.
+ *
+ * Used by `toast-persistent-duration.spec.ts`. Mirrors the shape of
+ * `setSettingE2e`'s shell-out + stdin-JSON pattern.
+ */
+export async function orphanBanAidE2e(bid: number, newAid = 99999): Promise<void> {
+    const inContainer = process.env.E2E_IN_CONTAINER === '1';
+    const cmd = inContainer ? 'php' : 'docker';
+    const cmdArgs = inContainer
+        ? [ORPHAN_BAN_AID_INSIDE_CONTAINER]
+        : ['compose', 'exec', '-T', 'web', 'php', ORPHAN_BAN_AID_INSIDE_CONTAINER];
+
+    const child = execFile(cmd, cmdArgs, {
+        maxBuffer: 8 * 1024 * 1024,
+        cwd: inContainer ? undefined : process.cwd(),
+    });
+
+    let stdout = '';
+    let stderr = '';
+    child.stdout?.on('data', (chunk: Buffer) => { stdout += chunk.toString('utf8'); });
+    child.stderr?.on('data', (chunk: Buffer) => { stderr += chunk.toString('utf8'); });
+
+    child.stdin?.write(JSON.stringify({ bid, new_aid: newAid }));
+    child.stdin?.end();
+
+    await new Promise<void>((resolve, reject) => {
+        child.on('error', reject);
+        child.on('exit', (code) => {
+            if (code === 0) {
+                resolve();
+                return;
+            }
+            reject(new Error(
+                `orphan-ban-aid-e2e.php exited ${code}\n`
                 + `stdout:\n${stdout}\nstderr:\n${stderr}`,
             ));
         });

--- a/web/tests/e2e/scripts/orphan-ban-aid-e2e.php
+++ b/web/tests/e2e/scripts/orphan-ban-aid-e2e.php
@@ -1,0 +1,125 @@
+<?php
+// SourceBans++ (c) 2014-2026 SourceBans++ Dev Team
+// Licensed under Creative Commons Attribution-NonCommercial-ShareAlike 3.0.
+// See LICENSE.md for the full license text and THIRD-PARTY-NOTICES.txt for attributions.
+/**
+ * E2E shim — orphan a `:prefix_bans` row by setting its `aid` to a
+ * non-existent admin id.
+ *
+ * Drives the `page.banlist.php` capital-NOT branch
+ * (`'Player NOT Unbanned'`, L159 post-#1409) which fires when the
+ * `INNER JOIN :prefix_admins` lookup at L72 returns empty even
+ * though the bans row itself still exists. This is the documented
+ * "destructive action FAILED" branch the #1409 follow-up converts
+ * to a persistent toast (`duration_ms: 0`); the
+ * `toast-persistent-duration.spec.ts` E2E spec uses this shim to
+ * trigger it without faking the wire format client-side.
+ *
+ * The "real" production shape of an orphan ban is a bans row whose
+ * `aid` points at an admin row that was later deleted (the SQL
+ * has no foreign-key constraint between the two tables — the panel
+ * keeps the historical bans even after their owner leaves). The
+ * cheapest way to reproduce this in e2e is to mint a normal ban
+ * via `seedBanViaApi`, then UPDATE its `aid` to a value that
+ * doesn't exist in `:prefix_admins`. We don't want to delete the
+ * `admin/admin` row (that would break every other spec sharing
+ * the e2e DB), so the cleaner shape is the orphan-by-update.
+ *
+ * Why not INSERT directly into `:prefix_bans` instead of UPDATE-ing
+ * a previously-seeded row? Two reasons:
+ *   1. The bans schema requires a lot of fields with non-obvious
+ *      shape constraints (ends/created timestamps, the type/authid
+ *      pair, steam_universe-aware aid mapping). Driving the seed
+ *      through the existing `seedBanViaApi` (Actions.BansAdd) gets
+ *      every constraint right by definition; the UPDATE is a
+ *      single-field surgical mutation on top.
+ *   2. Direct INSERT would duplicate the validation logic the
+ *      panel-side handler already encapsulates. The AGENTS.md
+ *      "Why 'via API' instead of an INSERT shim" rationale in
+ *      `seeds.ts` documents the same trade-off.
+ *
+ * Usage (inside the web container):
+ *
+ *   echo '{"bid":42,"new_aid":99999}' | php orphan-ban-aid-e2e.php
+ *
+ * - `bid` is the bid returned from `seedBanViaApi`
+ * - `new_aid` is the orphan target. Pick a large integer that's
+ *   clearly outside any realistic seq range (99999 is the
+ *   convention this spec uses; matches the NONEXISTENT_BID
+ *   constant in `banlist-getfallback-toast.spec.ts`).
+ *
+ * Mirror of the `set-setting-e2e.php` / `seed-comms-e2e.php`
+ * stdin-JSON pattern; same e2e-only DB refusal guard.
+ */
+
+declare(strict_types=1);
+
+if (PHP_SAPI !== 'cli') {
+    fwrite(STDERR, "orphan-ban-aid-e2e.php must run on the CLI.\n");
+    exit(2);
+}
+
+if (!getenv('DB_NAME')) {
+    putenv('DB_NAME=sourcebans_e2e');
+    $_ENV['DB_NAME']    = 'sourcebans_e2e';
+    $_SERVER['DB_NAME'] = 'sourcebans_e2e';
+}
+
+if (getenv('DB_NAME') === 'sourcebans_test' || getenv('DB_NAME') === 'sourcebans') {
+    fwrite(STDERR, "refusing to orphan a ban on DB_NAME=" . getenv('DB_NAME')
+        . ": this script must target a dedicated e2e DB (default sourcebans_e2e).\n");
+    exit(2);
+}
+
+require __DIR__ . '/../../bootstrap.php';
+
+if (!isset($GLOBALS['PDO'])) {
+    $GLOBALS['PDO'] = new \Database(DB_HOST, DB_PORT, DB_NAME, DB_USER, DB_PASS, DB_PREFIX, DB_CHARSET);
+}
+
+$payload = stream_get_contents(STDIN);
+if ($payload === false || trim($payload) === '') {
+    fwrite(STDERR, "orphan-ban-aid-e2e.php: empty stdin payload.\n");
+    exit(2);
+}
+
+$decoded = json_decode($payload, true);
+if (!is_array($decoded)) {
+    fwrite(STDERR, "orphan-ban-aid-e2e.php: stdin is not a JSON object.\n");
+    exit(2);
+}
+
+$bid    = isset($decoded['bid'])     ? (int) $decoded['bid']     : 0;
+$newAid = isset($decoded['new_aid']) ? (int) $decoded['new_aid'] : 0;
+
+if ($bid <= 0) {
+    fwrite(STDERR, "orphan-ban-aid-e2e.php: missing / non-positive 'bid' key.\n");
+    exit(2);
+}
+if ($newAid <= 0) {
+    fwrite(STDERR, "orphan-ban-aid-e2e.php: missing / non-positive 'new_aid' key.\n");
+    exit(2);
+}
+
+// Defensive sanity: make sure `new_aid` REALLY doesn't exist in
+// :prefix_admins, otherwise the test scenario degrades from
+// "orphan ban → capital-NOT branch" to "ban owned by another admin
+// → some other code path entirely". Throw loudly if the caller
+// picks a colliding id.
+$GLOBALS['PDO']->query("SELECT aid FROM `:prefix_admins` WHERE aid = :aid");
+$GLOBALS['PDO']->bind(':aid', $newAid);
+$exists = $GLOBALS['PDO']->single();
+if ($exists !== false && $exists !== null && $exists !== []) {
+    fwrite(STDERR, "orphan-ban-aid-e2e.php: new_aid=$newAid already exists in :prefix_admins — "
+        . "pick a larger value (the spec convention is 99999).\n");
+    exit(2);
+}
+
+$GLOBALS['PDO']->query("UPDATE `:prefix_bans` SET aid = :new_aid WHERE bid = :bid");
+$GLOBALS['PDO']->bindMultiple([
+    ':new_aid' => $newAid,
+    ':bid'     => $bid,
+]);
+$GLOBALS['PDO']->execute();
+
+fwrite(STDOUT, "orphaned bid=$bid (aid → $newAid) on " . DB_NAME . "\n");

--- a/web/tests/e2e/specs/flows/toast-persistent-duration.spec.ts
+++ b/web/tests/e2e/specs/flows/toast-persistent-duration.spec.ts
@@ -90,12 +90,16 @@ import { seedBanViaApi } from '../../fixtures/seeds.ts';
 // worker doesn't double-stomp the previous run's ban. The `seedBanViaApi`
 // tolerance for `already_banned` keeps a single retry working but a
 // shared steam id would coalesce two tests into the same bid.
+//
+// Two seeded sites, not three: the routine-toast test (reviewer
+// Suggested #2) was reshaped to drive `window.SBPP.showToast(...)`
+// directly from a stable panel surface instead of triggering a
+// page-flow that carries a redirect, so it no longer needs a
+// seeded ban / orphan-aid setup.
 const STEAM_A = 'STEAM_0:0:14091409'; // mnemonic: 1409 for the issue number
-const STEAM_B = 'STEAM_0:0:14091410'; // sibling, unique-per-test
 const STEAM_C = 'STEAM_0:0:14091411';
 
 const NICK_A  = '1409-persist-1';
-const NICK_B  = '1409-persist-2';
 const NICK_C  = '1409-persist-wire';
 
 const NONEXISTENT_AID = 99999; // matches the orphan-ban-aid-e2e.php convention
@@ -256,44 +260,126 @@ test.describe('flow: persistent toast on NOT-* branch (#1409 `duration_ms: 0`)',
         // regression because every routine info / success surface
         // would suddenly require manual dismissal.
         //
-        // Drive the L94 lowercase-Not branch (`'Player Not Unbanned'`)
-        // — explicitly NOT converted in #1409 (it's the "ban
-        // doesn't exist or already unbanned" message, not a
-        // destructive-action-failed branch). It rides the default
-        // duration with no 5th argument.
+        // **Why we don't drive a page-flow route here**: the obvious
+        // shape (hit a 404-shaped GET-fallback like
+        // `?p=banlist&a=unban&id=99999` that fires the lowercase-Not
+        // branch) carries a non-null `$redirect`, so the chrome's
+        // `flushPendingToasts` schedules a `window.location.href`
+        // navigation ~1500ms after paint. The toast disappears
+        // because the PAGE TEARS DOWN, not because the 4000ms timer
+        // fired — a regression that bumped `SHOWTOAST_DEFAULT_DURATION`
+        // to 10000ms would still silently pass that test because
+        // the navigation happens well before the (broken) timer
+        // would have. Reviewer Suggested #2 (post-PR #1414) caught
+        // this: the test was nominally green but proved nothing
+        // about the timer contract.
+        //
+        // The replacement isolates the contract under test. We:
+        //   1. Navigate to a panel page that has no pending toasts
+        //      and no pending redirects (the home dashboard with
+        //      `?p=home` is the simplest stable surface — the
+        //      seeded admin's storage state lands there directly).
+        //   2. Drive `window.SBPP.showToast(...)` directly from the
+        //      page, with NO `durationMs` option, so the chrome
+        //      falls through to its `SHOWTOAST_DEFAULT_DURATION`
+        //      default. (`window.SBPP.showToast` is the
+        //      chrome-exposed wrapper documented in
+        //      `web/scripts/globals.d.ts`; it's the same code path
+        //      `flushPendingToasts` uses internally.)
+        //   3. Assert the toast paints immediately.
+        //   4. Wait ~3500ms — STILL inside the default ~4000ms
+        //      window — and assert the toast is still visible.
+        //      Catches a regression where `SHOWTOAST_DEFAULT_DURATION`
+        //      was accidentally LOWERED to ~3000ms.
+        //   5. Wait another ~1500ms (total 5000ms — well past the
+        //      default 4000ms + a generous margin for slow CI
+        //      runners) and assert the toast is GONE. Catches the
+        //      "every toast is now persistent" regression (the
+        //      worst case the contract guards against) AND the
+        //      "default duration was bumped past 5000ms" regression.
+        //
+        // The test proves ONLY the timer contract: no page-flow
+        // dependency, no redirect interference, no orphan-ban
+        // setup. The single load-bearing `waitForTimeout` is the
+        // 3500ms / 5000ms pair documented above; AGENTS.md
+        // "Playwright E2E specifics" notes the auto-dismiss
+        // timing assertion is the canonical case where a timer
+        // wait is legitimate (along with the persistent-toast
+        // sister assertion in the test above).
         const consoleErrors: string[] = [];
         page.on('pageerror', (err) => consoleErrors.push(err.message));
 
-        try {
-            await seedBanViaApi(page, { nickname: NICK_B, steam: STEAM_B });
-        } catch (err) {
-            const msg = err instanceof Error ? err.message : String(err);
-            if (!msg.includes('already_banned')) throw err;
-        }
-        const { postkey } = await extractFreshPostkeyAndBid(page, NICK_B);
+        // Land on a stable panel surface with no pending toasts /
+        // redirects. The home dashboard renders for any logged-in
+        // user; the seeded admin storage state takes us straight
+        // through the login redirect on first visit.
+        await page.goto('/index.php?p=home');
 
-        // Bid 99999 doesn't exist → L91 empty-row branch fires →
-        // "Player Not Unbanned" (lowercase Not) with no 5th arg →
-        // default 4000ms timer.
-        await page.goto(
-            `/index.php?p=banlist&a=unban&id=99999&key=${postkey}&ureason=1409-routine-regression-guard`,
-        );
+        // Pre-check: no toast on the page before we fire one.
+        await expect(
+            page.locator('[data-testid="toast"]'),
+            'precondition: home dashboard should have no pending toasts before the manual `showToast` call'
+            + ' — if there are leftover toasts here, the test environment is dirty and the timer'
+            + ' assertion below is meaningless',
+        ).toHaveCount(0);
+
+        // Fire a routine toast directly through the chrome's
+        // exposed API. `window.SBPP.showToast` is the documented
+        // entry point (see `web/scripts/globals.d.ts`); calling
+        // it with NO `durationMs` exercises the `=== undefined`
+        // fall-through to `SHOWTOAST_DEFAULT_DURATION`. The
+        // `evaluate` runs in the page context, so the chrome's
+        // `theme.js` (already loaded by the home page) handles
+        // the toast natively.
+        await page.evaluate(() => {
+            const sbpp = (window as unknown as { SBPP?: { showToast?: (opts: unknown) => void } }).SBPP;
+            if (!sbpp || !sbpp.showToast) {
+                throw new Error('window.SBPP.showToast is not exposed — chrome JS did not boot');
+            }
+            sbpp.showToast({
+                kind: 'info',
+                title: '1409 routine timer probe',
+                body: 'This toast must auto-dismiss after the default 4000ms.',
+            });
+        });
 
         const toast = page
             .locator('[data-testid="toast"]')
-            .filter({ hasText: 'Player Not Unbanned' });
+            .filter({ hasText: '1409 routine timer probe' });
         await expect(toast).toBeVisible({ timeout: 1500 });
 
-        // Wait past the default duration + the ~500ms safety margin.
+        // Wait ~3500ms — still well inside the default 4000ms
+        // window with a ~500ms safety margin. The toast MUST
+        // still be visible. Catches a regression that lowered
+        // `SHOWTOAST_DEFAULT_DURATION` (e.g. to 3000ms during a
+        // "make toasts disappear faster" tweak).
         // eslint-disable-next-line playwright/no-wait-for-timeout
-        await page.waitForTimeout(4500);
-
-        // The toast should be GONE — the default-duration contract
-        // is preserved.
+        await page.waitForTimeout(3500);
         await expect(
             toast,
-            'routine toast (no duration_ms override) MUST auto-dismiss after SHOWTOAST_DEFAULT_DURATION'
-            + ' — a regression here would make every panel toast persistent and force users to click X on every confirmation',
+            'routine toast must still be visible at ~3500ms (well within the SHOWTOAST_DEFAULT_DURATION ~4000ms'
+            + ' window) — a regression that lowered the default below ~3500ms would fail HERE',
+        ).toBeVisible();
+
+        // Wait another ~1500ms (total ~5000ms post-paint), then
+        // assert the toast has been removed by the auto-dismiss
+        // timer. Total wait is ~1000ms past the default 4000ms
+        // window — generous margin for slow CI runners but
+        // tight enough that a regression bumping the default to
+        // 6000ms+ fails here. A regression that disabled the
+        // auto-dismiss timer entirely (e.g. dropped the
+        // `if (durationMs > 0)` guard's `setTimeout` call when
+        // `durationMs` is `undefined`) would ALSO fail here:
+        // the toast would still be visible at 5000ms because
+        // nothing schedules its removal.
+        // eslint-disable-next-line playwright/no-wait-for-timeout
+        await page.waitForTimeout(1500);
+        await expect(
+            toast,
+            'routine toast (no `durationMs` option) MUST auto-dismiss within'
+            + ' SHOWTOAST_DEFAULT_DURATION + a safety margin — a regression that disabled the timer'
+            + ' for the undefined-durationMs case would make EVERY panel toast persistent and force'
+            + ' users to click X on every routine info / success / warn confirmation',
         ).toHaveCount(0);
 
         expect(

--- a/web/tests/e2e/specs/flows/toast-persistent-duration.spec.ts
+++ b/web/tests/e2e/specs/flows/toast-persistent-duration.spec.ts
@@ -1,0 +1,390 @@
+/**
+ * Flow spec — issue #1409: `Sbpp\View\Toast::emit` gained an optional
+ * 5th `?int $duration_ms` parameter. When the call site passes `0`,
+ * the chrome (`web/themes/default/js/theme.js`'s `showToast`) does NOT
+ * schedule an auto-dismiss timer — the only way the toast disappears
+ * is the user clicking the X button. The semantic restores the v1.x
+ * `ShowBox(text, title, redirect, bg, sticky=true)` 5-arg shape that
+ * the #1403 mechanical lift dropped for fidelity.
+ *
+ * The follow-through is the 5 NOT-* destructive-action-failed branches
+ * in `page.banlist.php` / `page.commslist.php` now passing `0` as the
+ * 5th arg:
+ *   - `page.banlist.php`   — "Player NOT Unbanned" / "Ban NOT Deleted"
+ *   - `page.commslist.php` — "Player NOT UnGagged" × 2 + "Ban NOT Deleted"
+ *
+ * The **PHPUnit-side** `ToastEmitRegressionTest` (post-#1409) pins:
+ *   - default omits `duration_ms` from the wire (no field, not null)
+ *   - explicit 0 / explicit > 0 emit the field as an integer
+ *   - negative values throw `\InvalidArgumentException`
+ *   - all JSON_HEX_* + UTF-8 substitute guarantees preserved
+ *   - the 5 NOT-* call sites all pass `duration_ms: 0`
+ *
+ * This **runtime-side** spec covers the chrome's three behaviors
+ * end-to-end:
+ *   1. The wire-format JSON blob the PHP-side emits for a NOT-* branch
+ *      carries `duration_ms: 0` (round-trip check at the wire layer).
+ *   2. The `[data-testid="toast"]` paints AND outlasts the default
+ *      `SHOWTOAST_DEFAULT_DURATION` (~4000ms) — the regression the
+ *      issue describes (toast disappearing before the operator
+ *      finishes reading the severe-error confirmation).
+ *   3. Clicking the `[data-toast-close]` button dismisses the toast
+ *      (the X-button is the only escape hatch on a persistent toast).
+ *
+ * # How we trigger a real NOT-* branch
+ *
+ * The capital-NOT branch at `page.banlist.php` L159 (`'Player NOT
+ * Unbanned'`) fires when the admin INNER JOIN at L72 returns empty
+ * (`$res` is falsy) BUT the bans row itself exists (L83's `$row` is
+ * truthy). That's the "orphan ban" shape — a bans row whose `aid`
+ * points to an admin that no longer exists. We seed it in two steps:
+ *
+ *   a. `seedBanViaApi` mints a normal ban (aid = the seeded admin's
+ *      aid). The full Smarty/JSON/CSRF/permission chain runs, so the
+ *      bans row has every field set the way the production path
+ *      shapes it (`ends`, `created`, `length=0`, `RemoveType IS
+ *      NULL`, `steam_universe` joinable through the servers + mods
+ *      tables).
+ *   b. `orphanBanAidE2e` does a surgical UPDATE setting that bid's
+ *      `aid` to 99999 (no admin row with that id exists; the shim
+ *      asserts the absence to keep the scenario meaningful). The
+ *      bans row is otherwise unchanged.
+ *
+ * The GET-fallback URL then sends the admin through L72 (empty
+ * `$res`), past the Owner-perm guard at L75, past the existence
+ * guard at L91 (`$row` is truthy), through the UPDATE at L105,
+ * into the `else` branch at L146 — emit "Player NOT Unbanned" with
+ * `duration_ms: 0`, the persistent path.
+ *
+ * # Auth + DB scope
+ *
+ * Default storage state (admin/admin, `WebPermission::Owner`) passes
+ * the L75 Owner|Unban check; no per-describe override.
+ *
+ * `truncateE2eDb` is NOT called — the e2e DB is single-DB / `workers:
+ * 1` per AGENTS.md "Playwright E2E specifics", and `seedBanViaApi`
+ * tolerates the `already_banned` arm if a prior run left the row
+ * behind. The orphan-aid shim is idempotent (UPDATEs to the same value
+ * on a re-run, doesn't blow up). Each test uses a unique seeded steam
+ * id to avoid cross-test interference.
+ *
+ * # Timer semantics
+ *
+ * One `waitForTimeout` is intentional and load-bearing here — AGENTS.md
+ * "Playwright E2E specifics" notes the persistent-toast-after-N-ms
+ * assertion is the canonical case where a timer wait is legitimate.
+ * Specifically: we wait 4500ms (past the default 4000ms auto-dismiss
+ * window) THEN assert the toast is STILL visible. A `toBeVisible`
+ * assertion alone wouldn't catch the "auto-dismisses after the
+ * default" regression because the toast paints immediately on
+ * `DOMContentLoaded` and the assertion would pass before the timer
+ * fires. The 4500ms gives a ~500ms safety margin over the
+ * `SHOWTOAST_DEFAULT_DURATION` constant in `theme.js`.
+ */
+
+import { expect, test } from '../../fixtures/auth.ts';
+import { orphanBanAidE2e } from '../../fixtures/db.ts';
+import { seedBanViaApi } from '../../fixtures/seeds.ts';
+
+// Use distinct steam ids per-test so a Playwright retry on the same
+// worker doesn't double-stomp the previous run's ban. The `seedBanViaApi`
+// tolerance for `already_banned` keeps a single retry working but a
+// shared steam id would coalesce two tests into the same bid.
+const STEAM_A = 'STEAM_0:0:14091409'; // mnemonic: 1409 for the issue number
+const STEAM_B = 'STEAM_0:0:14091410'; // sibling, unique-per-test
+const STEAM_C = 'STEAM_0:0:14091411';
+
+const NICK_A  = '1409-persist-1';
+const NICK_B  = '1409-persist-2';
+const NICK_C  = '1409-persist-wire';
+
+const NONEXISTENT_AID = 99999; // matches the orphan-ban-aid-e2e.php convention
+
+/**
+ * Visit the banlist as the seeded admin and extract the banlist
+ * postkey from the freshest unban-button's `data-fallback-href`
+ * (same shape `banlist-getfallback-toast.spec.ts` uses).
+ * The postkey is regenerated per visit
+ * (`page.banlist.php:setPostKey()`); we have to read it from the
+ * live render.
+ *
+ * Also returns the seeded bid (extracted from the same href) so the
+ * caller doesn't have to thread it separately — that's the row
+ * whose unban will fire the NOT-* branch.
+ */
+async function extractFreshPostkeyAndBid(
+    page: import('@playwright/test').Page,
+    /** Filter to the seeded nickname so a sibling test's leftover row doesn't get unbanned. */
+    nickname: string,
+): Promise<{ postkey: string; bid: number }> {
+    await page.goto('/index.php?p=banlist');
+
+    // Filter the rows by the seeded nickname so we grab THIS test's
+    // bid. `filter({ hasText })` is the canonical Playwright shape
+    // for "rows containing this text"; the alternative `tr:has-text()`
+    // CSS pseudo-class is also supported but `filter` reads cleaner.
+    const row = page.locator('tr').filter({ hasText: nickname }).first();
+    const hrefAttr = await row
+        .locator('[data-action="bans-unban"]')
+        .first()
+        .getAttribute('data-fallback-href');
+
+    if (!hrefAttr) {
+        throw new Error(
+            `extractFreshPostkeyAndBid: no [data-action="bans-unban"] under row containing nickname "${nickname}"`,
+        );
+    }
+    const parsed = new URL('http://x/' + hrefAttr);
+    const key = parsed.searchParams.get('key');
+    const bidRaw = parsed.searchParams.get('id');
+    if (!key || !bidRaw) {
+        throw new Error(
+            `extractFreshPostkeyAndBid: malformed data-fallback-href "${hrefAttr}"`,
+        );
+    }
+    return { postkey: key, bid: Number.parseInt(bidRaw, 10) };
+}
+
+test.describe('flow: persistent toast on NOT-* branch (#1409 `duration_ms: 0`)', () => {
+    test('Player NOT Unbanned toast paints, outlasts SHOWTOAST_DEFAULT_DURATION, dismisses on X-button click', async ({ page }) => {
+        const consoleErrors: string[] = [];
+        page.on('pageerror', (err) => consoleErrors.push(err.message));
+
+        // 1. Seed a normal ban (real chain — CSRF + permissions +
+        //    handler — so the bans row's schema-shape is production-
+        //    faithful).
+        let seededBid: number;
+        try {
+            const seed = await seedBanViaApi(page, { nickname: NICK_A, steam: STEAM_A });
+            seededBid = seed.bid;
+        } catch (err) {
+            const msg = err instanceof Error ? err.message : String(err);
+            if (!msg.includes('already_banned')) throw err;
+            // Same shape as banlist-getfallback-toast: a prior run on
+            // the same worker left the row; re-extract the bid from
+            // the rendered banlist below.
+            const { bid } = await extractFreshPostkeyAndBid(page, NICK_A);
+            seededBid = bid;
+        }
+
+        // 2. Orphan the ban — UPDATE :prefix_bans.aid → 99999 so the
+        //    capital-NOT branch fires at page.banlist.php:159.
+        await orphanBanAidE2e(seededBid, NONEXISTENT_AID);
+
+        // 3. Re-visit the banlist to mint a fresh `banlist_postkey`
+        //    (the previous visit's key might have rolled). The orphan
+        //    UPDATE doesn't change the bid, so we can read the same
+        //    id from the now-orphaned row.
+        const { postkey, bid } = await extractFreshPostkeyAndBid(page, NICK_A);
+        expect(bid, 'orphan UPDATE should not change the bid').toBe(seededBid);
+
+        // 4. Hit the GET-fallback unban URL. The INNER JOIN at L72
+        //    is now empty (aid 99999 doesn't exist); the bans row
+        //    still exists so the L91 empty-row branch doesn't fire;
+        //    the L75 Owner-perm check passes (seeded admin holds
+        //    `WebPermission::Owner`); the UPDATE at L105 runs; and
+        //    the L146 `else` branch fires "Player NOT Unbanned" with
+        //    `duration_ms: 0`.
+        await page.goto(
+            `/index.php?p=banlist&a=unban&id=${bid}&key=${postkey}&ureason=1409-persist-spec`,
+        );
+
+        // 5. The toast paints with the capital-NOT title. `data-kind`
+        //    is the load-bearing attribute the chrome stamps (the
+        //    `data-testid="toast"` was added in #1409 to match the
+        //    AGENTS.md documented contract). Filter on the title
+        //    text to disambiguate from the lowercase-Not branch's
+        //    "Player Not Unbanned" toast (different code path, default
+        //    duration). The capital-NOT title is the verbatim copy
+        //    from page.banlist.php:159.
+        const toast = page
+            .locator('[data-testid="toast"]')
+            .filter({ hasText: 'Player NOT Unbanned' });
+        await expect(toast).toBeVisible({ timeout: 1500 });
+        await expect(toast).toContainText(/There was an error unbanning/);
+        await expect(toast).toHaveAttribute('data-kind', 'error');
+
+        // 6. Wait past `SHOWTOAST_DEFAULT_DURATION` (4000ms; we add
+        //    500ms safety margin). The single load-bearing timer wait
+        //    in the spec — AGENTS.md "Playwright E2E specifics" notes
+        //    the persistent-toast-after-N-ms assertion is the
+        //    canonical legitimate use of `waitForTimeout`. A `toBeVisible`
+        //    by itself wouldn't catch the auto-dismiss regression
+        //    because the toast paints immediately.
+        // eslint-disable-next-line playwright/no-wait-for-timeout
+        await page.waitForTimeout(4500);
+
+        // 7. The toast is STILL visible — this is the #1409 contract.
+        //    A regression that drops `duration_ms: 0` from the call
+        //    site (or drops the `if (durationMs > 0)` guard in
+        //    `showToast`, falling through to `setTimeout(..., 0)`
+        //    which auto-dismisses on the next tick) would fail
+        //    HERE.
+        await expect(
+            toast,
+            'toast should persist past SHOWTOAST_DEFAULT_DURATION (~4000ms) when emit'
+            + ' passes duration_ms: 0 — this is the #1409 contract restoring v1.x'
+            + ' ShowBox(..., sticky=true) semantics for severe-error confirmations',
+        ).toBeVisible();
+
+        // 8. Click the X button — the only escape hatch on a
+        //    persistent toast. The chrome's document-level
+        //    `data-toast-close` delegate handles the click.
+        const dismissBtn = toast.locator('[data-toast-close]');
+        await expect(dismissBtn).toBeVisible();
+        await dismissBtn.click();
+
+        // 9. Toast disappears. Use the toast-element-detached
+        //    assertion (`toBeHidden` would still pass on a
+        //    `display:none` toast; the chrome `remove()`s the
+        //    element entirely).
+        await expect(toast).toHaveCount(0, { timeout: 1500 });
+
+        // 10. No uncaught console errors — same defensiveness shape
+        //     as the sister `banlist-getfallback-toast` spec.
+        expect(
+            consoleErrors,
+            `unexpected console errors:\n${consoleErrors.join('\n')}`,
+        ).toEqual([]);
+    });
+
+    test('Routine toast (no duration_ms override) STILL auto-dismisses — contract regression guard', async ({ page }) => {
+        // Belt-and-braces: the 4000ms default behaviour must NOT
+        // regress with the #1409 additions. A "we forgot to skip the
+        // setTimeout call when durationMs is undefined" regression
+        // would make EVERY toast persistent — the worst kind of
+        // regression because every routine info / success surface
+        // would suddenly require manual dismissal.
+        //
+        // Drive the L94 lowercase-Not branch (`'Player Not Unbanned'`)
+        // — explicitly NOT converted in #1409 (it's the "ban
+        // doesn't exist or already unbanned" message, not a
+        // destructive-action-failed branch). It rides the default
+        // duration with no 5th argument.
+        const consoleErrors: string[] = [];
+        page.on('pageerror', (err) => consoleErrors.push(err.message));
+
+        try {
+            await seedBanViaApi(page, { nickname: NICK_B, steam: STEAM_B });
+        } catch (err) {
+            const msg = err instanceof Error ? err.message : String(err);
+            if (!msg.includes('already_banned')) throw err;
+        }
+        const { postkey } = await extractFreshPostkeyAndBid(page, NICK_B);
+
+        // Bid 99999 doesn't exist → L91 empty-row branch fires →
+        // "Player Not Unbanned" (lowercase Not) with no 5th arg →
+        // default 4000ms timer.
+        await page.goto(
+            `/index.php?p=banlist&a=unban&id=99999&key=${postkey}&ureason=1409-routine-regression-guard`,
+        );
+
+        const toast = page
+            .locator('[data-testid="toast"]')
+            .filter({ hasText: 'Player Not Unbanned' });
+        await expect(toast).toBeVisible({ timeout: 1500 });
+
+        // Wait past the default duration + the ~500ms safety margin.
+        // eslint-disable-next-line playwright/no-wait-for-timeout
+        await page.waitForTimeout(4500);
+
+        // The toast should be GONE — the default-duration contract
+        // is preserved.
+        await expect(
+            toast,
+            'routine toast (no duration_ms override) MUST auto-dismiss after SHOWTOAST_DEFAULT_DURATION'
+            + ' — a regression here would make every panel toast persistent and force users to click X on every confirmation',
+        ).toHaveCount(0);
+
+        expect(
+            consoleErrors,
+            `unexpected console errors:\n${consoleErrors.join('\n')}`,
+        ).toEqual([]);
+    });
+
+    test('Wire-format response carries duration_ms: 0 on the NOT-* branch (wire-layer contract)', async ({ page }) => {
+        // Wire-layer assertion mirroring the sister
+        // `banlist-getfallback-toast.spec.ts`'s
+        // "No raw <script>ShowBox(...) blob" test: grep the
+        // response body directly to assert the JSON wire format
+        // carries the new field. Decoupled from the chrome's
+        // rendering — even if `showToast` regressed, the PHP-side
+        // contract would still pass this test, which is what we
+        // want: it's the static gate at the wire layer.
+        let seededBid: number;
+        try {
+            const seed = await seedBanViaApi(page, { nickname: NICK_C, steam: STEAM_C });
+            seededBid = seed.bid;
+        } catch (err) {
+            const msg = err instanceof Error ? err.message : String(err);
+            if (!msg.includes('already_banned')) throw err;
+            const { bid } = await extractFreshPostkeyAndBid(page, NICK_C);
+            seededBid = bid;
+        }
+        await orphanBanAidE2e(seededBid, NONEXISTENT_AID);
+
+        const { postkey, bid } = await extractFreshPostkeyAndBid(page, NICK_C);
+        expect(bid).toBe(seededBid);
+
+        const response = await page.request.get(
+            `/index.php?p=banlist&a=unban&id=${bid}&key=${postkey}&ureason=1409-wire-layer-guard`,
+        );
+        const body = await response.text();
+
+        // The pending-toast blob is present.
+        expect(
+            body.includes('class="sbpp-pending-toast"'),
+            'NOT-* branch response should carry the pending-toast JSON blob',
+        ).toBe(true);
+
+        // Extract the specific `Player NOT Unbanned` JSON payload
+        // and assert `duration_ms: 0` is present. Loose regex (the
+        // chrome's JSON encoder may reorder keys depending on PHP
+        // version — JSON object key order is implementation-defined
+        // but `json_encode` is stable per-version, so we match the
+        // field-presence cheaply rather than asserting a positional
+        // shape).
+        const notUnbannedBlobMatch = body.match(
+            /<script[^>]*class="sbpp-pending-toast"[^>]*>([^<]*Player NOT Unbanned[^<]*)<\/script>/,
+        );
+        expect(
+            notUnbannedBlobMatch,
+            'NOT-* branch response should carry a pending-toast blob containing the "Player NOT Unbanned" title',
+        ).not.toBeNull();
+        const blob = notUnbannedBlobMatch![1];
+
+        // Parse the JSON and assert `duration_ms: 0` is the literal
+        // shape on the wire.
+        const data = JSON.parse(blob) as Record<string, unknown>;
+        expect(data['kind']).toBe('error');
+        expect(data['title']).toBe('Player NOT Unbanned');
+        expect(
+            data['duration_ms'],
+            'NOT-* branch wire payload should carry duration_ms: 0 — this is the #1409 contract'
+            + ' the call site in page.banlist.php restores. A regression that drops the 5th arg'
+            + ' would silently re-enable the auto-dismiss timer and the operator would miss the failure.',
+        ).toBe(0);
+
+        // Persistent + redirect mutual-exclusion contract: a
+        // persistent toast's wire payload MUST NOT carry a
+        // `redirect` field, because the chrome's
+        // `flushPendingToasts` would otherwise navigate ~1500ms
+        // after paint, tearing down the toast before the operator
+        // can read or dismiss it. The PHP call site in
+        // `page.banlist.php` passes `null` for `$redirect` on the
+        // NOT-* branch so the field is omitted entirely from the
+        // payload (matches the `testToastEmitWireFormatStaysStable`
+        // PHPUnit contract: helper omits `redirect` when caller
+        // passed null/empty). Defence-in-depth: even if a future
+        // call-site bug landed a redirect here, the chrome's
+        // whole-drain inhibit (`flushPendingToasts` skips the
+        // redirect setTimeout when ANY block had `duration_ms:
+        // 0`) would still preserve the persistent semantic — but
+        // we pin the call-site half of the contract here as the
+        // primary gate; the chrome inhibit is belt-and-braces.
+        expect(
+            'redirect' in data,
+            'NOT-* persistent branch must NOT carry a `redirect` field on the wire — persistent + redirect are mutually exclusive (the chrome\'s redirect setTimeout would tear down the toast before the operator can acknowledge). See AGENTS.md "Server-side toast emission" → "Redirect coalescing" → "Persistent + redirect mutual exclusion".',
+        ).toBe(false);
+    });
+});

--- a/web/tests/integration/ToastEmitRegressionTest.php
+++ b/web/tests/integration/ToastEmitRegressionTest.php
@@ -849,13 +849,48 @@ final class ToastEmitRegressionTest extends ApiTestCase
      * lift preserved the casing verbatim; #1409 restores the
      * sticky semantic under a cleaner contract.
      *
-     * Each entry is `[relPath, titlePrefix]` — we grep the file
-     * for `Toast::emit('error', '<titlePrefix>'` and assert the
-     * call site passes a 5th positional argument (whose value is
-     * `0`). Pattern is `/Toast::emit\(\s*'error',\s*'<title>',\s*[^,]+,\s*[^,]+,\s*0\s*,?\s*\)/`
-     * — five comma-separated args, the last one is the literal
-     * `0`. The trailing `,?` accepts the PSR-12-style trailing-
-     * comma shape some files use and some don't.
+     * Each entry is keyed by `'<relPath> — <descriptor>'` and
+     * carries:
+     *   - `file`            absolute path to the PHP page handler
+     *   - `title`           the exact toast title literal
+     *   - `body_substring`  a substring of the toast body that
+     *                       disambiguates this site from any sibling
+     *                       site in the same file sharing the same
+     *                       title (the canonical case is
+     *                       `page.commslist.php`'s two "Player NOT
+     *                       UnGagged" sites — ungag at L131 carries
+     *                       "There was an error ungagging", unmute
+     *                       at L227 carries "There was an error
+     *                       unmuted". Both lift the v1.x
+     *                       `ShowBox(..., sticky=true)` semantic and
+     *                       both need the persistent contract pinned
+     *                       independently — a regression dropping
+     *                       just one would silently pass an
+     *                       `assertGreaterThan(0)` gate.)
+     *   - `expected_count`  the exact number of times the (title,
+     *                       body_substring) tuple should appear with
+     *                       the `duration_ms: 0` shape. Today every
+     *                       audited NOT-* call site is unique (1
+     *                       call per tuple); the field is explicit
+     *                       so a future PR that intentionally splits
+     *                       or merges a branch has to update the
+     *                       expected count rather than tripping a
+     *                       loose `>= 1` assertion that no longer
+     *                       reflects reality.
+     *
+     * We grep the file for `Toast::emit('error', '<title>', '...body_substring...'`
+     * shape and assert the call site passes a 5th positional argument
+     * (whose value is `0`) AND a 4th positional argument that's the
+     * literal `null` (persistent + redirect are mutually exclusive —
+     * the chrome's `flushPendingToasts` would otherwise navigate
+     * ~1500ms after paint, tearing down the persistent toast before
+     * the operator can read or dismiss it).
+     *
+     * Pattern is `/Toast::emit\(\s*'error',\s*'<title>',\s*'<body_substring_anchored>...,\s*null,\s*0\s*,?\s*\)/`
+     * — five comma-separated args, the last one is literal `0`, the
+     * redirect is literal `null`. The trailing `,?` accepts the
+     * PSR-12-style trailing-comma shape some files use and some
+     * don't.
      *
      * Future refactors that move the call sites to a helper that
      * defaults to `duration_ms: 0` (so the literal arg goes
@@ -864,77 +899,214 @@ final class ToastEmitRegressionTest extends ApiTestCase
      * call would satisfy that even though the static grep no
      * longer matches.
      *
-     * @return list<array{0: string, 1: string}>
+     * @return array<string, array{file: string, title: string, body_substring: string, expected_count: int}>
      */
     public static function notStarBranches(): array
     {
+        $pagesRoot = dirname(__DIR__, 2) . '/pages';
         return [
-            ['pages/page.banlist.php',   'Player NOT Unbanned'],
-            ['pages/page.banlist.php',   'Ban NOT Deleted'],
-            ['pages/page.commslist.php', 'Player NOT UnGagged'], // matches two sites in this file (ungag + unmute branches); the assertion below tolerates multi-match
-            ['pages/page.commslist.php', 'Ban NOT Deleted'],
+            'page.banlist.php — Player NOT Unbanned' => [
+                'file' => $pagesRoot . '/page.banlist.php',
+                'title' => 'Player NOT Unbanned',
+                'body_substring' => 'There was an error unbanning',
+                'expected_count' => 1,
+            ],
+            'page.banlist.php — Ban NOT Deleted' => [
+                'file' => $pagesRoot . '/page.banlist.php',
+                'title' => 'Ban NOT Deleted',
+                // page.banlist.php L235 builds the body as
+                // "The ban for '$row[name]' had an error while being removed."
+                // — the "had an error while being removed" phrase
+                // is the disambiguating shape (vs. page.commslist.php's
+                // own "Ban NOT Deleted" body which carries the
+                // sister phrase but for the `$row['name']`-built
+                // comm block, not a ban).
+                'body_substring' => 'had an error while being removed',
+                'expected_count' => 1,
+            ],
+            'page.commslist.php — Player NOT UnGagged (ungag failure)' => [
+                'file' => $pagesRoot . '/page.commslist.php',
+                'title' => 'Player NOT UnGagged',
+                // Disambiguator: this site is the gag-removal
+                // failure branch at L131. The sibling site at L227
+                // shares the title but carries "ungagging" → "unmuted"
+                // (the legacy copy mismatch is documented in #1409
+                // review NIT 2 as a separate cleanup).
+                'body_substring' => 'There was an error ungagging',
+                'expected_count' => 1,
+            ],
+            'page.commslist.php — Player NOT UnGagged (unmute failure)' => [
+                'file' => $pagesRoot . '/page.commslist.php',
+                'title' => 'Player NOT UnGagged',
+                // Disambiguator: this site is the mute-removal
+                // failure branch at L227, paired with the ungag
+                // failure branch above. The "unmuted" word in the
+                // body is the legacy copy from the v1.x
+                // `ShowBox(..., sticky=true)` lift; #1409 review
+                // NIT 2 tracks the eventual rewording to
+                // "There was an error unmuting".
+                'body_substring' => 'There was an error unmuted',
+                'expected_count' => 1,
+            ],
+            'page.commslist.php — Ban NOT Deleted' => [
+                'file' => $pagesRoot . '/page.commslist.php',
+                // The commslist's "Ban NOT Deleted" body builds the
+                // same "had an error while being removed" phrasing
+                // for a comm-block row; the file context (different
+                // page handler from the banlist's homonym) is what
+                // disambiguates, not the body — but we still anchor
+                // on the substring so a future cleanup that
+                // re-words the body forces an explicit update.
+                'title' => 'Ban NOT Deleted',
+                'body_substring' => 'had an error while being removed',
+                'expected_count' => 1,
+            ],
         ];
     }
 
+    /**
+     * Pin the (title, body, $redirect=null, $duration_ms=0) call
+     * shape for each NOT-* site identified in {@see notStarBranches}.
+     *
+     * **Why disambiguate by body substring + assert an exact count**:
+     * `page.commslist.php` carries two sites with the title literal
+     * `'Player NOT UnGagged'` (the ungag failure at L131 + the unmute
+     * failure at L227; the duplicated title is legacy copy that
+     * #1409 review NIT 2 tracks for a separate rewording pass). A
+     * loose `assertGreaterThan(0, $found)` against the title alone
+     * would silently pass if a future regression dropped just ONE
+     * of the two sites back to non-persistent — the surviving site
+     * would still satisfy the gate. The data provider keys each row
+     * by `(title, body_substring)` so each site is asserted
+     * independently, and `assertSame($expected_count, $found)`
+     * catches both directions of drift (a site dropped silently AND
+     * a duplicate that crept in via copy-paste).
+     *
+     * Reviewer Suggested #1 (post-PR #1414). Pre-fix the assertion
+     * was `assertGreaterThan(0, $found, ...)` keyed only on the
+     * title; the new shape encodes the body substring + expected
+     * count in the data provider so each site has its own dedicated
+     * fail message.
+     *
+     * @param string $file           Absolute path to the page handler.
+     * @param string $title          The exact title literal on the wire.
+     * @param string $body_substring A substring of the body that
+     *                               disambiguates this site from any
+     *                               sibling sharing the same title.
+     * @param int    $expected_count The number of times the call shape
+     *                               must appear (currently always 1).
+     */
     #[DataProvider('notStarBranches')]
-    public function testNotStarBranchesPassPersistentDurationMs(string $rel, string $titlePrefix): void
-    {
-        $abs = ROOT . $rel;
+    public function testNotStarBranchesPassPersistentDurationMs(
+        string $file,
+        string $title,
+        string $body_substring,
+        int $expected_count,
+    ): void {
         $this->assertFileExists(
-            $abs,
-            "NOT-* branch source $rel was renamed or removed — update notStarBranches() above.",
+            $file,
+            "NOT-* branch source $file was renamed or removed — update notStarBranches() above.",
         );
-        $contents = (string) file_get_contents($abs);
+        $contents = (string) file_get_contents($file);
+        $rel = substr($file, strlen(ROOT));
 
         // Five-arg pattern: kind, title, body, redirect, duration_ms.
-        // The body / redirect / first-4-arg shape is intentionally
-        // loose — we only care that the 5th arg is `0`. The pattern
-        // tolerates multi-line emit calls (most of them ARE multi-
-        // line per the codebase's style); `s` flag is mandatory.
-        // The title literal is anchored with surrounding quotes so
-        // a partial-match like "Player NOT UnGagged" doesn't pick
-        // up a hypothetical "Player NOT UnGagged Successfully" too.
-        $titleQuoted = preg_quote($titlePrefix, '#');
-        $pattern = '#\\\\?Sbpp\\\\View\\\\Toast::emit\\(\\s*'
-            . "'error',\\s*"            // kind
-            . "'{$titleQuoted}',\\s*"  // title (anchored, exact)
-            . '[^,]+?,\\s*'             // body (one comma-free chunk)
-            . '[^,]+?,\\s*'             // redirect (one comma-free chunk)
-            . '0\\s*,?\\s*\\)#s';        // duration_ms (literal 0, optional trailing comma)
-
-        $found = preg_match_all($pattern, $contents, $matches);
-        $this->assertGreaterThan(
-            0,
-            $found,
-            "Call site $rel:'$titlePrefix' does not pass `duration_ms: 0` as the 5th positional arg to `\\Sbpp\\View\\Toast::emit(...)`. The severe-error toast would auto-dismiss after ~4000ms and the operator would miss the failure confirmation — exactly the v1.x `ShowBox(..., sticky=true)` semantic #1409 restored. If the call site was migrated to a helper that defaults to `duration_ms: 0`, update `notStarBranches()` above to remove this branch from the static gate.",
-        );
-
-        // Belt-and-braces companion: every NOT-* match must pass
-        // `null` for the 4th `$redirect` arg. Persistent +
-        // redirect are mutually exclusive — the chrome's
-        // `flushPendingToasts` would otherwise navigate ~1500ms
-        // after paint, tearing down the toast before the operator
-        // can read or dismiss it (defeating the persistent
-        // semantic). Pin the call-site half of the contract here;
-        // the chrome's defence-in-depth inhibit is exercised
-        // end-to-end by
-        // `web/tests/e2e/specs/flows/toast-persistent-duration.spec.ts`.
+        // - `kind`            must be literal `'error'`
+        // - `title`           must match the exact provider literal
+        //                     (surrounding quotes anchor it)
+        // - `body`            captured as a non-greedy `.*?` window
+        //                     between the title comma and the
+        //                     `, null, 0,` tail. The body span has
+        //                     to contain the disambiguating
+        //                     substring — checked as a separate
+        //                     `str_contains` after the regex
+        //                     matches, which is robust against
+        //                     every body shape the codebase
+        //                     produces: single-quoted concat
+        //                     (`'There was an error ungagging ' . $row['name']`,
+        //                     L131 / L227), double-quoted concat
+        //                     (`"The ban for '" . $steam['name'] . "' had an error while being removed."`,
+        //                     L271), heredoc, etc. A regex
+        //                     attempting to parse the body shape
+        //                     directly fights PHP's quoting rules
+        //                     for no payoff; the
+        //                     "what's between title and redirect"
+        //                     definition is unambiguous.
+        // - `redirect`        MUST be literal `null` (the call-site half
+        //                     of the persistent+redirect mutual-exclusion
+        //                     contract — see AGENTS.md "Server-side
+        //                     toast emission" → "Redirect coalescing").
+        //                     A string here ('null' or any URL) would
+        //                     re-introduce the chrome's redirect
+        //                     setTimeout and tear down the persistent
+        //                     toast ~1500ms after paint.
+        // - `duration_ms`     MUST be literal `0`. The optional `,?`
+        //                     accepts both PSR-12 trailing-comma and
+        //                     legacy-no-trailing-comma shapes.
         //
-        // The tighter check pins specifically the literal `null`
-        // 4th argument (`'null'` would NOT satisfy — that's a
-        // string "null" which the chrome would treat as a real
-        // redirect target).
-        $strictPattern = '#\\\\?Sbpp\\\\View\\\\Toast::emit\\(\\s*'
-            . "'error',\\s*"
-            . "'{$titleQuoted}',\\s*"
-            . '[^,]+?,\\s*'            // body
-            . 'null\\s*,\\s*'           // redirect MUST be the literal `null`
-            . '0\\s*,?\\s*\\)#s';
-        $strictFound = preg_match_all($strictPattern, $contents, $strictMatches);
-        $this->assertGreaterThan(
-            0,
-            $strictFound,
-            "Call site $rel:'$titlePrefix' passes `duration_ms: 0` but ALSO passes a non-null `\$redirect` — the two are mutually exclusive per AGENTS.md \"Server-side toast emission\" → \"Duration semantics\". The chrome's `flushPendingToasts` redirect coalescing would navigate ~1500ms after paint, tearing down the persistent toast before the operator can read or dismiss it (the exact #1409 regression vector). Drop the redirect to `null` so the operator stays on the rendered surface and acknowledges the failure via the X button.",
+        // The `s` flag is mandatory — the call sites are multi-line
+        // per the codebase's style.
+        // The body capture is `((?:(?!\);).)*?)` — a lazy match
+        // that explicitly REJECTS the `);` statement terminator
+        // (`\)` close-paren followed by `;` semi). Without that
+        // guard, a regressed call site that drops the 5th arg (e.g.
+        // `Toast::emit('error', 'Player NOT UnGagged', $body);`)
+        // would let the body capture extend across the `);` into
+        // the next `Toast::emit(...)` block and match its `, null,
+        // 0,` tail — silently passing the gate while the regressed
+        // site has neither the null redirect nor the persistent
+        // duration. The negative lookahead pins the body to the
+        // current statement only. (No body in the codebase
+        // currently contains a literal `);` substring — bodies
+        // are concatenations like `'msg ' . $row['name']`; the
+        // closing `]` of `$row['name']` is harmless.)
+        $titleQuoted = preg_quote($title, '#');
+        $pattern = '#\\\\?Sbpp\\\\View\\\\Toast::emit\\(\\s*'
+            . "'error',\\s*"                  // kind
+            . "'{$titleQuoted}',\\s*"        // title (exact)
+            . '((?:(?!\\);).)*?)'             // body capture (lazy; statement-bounded)
+            . ',\\s*null\\s*,\\s*'             // redirect MUST be literal null
+            . '0\\s*,?\\s*\\)#s';              // duration_ms = 0
+
+        // Count only matches whose captured body span contains the
+        // disambiguating substring. Two sibling sites with the same
+        // title (the canonical `Player NOT UnGagged` × 2 shape in
+        // commslist) would both match the title-anchored pattern;
+        // the body-substring filter is what keeps the count
+        // per-site rather than per-title.
+        $matchCount = preg_match_all($pattern, $contents, $matches);
+        $found = 0;
+        if ($matchCount > 0) {
+            foreach ($matches[1] as $bodySpan) {
+                if (str_contains((string) $bodySpan, $body_substring)) {
+                    $found++;
+                }
+            }
+        }
+        $this->assertSame(
+            $expected_count,
+            $found,
+            sprintf(
+                "Call site %s:'%s' (body containing \"%s\") does not match the persistent+null-redirect shape exactly %d time(s); got %d match(es). "
+                . "The required call shape is:\n"
+                . "    \\Sbpp\\View\\Toast::emit(\n"
+                . "        'error',\n"
+                . "        '%s',\n"
+                . "        '...%s...' . \$row['name'],   // (or sibling body shape)\n"
+                . "        null,                           // \$redirect MUST be null (persistent+redirect mutex)\n"
+                . "        0,                              // \$duration_ms MUST be 0 (persistent)\n"
+                . "    );\n"
+                . "A drop to non-persistent (5th arg removed or non-zero) re-enables the chrome's ~4000ms auto-dismiss timer — the operator misses the severe-error confirmation and the v1.x `ShowBox(..., sticky=true)` semantic #1409 restored is gone again. "
+                . "A non-null \$redirect re-introduces the chrome's `flushPendingToasts` redirect setTimeout, which navigates ~1500ms after paint and tears down the persistent toast (the chrome's whole-drain inhibit is defence-in-depth but the call-site half is the primary contract). "
+                . "If you intentionally split or merged a NOT-* branch, update `notStarBranches()` above with the new expected count or remove the entry entirely.",
+                $rel,
+                $title,
+                $body_substring,
+                $expected_count,
+                $found,
+                $title,
+                $body_substring,
+            ),
         );
     }
 

--- a/web/tests/integration/ToastEmitRegressionTest.php
+++ b/web/tests/integration/ToastEmitRegressionTest.php
@@ -7,6 +7,7 @@ declare(strict_types=1);
 
 namespace Sbpp\Tests\Integration;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use Sbpp\Tests\ApiTestCase;
 use Sbpp\View\Toast;
 
@@ -588,4 +589,372 @@ final class ToastEmitRegressionTest extends ApiTestCase
         return $hits;
     }
 
+    // -----------------------------------------------------------------
+    // #1409 — `$duration_ms` parameter contract
+    //
+    // The 5th parameter on `Sbpp\View\Toast::emit` is the persistent-
+    // toast escape hatch — `null` (default) keeps the chrome's
+    // SHOWTOAST_DEFAULT_DURATION (~4000ms) timing, `0` disables auto-
+    // dismiss entirely (X-button only), `> 0` overrides the timer in
+    // milliseconds. The tests below pin every leg of the contract:
+    //
+    //   - omitted from the wire format when caller passed null
+    //   - included on the wire when caller passed 0 or a positive int
+    //   - encoded as an integer (not a string) so the consumer's
+    //     `typeof data.duration_ms === 'number'` gate passes
+    //   - rejected at the PHP boundary on negative input (Fail closed)
+    //   - all existing JSON_HEX_* + JSON_INVALID_UTF8_SUBSTITUTE
+    //     guarantees preserved when the new field is present
+    //   - the 5 NOT-* destructive-action-failed branches in
+    //     `page.banlist.php` / `page.commslist.php` use `0` so a
+    //     future refactor can't silently regress the persistent
+    //     semantic the user explicitly asked for
+    //
+    // The companion runtime test is
+    // `web/tests/e2e/specs/flows/toast-persistent-duration.spec.ts`
+    // which drives a NOT-* branch through the chrome end-to-end and
+    // asserts the toast outlasts SHOWTOAST_DEFAULT_DURATION.
+    // -----------------------------------------------------------------
+
+    /**
+     * `$duration_ms` defaults to `null` and is OMITTED from the wire
+     * payload in that case — the chrome's `flushPendingToasts`
+     * forwards `duration_ms` only when `typeof data.duration_ms ===
+     * 'number'`, so omitting the field is the canonical "use the
+     * default timer" signal. Emitting `{"duration_ms": null}`
+     * instead would technically work (the `typeof null === 'object'`
+     * check filters it out) but it wastes bytes and reads as "the
+     * server is intentionally signalling no override" which is
+     * indistinguishable from the absent case.
+     *
+     * Pinning the omission here means a future PR that flips to
+     * always-serialise has to update the chrome's gate in the same
+     * commit OR explicitly justify why every payload should carry
+     * a `null` placeholder.
+     */
+    public function testToastEmitOmitsDurationMsByDefault(): void
+    {
+        ob_start();
+        Toast::emit('info', 'Routine', 'Body');
+        $out = (string) ob_get_clean();
+
+        $data = $this->decodeFirstPayload($out);
+        $this->assertArrayNotHasKey(
+            'duration_ms',
+            $data,
+            'Wire payload must omit `duration_ms` when the caller did not pass a 5th argument. The chrome consumer\'s `typeof data.duration_ms === \'number\'` gate keeps absence and the chrome\'s SHOWTOAST_DEFAULT_DURATION (~4000ms) as the single source of truth for the default timing.',
+        );
+    }
+
+    /**
+     * Companion to the redirect coalescing contract: when the
+     * caller passes a 5th-argument override, the helper emits
+     * `duration_ms` in the payload AS AN INTEGER. The consumer's
+     * `typeof data.duration_ms === 'number'` gate is what forwards
+     * the value to `showToast({durationMs})`; if the encoder
+     * emitted it as a JSON string (e.g. via a stringly-typed
+     * coercion bug) the gate would skip the override entirely AND
+     * the chrome would silently fall back to the default timing —
+     * the worst kind of regression because the toast paints
+     * normally and only the timing is wrong.
+     *
+     * `0` is the canonical persistent-toast value the 5 NOT-*
+     * call sites use. Pinning the encode shape here means a
+     * future refactor that "simplifies" by stringly-typing the
+     * field has to update both halves of the gate in the same
+     * PR.
+     */
+    public function testToastEmitIncludesDurationMsWhenSet(): void
+    {
+        ob_start();
+        Toast::emit(
+            'error',
+            'Ban NOT Deleted',
+            "The ban for 'TestPlayer' had an error while being removed.",
+            'index.php?p=banlist',
+            0,
+        );
+        $out = (string) ob_get_clean();
+
+        $data = $this->decodeFirstPayload($out);
+        $this->assertArrayHasKey(
+            'duration_ms',
+            $data,
+            'Wire payload must include `duration_ms` when the caller passed 0 — the persistent-toast contract depends on the chrome receiving the explicit value.',
+        );
+        $this->assertSame(
+            0,
+            $data['duration_ms'] ?? null,
+            'Wire payload must carry `duration_ms` as an integer (not a JSON string). The chrome\'s `typeof data.duration_ms === \'number\'` gate filters out string-typed values, which would silently drop the override and fall back to the default timing.',
+        );
+        $this->assertIsInt(
+            $data['duration_ms'],
+            'JSON decoder must reify `duration_ms` as a PHP int — same reason as above. A regression to a string-typed encode would parse back as a string here.',
+        );
+
+        // Belt-and-braces: the rest of the payload still parses
+        // cleanly. The chrome can't render a toast that's missing
+        // kind / title.
+        $this->assertSame('error', $data['kind'] ?? null);
+        $this->assertSame('Ban NOT Deleted', $data['title'] ?? null);
+        $this->assertSame('index.php?p=banlist', $data['redirect'] ?? null);
+    }
+
+    /**
+     * The positive-override leg of the contract: `> 0` is an
+     * explicit ms override (currently no in-tree caller uses it,
+     * but the contract exists for future surfaces — e.g. a
+     * long-form Markdown-rendered toast that needs a longer read
+     * window without going fully persistent).
+     *
+     * The encoder shouldn't special-case the value range — `0` and
+     * `8000` ride the same code path. This test pins the
+     * stringly-typed-encode regression on the positive side
+     * (the `0`-side test above pins the same thing but at zero,
+     * which a future bug might special-case "because zero is
+     * falsy in JavaScript"; covering both ends keeps the contract
+     * symmetric).
+     */
+    public function testToastEmitIncludesDurationMsForPositiveOverride(): void
+    {
+        ob_start();
+        Toast::emit('info', 'Long form', 'Take your time reading this.', null, 8000);
+        $out = (string) ob_get_clean();
+
+        $data = $this->decodeFirstPayload($out);
+        $this->assertArrayHasKey('duration_ms', $data);
+        $this->assertSame(8000, $data['duration_ms'] ?? null);
+        $this->assertIsInt($data['duration_ms']);
+        // No redirect was supplied — the helper must still omit
+        // that field even when `duration_ms` is present (the two
+        // optional fields are independent).
+        $this->assertArrayNotHasKey(
+            'redirect',
+            $data,
+            'Helper must keep optional fields independent — passing `$duration_ms` does not justify emitting a `null` redirect.',
+        );
+    }
+
+    /**
+     * Fail closed: negative `$duration_ms` is programmer error
+     * (the caller's arithmetic is broken). Coercing via
+     * `max(0, $duration_ms)` would silently flip the toast to
+     * persistent — the worst-of-both outcome because the
+     * developer's bug is masked AND the user gets a toast they
+     * have to click X to dismiss. Throwing the
+     * `\InvalidArgumentException` surfaces the bug immediately at
+     * the call site, which is where the fix needs to land.
+     *
+     * Pre-existing helpers in this layer don't validate inputs
+     * (e.g. `$kind` is loose-typed by convention — passing
+     * `'huh'` instead of `'success'` produces a toast with a
+     * generic icon, no exception). But `$duration_ms` is
+     * different: the chrome side has no clamp / sanity check
+     * either (the typeof gate filters non-numbers but happily
+     * forwards `-5` through to `setTimeout`, which silently
+     * coerces to 1ms on most browsers — auto-dismisses
+     * immediately, indistinguishable from "the toast never
+     * painted"). The PHP-side throw is the single layer that
+     * catches the bug.
+     */
+    public function testToastEmitRejectsNegativeDuration(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        // Capture the side-effect output even when the exception
+        // throws — we want to assert NOTHING was echoed before the
+        // throw (no partial wire-payload landing in the response
+        // body that the chrome would then try to parse).
+        ob_start();
+        try {
+            Toast::emit('error', 'Bad', 'Body', null, -1);
+        } finally {
+            $out = (string) ob_get_clean();
+            $this->assertSame(
+                '',
+                $out,
+                'Helper must validate `$duration_ms` BEFORE echoing the wire payload — a partial emit on the reject path would land a half-formed JSON blob in the response body and the chrome\'s `JSON.parse` would throw on the next page-load.',
+            );
+        }
+    }
+
+    /**
+     * Belt-and-braces on the JSON-escape contract: when
+     * `duration_ms` is present, all the existing JSON_HEX_* +
+     * JSON_INVALID_UTF8_SUBSTITUTE guarantees still apply. A
+     * future regression that adds the field via a custom encode
+     * step (e.g. string-concatenating the payload manually
+     * "because it's just one new field") would silently drop
+     * every defensiveness flag.
+     *
+     * The shape mirrors `testToastEmitJsonEscapingDefendsScriptBreakout`
+     * with the addition of `duration_ms: 0` to prove the new
+     * field doesn't break the existing contract.
+     */
+    public function testToastEmitWireFormatStaysHexEscapedWithDurationMs(): void
+    {
+        ob_start();
+        Toast::emit(
+            'error',
+            '</script><script>alert(1)</script>',
+            "&<>'\"" . "\xC3broken", // malformed UTF-8 too
+            null,
+            0,
+        );
+        $out = (string) ob_get_clean();
+
+        // The script-breakout defence still fires.
+        $this->assertStringNotContainsString(
+            '</script><script>alert(1)</script>',
+            substr($out, 0, (int) strrpos($out, '</script>')),
+            'JSON_HEX_TAG must still escape `<` even when `duration_ms` is present — a hostile payload cannot terminate the script element via either the title or body field.',
+        );
+        $this->assertStringContainsString(
+            '\u003C',
+            $out,
+            'JSON_HEX_TAG hex-escape contract preserved with `duration_ms` field present.',
+        );
+
+        // The UTF-8 substitute defence still fires.
+        $this->assertMatchesRegularExpression(
+            '/\\\\u(?:FFFD|fffd)/',
+            $out,
+            'JSON_INVALID_UTF8_SUBSTITUTE substitute contract preserved with `duration_ms` field present.',
+        );
+
+        // The new field is intact + correctly typed.
+        $data = $this->decodeFirstPayload($out);
+        $this->assertSame(0, $data['duration_ms'] ?? null);
+        $this->assertIsInt($data['duration_ms']);
+
+        // The rest of the payload is parseable.
+        $this->assertSame('error', $data['kind'] ?? null);
+        $this->assertIsString($data['title'] ?? null);
+        $this->assertIsString($data['body'] ?? null);
+    }
+
+    /**
+     * Pin the call-site contract for the 5 NOT-* branches the
+     * #1409 follow-up converted to persistent toasts. A future
+     * refactor that drops the 5th positional argument from any of
+     * these branches would silently restore the auto-dismiss
+     * timer on a severe-error confirmation the operator was
+     * supposed to acknowledge — exactly the regression vector
+     * #1409 closes.
+     *
+     * The branches all share a literal "NOT" (capital N-O-T,
+     * with a space) in the toast title — that's the convention
+     * the v1.x `ShowBox(..., sticky=true)` callers used to
+     * distinguish "this destructive operation FAILED" from "this
+     * destructive operation succeeded". The #1403 mechanical
+     * lift preserved the casing verbatim; #1409 restores the
+     * sticky semantic under a cleaner contract.
+     *
+     * Each entry is `[relPath, titlePrefix]` — we grep the file
+     * for `Toast::emit('error', '<titlePrefix>'` and assert the
+     * call site passes a 5th positional argument (whose value is
+     * `0`). Pattern is `/Toast::emit\(\s*'error',\s*'<title>',\s*[^,]+,\s*[^,]+,\s*0\s*,?\s*\)/`
+     * — five comma-separated args, the last one is the literal
+     * `0`. The trailing `,?` accepts the PSR-12-style trailing-
+     * comma shape some files use and some don't.
+     *
+     * Future refactors that move the call sites to a helper that
+     * defaults to `duration_ms: 0` (so the literal arg goes
+     * away) should update this test in the same PR; the contract
+     * is "the persistent semantic is preserved", and a helper
+     * call would satisfy that even though the static grep no
+     * longer matches.
+     *
+     * @return list<array{0: string, 1: string}>
+     */
+    public static function notStarBranches(): array
+    {
+        return [
+            ['pages/page.banlist.php',   'Player NOT Unbanned'],
+            ['pages/page.banlist.php',   'Ban NOT Deleted'],
+            ['pages/page.commslist.php', 'Player NOT UnGagged'], // matches two sites in this file (ungag + unmute branches); the assertion below tolerates multi-match
+            ['pages/page.commslist.php', 'Ban NOT Deleted'],
+        ];
+    }
+
+    #[DataProvider('notStarBranches')]
+    public function testNotStarBranchesPassPersistentDurationMs(string $rel, string $titlePrefix): void
+    {
+        $abs = ROOT . $rel;
+        $this->assertFileExists(
+            $abs,
+            "NOT-* branch source $rel was renamed or removed — update notStarBranches() above.",
+        );
+        $contents = (string) file_get_contents($abs);
+
+        // Five-arg pattern: kind, title, body, redirect, duration_ms.
+        // The body / redirect / first-4-arg shape is intentionally
+        // loose — we only care that the 5th arg is `0`. The pattern
+        // tolerates multi-line emit calls (most of them ARE multi-
+        // line per the codebase's style); `s` flag is mandatory.
+        // The title literal is anchored with surrounding quotes so
+        // a partial-match like "Player NOT UnGagged" doesn't pick
+        // up a hypothetical "Player NOT UnGagged Successfully" too.
+        $titleQuoted = preg_quote($titlePrefix, '#');
+        $pattern = '#\\\\?Sbpp\\\\View\\\\Toast::emit\\(\\s*'
+            . "'error',\\s*"            // kind
+            . "'{$titleQuoted}',\\s*"  // title (anchored, exact)
+            . '[^,]+?,\\s*'             // body (one comma-free chunk)
+            . '[^,]+?,\\s*'             // redirect (one comma-free chunk)
+            . '0\\s*,?\\s*\\)#s';        // duration_ms (literal 0, optional trailing comma)
+
+        $found = preg_match_all($pattern, $contents, $matches);
+        $this->assertGreaterThan(
+            0,
+            $found,
+            "Call site $rel:'$titlePrefix' does not pass `duration_ms: 0` as the 5th positional arg to `\\Sbpp\\View\\Toast::emit(...)`. The severe-error toast would auto-dismiss after ~4000ms and the operator would miss the failure confirmation — exactly the v1.x `ShowBox(..., sticky=true)` semantic #1409 restored. If the call site was migrated to a helper that defaults to `duration_ms: 0`, update `notStarBranches()` above to remove this branch from the static gate.",
+        );
+
+        // Belt-and-braces companion: every NOT-* match must pass
+        // `null` for the 4th `$redirect` arg. Persistent +
+        // redirect are mutually exclusive — the chrome's
+        // `flushPendingToasts` would otherwise navigate ~1500ms
+        // after paint, tearing down the toast before the operator
+        // can read or dismiss it (defeating the persistent
+        // semantic). Pin the call-site half of the contract here;
+        // the chrome's defence-in-depth inhibit is exercised
+        // end-to-end by
+        // `web/tests/e2e/specs/flows/toast-persistent-duration.spec.ts`.
+        //
+        // The tighter check pins specifically the literal `null`
+        // 4th argument (`'null'` would NOT satisfy — that's a
+        // string "null" which the chrome would treat as a real
+        // redirect target).
+        $strictPattern = '#\\\\?Sbpp\\\\View\\\\Toast::emit\\(\\s*'
+            . "'error',\\s*"
+            . "'{$titleQuoted}',\\s*"
+            . '[^,]+?,\\s*'            // body
+            . 'null\\s*,\\s*'           // redirect MUST be the literal `null`
+            . '0\\s*,?\\s*\\)#s';
+        $strictFound = preg_match_all($strictPattern, $contents, $strictMatches);
+        $this->assertGreaterThan(
+            0,
+            $strictFound,
+            "Call site $rel:'$titlePrefix' passes `duration_ms: 0` but ALSO passes a non-null `\$redirect` — the two are mutually exclusive per AGENTS.md \"Server-side toast emission\" → \"Duration semantics\". The chrome's `flushPendingToasts` redirect coalescing would navigate ~1500ms after paint, tearing down the persistent toast before the operator can read or dismiss it (the exact #1409 regression vector). Drop the redirect to `null` so the operator stays on the rendered surface and acknowledges the failure via the X button.",
+        );
+    }
+
+    /**
+     * Decode the FIRST `sbpp-pending-toast` JSON blob from the
+     * helper's output. Shared between every wire-format test
+     * above — encapsulates the parse-the-script-body dance so
+     * each test reads as "what does the payload look like".
+     *
+     * @return array<string, mixed>
+     */
+    private function decodeFirstPayload(string $out): array
+    {
+        $start = strpos($out, '">') + 2;
+        $end = strrpos($out, '</script>');
+        $this->assertNotFalse($end, 'Could not find script close tag in helper output.');
+        $json = substr($out, $start, $end - $start);
+        $decoded = json_decode($json, true);
+        $this->assertIsArray($decoded, "Helper emitted invalid JSON: $json");
+        /** @var array<string, mixed> $decoded */
+        return $decoded;
+    }
 }

--- a/web/themes/default/js/theme.js
+++ b/web/themes/default/js/theme.js
@@ -1471,15 +1471,27 @@
     // would collide on the testid and Playwright's `getByTestId`
     // strict mode rejects multi-match), but the painted toast is
     // the canonical anchor for E2E specs. The `data-testid` lets
-    // suites use `[data-testid="toast"]`; `role="status"` gives
-    // assistive-tech callers an announcement target and is the
-    // documented alternative anchor a future a11y-focused spec
-    // can key on. Pre-#1409 the chrome emitted neither — every
-    // existing spec keyed on `.toast[data-kind="..."]`, which
-    // still works (CSS class + dataset attribute) but is not the
-    // documented contract.
+    // suites use `[data-testid="toast"]`; the role attribute
+    // gives assistive-tech callers an announcement target.
+    // Pre-#1409 the chrome emitted neither — every existing
+    // spec keyed on `.toast[data-kind="..."]`, which still works
+    // (CSS class + dataset attribute) but is not the documented
+    // contract.
     el.setAttribute('data-testid', 'toast');
-    el.setAttribute('role', 'status');
+    // Kind-aware ARIA role (#1409 review Suggested #3): error
+    // toasts get `role="alert"` (assertive — screen readers
+    // interrupt the current announcement to surface this);
+    // every other kind gets `role="status"` (polite — waits
+    // for the user to finish what they're listening to). The
+    // distinction matters most for persistent error toasts
+    // (`duration_ms: 0`): a polite announcement that the
+    // screen-reader user might never hear because they're
+    // focused elsewhere defeats the entire "operator must
+    // acknowledge before moving on" semantic. Apple HIG,
+    // Material Design, and Bootstrap all converge on
+    // `alert` for errors + `status` for info/success;
+    // ARIA spec authors picked the same split.
+    el.setAttribute('role', kind === 'error' ? 'alert' : 'status');
     const icon = kind === 'error' ? 'circle-x' : kind === 'warn' ? 'triangle-alert' : kind === 'success' ? 'circle-check' : 'info';
     el.innerHTML = '<i data-lucide="' + icon + '" style="color:var(--' + kind + ')"></i>'
       + '<div style="flex:1;min-width:0"><div class="font-semibold text-sm">' + escapeHtml(title) + '</div>'

--- a/web/themes/default/js/theme.js
+++ b/web/themes/default/js/theme.js
@@ -1414,11 +1414,30 @@
 
   // ---- TOASTS ----------------------------------------------
   /**
+   * Default auto-dismiss window in milliseconds. Mirrors the
+   * `Sbpp\View\Toast::emit` PHP-side contract: a `null` /
+   * missing `duration_ms` field on the wire payload means
+   * "use this default". The constant is named (not inlined as
+   * a `4000` literal) so a future tweak / theme override lands
+   * in one place. Don't reach for this from outside the toast
+   * pathway — `showToast({durationMs: SHOWTOAST_DEFAULT_DURATION})`
+   * is identical to the default and noisier than just omitting
+   * the option.
+   */
+  const SHOWTOAST_DEFAULT_DURATION = 4000;
+
+  /**
    * @typedef {Object} ToastOpts
-   * @property {string} [kind]      'info' | 'success' | 'warn' | 'error'
+   * @property {string} [kind]        'info' | 'success' | 'warn' | 'error'
    * @property {string} title
    * @property {string} [body]
-   * @property {number} [duration]  ms before auto-dismiss; default 4000
+   * @property {number} [durationMs]  Auto-dismiss timer in ms. Three values are meaningful:
+   *   - `undefined` (default): the chrome uses `SHOWTOAST_DEFAULT_DURATION` (~4000ms).
+   *   - `0`: persistent — the toast does NOT auto-dismiss; user must click the X button.
+   *   - `> 0`: explicit override in ms.
+   *   Mirrors the `duration_ms` field on `Sbpp\View\Toast::emit`'s
+   *   wire format; the chrome's `flushPendingToasts` drain forwards
+   *   the value verbatim when the server included it.
    */
 
   /**
@@ -1429,7 +1448,12 @@
     const kind = opts.kind || 'info';
     const title = opts.title;
     const body = opts.body;
-    const duration = opts.duration === undefined ? 4000 : opts.duration;
+    // `durationMs === 0` is a documented, load-bearing value (the
+    // persistent shape). The `=== undefined` check is what's used
+    // for the default fall-through; `!opts.durationMs` would
+    // collapse `0` into the default branch and silently disable
+    // the persistent semantic.
+    const durationMs = opts.durationMs === undefined ? SHOWTOAST_DEFAULT_DURATION : opts.durationMs;
     let stack = document.getElementById('toast-stack');
     if (!stack) {
       stack = document.createElement('div');
@@ -1440,15 +1464,38 @@
     const el = document.createElement('div');
     el.className = 'toast';
     el.dataset.kind = kind;
+    // Bring the painted element in line with the documented
+    // contract in AGENTS.md "Server-side toast emission" /
+    // "Anti-patterns" — wire-format `<script>` blocks
+    // deliberately carry NO `data-testid` (multi-emit responses
+    // would collide on the testid and Playwright's `getByTestId`
+    // strict mode rejects multi-match), but the painted toast is
+    // the canonical anchor for E2E specs. The `data-testid` lets
+    // suites use `[data-testid="toast"]`; `role="status"` gives
+    // assistive-tech callers an announcement target and is the
+    // documented alternative anchor a future a11y-focused spec
+    // can key on. Pre-#1409 the chrome emitted neither — every
+    // existing spec keyed on `.toast[data-kind="..."]`, which
+    // still works (CSS class + dataset attribute) but is not the
+    // documented contract.
+    el.setAttribute('data-testid', 'toast');
+    el.setAttribute('role', 'status');
     const icon = kind === 'error' ? 'circle-x' : kind === 'warn' ? 'triangle-alert' : kind === 'success' ? 'circle-check' : 'info';
     el.innerHTML = '<i data-lucide="' + icon + '" style="color:var(--' + kind + ')"></i>'
       + '<div style="flex:1;min-width:0"><div class="font-semibold text-sm">' + escapeHtml(title) + '</div>'
       + (body ? '<div class="text-xs text-muted" style="margin-top:2px">' + escapeHtml(body) + '</div>' : '')
       + '</div>'
-      + '<button class="btn btn--ghost btn--icon" data-toast-close><i data-lucide="x"></i></button>';
+      + '<button class="btn btn--ghost btn--icon" data-toast-close aria-label="Dismiss"><i data-lucide="x"></i></button>';
     stack.appendChild(el);
     if (window.lucide) window.lucide.createIcons();
-    setTimeout(() => el.remove(), duration);
+    // `durationMs > 0` is the only path that schedules the
+    // auto-dismiss timer. `durationMs === 0` is the persistent
+    // shape (no timer; user must click the X button). A naive
+    // `setTimeout(..., 0)` would auto-dismiss IMMEDIATELY on the
+    // next tick — exactly the opposite of what `0` means here.
+    if (durationMs > 0) {
+      setTimeout(() => el.remove(), durationMs);
+    }
   }
 
   document.addEventListener('click', (/** @type {MouseEvent} */ e) => {
@@ -1505,6 +1552,33 @@
   // from the DOM so a hypothetical re-run of this drainer (e.g. an
   // HMR refresh in dev) doesn't double-fire.
   //
+  // Duration override: optional `duration_ms` field on the wire
+  // payload forwards to `showToast({durationMs})`. Three values are
+  // meaningful (mirror of the PHP-side `Sbpp\View\Toast::emit`
+  // contract): missing / non-numeric → chrome uses
+  // `SHOWTOAST_DEFAULT_DURATION`; `0` → persistent (no auto-dismiss
+  // timer; user must click the X button); `> 0` → explicit ms
+  // override. The `typeof data.duration_ms === 'number'` guard is
+  // load-bearing: a hostile / malformed payload sending a string
+  // or boolean must NOT pass through unchecked — `showToast` would
+  // then schedule `setTimeout(..., "0")` (Number-coerced to 0,
+  // auto-dismisses immediately) or `setTimeout(..., true)` (Number-
+  // coerced to 1, dismisses after 1ms). The typeof gate keeps the
+  // chrome's behaviour deterministic regardless of upstream noise.
+  //
+  // Persistent + redirect interaction (#1409): when ANY toast in
+  // the drained queue carries `duration_ms: 0`, the redirect
+  // setTimeout below is SUPPRESSED — persistent + redirect are
+  // mutually exclusive (the redirect would otherwise navigate
+  // ~1500ms after paint, tearing down the toast before the
+  // operator can read or dismiss it). The call-site contract is
+  // "don't pass a redirect when emitting `duration_ms: 0`" (per
+  // AGENTS.md "Server-side toast emission" → "Duration semantics"),
+  // and the chrome's inhibit is defence-in-depth so a future
+  // caller forgetting that rule doesn't silently produce broken
+  // UX. Both halves ship together; neither is sufficient on its
+  // own.
+  //
   // Malformed JSON is logged and skipped — a single broken entry
   // can't take down the rest of the queue. Empty queue is a no-op
   // (the overwhelming majority of requests).
@@ -1516,17 +1590,53 @@
     if (!blocks.length) return;
     /** @type {string | null} */
     let redirectTo = null;
+    // #1409: track whether ANY toast in this drain is persistent
+    // (`duration_ms === 0`). If so, the redirect setTimeout below
+    // is suppressed entirely — persistent + redirect are mutually
+    // exclusive (the redirect would navigate ~1500ms after paint,
+    // tearing down the toast before the operator can read or
+    // dismiss it, defeating the entire point of the persistent
+    // semantic). Call sites that pair `duration_ms: 0` with a
+    // redirect produce broken UX in two halves: the call site
+    // SHOULD pass `null` for `$redirect` when emitting persistent
+    // (the documented contract in AGENTS.md "Duration semantics"),
+    // and the chrome SHOULD inhibit the redirect as defence-in-
+    // depth if a future caller forgets. Both halves ship together.
+    //
+    // Whole-drain inhibit (not per-block): if the queue carries a
+    // mix of persistent + non-persistent toasts, the persistent
+    // one's needs-acknowledgement semantic wins. The non-persistent
+    // toasts still paint with their auto-dismiss timers — they
+    // disappear normally on their own clocks — but the redirect
+    // is gated on the user's explicit X-click on the persistent
+    // toast. (In practice no in-tree caller emits a mixed queue
+    // today; the contract is conservative for future surfaces.)
+    let hasPersistentToast = false;
     blocks.forEach((/** @type {Element} */ blob) => {
       try {
         const raw = blob.textContent || '{}';
-        const data = /** @type {{kind?: string, title?: string, body?: string, redirect?: string}} */ (
+        const data = /** @type {{kind?: string, title?: string, body?: string, redirect?: string, duration_ms?: number}} */ (
           JSON.parse(raw)
         );
-        showToast({
+        /** @type {ToastOpts} */
+        const opts = {
           kind: /** @type {any} */ (data.kind || 'info'),
           title: data.title || '',
           body: data.body || '',
-        });
+        };
+        // Forward `duration_ms` only when the server explicitly
+        // sent a numeric value. `undefined` (key absent) falls
+        // through to `showToast`'s `SHOWTOAST_DEFAULT_DURATION`
+        // branch via the `=== undefined` check in showToast itself
+        // — we deliberately don't assign here so the property
+        // stays absent on `opts` for the common case.
+        if (typeof data.duration_ms === 'number') {
+          opts.durationMs = data.duration_ms;
+          if (data.duration_ms === 0) {
+            hasPersistentToast = true;
+          }
+        }
+        showToast(opts);
         if (
           redirectTo === null
           && typeof data.redirect === 'string'
@@ -1539,7 +1649,7 @@
       }
       blob.remove();
     });
-    if (redirectTo !== null) {
+    if (redirectTo !== null && !hasPersistentToast) {
       const target = redirectTo;
       setTimeout(() => { window.location.href = target; }, 1500);
     }


### PR DESCRIPTION
## Description

Adds an optional 5th parameter `?int $duration_ms = null` to `Sbpp\View\Toast::emit`:
- `null` (default) — chrome uses `SHOWTOAST_DEFAULT_DURATION` (~4000ms), unchanged behavior
- `0` — persistent; the toast stays until the user clicks the X button
- `> 0` — explicit override in milliseconds
- negative — throws `\InvalidArgumentException` (Fail closed; per AGENTS.md instinct)

Wire format extends with an optional `duration_ms` field on the JSON payload; the chrome's `flushPendingToasts` forwards it to `showToast({...durationMs})` via a `typeof data.duration_ms === 'number'` gate. `SHOWTOAST_DEFAULT_DURATION` is now a named constant (was inline `4000` in `theme.js`); `showToast` gains a `durationMs > 0` guard so `0` skips `setTimeout` entirely instead of auto-dismissing on the next event-loop tick. All existing `JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_INVALID_UTF8_SUBSTITUTE | JSON_THROW_ON_ERROR` guarantees retained.

Converts the 5 NOT-* destructive-action-failed branches the #1403 lift flagged. **Persistent + redirect are mutually exclusive** — the chrome's redirect coalescing would otherwise navigate ~1500ms after paint, tearing the persistent toast down before the operator can read or acknowledge it. Each NOT-* call site passes `null` for `$redirect`:
- `page.banlist.php` — "Player NOT Unbanned", "Ban NOT Deleted"
- `page.commslist.php` — "Player NOT UnGagged" (ungag failure), "Player NOT UnGagged" (unmute failure), "Ban NOT Deleted"

Chrome-side defence-in-depth: `flushPendingToasts` now tracks whether any drained block carries `duration_ms: 0` and suppresses the redirect `setTimeout` for the whole drain when one is present — so a future caller forgetting the mutual-exclusion rule still preserves the persistent semantic instead of producing silently broken UX. The call-site half (`$redirect=null`) is the primary contract pinned by the new `testNotStarBranchesPassPersistentDurationMs` strict-regex test; the chrome inhibit is belt-and-braces.

The painted toast element gains the documented testability hooks the chrome implicitly carried but never exposed: `data-testid="toast"`, `role="status"`, plus `aria-label="Dismiss"` on the X close button. The wire-format `<script class="sbpp-pending-toast">` block deliberately stays testid-free (multi-emit responses would collide on `getByTestId` strict mode — explicitly asserted by the existing `testToastEmitWireFormatStaysStable`).

## Motivation and Context

Closes #1409. Follow-up to #1403 which lifted `Toast::emit` from `page.submit.php` and converted 35 legacy `<script>ShowBox(...)</script>` sites. The mechanical fidelity sweep dropped one semantic: v1.x `ShowBox(text, title, redirect, bg, sticky=true)`'s 5-arg shape disabled auto-dismiss for severe-error confirmations. Today every `Toast::emit(...)` rides the 4000ms auto-dismiss; the NOT-* branches read OK at that timing but the "stop and acknowledge before it disappears" semantic was lost. This PR restores it under a cleaner contract.

## How Has This Been Tested?

- `./sbpp.sh phpstan` — clean (no new errors)
- `./sbpp.sh test --filter=ToastEmit` — 16 tests, 72 assertions; the new contracts pin: default omits `duration_ms` from wire, explicit `0` produces persistent payload, positive override surfaces (`8000`), negative throws `\InvalidArgumentException`, all JSON_HEX_* + UTF-8 substitute guarantees preserved with the new field, every NOT-* branch's call site uses `duration_ms: 0` AND `$redirect=null`
- `./sbpp.sh test` — full PHPUnit suite green (698 tests, 2787 assertions)
- `./sbpp.sh ts-check` — clean
- `./sbpp.sh composer api-contract` — no diff (no API handler change)
- `CI=1 ./sbpp.sh e2e specs/flows/toast-persistent-duration.spec.ts` — 6 tests across chromium + mobile-chromium projects: drives a NOT-* failure path via an orphan-ban setup, asserts the toast is STILL visible 5s post-paint (vs default ~4s auto-dismiss), then verifies the manual-dismiss button works; sibling regression guard proves routine toasts still auto-dismiss; wire-layer test asserts `duration_ms: 0` is present AND `redirect` is absent on the wire
- `CI=1 ./sbpp.sh e2e --grep '@toast|toast'` — 49 toast-related specs pass (7 properly skipped as desktop-only on mobile project)
- `CI=1 ./sbpp.sh e2e` — full suite green (321 passed, 293 skipped, 0 failed)

The existing `banlist-getfallback-toast` / `commslist-getfallback-toast` / `lostpassword-toast` / `admin-edit-comms-toast` / `protest-toast` specs are unaffected (they cover the success / lowercase-error paths that still ride the default duration).

## Screenshots (if appropriate):

Behavioral difference only — no chrome change. Pre-fix, a "Ban NOT Deleted" toast painted, then auto-disappeared after 4s; operators sometimes blinked / scrolled and missed the message entirely. Post-fix, the toast paints and stays until the operator clicks the X button.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue) — restores a v1.x semantic that was silently dropped in the v2.0 toast lift
- [x] New feature (non-breaking change which adds functionality) — additive optional parameter; all existing call sites unchanged

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation. (AGENTS.md "Server-side toast emission" Conventions block updated + "Where to find what" row updated + four new anti-pattern entries: don't pair persistent with redirect, don't use 0 for routine toasts, don't mirror the literal 4000ms, don't `setTimeout(fn, 0)` instead of skipping the timer.)
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](CONTRIBUTING.md) document.

Refs:
- #1403 (precursor mechanical-lift PR that flagged this drop)
- `Sbpp\View\Toast::emit` — `web/includes/View/Toast.php`
- `showToast` / `flushPendingToasts` / `SHOWTOAST_DEFAULT_DURATION` — `web/themes/default/js/theme.js`