### PR TITLE
fix(1419): drop api-contract from prod Apache deny list (login spinner under prod Docker image)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3071,6 +3071,46 @@ contacting every contributor individually.
   back to the raw message for unrecognised codes so debugging
   stays possible. Anti-pattern: surfacing `$e->getMessage()`
   directly to operator-facing error banners.
+- Adding a `<FilesMatch>` regex pattern in
+  `docker/apache/sbpp-prod.conf` whose alternation matches a
+  basename shared by a published browser asset → removed at
+  #1419. Pre-fix the union carried `api-contract\..*` (intended
+  to shield some never-existed `api-contract.*` config artifact
+  at the panel root). `<FilesMatch>` matches the **basename**
+  regardless of which directory the URL resolves under, so the
+  regex also denied the published `web/scripts/api-contract.js`
+  — the chrome JS `core/header.tpl` loads on every page render
+  to define the `Actions.*` / `Perms.*` namespaces every
+  `sb.api.call(Actions.PascalName, …)` site depends on. The
+  panel-runtime symptom under the production Docker image:
+  password login spins forever (the form's submit handler
+  `e.preventDefault()`s and `setBusy(submitBtn, true)` BEFORE
+  `sb.api.call(Actions.AuthLogin, …)` fires; with `Actions`
+  undefined the call throws and neither `.then` branch ever
+  releases the spinner), and every panel chrome action button
+  that drives a JSON action (Notes pane, ban/comm unblock,
+  admin/mod delete, group-ban dispatcher, server refresh, …)
+  is dead-on-arrival. Steam login is unaffected because the
+  OpenID round-trip is server-side redirects with no JS
+  dependency on `Actions.*` — exactly the asymmetry the bug
+  reporter saw. **The bug only surfaces under
+  `docker/Dockerfile.prod` →
+  `ghcr.io/sbpp/sourcebans-pp:*`** (the dev compose stack
+  uses a different Apache config; tarball installs don't
+  ship Apache at all). When extending the deny list, prefer
+  `<Files "exact-name">` for root-only configs that have a
+  unique basename, or a path-anchored
+  `<LocationMatch "^/exact-path$">` block when the basename
+  could collide with a published asset. Regression guard:
+  `web/tests/integration/ProdApacheConfigTest.php` runs every
+  extracted `<FilesMatch>` regex (and every `<Files>`
+  exact-name) against every published basename under
+  `web/scripts/` and `web/themes/default/js/` — a match
+  anywhere fails the build. The local `./sbpp.sh test`
+  runner stays symmetric with CI because
+  `docker-compose.yml` bind-mounts `./docker:/var/www/html/docker:ro`
+  so the test can read the conf from inside the dev
+  container.
 - `openTab()` JS (and the matching `<button onclick="openTab(...)">`
   chrome on `core/admin_tabs.tpl`) → the JS handler was dropped with
   sourcebans.js at #1123 D1; the buttons did nothing and every pane

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,6 +40,13 @@ services:
       - vendor:/var/www/html/web/includes/vendor
       - cache:/var/www/html/web/cache
       - smarty:/var/www/html/web/templates_c
+      # Read-only mount of the docker/ tree so file-shape integration
+      # tests under web/tests/integration/ can read the production
+      # Apache + entrypoint config they're gating without leaving the
+      # container. CI's `actions/checkout@v4` pulls the full repo, so
+      # `web/../docker/...` resolves naturally there; this mount keeps
+      # the local `./sbpp.sh test` runner symmetric with CI.
+      - ./docker:/var/www/html/docker:ro
 
   db:
     image: mariadb:10.11

--- a/docker/README.md
+++ b/docker/README.md
@@ -61,7 +61,13 @@ sbpp.sh                  thin wrapper around `docker compose` + common dev tasks
 
 The web container mounts `./web` from the host, with two named-volume
 overlays (`vendor/` and `cache/`) so Composer artifacts and Smarty cache
-don't leak onto the host filesystem.
+don't leak onto the host filesystem. The `./docker` tree is also bind-
+mounted read-only at `/var/www/html/docker` so file-shape integration
+tests under `web/tests/integration/` can read production-only configs
+(`docker/apache/sbpp-prod.conf`, `docker/Dockerfile.prod`, etc.) the
+runtime panel never touches; CI's `actions/checkout@v4` pulls the full
+repo, so this mount keeps the local `./sbpp.sh test` runner symmetric
+with the CI gate.
 
 ## Common tasks
 

--- a/docker/apache/sbpp-prod.conf
+++ b/docker/apache/sbpp-prod.conf
@@ -70,9 +70,23 @@
 
 # `composer.json` / `composer.lock` are checked-in but should never be
 # fetched (they reveal exact dependency versions for vulnerability
-# scanning). Same for the project's own helpers (`init-recovery.php`,
-# `phpstan.neon`, etc.) at the panel root.
-<FilesMatch "(?i)^(composer\.(json|lock)|phpstan\..*|phpunit\.xml.*|package\.json|tsconfig\.json|api-contract\..*)$">
+# scanning). Same for the project's own root-level helpers
+# (`phpstan.neon`, `phpunit.xml.dist`, `package.json`, `tsconfig.json`).
+#
+# IMPORTANT: every basename listed here must be a panel-root-only
+# config file with NO published browser asset sharing the basename.
+# `<FilesMatch>` matches the basename component regardless of which
+# directory the request resolves to, so a pattern like
+# `api-contract\..*` would also match the published `/scripts/api-contract.js`
+# the chrome loads from `core/header.tpl` — silently 403'ing it and
+# breaking every `sb.api.call(Actions.PascalName, …)` site in the
+# panel JS (login spinner runs forever, all admin row actions are
+# dead). See #1419 for the bug class. Prefer adding new deny rules
+# to a `<Files "exact-name">` block (panel-root only) when the
+# protected file has a unique basename, or to a path-anchored
+# `<LocationMatch "^/exact-path$">` block when basename collisions
+# are a real concern.
+<FilesMatch "(?i)^(composer\.(json|lock)|phpstan\..*|phpunit\.xml.*|package\.json|tsconfig\.json)$">
     Require all denied
 </FilesMatch>
 

--- a/web/tests/integration/ProdApacheConfigTest.php
+++ b/web/tests/integration/ProdApacheConfigTest.php
@@ -1,0 +1,352 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sbpp\Tests\Integration;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Issue #1419: production Docker image (`docker/Dockerfile.prod` →
+ * `ghcr.io/sbpp/sourcebans-pp:*`) ships a hardening Apache conf
+ * (`docker/apache/sbpp-prod.conf`) that uses `<FilesMatch>` /
+ * `<Files>` to deny access to root-level config files
+ * (`composer.json`, `phpstan.*`, `phpunit.xml*`, `package.json`,
+ * `tsconfig.json`, `config.php`).
+ *
+ * Pre-fix the union regex carried `api-contract\..*` in the
+ * `<FilesMatch>` alternation, intended to shield some never-existed
+ * `api-contract.*` config artifact at the panel root. `<FilesMatch>`
+ * matches the **basename** regardless of which directory the URL
+ * resolves under, so the regex also matched the published
+ * `web/scripts/api-contract.js` — the chrome JS `core/header.tpl`
+ * loads on every page render to define the `Actions.*` / `Perms.*`
+ * namespaces that every `sb.api.call(Actions.PascalName, …)` site
+ * in the panel JS depends on.
+ *
+ * With it 403'd:
+ *
+ *   - The login form's submit handler (`page_login.tpl`) calls
+ *     `sb.api.call(Actions.AuthLogin, …)` — `Actions` is undefined,
+ *     the call throws, but the handler already ran `e.preventDefault()`
+ *     and `setBusy(submitBtn, true)`. The success / failure `.then`
+ *     branches never fire, the spinner runs forever, the form never
+ *     navigates. Reporter's exact symptom on #1419.
+ *   - Every panel chrome action button that drives a JSON action
+ *     (Notes pane, ban/comm unblock, admin/mod delete, group-ban
+ *     dispatcher, server refresh, comment edit, …) is dead-on-arrival.
+ *
+ * Steam login is unaffected because the Steam OpenID round-trip is
+ * server-side redirects with no JS dependency on `Actions.*`.
+ *
+ * The bug only surfaces under the production Docker image — the
+ * `zz-sbpp-prod.conf` is loaded by `docker/Dockerfile.prod` only;
+ * the dev compose stack uses a different Apache config without
+ * the deny union, and tarball installs don't ship Apache at all.
+ *
+ * Test contracts
+ * --------------
+ *
+ * Three test methods, all pure file-scanning (no DB / Smarty / vendor
+ * bring-up). Extends `PHPUnit\Framework\TestCase` directly (not
+ * `ApiTestCase`) so test discovery + CI scheduling stay cheap.
+ *
+ *   1. {@see testFilesMatchRegexesDoNotShadowPublishedBrowserAssets}
+ *      — the structural gate. Every `<FilesMatch>` regex extracted
+ *      from the conf is run via PCRE against every published
+ *      browser-asset basename under `web/scripts/` and
+ *      `web/themes/default/js/`. A match on any is the regression
+ *      class #1419 belongs to and fails the build with the offending
+ *      regex + asset basename pair named in the message.
+ *   2. {@see testFilesExactNamesDoNotShadowPublishedBrowserAssets}
+ *      — sister gate for the `<Files "exact-name">` shape. The conf
+ *      currently uses one (`<Files "config.php">`); a future
+ *      contributor adding `<Files "api-contract.js">` directly would
+ *      bypass the FilesMatch gate but hit this one.
+ *   3. {@see testHistoricalApiContractDenyPatternStaysOut} —
+ *      forward-looking spot-check pinning the literal substring
+ *      `api-contract` doesn't reappear inside any `<FilesMatch>` /
+ *      `<Files>` directive. Narrower than (1) + (2); reads as a
+ *      direct #1419 reference at PR-review time.
+ *
+ * Plus {@see testIntendedDenyTargetsStillMatch} as a sanity check —
+ * a future refactor of the union regex must not silently delete the
+ * actual hardening (composer.json leaking deps, phpstan.neon leaking
+ * static-analysis config). Same bug class, opposite direction.
+ */
+final class ProdApacheConfigTest extends TestCase
+{
+    /**
+     * `ROOT` (defined in `tests/bootstrap.php`) points at `web/`. The
+     * conf file lives at the repo root under `docker/apache/`, one
+     * level up from `web/`. PHP's filesystem functions resolve `..`
+     * components fine; the path stays a literal for clarity.
+     */
+    private const CONF_PATH = ROOT . '../docker/apache/sbpp-prod.conf';
+
+    /**
+     * Pull every `<FilesMatch "REGEX">` block out of the conf file and
+     * return the inner regex string.
+     *
+     * Apache's `<FilesMatch>` directive accepts a PCRE-compatible
+     * regex with the same syntax PHP's `preg_match` uses, so each
+     * extracted regex can be wrapped in delimiters and run directly
+     * against candidate basenames. `(?i)` inline modifiers are
+     * supported on both engines.
+     *
+     * @return list<string>
+     */
+    private static function readFilesMatchRegexes(): array
+    {
+        $contents = (string) file_get_contents(self::CONF_PATH);
+        if ($contents === '') {
+            return [];
+        }
+        $count = preg_match_all('/<FilesMatch\s+"([^"]+)"\s*>/i', $contents, $m);
+        if ($count === false || $count === 0) {
+            return [];
+        }
+        return $m[1];
+    }
+
+    /**
+     * Pull every `<Files "exact-name">` block (literal basename match,
+     * not regex). The conf currently uses one — `<Files "config.php">`
+     * — but a future addition that lands an exact-name deny on a
+     * published asset basename would be the same bug class.
+     *
+     * @return list<string>
+     */
+    private static function readFilesExactNames(): array
+    {
+        $contents = (string) file_get_contents(self::CONF_PATH);
+        if ($contents === '') {
+            return [];
+        }
+        // `<Files` not followed by `Match` (which the FilesMatch
+        // extractor handles separately).
+        $count = preg_match_all('/<Files(?!Match)\s+"([^"]+)"\s*>/i', $contents, $m);
+        if ($count === false || $count === 0) {
+            return [];
+        }
+        return $m[1];
+    }
+
+    /**
+     * Discover every published browser-asset basename the chrome loads
+     * via `<script src="...">`. Two source dirs:
+     *
+     *   - `web/scripts/*.js` — chrome JS (`api.js`, `sb.js`, the
+     *     autogenerated `api-contract.js`, `comment-actions.js`,
+     *     `server-tile-hydrate.js`, `server-context-menu.js`,
+     *     `banlist.js`).
+     *   - `web/themes/default/js/*.js` — theme-side chrome JS
+     *     (`theme.js`, `lucide.min.js`).
+     *
+     * `*.d.ts` files are excluded by the `.js` suffix gate — those
+     * are TypeScript type-defs for `tsc --checkJs`, not
+     * browser-loaded assets.
+     *
+     * Discovered dynamically (rather than hard-coded) so the test
+     * doesn't go stale when a new chrome JS file lands; new files
+     * are automatically protected against the bug class.
+     *
+     * @return list<string>
+     */
+    private static function publishedBrowserAssetBasenames(): array
+    {
+        $names = [];
+        foreach ([
+            ROOT . 'scripts',
+            ROOT . 'themes/default/js',
+        ] as $dir) {
+            if (!is_dir($dir)) {
+                continue;
+            }
+            $entries = scandir($dir);
+            if ($entries === false) {
+                continue;
+            }
+            foreach ($entries as $entry) {
+                if ($entry === '.' || $entry === '..') {
+                    continue;
+                }
+                if (!str_ends_with($entry, '.js')) {
+                    continue;
+                }
+                $names[] = $entry;
+            }
+        }
+        sort($names);
+        return $names;
+    }
+
+    public function testConfFileExists(): void
+    {
+        $this->assertFileExists(
+            self::CONF_PATH,
+            'docker/apache/sbpp-prod.conf must exist (the prod Docker image ships it via a2enconf zz-sbpp-prod).',
+        );
+    }
+
+    /**
+     * The structural regression gate — run every extracted FilesMatch
+     * regex against every published asset basename. A match anywhere
+     * is the bug class #1419 belongs to.
+     */
+    public function testFilesMatchRegexesDoNotShadowPublishedBrowserAssets(): void
+    {
+        $regexes = self::readFilesMatchRegexes();
+        $this->assertNotEmpty(
+            $regexes,
+            'sbpp-prod.conf should declare at least one <FilesMatch> deny rule (composer.json / phpstan.* / etc.).',
+        );
+
+        $assets = self::publishedBrowserAssetBasenames();
+        $this->assertNotEmpty(
+            $assets,
+            'web/scripts/ and web/themes/default/js/ should contain at least one .js file (the chrome JS).',
+        );
+
+        $hits = [];
+        foreach ($regexes as $regex) {
+            // `#` delimiters; escape any literal `#` inside the regex
+            // (none today, but future-proofing). The Apache regex is
+            // case-mode-controlled by the `(?i)` inline flag, so no
+            // additional `i` modifier on the PHP side.
+            $compiled = '#' . str_replace('#', '\\#', $regex) . '#';
+            foreach ($assets as $basename) {
+                if (preg_match($compiled, $basename) === 1) {
+                    $hits[] = sprintf(
+                        '<FilesMatch %s> would deny published browser asset "%s"',
+                        var_export($regex, true),
+                        $basename,
+                    );
+                }
+            }
+        }
+
+        $this->assertSame(
+            0,
+            count($hits),
+            "docker/apache/sbpp-prod.conf <FilesMatch> regex shadows one or more published browser assets — see"
+            . " #1419 for the login-spinner / dead-action-button bug class. Use <Files \"exact-name\"> for root-only"
+            . " configs that have a unique basename, or a path-anchored <LocationMatch> when the basename collides"
+            . " with a published asset:\n - "
+                . implode("\n - ", $hits),
+        );
+    }
+
+    /**
+     * Sister gate to (1) for the `<Files "exact-name">` shape. The
+     * conf today only carries `<Files "config.php">`; this test
+     * catches a future contributor who lands `<Files "api-contract.js">`
+     * directly (which would bypass the regex-based gate above).
+     */
+    public function testFilesExactNamesDoNotShadowPublishedBrowserAssets(): void
+    {
+        $names = self::readFilesExactNames();
+        $assets = self::publishedBrowserAssetBasenames();
+
+        $hits = [];
+        foreach ($names as $name) {
+            if (in_array($name, $assets, true)) {
+                $hits[] = $name;
+            }
+        }
+
+        $this->assertSame(
+            0,
+            count($hits),
+            "docker/apache/sbpp-prod.conf <Files \"...\"> exact-name deny shadows a published browser asset — see"
+            . " #1419 for the bug class:\n - "
+                . implode("\n - ", $hits),
+        );
+    }
+
+    /**
+     * Forward-looking spot-check pinning the specific historical bug
+     * pattern out. Narrower than the structural gates above; reads
+     * as a direct #1419 reference at PR-review time and catches the
+     * specific copy-paste shape without depending on the asset
+     * discovery.
+     */
+    public function testHistoricalApiContractDenyPatternStaysOut(): void
+    {
+        $contents = (string) file_get_contents(self::CONF_PATH);
+        $this->assertNotEmpty($contents, 'docker/apache/sbpp-prod.conf must be readable.');
+
+        // Match `<FilesMatch "...api-contract...">` or `<Files "...api-contract...">`.
+        $count = preg_match_all('/<Files(?:Match)?\s+"[^"]*api-contract[^"]*"/i', $contents);
+
+        $this->assertSame(
+            0,
+            $count === false ? -1 : $count,
+            "docker/apache/sbpp-prod.conf re-introduces the #1419 deny pattern shadowing `api-contract.*`."
+            . " That pattern matches the published `web/scripts/api-contract.js` (loaded by `core/header.tpl`)"
+            . " and breaks every `sb.api.call(Actions.PascalName, …)` site in the panel chrome. The login"
+            . " spinner runs forever; admin row actions are dead-on-arrival under the prod Docker image.",
+        );
+    }
+
+    /**
+     * Sanity check: the intended hardening targets stay matched.
+     * Without this, a future refactor of the union regex could
+     * silently delete a deny rule and leak `composer.json` /
+     * `phpstan.neon` / etc. to the web — same bug class, opposite
+     * direction.
+     */
+    public function testIntendedDenyTargetsStillMatch(): void
+    {
+        $regexes = self::readFilesMatchRegexes();
+
+        // Each row pins one root-level config file the conf's
+        // documented intent denies. The list mirrors the union in
+        // the conf's <FilesMatch> regex AND the comment block above
+        // it; new entries land in the same PR as the conf change.
+        //
+        // Out of scope here (conf doesn't currently deny them, and
+        // widening the deny list is a separate concern):
+        //   - `phpstan-baseline.neon` / `phpstan-bootstrap.php` —
+        //     sensitive (suppressed-warning map / autoload glue)
+        //     but not covered by the `phpstan\.` prefix-and-dot
+        //     regex; would need `phpstan[-.].*`.
+        //   - `web/api-contract.json` etc. — no such file exists
+        //     today; the published asset is `scripts/api-contract.js`,
+        //     and `<FilesMatch>` matches the basename regardless of
+        //     directory (which is exactly the #1419 trap).
+        $intendedTargets = [
+            'composer.json',
+            'composer.lock',
+            'phpstan.neon',
+            'phpstan.dist.neon',
+            'phpunit.xml',
+            'phpunit.xml.dist',
+            'package.json',
+            'tsconfig.json',
+        ];
+
+        $missing = [];
+        foreach ($intendedTargets as $name) {
+            $matched = false;
+            foreach ($regexes as $regex) {
+                $compiled = '#' . str_replace('#', '\\#', $regex) . '#';
+                if (preg_match($compiled, $name) === 1) {
+                    $matched = true;
+                    break;
+                }
+            }
+            if (!$matched) {
+                $missing[] = $name;
+            }
+        }
+
+        $this->assertSame(
+            [],
+            $missing,
+            "docker/apache/sbpp-prod.conf no longer denies one or more intended root-level config files."
+            . " If the file is intentionally renamed / removed from the deny list, update both the conf"
+            . " AND ProdApacheConfigTest::testIntendedDenyTargetsStillMatch in the same PR.",
+        );
+    }
+}


### PR DESCRIPTION
## Summary

The production Docker image (`docker/Dockerfile.prod` →
`ghcr.io/sbpp/sourcebans-pp:*`) ships an Apache hardening conf
(`docker/apache/sbpp-prod.conf`) whose `<FilesMatch>` deny list union
carried a stray `api-contract\..*` alternation. Apache's `<FilesMatch>`
matches the **basename** regardless of which directory the URL resolves
under, so the regex also denied the published `web/scripts/api-contract.js`
— the autogenerated chrome JS `core/header.tpl` loads on every page
render to define the `Actions.*` / `Perms.*` namespaces every
`sb.api.call(Actions.PascalName, …)` site in the panel JS depends on.

Symptoms under the production Docker image:

- **Password login spins forever.** The form's submit handler in
  `page_login.tpl` runs `e.preventDefault()` + `setBusy(submitBtn, true)`
  BEFORE `sb.api.call(Actions.AuthLogin, …)` fires; with `Actions`
  undefined the call throws and neither `.then` branch ever releases
  the spinner. Reporter's exact symptom on #1419 ("login spinner runs
  but nothing happens").
- **Every panel chrome action button** that drives a JSON action (Notes
  pane, ban/comm unblock, admin/mod delete, group-ban dispatcher,
  server refresh, comment edit, …) is dead-on-arrival.
- **Steam login is unaffected** because the OpenID round-trip is
  server-side redirects with no JS dependency on `Actions.*` — exactly
  the asymmetry the bug reporter saw.

The bug only surfaces under the production Docker image. The dev
compose stack uses a different Apache config without the deny union,
and tarball installs don't ship Apache at all. Per git archaeology the
regex was byte-identical from rc3 → rc5 (`docker/apache/sbpp-prod.conf`
was introduced wholesale in `ba3c8872` with the rule already present);
rc3 reporters who "didn't see the bug" had only exercised Steam login.

## Fix

1. **`docker/apache/sbpp-prod.conf`** — drop `api-contract\..*` from
   the `<FilesMatch>` regex union. The single load-bearing change.
   Also adds a comment block above the rule explaining that every
   basename listed there must be a panel-root-only config file with
   NO published browser asset sharing the basename, with concrete
   guidance for future deny-rule additions: prefer `<Files "exact-name">`
   for unique-basename root configs, `<LocationMatch "^/exact-path$">`
   when basename collisions are a real concern.

2. **`web/tests/integration/ProdApacheConfigTest.php`** — new per-PR
   static gate (5 tests / 8 assertions). Pure file-scanning + PCRE
   matching, no DB / Smarty / vendor bring-up. Four contracts:
   - **Structural check**: every `<FilesMatch>` regex extracted from
     the conf is run against every published browser-asset basename
     under `web/scripts/` and `web/themes/default/js/`. A match
     anywhere fails the build with the offending regex + asset
     basename pair named in the message. Assets are discovered
     dynamically so a new chrome JS file landing in a future PR is
     automatically protected against the bug class.
   - **Sister gate** for the `<Files "exact-name">` shape (the conf
     carries `<Files "config.php">` today; a future
     `<Files "api-contract.js">` would bypass the FilesMatch gate but
     hit this one).
   - **Forward-looking spot-check** pinning the literal substring
     `api-contract` doesn't reappear inside any deny directive —
     reads as a direct #1419 reference at PR-review time.
   - **Sanity check** that the intended hardening targets stay matched
     (composer.{json,lock}, phpstan.neon, phpunit.xml.dist,
     package.json, tsconfig.json) so a future refactor of the regex
     doesn't silently delete the actual hardening.

3. **`docker-compose.yml`** + **`docker/README.md`** — bind-mount
   `./docker:/var/www/html/docker:ro` so the new test can read the
   conf from inside the dev container. CI's `actions/checkout@v4`
   pulls the full repo so the test runs there without changes; the
   mount is what keeps the local `./sbpp.sh test` runner symmetric
   with the CI gate.

4. **`AGENTS.md`** — new entry under "Anti-patterns (do NOT
   reintroduce)" naming the bug class, the symptom asymmetry, the
   prod-only surfacing, and the regression guard.

## Verification

- `./sbpp.sh phpstan` → **0 errors**.
- `./sbpp.sh test` → **886 tests / 3329 assertions** all green
  (includes the new 5-test `ProdApacheConfigTest`).
- `./sbpp.sh ts-check` → green.
- `./sbpp.sh composer api-contract` → no diff vs checked-in file.
- **Bug-bites verification**: temporarily reverted the conf fix
  (`git stash` on `sbpp-prod.conf`) and reran the gate. Both the
  structural check and the historical-pattern check fire with
  informative messages naming the exact offending regex + asset:

  ```
   ✘ Files match regexes do not shadow published browser assets
      ├ <FilesMatch '(?i)^(...|api-contract\\..*)$'> would deny published
      ├   browser asset "api-contract.js"
   ✘ Historical api contract deny pattern stays out
      ├ docker/apache/sbpp-prod.conf re-introduces the #1419 deny pattern
      ├ shadowing `api-contract.*`...
  ```

## Out of scope (follow-ups)

- **Pre-publish CI smoke-test in `docker-image.yml`**: build the image
  single-arch with `--load`, run it, curl `/scripts/*.js` +
  `/themes/default/js/*.js`, assert HTTP 200 before
  signing/publishing. The Docker-image workflow is release-only by
  design (#1381); a smoke-test there would close the remaining
  "regression slips through to a tagged release" window. Worth a
  separate PR — adds ~2-3 minutes to release build time.
- **`phpstan-baseline.neon` / `phpstan-bootstrap.php` not covered**
  by the conf's `phpstan\..*` regex (no dot after `phpstan`).
  Sensitive too (suppressed-warning map / autoload glue). Widening
  the deny list is a separate concern; the new structural test now
  gates "deny rules don't shadow assets" so any such widening can
  land safely.

## Test plan

- [x] Local stack: `ProdApacheConfigTest` passes after the fix and
      fails when the fix is reverted (with named offending regex).
- [x] Local stack: full PHPUnit + PHPStan + ts-check suites pass.
- [ ] After merge: rebuild the prod image from the next tagged
      release and confirm `curl https://<host>/scripts/api-contract.js`
      returns **200** (was **403** pre-fix on rc3-rc5).
- [ ] After merge: confirm password login completes end-to-end
      under the production Docker image (per #1419 reporter's
      reproduction).

## Reviewer's reading guide

The single load-bearing change is removing `api-contract\..*` from
the `<FilesMatch>` regex on `sbpp-prod.conf:75`. Everything else
(test, AGENTS.md anti-pattern, dev-stack mount, README note) is the
regression-prevention scaffold so the same bug shape can't land
silently again.

Fixes #1419