### PR TITLE
Re-allign miss-aligned adv search options

### DIFF
--- a/web/themes/default/box_admin_admins_search.tpl
+++ b/web/themes/default/box_admin_admins_search.tpl
@@ -218,8 +218,8 @@
         {/if}
 
         <div class="grid gap-3" style="grid-template-columns:12rem 1fr;align-items:end">
-            <div>
-                <label class="label" for="search-admins-webgroup">Web group</label>
+            <label class="label" for="search-admins-webgroup">Web group</label>
+            <div class="flex gap-2" style="flex-wrap:wrap">
                 <select class="select"
                         id="search-admins-webgroup"
                         name="webgroup"
@@ -230,12 +230,11 @@
                     {/foreach}
                 </select>
             </div>
-            <div class="text-xs text-muted">Filter by panel group membership.</div>
         </div>
 
         <div class="grid gap-3" style="grid-template-columns:12rem 1fr;align-items:end">
-            <div>
-                <label class="label" for="search-admins-srvadmgroup">SourceMod admin group</label>
+            <label class="label" for="search-admins-srvadmgroup">SourceMod admin group</label>
+            <div class="flex gap-2" style="flex-wrap:wrap">
                 <select class="select"
                         id="search-admins-srvadmgroup"
                         name="srvadmgroup"
@@ -246,12 +245,11 @@
                     {/foreach}
                 </select>
             </div>
-            <div class="text-xs text-muted">Filter by SourceMod admin-group attachment.</div>
         </div>
 
         <div class="grid gap-3" style="grid-template-columns:12rem 1fr;align-items:end">
-            <div>
-                <label class="label" for="search-admins-srvgroup">Server group</label>
+            <label class="label" for="search-admins-srvgroup">Server group</label>
+            <div class="flex gap-2" style="flex-wrap:wrap">
                 <select class="select"
                         id="search-admins-srvgroup"
                         name="srvgroup"
@@ -262,12 +260,11 @@
                     {/foreach}
                 </select>
             </div>
-            <div class="text-xs text-muted">Filter by server-group membership.</div>
         </div>
 
         <div class="grid gap-3" style="grid-template-columns:12rem 1fr;align-items:end">
-            <div>
-                <label class="label" for="search-admins-admwebflag">Web permissions</label>
+            <label class="label" for="search-admins-admwebflag">Web permissions</label>
+            <div class="flex gap-2" style="flex-wrap:wrap">
                 <select class="select"
                         id="search-admins-admwebflag"
                         name="admwebflag[]"
@@ -280,12 +277,11 @@
                     {/foreach}
                 </select>
             </div>
-            <div class="text-xs text-muted">Hold <kbd data-modkey>Ctrl</kbd> to multi-select. Submits the current selection as repeated <code>admwebflag[]=ADMIN_*</code> parameters.</div>
         </div>
 
         <div class="grid gap-3" style="grid-template-columns:12rem 1fr;align-items:end">
-            <div>
-                <label class="label" for="search-admins-admsrvflag">Server permissions</label>
+            <label class="label" for="search-admins-admsrvflag">Server permissions</label>
+            <div class="flex gap-2" style="flex-wrap:wrap">
                 <select class="select"
                         id="search-admins-admsrvflag"
                         name="admsrvflag[]"
@@ -298,12 +294,11 @@
                     {/foreach}
                 </select>
             </div>
-            <div class="text-xs text-muted">Hold <kbd data-modkey>Ctrl</kbd> to multi-select. Submits the current selection as repeated <code>admsrvflag[]=SM_*</code> parameters.</div>
         </div>
 
         <div class="grid gap-3" style="grid-template-columns:12rem 1fr;align-items:end">
-            <div>
-                <label class="label" for="search-admins-server">Server</label>
+            <label class="label" for="search-admins-server">Server</label>
+            <div class="flex gap-2" style="flex-wrap:wrap">
                 <select class="select"
                         id="search-admins-server"
                         name="server"
@@ -318,7 +313,6 @@
                     {/foreach}
                 </select>
             </div>
-            <div class="text-xs text-muted">Show admins with explicit access to the selected server. Hostnames load asynchronously.</div>
         </div>
 
         <div class="flex gap-2 justify-end" style="border-top:1px solid var(--border);padding-top:0.75rem">

--- a/web/themes/default/box_admin_bans_search.tpl
+++ b/web/themes/default/box_admin_bans_search.tpl
@@ -273,8 +273,8 @@
         </div>
 
         <div class="grid gap-3" style="grid-template-columns:10rem 1fr auto;align-items:end">
-            <div>
-                <label class="label" for="search-bans-btype">Type</label>
+            <label class="label" for="search-bans-btype">Type</label>
+            <div class="flex items-center gap-2" style="flex-wrap:wrap">
                 <select class="select"
                         id="search-bans-btype"
                         data-testid="search-bans-btype">
@@ -282,7 +282,6 @@
                     <option value="1">IP address</option>
                 </select>
             </div>
-            <div class="text-xs text-muted">Filter to either SteamID-only or IP-only ban records.</div>
             <button type="submit"
                     class="btn btn--secondary btn--sm"
                     data-testid="search-bans-submit-btype"
@@ -294,8 +293,8 @@
 
         {if NOT $hideadminname}
             <div class="grid gap-3" style="grid-template-columns:10rem 1fr auto;align-items:end">
-                <div>
-                    <label class="label" for="search-bans-admin">Admin</label>
+                <label class="label" for="search-bans-admin">Admin</label>
+                <div class="flex items-center gap-2" style="flex-wrap:wrap">
                     <select class="select"
                             id="search-bans-admin"
                             data-testid="search-bans-admin">
@@ -305,7 +304,6 @@
                         {/foreach}
                     </select>
                 </div>
-                <div class="text-xs text-muted">Show only bans issued by the selected admin.</div>
                 <button type="submit"
                         class="btn btn--secondary btn--sm"
                         data-testid="search-bans-submit-admin"
@@ -317,8 +315,8 @@
         {/if}
 
         <div class="grid gap-3" style="grid-template-columns:10rem 1fr auto;align-items:end">
-            <div>
-                <label class="label" for="search-bans-server">Server</label>
+            <label class="label" for="search-bans-server">Server</label>
+            <div class="flex items-center gap-2" style="flex-wrap:wrap">
                 <select class="select"
                         id="search-bans-server"
                         data-testid="search-bans-server">
@@ -332,7 +330,6 @@
                     {/foreach}
                 </select>
             </div>
-            <div class="text-xs text-muted">Hostnames load asynchronously; pre-resolution shows ip:port.</div>
             <button type="submit"
                     class="btn btn--secondary btn--sm"
                     data-testid="search-bans-submit-server"

--- a/web/themes/default/box_admin_comms_search.tpl
+++ b/web/themes/default/box_admin_comms_search.tpl
@@ -251,8 +251,8 @@
         </div>
 
         <div class="grid gap-3" style="grid-template-columns:10rem 1fr auto;align-items:end">
-            <div>
-                <label class="label" for="search-comms-btype">Type</label>
+            <label class="label" for="search-comms-btype">Type</label>
+            <div class="flex items-center gap-2" style="flex-wrap:wrap">
                 <select class="select"
                         id="search-comms-btype"
                         data-testid="search-comms-btype">
@@ -260,7 +260,6 @@
                     <option value="2">Gag</option>
                 </select>
             </div>
-            <div class="text-xs text-muted">Filter by mute (voice) or gag (text) class.</div>
             <button type="submit"
                     class="btn btn--secondary btn--sm"
                     data-testid="search-comms-submit-btype"
@@ -272,8 +271,8 @@
 
         {if NOT $hideadminname}
             <div class="grid gap-3" style="grid-template-columns:10rem 1fr auto;align-items:end">
-                <div>
-                    <label class="label" for="search-comms-admin">Admin</label>
+                <label class="label" for="search-comms-admin">Admin</label>
+                <div class="flex items-center gap-2" style="flex-wrap:wrap">
                     <select class="select"
                             id="search-comms-admin"
                             data-testid="search-comms-admin">
@@ -283,7 +282,6 @@
                         {/foreach}
                     </select>
                 </div>
-                <div class="text-xs text-muted">Show only blocks issued by the selected admin.</div>
                 <button type="submit"
                         class="btn btn--secondary btn--sm"
                         data-testid="search-comms-submit-admin"
@@ -295,8 +293,8 @@
         {/if}
 
         <div class="grid gap-3" style="grid-template-columns:10rem 1fr auto;align-items:end">
-            <div>
-                <label class="label" for="search-comms-server">Server</label>
+            <label class="label" for="search-comms-server">Server</label>
+            <div class="flex items-center gap-2" style="flex-wrap:wrap">
                 <select class="select"
                         id="search-comms-server"
                         data-testid="search-comms-server">
@@ -310,7 +308,6 @@
                     {/foreach}
                 </select>
             </div>
-            <div class="text-xs text-muted">Hostnames load asynchronously; pre-resolution shows ip:port.</div>
             <button type="submit"
                     class="btn btn--secondary btn--sm"
                     data-testid="search-comms-submit-server"


### PR DESCRIPTION
Moved content into flex containers so content is displayed correctly.
Removed the "text-muted" divs, they are (should be) self explanatory.

<img width="829" height="733" alt="5dzND" src="https://github.com/user-attachments/assets/32a8e026-b103-4cf3-bf06-5c45f3919c16" />
<img width="830" height="660" alt="NWdVz" src="https://github.com/user-attachments/assets/00dabe79-2919-437a-8ef2-1b61804f19a0" />


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](CONTRIBUTING.md) document.

---
