### PR TITLE
feat(sbpp_main): Add SBPP_OnClientPostAdminCheck forward

### DIFF
--- a/game/addons/sourcemod/scripting/include/sourcebanspp.inc
+++ b/game/addons/sourcemod/scripting/include/sourcebanspp.inc
@@ -30,8 +30,8 @@
 #define _sourcebanspp_included
 
 #define SB_VERSION_MAJOR "1"
-#define SB_VERSION_MINOR "8"
-#define SB_VERSION_PATCH "8"
+#define SB_VERSION_MINOR "9"
+#define SB_VERSION_PATCH "0"
 
 #define SB_VERSION   SB_VERSION_MAJOR..."."...SB_VERSION_MINOR..."."...SB_VERSION_PATCH
 

--- a/game/addons/sourcemod/scripting/include/sourcebanspp.inc
+++ b/game/addons/sourcemod/scripting/include/sourcebanspp.inc
@@ -31,7 +31,7 @@
 
 #define SB_VERSION_MAJOR "1"
 #define SB_VERSION_MINOR "8"
-#define SB_VERSION_PATCH "7"
+#define SB_VERSION_PATCH "8"
 
 #define SB_VERSION   SB_VERSION_MAJOR..."."...SB_VERSION_MINOR..."."...SB_VERSION_PATCH
 
@@ -116,5 +116,14 @@ forward void SBPP_OnReportPlayer(int iReporter, int iTarget, const char[] sReaso
  * @return	bBlock	If enabled, blocks the trigger for OnClientPreAdminCheck
  *********************************************************/
 forward bool SBPP_OnClientPreAdminCheck(AdminCachePart part);
+
+/*********************************************************
+ * Called after a client's admin rights have been fully applied
+ * from the database (flags and groups assigned, cache checked).
+ *
+ * @param	client	The client index who received admin rights
+ * @noreturn
+ *********************************************************/
+forward void SBPP_OnClientPostAdminCheck(int client);
 
 //Yarr!

--- a/game/addons/sourcemod/scripting/sbpp_main.sp
+++ b/game/addons/sourcemod/scripting/sbpp_main.sp
@@ -115,7 +115,8 @@ SMCParser ConfigParser;
 
 GlobalForward g_hFwd_OnBanAdded
 			, g_hFwd_OnReportAdded
-			, g_hFwd_OnClientPreAdminCheck;
+			, g_hFwd_OnClientPreAdminCheck
+			, g_hFwd_OnClientPostAdminCheck;
 
 Handle PlayerRecheck[MAXPLAYERS + 1] =  { INVALID_HANDLE, ... }; /* Timer handle */
 
@@ -148,6 +149,7 @@ public APLRes AskPluginLoad2(Handle myself, bool late, char[] error, int err_max
 	g_hFwd_OnBanAdded = CreateGlobalForward("SBPP_OnBanPlayer", ET_Ignore, Param_Cell, Param_Cell, Param_Cell, Param_String);
 	g_hFwd_OnReportAdded = CreateGlobalForward("SBPP_OnReportPlayer", ET_Ignore, Param_Cell, Param_Cell, Param_String);
 	g_hFwd_OnClientPreAdminCheck = CreateGlobalForward("SBPP_OnClientPreAdminCheck", ET_Ignore, Param_Cell);
+	g_hFwd_OnClientPostAdminCheck = CreateGlobalForward("SBPP_OnClientPostAdminCheck", ET_Ignore, Param_Cell);
 
 	LateLoaded = late;
 
@@ -2631,6 +2633,10 @@ stock void CheckLoadAdmins(AdminCachePart part)
 		{
 			RunAdminCacheChecks(i);
 			NotifyPostAdminCheck(i);
+
+			Call_StartForward(g_hFwd_OnClientPostAdminCheck);
+			Call_PushCell(i);
+			Call_Finish();
 		}
 	}
 }


### PR DESCRIPTION
## Description

Add a new global forward `SBPP_OnClientPostAdminCheck(int client)` that is fired for each in-game client after their admin rights have been fully applied from the database (flags and groups assigned, `RunAdminCacheChecks` and `NotifyPostAdminCheck` completed).

Changes:
- `scripting/include/sourcebanspp.inc`: declare the new forward with documentation, bump patch version to `1.8.8`
- `scripting/sbpp_main.sp`: declare `g_hFwd_OnClientPostAdminCheck`, register it in `AskPluginLoad2`, fire it in `CheckLoadAdmins` after `NotifyPostAdminCheck(i)`

## Motivation and Context

There was no way for external plugins to know when a specific client had been granted admin rights by SourceBans++. The existing `SBPP_OnClientPreAdminCheck` only signals the start of a cache rebuild, and the SM core `OnClientPostAdminCheck` fires for all clients regardless of whether SBPP processed them.

This forward allows dependent plugins (e.g. Discord notifiers, admin loggers, permission-aware systems) to react reliably the moment SBPP has finished applying a client's flags and groups from the database.

## How Has This Been Tested?

Compiled against SourceMod 1.12+ with no warnings. Verified the forward fires correctly by writing a test plugin implementing `public void SBPP_OnClientPostAdminCheck(int client)` and confirming it triggers after admin cache loads for in-game authorized clients.

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.