### PR TITLE
ci(docs): stash config.php beside web/ instead of /tmp (sticky-bit trap)

### DIFF
--- a/.github/workflows/docs-screenshots-capture.yml
+++ b/.github/workflows/docs-screenshots-capture.yml
@@ -244,12 +244,35 @@ jobs:
           CAPTURE_ROUTES: panel
         run: npm run capture
 
+      # Stash to a sibling path inside `pr-head/` (alongside `web/`),
+      # NOT to `/tmp`. The dev container's entrypoint runs as root, so
+      # `web/config.php` lands on the bind-mounted host filesystem
+      # owned `root:root`. On GHA ubuntu-24.04 runners `/tmp` is on
+      # the same filesystem as the workspace, so `mv web/config.php
+      # /tmp/...` is a same-fs atomic `rename(2)` that PRESERVES
+      # ownership — and `/tmp` carries the sticky bit, so the runner
+      # (UID 1001) cannot move the still-root-owned file back later
+      # (per `rename(2)`: "EPERM: the directory containing oldpath
+      # has the sticky bit set and the process's effective UID is
+      # neither the UID of the file to be deleted nor that of the
+      # directory containing it"). PR 1430 was the first run after
+      # #1427 to actually exercise the stash/restore pair and hit
+      # this trap (`mv: cannot move '/tmp/sbpp-config-stash.php' to
+      # 'web/config.php': Operation not permitted`).
+      #
+      # `pr-head/.sbpp-config-stash.php` is a runner-owned, sticky-
+      # bit-free directory on the same filesystem as `pr-head/web/`,
+      # so the rename is atomic both ways regardless of which UID
+      # the docker container created the file as. The auto-commit
+      # step further down constrains the commit to `docs/src/assets/auto/**`,
+      # so a stale stash file (if the restore somehow no-ops) never
+      # leaks into the PR diff.
       - name: Stash config.php to expose the install wizard
         working-directory: pr-head
         run: |
           if [[ -f web/config.php ]]; then
-            mv web/config.php /tmp/sbpp-config-stash.php
-            echo "stashed web/config.php → /tmp/sbpp-config-stash.php"
+            mv web/config.php .sbpp-config-stash.php
+            echo "stashed web/config.php → pr-head/.sbpp-config-stash.php"
           else
             echo "web/config.php was already absent; nothing to stash"
           fi
@@ -276,9 +299,9 @@ jobs:
         if: always()
         working-directory: pr-head
         run: |
-          if [[ -f /tmp/sbpp-config-stash.php ]]; then
-            mv /tmp/sbpp-config-stash.php web/config.php
-            echo "restored /tmp/sbpp-config-stash.php → web/config.php"
+          if [[ -f .sbpp-config-stash.php ]]; then
+            mv .sbpp-config-stash.php web/config.php
+            echo "restored pr-head/.sbpp-config-stash.php → web/config.php"
           else
             echo "no stash to restore; nothing to do"
           fi

--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,12 @@ Temporary Items
 /web/cache/sessions/sess_*
 *.smx
 
+# Local stash file used by the install-screenshot capture flow
+# (`docs/README.md` → "Capturing screenshots"). Gitignored so an
+# interrupted run never leaks the panel's DB credentials into a
+# commit.
+/.sbpp-config-stash.php
+
 # Local Docker dev stack
 /.env
 /dump-*.sql

--- a/docs/README.md
+++ b/docs/README.md
@@ -133,10 +133,19 @@ for the duration of the install pass and restore it afterwards:
 
 ```sh
 # from the repo root, with the dev stack already running
-mv web/config.php /tmp/sbpp-config-stash.php
+mv web/config.php .sbpp-config-stash.php
 ( cd docs && CAPTURE_ROUTES=install npm run capture )
-mv /tmp/sbpp-config-stash.php web/config.php
+mv .sbpp-config-stash.php web/config.php
 ```
+
+The stash path is a sibling of `web/` on purpose. The dev container's
+entrypoint runs as root, so `web/config.php` lands on the bind mount
+owned by `root:root`; stashing through `/tmp` is a sticky-bit trap —
+the same-filesystem rename preserves ownership, and the unprivileged
+restore can't unlink a root-owned file out of a sticky directory
+(per `rename(2)`'s `EPERM` semantics — see the workflow's stash step
+for the full rationale). `.sbpp-config-stash.php` is gitignored so an
+interrupted run never leaks the credentials into a commit.
 
 CI does the same stash/restore dance automatically in
 `docs-screenshots-capture.yml`; this is only relevant when iterating


### PR DESCRIPTION
## Description

#1427 introduced the stash/restore dance around the install-pass capture so the wizard's #1335 C2 guard (refuses to start over an installed panel) actually exposes step 1-5 instead of the static 409 "already installed" page. The `mv web/config.php /tmp/sbpp-config-stash.php` shape it landed has a [sticky-bit trap](https://man7.org/linux/man-pages/man2/rename.2.html) that's invisible until the workflow runs end-to-end:

```
mv: cannot move '/tmp/sbpp-config-stash.php' to 'web/config.php': Operation not permitted
```

PR #1430 was the first PR to actually exercise the new stash/restore pair after #1427 landed and surfaced the bug — see the [failing run](https://github.com/sbpp/sourcebans-pp/actions/runs/26252635044/job/77267432686?pr=1430).

This PR moves the stash to `pr-head/.sbpp-config-stash.php` (a sibling of `web/`) so the rename is atomic both ways regardless of which UID the docker container created the file as. The local-dev dance in `docs/README.md` is updated in lockstep, and `.gitignore` adds `/.sbpp-config-stash.php` so an interrupted local run never leaks the panel's DB credentials into a commit.

## Motivation and Context

**Root cause.** The dev container's entrypoint (`docker/php/web-entrypoint.sh`) runs as root, so `cat > config.php` creates `web/config.php` owned `root:root` (UID 0:0) on the bind-mounted host filesystem. On GHA ubuntu-24.04 runners, `/tmp` and `/home/runner/work/` live on the *same* filesystem, so the stash's `mv web/config.php /tmp/...` is a same-fs atomic `rename(2)` that *preserves* ownership — the file lands in `/tmp` still owned by root.

`/tmp` carries the sticky bit. Per `rename(2)`'s `EPERM` rule:

> The directory containing oldpath has the sticky bit (S\_ISVTX) set and the process's effective UID is neither the UID of the file to be deleted nor that of the directory containing it, and the process is not privileged.

So the runner (UID 1001) cannot move the still-root-owned stash file out of `/tmp` later. The restore step fails before it ever touches `web/`.

**Fix shape.** Stash to `pr-head/.sbpp-config-stash.php` instead — a sibling of `web/` on the same filesystem, in a runner-owned directory with no sticky bit. Same-fs atomic rename works both ways regardless of file ownership. The auto-commit step's `file_pattern: 'docs/src/assets/auto/**'` already constrains commits to the screenshot diff, so a stale stash file (if the restore somehow no-ops) never leaks into the PR.

**Why this slipped through #1427.** No PR between #1427 landing and PR #1430 was labelled `safe-to-screenshot`, so the stash/restore pair was never actually exercised end-to-end. The prior workflow runs (e.g. PR #1426's [run 26143228051](https://github.com/sbpp/sourcebans-pp/actions/runs/26143228051)) were on the *pre*-#1427 workflow code, which captured panel + install in one pass without stashing.

Unblocks PR #1430. Sister of #1427.

## How Has This Been Tested?

Static checks (mirroring CI gates):

- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/docs-screenshots-capture.yml'))"` — workflow YAML parses.

Reasoned about the syscall semantics:

| Stash path | mv direction | Same-fs rename(2) result | Sticky-bit unlink check |
| ---------- | ------------ | ------------------------ | ----------------------- |
| `/tmp/sbpp-config-stash.php` (BEFORE) | stash | atomic rename, owner preserved as root | n/a (creating in /tmp; runner owns the new dirent slot) |
| `/tmp/sbpp-config-stash.php` (BEFORE) | restore | atomic rename | **EPERM** — runner != owner, /tmp has sticky bit |
| `pr-head/.sbpp-config-stash.php` (AFTER) | stash | atomic rename, owner preserved as root | n/a (pr-head/ has no sticky bit, runner-owned) |
| `pr-head/.sbpp-config-stash.php` (AFTER) | restore | atomic rename | n/a (pr-head/ has no sticky bit) |

Maintainer-side test: apply `safe-to-screenshot` to PR #1430 (or any subsequent screenshot-needing PR) once this lands; the install + panel capture should complete end-to-end with both stash and restore log lines.

## Screenshots (if appropriate)

n/a — pure CI / docs change.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](CONTRIBUTING.md) document.