### PR TITLE
ci(docs): fix screenshot capture against the #1335 C2 install guard

### DIFF
--- a/.github/workflows/docs-screenshots-capture.yml
+++ b/.github/workflows/docs-screenshots-capture.yml
@@ -195,13 +195,66 @@ jobs:
       # Run the TRUSTED capture script. Outputs land in the PR head's
       # docs/src/assets/auto/ via CAPTURE_OUT_OVERRIDE so the auto-
       # commit step picks them up below.
-      - name: Capture screenshots
+      #
+      # Two passes — one per route group — because the install wizard
+      # and the post-install panel need opposite states of
+      # `web/config.php`:
+      #
+      #   - The panel needs `config.php` to bootstrap (without it
+      #     `web/init.php` redirects every panel URL to `/install/`).
+      #   - The install wizard's #1335 C2 guard refuses to start over
+      #     a panel where `config.php` exists (it renders a static
+      #     409 "already installed" page instead).
+      #
+      # The dev stack's entrypoint (`docker/php/web-entrypoint.sh`)
+      # creates `config.php` on first boot, so we land in the
+      # "panel works, wizard refuses" state by default. The dance
+      # below moves the file aside on the host (the bind-mounted
+      # `./web` means the container sees the rename immediately) for
+      # the duration of the install captures, then restores it.
+      - name: Capture panel screenshots
         working-directory: trusted/docs
         env:
           STEAM_API_KEY: '00000000000000000000000000000000'
           PANEL_URL: 'http://localhost:8080'
           CAPTURE_OUT_OVERRIDE: ${{ github.workspace }}/pr-head/docs/src/assets/auto
+          CAPTURE_ROUTES: panel
         run: npm run capture
+
+      - name: Stash config.php to expose the install wizard
+        working-directory: pr-head
+        run: |
+          if [[ -f web/config.php ]]; then
+            mv web/config.php /tmp/sbpp-config-stash.php
+            echo "stashed web/config.php → /tmp/sbpp-config-stash.php"
+          else
+            echo "web/config.php was already absent; nothing to stash"
+          fi
+
+      - name: Capture install screenshots
+        working-directory: trusted/docs
+        env:
+          STEAM_API_KEY: '00000000000000000000000000000000'
+          PANEL_URL: 'http://localhost:8080'
+          CAPTURE_OUT_OVERRIDE: ${{ github.workspace }}/pr-head/docs/src/assets/auto
+          CAPTURE_ROUTES: install
+        run: npm run capture
+
+      # Restore is `if: always()` so a failed install capture (timeout,
+      # unexpected wizard render, etc.) still leaves the panel in a
+      # bootable state for the tear-down step. The matching stash
+      # above only renames when the source file exists, so the pair
+      # is idempotent.
+      - name: Restore config.php
+        if: always()
+        working-directory: pr-head
+        run: |
+          if [[ -f /tmp/sbpp-config-stash.php ]]; then
+            mv /tmp/sbpp-config-stash.php web/config.php
+            echo "restored /tmp/sbpp-config-stash.php → web/config.php"
+          else
+            echo "no stash to restore; nothing to do"
+          fi
 
       - name: Tear down stack
         if: always()

--- a/docs/README.md
+++ b/docs/README.md
@@ -83,6 +83,39 @@ different port — see AGENTS.md "Parallel stacks"):
 PANEL_URL=http://localhost:8189 npm run capture
 ```
 
+### `CAPTURE_ROUTES` (install vs panel)
+
+`CAPTURE_ROUTES` picks which route group to capture; defaults to
+`all` (both groups). Useful when iterating on a specific surface:
+
+```sh
+CAPTURE_ROUTES=panel   npm run capture    # post-install panel only
+CAPTURE_ROUTES=install npm run capture    # wizard surfaces only
+```
+
+The install captures have a sharp edge worth knowing about. The
+dev stack's entrypoint (`docker/php/web-entrypoint.sh`) creates
+`web/config.php` on first boot, and the install wizard's #1335 C2
+guard refuses to start whenever `config.php` exists — it renders a
+static 409 "already installed" page instead of step 1. Running
+`CAPTURE_ROUTES=install` against a default-boot dev stack therefore
+silently screenshots that 409 page for every install route, which
+is almost never what you want.
+
+To capture real wizard surfaces locally, move `config.php` aside
+for the duration of the install pass and restore it afterwards:
+
+```sh
+# from the repo root, with the dev stack already running
+mv web/config.php /tmp/sbpp-config-stash.php
+( cd docs && CAPTURE_ROUTES=install npm run capture )
+mv /tmp/sbpp-config-stash.php web/config.php
+```
+
+CI does the same stash/restore dance automatically in
+`docs-screenshots-capture.yml`; this is only relevant when iterating
+locally.
+
 ## CI
 
 Four workflows under `.github/workflows/` cover the docs site:

--- a/docs/scripts/capture.mjs
+++ b/docs/scripts/capture.mjs
@@ -6,9 +6,10 @@
 //
 // Output lives under docs/src/assets/auto/{install,panel}/ and is
 // committed alongside the PR that changed the UI (see
-// .github/workflows/docs-screenshots.yml). Stable filenames mean
-// page references in the docs don't have to change when a screenshot
-// regenerates — the docs site picks up the new bytes automatically.
+// .github/workflows/docs-screenshots-capture.yml). Stable filenames
+// mean page references in the docs don't have to change when a
+// screenshot regenerates — the docs site picks up the new bytes
+// automatically.
 //
 // Prerequisites:
 //
@@ -19,13 +20,20 @@
 //
 //      and wait for the seed (admin/admin) to land. CI runs the
 //      same `docker compose up -d --wait` sequence in
-//      docs-screenshots.yml.
+//      docs-screenshots-capture.yml.
 //
-//   2. The wizard at /install/ is reachable. Locally the install
-//      directory is wiped after seed, so the install captures only
-//      run when /install/ exists. The dev stack rebuilds it on
-//      `./sbpp.sh reset`; CI's `docker compose up` always starts
-//      from a fresh DB so /install/ is fresh on first paint.
+//   2. The install wizard at /install/ is reachable. The wizard's
+//      #1335 C2 guard refuses to start over an installed panel —
+//      it short-circuits to a static 409 "already installed" page
+//      whenever `web/config.php` exists. The dev stack's entrypoint
+//      always creates `config.php` on first boot, so the install
+//      captures only paint real wizard surfaces when `config.php`
+//      is moved aside for the duration of the install captures.
+//      CI does this stash/restore dance in
+//      `docs-screenshots-capture.yml` around the
+//      `CAPTURE_ROUTES=install` invocation; locally the `install`
+//      arm of `CAPTURE_ROUTES` will silently render the 409 page
+//      until the operator moves `web/config.php` aside manually.
 //
 //   3. STEAM_API_KEY is set to the all-zero dummy
 //      (00000000000000000000000000000000) per #1333 §7. The dev seed
@@ -35,6 +43,16 @@
 //
 //      cd docs && npm run capture
 //      cd docs && PANEL_URL=http://localhost:8189 npm run capture
+//      cd docs && CAPTURE_ROUTES=panel npm run capture     # panel only
+//      cd docs && CAPTURE_ROUTES=install npm run capture   # wizard only
+//
+// `CAPTURE_ROUTES` selects which route groups to capture:
+//   - `all` (default) — every route group below
+//   - `panel`         — panel-01-login (anonymous) + the
+//                       authenticated panel surfaces
+//   - `install`       — the install wizard surfaces (steps 1, 2, 5).
+//                       Requires `web/config.php` to be absent so
+//                       the C2 guard doesn't intercept.
 //
 // The script is intentionally a runnable SKELETON for the first PR.
 // The route list below is the bones; flesh out per-route selectors
@@ -70,6 +88,19 @@ const ADMIN_PASS = process.env.PANEL_ADMIN_PASS ?? 'admin';
 // default size.
 const VIEWPORT = { width: 1280, height: 800 };
 
+// CAPTURE_ROUTES picks which route groups run. CI invokes us twice
+// (once per group) with config.php stashed around the install pass
+// so the wizard's #1335 C2 guard doesn't intercept; local dev
+// defaults to `all` and the install routes will silently render the
+// "already installed" 409 page until the operator stashes
+// `web/config.php` themselves.
+const CAPTURE_ROUTES_RAW = (process.env.CAPTURE_ROUTES ?? 'all').toLowerCase();
+/** @type {'all' | 'panel' | 'install'} */
+const CAPTURE_ROUTES =
+  CAPTURE_ROUTES_RAW === 'panel' || CAPTURE_ROUTES_RAW === 'install'
+    ? CAPTURE_ROUTES_RAW
+    : 'all';
+
 /**
  * @typedef {Object} CaptureRoute
  * @property {string} name        Stable filename slug — survives between runs.
@@ -80,13 +111,24 @@ const VIEWPORT = { width: 1280, height: 800 };
  * @property {string} [todo]      Note for future work; route still runs.
  */
 
+// Login route is captured from an anonymous context BEFORE the
+// authenticated routes are visited. Reason: `page.login.php` emits
+// `<script>window.location.href = 'index.php';</script>` whenever a
+// session already exists, and that inline navigation aborts the
+// Playwright `page.goto()` for `/index.php?p=login` with
+// `net::ERR_ABORTED`. Capturing login from a fresh (cookie-less)
+// context sidesteps the redirect entirely.
 /** @type {CaptureRoute[]} */
-const PANEL_ROUTES = [
+const PANEL_PUBLIC_ROUTES = [
   {
     name: 'panel-01-login',
     url: '/index.php?p=login',
     waitFor: 'form',
   },
+];
+
+/** @type {CaptureRoute[]} */
+const PANEL_AUTH_ROUTES = [
   {
     name: 'panel-02-dashboard',
     url: '/index.php?p=home',
@@ -219,19 +261,33 @@ async function main() {
 
   console.log(`[capture] PANEL_URL=${PANEL_URL}`);
   console.log(`[capture] STEAM_API_KEY=${STEAM_API_KEY}`);
+  console.log(`[capture] CAPTURE_ROUTES=${CAPTURE_ROUTES}`);
   console.log(
     `[capture] writing → ${OUT_INSTALL} (install) and ${OUT_PANEL} (panel)`,
   );
 
   const browser = await chromium.launch();
   try {
-    // Install captures first — they only work against a fresh DB
-    // where /install/ exists. CI ensures this via `docker compose up`
-    // from a clean volume.
-    await captureRoutes(browser, INSTALL_ROUTES, OUT_INSTALL);
-    // Panel captures need an authenticated session. Run with `login`
-    // turned on so the admin-only routes paint actual content.
-    await captureRoutes(browser, PANEL_ROUTES, OUT_PANEL, { login: true });
+    if (CAPTURE_ROUTES === 'all' || CAPTURE_ROUTES === 'install') {
+      // Install captures only paint real wizard surfaces when
+      // `web/config.php` is absent — see the header comment for
+      // the C2-guard rationale. CI stashes the file around this
+      // call; local-dev defaults render the 409 page.
+      await captureRoutes(browser, INSTALL_ROUTES, OUT_INSTALL);
+    }
+    if (CAPTURE_ROUTES === 'all' || CAPTURE_ROUTES === 'panel') {
+      // Anonymous pass — captures the login screen before any
+      // session cookie exists. Splitting this from the auth pass
+      // avoids the `<script>window.location.href='index.php'</script>`
+      // post-login redirect aborting the goto.
+      await captureRoutes(browser, PANEL_PUBLIC_ROUTES, OUT_PANEL);
+      // Authenticated pass — fresh context, drives the login form,
+      // then visits the admin-only routes so they paint actual
+      // content instead of the login wall.
+      await captureRoutes(browser, PANEL_AUTH_ROUTES, OUT_PANEL, {
+        login: true,
+      });
+    }
   } finally {
     await browser.close();
   }


### PR DESCRIPTION
## Summary

The `docs-screenshots-capture.yml` workflow has been silently failing
to refresh installer screenshots (and `panel-01-login`) since the
screenshot pipeline first landed (#1333). The last run on PR #1426
([run 26143228051](https://github.com/sbpp/sourcebans-pp/actions/runs/26143228051/job/76892912882))
made the failure visible:

```
[capture] FAILED .../install/?step=1: locator('form') timeout
[capture] FAILED .../install/?step=2: locator('form') timeout
[capture] FAILED .../install/?step=5: locator('form') timeout
[capture] FAILED .../index.php?p=login: net::ERR_ABORTED
```

Two distinct root causes, both fixed here:

1. **Install routes blocked by the #1335 C2 guard.** The wizard
   refuses to start over an installed panel: when `web/config.php`
   exists it short-circuits every `/install/?step=N` URL to a static
   409 "already installed" page with no `<form>`. The dev stack's
   `docker/php/web-entrypoint.sh` always creates `config.php` on
   first boot, so the `waitFor: 'form'` selector reliably times out.
2. **`panel-01-login` aborted by post-login redirect.**
   `page.login.php` emits `<script>window.location.href='index.php'</script>`
   whenever a session already exists. The single capture pass logged
   in first and then visited `/index.php?p=login`, where the inline
   redirect aborted Playwright's `page.goto()` with `net::ERR_ABORTED`.

## Changes

- `docs/scripts/capture.mjs` accepts a new `CAPTURE_ROUTES` env var
  (`all` / `panel` / `install`, default `all`). The login route
  moves into `PANEL_PUBLIC_ROUTES` and is captured from a fresh,
  cookie-less browser context BEFORE the authenticated panel pass.
- `.github/workflows/docs-screenshots-capture.yml` runs the capture
  in two passes: panel first, then host-side stash of
  `web/config.php` → `/tmp` (the bind-mount means the container
  sees the rename), then install routes, then `if: always()` restore
  so a failed install pass still leaves the panel in a bootable
  state for `docker compose down`.
- `docs/README.md` documents the new env var and the manual
  stash/restore for local-dev install captures.

Step 5 of the wizard (admin form) still redirects to step 2 on a
cold deep-link because steps 3-6 are POST-handoff-gated; the
existing TODO note in `capture.mjs` covers that follow-up — out of
scope here.

## Test plan

- [ ] Workflow YAML parses cleanly (verified locally via
      `python3 -c "import yaml; yaml.safe_load(open(...))"`).
- [ ] `node --check docs/scripts/capture.mjs` passes locally.
- [ ] A maintainer applies the `safe-to-screenshot` label on a PR
      that touches the install wizard / panel chrome and confirms
      that `docs-screenshots-capture.yml` produces non-stale PNGs
      for both `docs/src/assets/auto/install/*.png` and
      `docs/src/assets/auto/panel/*.png` (including `panel-01-login`).
- [ ] Local repro: `cd docs && npm run capture` produces the panel
      set with `web/config.php` in place, and rerunning with the
      docs/README.md-documented stash dance fills in the install
      set.