### PR TITLE
chore(docs+panel): trim LLM-flavored wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ engine.
 
 ## Links
 
-- **Docs:** <https://sbpp.github.io/> — install, upgrade, configure, FAQ
+- **Docs:** <https://sbpp.github.io/> (install, upgrade, configure, FAQ)
 - **Releases:** <https://github.com/sbpp/sourcebans-pp/releases>
 - **Issues:** <https://github.com/sbpp/sourcebans-pp/issues>
 - **Discord:** <https://discord.gg/tzqYqmAtF5>
@@ -46,7 +46,7 @@ dev stack, and [`ARCHITECTURE.md`](ARCHITECTURE.md) for the codebase
 tour.
 
 PRs that touch the web panel (`web/**`) are covered by a Contributor
-License Agreement — see [`CLA.md`](CLA.md). The CLA bot leaves
+License Agreement; see [`CLA.md`](CLA.md). The CLA bot leaves
 one-line sign instructions on your first such PR; you only need to
 sign once. Plugin-only PRs (`game/addons/sourcemod/**`) stay under
 GPLv3 and don't need a signature.
@@ -58,12 +58,12 @@ contact a maintainer on Discord if the report needs to be private.
 
 SourceBans++ is built and maintained on volunteer time. If your
 community, server network, or hosting business depends on it,
-sponsoring development helps keep the panel healthy &mdash; and
-funds the modernization work that's been landing across v2.x.
+sponsoring development helps keep the panel healthy and funds the
+modernization work landing across v2.x.
 
 [![Sponsor on GitHub](https://img.shields.io/github/sponsors/sbpp?style=flat-square&logo=github&label=Sponsor%20on%20GitHub)](https://github.com/sponsors/sbpp)
 
-**Game-server hosts and SourceBans++-as-a-feature providers** &mdash;
+**Game-server hosts and SourceBans++-as-a-feature providers:**
 production / commercial use of the web panel is covered by a
 separate commercial license; see **License** below.
 
@@ -78,5 +78,5 @@ separate commercial license; see **License** below.
   Hobby / community use is free under the linked terms; for
   production / commercial use (e.g. game-server hosting companies
   bundling SourceBans++ as a paid feature), a separate commercial
-  license is available &mdash; reach out via the contact link on
-  the [sponsor page](https://sbpp.github.io/sponsor/) or Discord.
+  license is available. Reach out via the contact link on the
+  [sponsor page](https://sbpp.github.io/sponsor/) or Discord.

--- a/docs/src/content/docs/configuring/announcements.mdx
+++ b/docs/src/content/docs/configuring/announcements.mdx
@@ -8,25 +8,24 @@ sidebar:
 
 import { Aside, Code } from '@astrojs/starlight/components';
 
-The home dashboard surfaces a slim "Latest announcement" strip
-between the stat cards and the recent-activity panels — visible only
-to logged-in administrators. Content is sourced from a JSON feed
-the SourceBans++ maintainers publish at:
+The home dashboard shows a slim "Latest announcement" strip between
+the stat cards and the recent-activity panels. It's visible only to
+logged-in administrators. Content comes from a JSON feed the
+SourceBans++ maintainers publish at:
 
 <Code lang="text" code="https://sbpp.github.io/announcements.json" />
 
 The panel fetches the feed once per install per day in the
-background, caches it on disk, and renders the freshest non-expired
-entry on every dashboard render thereafter. The fetch uses the same
-opt-out-by-default architecture as the panel's update check (a
-shutdown hook fires after the user's response is flushed; it never
-delays a request and never fails one if the upstream is unreachable).
+background, caches it on disk, and renders the latest non-expired
+entry on every dashboard load. The fetch uses the same opt-out
+architecture as the panel's update check: a shutdown hook fires
+after the response is flushed, so it never delays a request and
+never fails one if the upstream is unreachable.
 
 ## What gets fetched
 
-The published feed is a public, anonymous-readable JSON file. You
-can open it in your browser and read it yourself — there's no
-hidden state. A typical entry looks like this:
+The feed is a public JSON file you can open in your browser. There's
+no hidden state. A typical entry looks like this:
 
 ```json
 [
@@ -43,17 +42,16 @@ hidden state. A typical entry looks like this:
 
 Field-by-field:
 
-- `id` — short stable identifier (≤64 chars). Required.
-- `title` — one-line headline. Required.
-- `body_md` — optional Markdown body. Rendered through CommonMark in
-  safe mode (raw HTML is escaped, `javascript:` / `data:` URLs are
+- `id`: short stable identifier (≤64 chars). Required.
+- `title`: one-line headline. Required.
+- `body_md`: optional Markdown body. Rendered through CommonMark in
+  safe mode (raw HTML is escaped, `javascript:` and `data:` URLs are
   stripped). Same renderer your dashboard intro uses.
-- `url` — optional "read more" link. Must be `http://` or `https://`.
-- `published_at` — optional ISO-8601 timestamp; sets the displayed
+- `url`: optional "read more" link. Must be `http://` or `https://`.
+- `published_at`: optional ISO-8601 timestamp. Sets the displayed
   date and the sort order.
-- `expires_at` — optional ISO-8601 timestamp. The panel stops
-  rendering the entry after this time and silently drops it from
-  the cache.
+- `expires_at`: optional ISO-8601 timestamp. The panel stops
+  rendering the entry after this time and drops it from the cache.
 
 ## What's NOT sent
 
@@ -66,24 +64,22 @@ cookies, no tracking pixels. The only outbound metadata is the
 
 ## Why this is opt-out by default
 
-The strip is intentionally narrow — single banner, admin-only
-visibility, low-frequency content (security advisories,
-release announcements, occasional release-blocker heads-up). The
-maintainers want to be able to reach panel operators with one-click
+The strip is narrow: one banner, admin-only, low-frequency content
+(security advisories, release announcements, occasional release-blocker
+heads-up). The maintainers want a way to reach panel operators with
 visibility for things like:
 
-- A critical CVE is published — please update.
-- A backwards-incompatible upgrade just landed — read the upgrade
-  notes before running the updater.
-- A new SourceMod / MariaDB version requirement is shipping.
+- A critical CVE is published. Please update.
+- A backwards-incompatible upgrade landed. Read the upgrade notes
+  before running the updater.
+- A new SourceMod or MariaDB version requirement is shipping.
 
-Operators audit content via the **public diff history** of the
+Operators can audit content via the **public diff history** of the
 [`docs/public/announcements.json`](https://github.com/sbpp/sourcebans-pp/blob/main/docs/public/announcements.json)
 file. Every change ships through a pull request with the same
 review process as the rest of the project. There's no separate
-"announcements server" or admin-only API endpoint that could be
-compromised independently — the upstream is just a static file in
-this git repo.
+announcements server or admin-only API endpoint to compromise. The
+upstream is just a static file in this git repo.
 
 The cost of "always on" is one HTTPS GET per install per day to
 sbpp.github.io, capped at 256 KiB of response body, with a 5-second
@@ -102,17 +98,16 @@ the outbound network call regardless, define
 define('SB_ANNOUNCEMENTS_URL', '');
 ```
 
-When the constant is the empty string, the shutdown hook
-short-circuits before flushing the response — no network call ever
-fires, the cache file is never written, and the dashboard simply
-omits the strip. There is no in-panel toggle by design: the JSON
-feed is intentionally low-frequency and audit-friendly, so the only
-sensible "off" position is the air-gap escape hatch above.
+With an empty string, the shutdown hook short-circuits before
+flushing the response. No network call fires, the cache file is
+never written, and the dashboard omits the strip. There is no
+in-panel toggle: the feed is low-frequency and audit-friendly, so
+the only "off" position is the air-gap escape hatch above.
 
 <Aside type="note">
-The `define()` must run BEFORE `init.php`'s default define fires —
-`config.php` is loaded first, so this works as written. Don't put it
-in a hook that runs later.
+The `define()` must run before `init.php`'s default define fires.
+`config.php` is loaded first, so this works as written. Don't put
+it in a hook that runs later.
 </Aside>
 
 ## How announcements are proposed
@@ -123,16 +118,15 @@ docs site:
 
 1. Open a PR against
    [`sbpp/sourcebans-pp`](https://github.com/sbpp/sourcebans-pp).
-2. Edit `docs/public/announcements.json` to prepend your entry
-   (newest-first ordering — the panel sorts by `published_at` but
-   the file convention is "newest at the top of the array" so
-   reviewers see the most relevant change first).
+2. Edit `docs/public/announcements.json` to prepend your entry.
+   The panel sorts by `published_at`, but the file convention is
+   "newest at the top of the array" so reviewers see the most
+   relevant change first.
 3. The maintainers will review and merge. The
    [docs deploy trigger workflow](https://github.com/sbpp/sourcebans-pp/blob/main/.github/workflows/docs-deploy-trigger.yml)
    ships the updated file to `https://sbpp.github.io/announcements.json`
    within a few minutes of merge.
 
-The strict schema, audit history, and one-file source-of-truth are
-the load-bearing properties: any operator with internet access can
-inspect every announcement that has ever been pushed before it
-lands on their dashboard.
+The strict schema, audit history, and one-file source make this
+auditable: any operator with internet access can review every
+announcement before it lands on their dashboard.

--- a/docs/src/content/docs/customization/removing-default-message.md
+++ b/docs/src/content/docs/customization/removing-default-message.md
@@ -8,7 +8,7 @@ sidebar:
 
 The public dashboard ships with a placeholder welcome message
 ("Your new SourceBans install"). Most operators want to replace it
-with something specific to their community — a link to rules, a
+with something specific to their community: a link to rules, a
 link to Discord, a tagline, etc.
 
 ## Replace it
@@ -27,7 +27,7 @@ link to Discord, a tagline, etc.
 
 The intro text supports **Markdown**:
 
-- Headings (`# Heading`, `## Subheading`, …)
+- Headings (`# Heading`, `## Subheading`, etc.)
 - Bold (`**text**`) and italics (`*text*`)
 - Links (`[label](https://example.com)`)
 - Lists (numbered and unordered)
@@ -36,10 +36,9 @@ The intro text supports **Markdown**:
 - Blockquotes (`> quoted text`)
 
 The renderer is [CommonMark](https://commonmark.org/) running in
-"safe mode" — raw HTML in the source is escaped instead of rendered,
-and `javascript:` / `data:` URLs are stripped. So you can paste
-formatting freely without worrying about an admin accidentally (or
-deliberately) injecting unsafe markup.
+"safe mode": raw HTML is escaped instead of rendered, and
+`javascript:` / `data:` URLs are stripped. Paste formatting freely
+without worrying about unsafe markup.
 
 Reach for the **Markdown cheat sheet** link in the help icon next to
 the editor if you need a quick reference.
@@ -62,11 +61,11 @@ A short rules list:
 ```markdown
 ## House rules
 
-1. No cheating — we use SourceBans++ and we will catch you.
+1. No cheating. We use SourceBans++ and we will catch you.
 2. Respect other players. No slurs, no harassment.
 3. Mic spam after a verbal warning = mute.
 
-Banned? [Appeal here](/index.php?p=submit) — we read every one.
+Banned? [Appeal here](/index.php?p=submit). We read every one.
 ```
 
 ## Tips
@@ -74,7 +73,7 @@ Banned? [Appeal here](/index.php?p=submit) — we read every one.
 - **Keep it short.** This is the first thing visitors see; long
   walls of text get scrolled past.
 - **Link to your community elsewhere.** Discord invite, forum, ban
-  appeals page — anything actionable.
+  appeals page, anything actionable.
 - **Test with a fresh browser window.** The live preview shows you
   what the dashboard will render, but it's still worth opening the
   public dashboard in an incognito tab to confirm it reads well
@@ -85,14 +84,14 @@ Banned? [Appeal here](/index.php?p=submit) — we read every one.
 While you're under **Admin Panel → Settings**, a few other knobs
 are worth a look on first install:
 
-- **Settings → Settings → Sitename** — what the browser tab title
+- **Settings → Settings → Sitename**: what the browser tab title
   shows.
-- **Settings → Settings → URL** — used in emails the panel sends.
+- **Settings → Settings → URL**: used in emails the panel sends.
   Set it to your public URL.
-- **Settings → Features** — toggles for comm blocks, public ban
+- **Settings → Features**: toggles for comm blocks, public ban
   appeals, public report submissions, anonymous telemetry, and so
   on. Skim the list to see what's available.
-- **Settings → Themes** — pick a different chrome if you've
+- **Settings → Themes**: pick a different chrome if you've
   installed one.
 
 For translating the panel's UI into another language, see

--- a/docs/src/content/docs/customization/translating.md
+++ b/docs/src/content/docs/customization/translating.md
@@ -6,7 +6,7 @@ sidebar:
 ---
 
 SourceBans++ ships with English as the default. Translating into
-another language has two halves — the web panel (theme-based) and
+another language has two halves: the web panel (theme-based) and
 the in-game plugin (SourceMod's standard `.phrases.txt` files).
 
 ## Web panel
@@ -25,7 +25,7 @@ translations, and select your new theme in the panel's settings.
 
    ```php
    <?php
-   define('theme_name',       "SourceBans++ — Deutsch");
+   define('theme_name',       "SourceBans++ Deutsch");
    define('theme_author',     "Your name");
    define('theme_version',    "1.0.0");
    define('theme_link',       "https://your-site.example.com");
@@ -35,8 +35,8 @@ translations, and select your new theme in the panel's settings.
 
 3. **Translate each `.tpl` file.** Open the `.tpl` files in your
    theme directory and replace the English copy with your
-   translation. Don't touch the parts wrapped in `{...}` —
-   those are template variables Smarty fills in at render time.
+   translation. Don't touch the parts wrapped in `{...}`. Those
+   are template variables Smarty fills in at render time.
 
 4. **Activate your theme.** Sign in as an admin with **Web settings**
    permission, navigate to **Admin Panel → Settings → Themes**,
@@ -45,9 +45,9 @@ translations, and select your new theme in the panel's settings.
 :::caution
 SourceBans++ uses **Smarty 5** under the hood, which dropped the
 `{php}` tag. If you find a `{php}` block in an old fork theme,
-you'll need to replace it with
+replace it with
 [`{load_template}`](https://github.com/sbpp/sourcebans-pp/blob/main/web/includes/SmartyCustomFunctions.php)
-or move the logic into a PHP helper — the panel refuses to render
+or move the logic into a PHP helper. The panel refuses to render
 templates that still contain `{php}`.
 :::
 
@@ -88,8 +88,8 @@ The plugin uses SourceMod's standard translation files (per-plugin
    }
    ```
 
-   - Keep the `{1}`, `{2}`, … placeholders in the same positions —
-     they're how SourceMod injects player names, durations, etc.
+   - Keep the `{1}`, `{2}`, etc. placeholders in the same positions.
+     They're how SourceMod injects player names, durations, and so on.
    - If `#format` is present, follow its formatter spec (see
      SourceMod's
      [Translations](https://wiki.alliedmods.net/Translations_(SourceMod_Scripting))
@@ -105,8 +105,8 @@ falls back to English.
 ## Contributing translations back
 
 We always welcome translation PRs against
-[`sbpp/sourcebans-pp`](https://github.com/sbpp/sourcebans-pp) — both
-panel theme translations and plugin phrase translations.
+[`sbpp/sourcebans-pp`](https://github.com/sbpp/sourcebans-pp), for
+both panel theme translations and plugin phrase translations.
 
 For the panel, the practical path is to keep the default theme's
 structure and only swap the visible text, so the PR is a clean

--- a/docs/src/content/docs/faq/index.md
+++ b/docs/src/content/docs/faq/index.md
@@ -44,10 +44,10 @@ Take a stab at the issues labelled `good first issue` or `help wanted`
 on the [issue tracker](https://github.com/sbpp/sourcebans-pp/issues).
 The
 [`AGENTS.md`](https://github.com/sbpp/sourcebans-pp/blob/main/AGENTS.md)
-file in the repo root is the contributor cheatsheet — conventions,
+file in the repo root is the contributor cheatsheet: conventions,
 the local Docker dev stack, and the "where to find what" index.
 
-Translation PRs are always welcome too — see
+Translation PRs are always welcome too. See
 [Translating](/customization/translating/).
 
 ## Installing
@@ -56,7 +56,7 @@ Translation PRs are always welcome too — see
 
 Not really. You need the web panel at minimum to install, configure,
 and add servers. In theory you could stop using the panel after that
-and the in-game half would keep enforcing bans — but you'd lose
+and the in-game half would keep enforcing bans, but you'd lose
 access to most of what makes SourceBans++ useful: adding admins,
 managing bans, processing appeals, viewing the audit log.
 
@@ -75,7 +75,7 @@ If SourceMod runs on it, SourceBans++ usually runs on it.
 Yes. The panel and plugin halves only need to share a database; they
 can be on different hosts, different networks, even different
 continents. The DB user's grant has to allow connections from both
-hosts, which is the most common stumbling block — see
+hosts, which is the most common stumbling block. See
 [Database setup → Granting permission](/setup/mariadb/#granting-permission).
 
 ### Will it work on shared hosting?
@@ -84,7 +84,7 @@ Yes, with two caveats:
 
 - The host must run **PHP >= 8.5** with `pdo_mysql`, `openssl`,
   `xml`, and `mbstring`. Most modern shared hosts do. (Older 1.x
-  installs also required `gmp`; not needed since 2.x — native
+  installs also required `gmp`. Not needed since 2.x; native
   64-bit `int` math handles Steam ID conversion.)
 - The host must allow **remote database connections** if your
   game servers aren't on the same host. Many shared hosts
@@ -96,7 +96,7 @@ Yes, with two caveats:
 ### Why am I seeing a blank white page?
 
 PHP hit a fatal error before any output was sent. The actual error
-goes to your webserver's PHP error log — see
+goes to your webserver's PHP error log. See
 [Panel won't load](/troubleshooting/panel-not-loading/#1-server-level-errors-blank-white-page)
 for the typical log paths and how to read them.
 
@@ -126,7 +126,7 @@ That re-enables password login alongside Steam OpenID. Sign in,
 then fix the configuration the way you intended.
 
 :::caution
-Editing `_settings` directly is a foot-gun — bad values can break
+Editing `_settings` directly is a foot-gun: bad values can break
 the panel's bootstrap. Touch only the row you intend to fix, and
 back up the table first if you're not sure.
 :::
@@ -154,7 +154,7 @@ files; if `basebans.smx` is still in `plugins/`, move it manually.
 
 The `"sourcebans"` block is missing from SourceMod's
 `databases.cfg`. The [Quickstart](/getting-started/quickstart/#databasescfg)
-shows the canonical block — add it, save, reload the map, and the
+shows the canonical block. Add it, save, reload the map, and the
 plugin will pick it up.
 
 ### Why does the panel only show "Max Players" instead of the actual player list?
@@ -191,7 +191,7 @@ delete the `install/` and `updater/` directories when done.
 
 ### Is upgrading to 2.0.x different?
 
-Yes — read [Upgrading from 1.8.x to 2.0.x](/updating/1-8-to-2-0/)
+Yes. Read [Upgrading from 1.8.x to 2.0.x](/updating/1-8-to-2-0/)
 first. v2.0 raises the PHP version floor, resets the active theme,
 and ships default-on anonymous telemetry. The upgrade itself is
 otherwise normal.

--- a/docs/src/content/docs/getting-started/overview.mdx
+++ b/docs/src/content/docs/getting-started/overview.mdx
@@ -1,15 +1,15 @@
 ---
 title: Overview
-description: How SourceBans++ is structured — the web panel, the SourceMod plugins, the shared database, and how they fit together.
+description: How SourceBans++ is structured. The web panel, the SourceMod plugins, the shared database, and how they fit together.
 sidebar:
   order: 1
 ---
 
 import { CardGrid, LinkCard, Tabs, TabItem, Aside } from '@astrojs/starlight/components';
 
-This page is a quick mental model of how SourceBans++ is put together,
-so the rest of the guide reads as "wire up these named pieces" rather
-than a wall of commands. Skip ahead if you already run an ops-grade
+A quick mental model of how SourceBans++ fits together, so the rest
+of the guide reads as "wire up these named pieces" rather than a
+wall of commands. Skip ahead if you already run an ops-grade
 SourceMod stack.
 
 ## The big picture
@@ -42,9 +42,9 @@ talks to the database directly. You install it once, on any host that
 can run PHP and reach the database (typically the same host).
 
 The **SourceMod plugins** run on each of your game servers (one
-install per game server). They enforce bans in-game — disconnecting
-banned players, muting players in comm blocks — and write new
-admin actions back to the database so the panel sees them too.
+install per game server). They enforce bans in-game by disconnecting
+banned players and muting players in comm blocks. They also write
+new admin actions back to the database so the panel sees them too.
 
 Both halves share **one database**. There is no API contract between
 the plugin and the panel; they coordinate through shared SQL tables.
@@ -59,15 +59,15 @@ This matters because:
 
 A first-time install walks through, in order:
 
-1. **A database** — MariaDB or MySQL, hosted wherever's convenient.
+1. **A database**: MariaDB or MySQL, hosted wherever's convenient.
    See [Database setup](/setup/mariadb/).
-2. **The web panel** — Pick an install path below.
-3. **One or more game servers** — Add each to the panel to get a
+2. **The web panel**: pick an install path below.
+3. **One or more game servers**: add each to the panel to get a
    `ServerID`. See [Adding a server](/setup/adding-server/).
-4. **The SourceMod plugins** — Drop them onto each game server, edit
-   two config files (`databases.cfg` and `sourcebans.cfg`), restart
-   the server. See [Plugin setup](/setup/plugin-setup/).
-5. **Your admin team** — Create admins, group them, hand out
+4. **The SourceMod plugins**: drop them onto each game server, edit
+   `databases.cfg` and `sourcebans.cfg`, restart the server. See
+   [Plugin setup](/setup/plugin-setup/).
+5. **Your admin team**: create admins, group them, hand out
    permissions. See [Admins & groups](/setup/admins-and-groups/).
 
 After that you're in day-to-day operation: people get banned, you
@@ -76,13 +76,13 @@ review appeals, you tune permissions.
 ## Pick an install path
 
 We ship three install paths for the panel. The plugin side is the
-same regardless of which one you pick — these only differ in how
-the **web panel** gets stood up.
+same regardless. These options only differ in how the **web panel**
+gets stood up.
 
 <Tabs syncKey="install-path">
   <TabItem label="Tarball / shared hosting" icon="cloud-download">
     **Best when:** you already run a webserver, share hosting with
-    other apps, or want maximum control over PHP / Apache / nginx
+    other apps, or want full control over PHP, Apache, or nginx
     config. The traditional install path: download a release zip,
     upload via FTP / cPanel / SSH, walk the install wizard once.
 
@@ -91,23 +91,22 @@ the **web panel** gets stood up.
 
   <TabItem label="Docker" icon="seti:docker">
     **Best when:** you own the host, want one-command upgrades
-    (`docker compose pull && up -d`), zero-touch TLS, or
-    reproducible deploys across machines. Ships a hardened
-    multi-arch image (`ghcr.io/sbpp/sourcebans-pp`) signed with
-    Sigstore cosign.
+    (`docker compose pull && up -d`), automatic TLS, or
+    reproducible deploys across machines. Ships a multi-arch
+    image (`ghcr.io/sbpp/sourcebans-pp`) signed with Sigstore cosign.
 
     Step it out with the **[Docker quickstart](/getting-started/quickstart-docker/)**.
   </TabItem>
 
   <TabItem label="App platform (one click)" icon="rocket">
     **Best when:** you don't want to manage a host at all and your
-    panel doesn't need exotic customisation. Deploy buttons for
+    panel doesn't need custom configuration. Deploy buttons for
     DigitalOcean App Platform, Railway, Render, and Fly.io are
     tracked in [issue #1382](https://github.com/sbpp/sourcebans-pp/issues/1382).
 
     <Aside type="note">
-      The image already speaks every platform-conventional knob —
-      `PORT` injection, `DATABASE_URL` parsing, `/health.php` probes,
+      The image speaks every platform-conventional knob: `PORT`
+      injection, `DATABASE_URL` parsing, `/health.php` probes, and
       `*_FILE` secrets. Until the deploy buttons land, point any
       platform that runs container images at
       `ghcr.io/sbpp/sourcebans-pp:latest` and set the env vars from
@@ -121,30 +120,30 @@ the **web panel** gets stood up.
 A handful of terms come up over and over in the panel and in this
 guide.
 
-**Admin** — a panel user with a Steam ID, an email, and a set of
+**Admin**: a panel user with a Steam ID, an email, and a set of
 permission flags. Admins also exist server-side (the plugin reads them
 from the panel into SourceMod), so a panel admin with the right flags
 is automatically an in-game admin too.
 
-**Group** — a named bundle of permission flags. Most installs assign
+**Group**: a named bundle of permission flags. Most installs assign
 permissions to groups (e.g. "Moderators", "Senior admins") and then
 assign admins to groups, instead of granting permissions per-admin.
 
-**Server** — a single game-server instance registered in the panel.
+**Server**: a single game-server instance registered in the panel.
 Each one has an `IP:port`, an RCON password, and a numeric `ServerID`
 that the SourceMod plugin uses to tag its writes.
 
-**Ban** — a Steam ID or IP record with a duration, reason, and the
+**Ban**: a Steam ID or IP record with a duration, reason, and the
 admin who issued it. Permanent bans have no expiry. Temporary bans
 expire on their own.
 
-**Comm block** — a mute or gag. Mutes silence voice; gags silence
+**Comm block**: a mute or gag. Mutes silence voice; gags silence
 text chat. Same concept as a ban, applied to communication rather
 than connection.
 
-**RCON** — Source's remote-control protocol. The panel uses it to
+**RCON**: Source's remote-control protocol. The panel uses it to
 push commands (kick, ban, reload) to a running game server. The
-password lives in the panel and in the game server's config; getting
+password lives in the panel and in the game server's config. Getting
 them out of sync is the most common "panel can't talk to the server"
 cause.
 
@@ -154,12 +153,12 @@ cause.
   <LinkCard
     title="Check the requirements"
     href="/getting-started/prerequisites/"
-    description="PHP version, DB engine, SourceMod version, Docker version — whichever path you picked above."
+    description="PHP version, DB engine, SourceMod version, Docker version, whichever path you picked above."
   />
   <LinkCard
     title="Tarball quickstart"
     href="/getting-started/quickstart/"
-    description="Fresh tarball install — database, web upload, wizard, plugin config."
+    description="Fresh tarball install: database, web upload, wizard, plugin config."
   />
   <LinkCard
     title="Docker quickstart"

--- a/docs/src/content/docs/getting-started/prerequisites.mdx
+++ b/docs/src/content/docs/getting-started/prerequisites.mdx
@@ -8,10 +8,9 @@ sidebar:
 
 import { Tabs, TabItem, Aside } from '@astrojs/starlight/components';
 
-A single-page list of what your host needs to provide before you can
-install SourceBans++. If anything below is unfamiliar, ask your host's
-support team — most shared and dedicated hosts can confirm or enable
-these in a few clicks.
+What your host needs to provide before you can install SourceBans++.
+If anything below is unfamiliar, ask your host's support team. Most
+shared and dedicated hosts can confirm or enable these in a few clicks.
 
 ## Web side
 
@@ -29,21 +28,21 @@ Pick the path you'll use:
   <TabItem label="Docker" icon="seti:docker">
     You need:
 
-    - **Docker 24+** — `docker --version` should print `24.x` or
+    - **Docker 24+**. `docker --version` should print `24.x` or
       newer. Docker Desktop ships a current version; Docker Engine
       on Linux can be upgraded via the [official install
       instructions](https://docs.docker.com/engine/install/).
-    - **Docker Compose v2** — `docker compose version` should
+    - **Docker Compose v2**. `docker compose version` should
       print `v2.x` or newer. v2 ships as a Docker CLI plugin (built
       into Docker Desktop; available as `docker-compose-plugin` on
       Debian/Ubuntu, `docker-compose` on RHEL/Fedora).
     - **At least 512 MB of free RAM** on the host. The panel itself
       idles around 150 MB; MariaDB takes the rest.
 
-    You do NOT need PHP, Composer, MariaDB, or a webserver installed
-    on the host — the image bundles all four. The **Database** /
-    **PHP** sections below are informational only for the Docker
-    install path.
+    You do NOT need PHP, Composer, MariaDB, or a webserver on the
+    host. The image bundles all four. The **Database** and **PHP**
+    sections below are informational only for the Docker install
+    path.
 
     Step it out in the [Docker quickstart](/getting-started/quickstart-docker/).
   </TabItem>
@@ -65,14 +64,14 @@ SourceBans++ has supported both since the project started.
 
 <Tabs syncKey="db">
   <TabItem label="MariaDB" icon="seti:db">
-    **>= 10.0** is the floor. We recommend MariaDB for new installs —
-    it's what the dev stack and CI use, and the
+    **>= 10.0** is the floor. We recommend MariaDB for new installs.
+    It's what the dev stack and CI use, and the
     [Database setup](/setup/mariadb/) guide targets it directly.
   </TabItem>
 
   <TabItem label="MySQL" icon="seti:db">
     **>= 5.6** is the floor (8.0+ is fine and recommended). MySQL 8
-    dropped the combined `GRANT … IDENTIFIED BY` syntax — use the
+    dropped the combined `GRANT … IDENTIFIED BY` syntax. Use the
     two-statement form shown in
     [Database setup → Granting permission](/setup/mariadb/#granting-permission).
   </TabItem>
@@ -90,8 +89,8 @@ some CJK characters fail to insert and the plugin logs a SQL error.
   but the panel can run out of memory on large ban-list pages below
   64 MB.
 - These PHP extensions must be loaded:
-  - `pdo_mysql` — MySQL/MariaDB driver
-  - `openssl` — TLS for SMTP and the panel's session tokens
+  - `pdo_mysql`: MySQL/MariaDB driver
+  - `openssl`: TLS for SMTP and the panel's session tokens
   - `xml`
   - `mbstring`
 
@@ -110,7 +109,7 @@ fix.
 ### Composer (only when installing from `main`)
 
 The release zip on the GitHub Releases page bundles everything
-already — **a normal install needs no Composer step.**
+already. **A normal install needs no Composer step.**
 
 You only need Composer if you're installing from a `git clone` of
 the `main` branch (development install). In that case:
@@ -126,16 +125,16 @@ recovery page (`/install/recovery.php`) that explains the fix.
 
 The SourceMod plugins are what runs on your game servers:
 
-- **SourceMod 1.11 or newer** — 1.12 stable recommended.
-- **Metamod: Source** — SourceMod's loader.
+- **SourceMod 1.11 or newer** (1.12 stable recommended).
+- **Metamod: Source**: SourceMod's loader.
 
-Most game-server hosts ship SourceMod 1.11+ by default; if yours
+Most game-server hosts ship SourceMod 1.11+ by default. If yours
 doesn't, you can install it from
 [sourcemod.net](https://www.sourcemod.net/).
 
 The plugin also needs SourceMod's `dbi.mysql` extension to talk to
 the database. On Linux this is bundled with SourceMod itself; on
-exotic setups it may need to be enabled explicitly — see
+exotic setups it may need to be enabled explicitly. See
 [Driver not found](/troubleshooting/could-not-find-driver/) if the
 plugin logs a connection error.
 
@@ -160,17 +159,17 @@ picked at the top of this page:
 
 <Tabs syncKey="install-path">
   <TabItem label="Tarball / shared hosting" icon="cloud-download">
-    [Tarball quickstart](/getting-started/quickstart/) — unzip,
+    [Tarball quickstart](/getting-started/quickstart/): unzip,
     upload, run the wizard.
   </TabItem>
 
   <TabItem label="Docker" icon="seti:docker">
-    [Docker quickstart](/getting-started/quickstart-docker/) —
+    [Docker quickstart](/getting-started/quickstart-docker/):
     `docker compose up -d` to a fully running panel.
   </TabItem>
 
   <TabItem label="App platform (one click)" icon="rocket">
-    [Docker quickstart](/getting-started/quickstart-docker/) — the
+    [Docker quickstart](/getting-started/quickstart-docker/): the
     "Deploy with one click" section covers the per-platform shape.
   </TabItem>
 </Tabs>

--- a/docs/src/content/docs/getting-started/quickstart-docker.mdx
+++ b/docs/src/content/docs/getting-started/quickstart-docker.mdx
@@ -1,6 +1,6 @@
 ---
 title: Quickstart (Docker)
-description: Deploy SourceBans++ with Docker Compose end-to-end — single host, persistent volumes, automatic TLS via Caddy.
+description: Deploy SourceBans++ with Docker Compose. Single host, persistent volumes, automatic TLS via Caddy.
 sidebar:
   order: 4
   label: Quickstart (Docker)
@@ -17,18 +17,18 @@ Compose** in a few minutes. By the end you'll have:
 - An initial admin account ready to log in.
 
 The Docker image (`ghcr.io/sbpp/sourcebans-pp`) is a multi-arch build
-(linux/amd64 + linux/arm64), signed with Sigstore cosign, and
-hardened: it ships no install wizard, no developer tools, and runs
-the panel as the non-root `www-data` user.
+(linux/amd64 + linux/arm64) signed with Sigstore cosign. It ships no
+install wizard, no developer tools, and runs the panel as the
+non-root `www-data` user.
 
 <Aside type="tip" title="Tarball or Docker?">
 The [tarball quickstart](/getting-started/quickstart/) walks through
-an "unzip + upload + wizard" install — best when you're sharing
+an "unzip + upload + wizard" install. Use it when you're sharing
 hosting or already run a webserver you'd like to drop the panel into.
 
-This Docker path is best when you want one-command upgrades
-(`docker compose pull && up -d`), zero-touch TLS, and reproducible
-deploys across machines. Same panel either way; pick whichever
+This Docker path is for when you want one-command upgrades
+(`docker compose pull && up -d`), automatic TLS, and reproducible
+deploys across machines. Same panel either way. Pick whichever
 matches your operations setup.
 </Aside>
 
@@ -37,8 +37,8 @@ matches your operations setup.
 You need:
 
 - **Docker 24+** and **Compose v2** (bundled into Docker Desktop and
-  recent Docker Engine releases — `docker compose version` should
-  print `v2.x` or newer).
+  recent Docker Engine releases). `docker compose version` should
+  print `v2.x` or newer.
 - **A host with at least 512 MB of free RAM.** The panel itself uses
   ~150 MB at idle; MariaDB takes the rest.
 - A **Steam Web API key** from
@@ -48,8 +48,8 @@ You need:
   (`STEAM_0:0:12345678` form). [SteamID I/O](https://steamid.io/)
   converts between formats.
 
-You do **not** need PHP, Composer, MariaDB, or a webserver installed
-on the host — the image carries everything.
+You do **not** need PHP, Composer, MariaDB, or a webserver on the
+host. The image carries everything.
 
 ## Step 1 — Get the compose stack
 
@@ -85,8 +85,8 @@ Open `.env` in your editor. The template is grouped into
 **Optional** sections. At minimum:
 
 <Steps>
-1. **`SB_SECRET_KEY`** — the JWT signing key. Generate once and
-   persist it forever (rotating it logs every admin out):
+1. **`SB_SECRET_KEY`**: the JWT signing key. Generate once and keep
+   it forever. Rotating it logs every admin out.
 
    ```sh
    openssl rand -base64 47
@@ -94,7 +94,7 @@ Open `.env` in your editor. The template is grouped into
 
    Paste the output into `SB_SECRET_KEY=...`.
 
-2. **`DB_ROOT_PASS`** and **`DB_PASS`** — the MariaDB root password
+2. **`DB_ROOT_PASS`** and **`DB_PASS`**: the MariaDB root password
    (used once for first-boot DB creation) and the panel user's
    password. Generate two distinct strong passwords:
 
@@ -103,21 +103,21 @@ Open `.env` in your editor. The template is grouped into
    openssl rand -base64 24    # DB_PASS
    ```
 
-3. **`STEAMAPIKEY`** — paste your Steam Web API key.
+3. **`STEAMAPIKEY`**: paste your Steam Web API key.
 
-4. **`INITIAL_ADMIN_*`** — fill in all four fields (name, SteamID,
+4. **`INITIAL_ADMIN_*`**: fill in all four fields (name, SteamID,
    email, password). The entrypoint seeds an Owner-flagged admin from
-   these values on first boot only; subsequent boots ignore them.
+   these values on first boot only. Subsequent boots ignore them.
    Change the password from the panel's "Your account" page after
    first login.
 
-5. **`SBPP_DOMAIN`** — if you plan to use the Caddy reverse-proxy
+5. **`SBPP_DOMAIN`**: if you plan to use the Caddy reverse-proxy
    stub for automatic TLS, set this to the public domain that points
    at your host (e.g. `panel.yourcommunity.example`).
 </Steps>
 
-The template is heavily commented; read through the rest of it for
-the optional knobs (image-tag pinning, trusted-proxy CIDR ranges,
+The template is commented in detail. Read through the rest of it
+for the optional knobs (image-tag pinning, trusted-proxy CIDR ranges,
 `DATABASE_URL` for managed databases, the `*_FILE` Docker-secret
 pattern).
 
@@ -130,7 +130,7 @@ is not.
 ## Step 3 — Start the stack
 
 If you're putting the panel behind your own existing reverse proxy
-(nginx, Traefik, Cloudflare Tunnel, …) or skipping TLS for a private
+(nginx, Traefik, Cloudflare Tunnel) or skipping TLS for a private
 network deploy:
 
 ```sh
@@ -152,9 +152,9 @@ stub:
 
 3. Set `SBPP_TRUSTED_PROXIES=172.16.0.0/12 10.0.0.0/8` in `.env` so
    the panel trusts Caddy's `X-Forwarded-*` headers from the Docker
-   bridge range. (Caddy adds these headers on every reverse-proxy
-   directive; without trust, the panel would log Caddy's IP instead
-   of the real client.)
+   bridge range. Caddy adds these headers on every reverse-proxy
+   directive. Without trust, the panel would log Caddy's IP instead
+   of the real client.
 
 4. Bring the stack up:
 
@@ -187,7 +187,7 @@ You should see a sequence of `[prod-entrypoint]` lines:
 [prod-entrypoint] step 6: checking for pending updater migrations
 [prod-entrypoint] step 7: removing install/ + updater/ from writable layer
 [prod-entrypoint] step 8: ensuring writable cache/templates_c/demos
-[prod-entrypoint] boot complete — handing off to: apache2-foreground
+[prod-entrypoint] boot complete; handing off to: apache2-foreground
 ```
 
 Once the last line lands, the panel is up. Open
@@ -226,8 +226,8 @@ tarball install:
 </CardGrid>
 
 The plugins live on your **game** servers and read directly from the
-same database the panel writes to — they don't need to know the
-panel is running in Docker.
+same database the panel writes to. They don't need to know the panel
+is running in Docker.
 
 ## Persistent volumes
 
@@ -238,7 +238,7 @@ panel is running in Docker.
 | `dbdata` | `/var/lib/mysql` | **Required.** The only source of truth for ban / admin / log rows. Loss = panel reset. |
 | `demos` | `/var/www/html/web/demos` | **Required.** Uploaded ban-evidence demos; not regenerable from anything else. |
 | `cache` | `/var/www/html/web/cache` | Optional. Smarty compile cache + PHP sessions. Wiping logs every admin out but doesn't lose data. |
-| `smarty` | `/var/www/html/web/templates_c` | Optional. Same shape as `cache` — rebuilt on demand. |
+| `smarty` | `/var/www/html/web/templates_c` | Optional. Same shape as `cache`, rebuilt on demand. |
 
 Back up the `dbdata` and `demos` volumes regularly. The simplest
 backup is a `mariadb-dump` for the DB and a `tar` for the demos:
@@ -255,12 +255,12 @@ docker run --rm -v <stack>_demos:/data -v "$PWD:/backup" alpine \
 ```
 
 (`<stack>` is the project name compose derives from the directory
-the compose file lives in — usually the directory's basename, e.g.
+the compose file lives in, usually the directory's basename, e.g.
 `sourcebans-prod_demos`.)
 
 ## Upgrading
 
-The image is **immutable** — upgrades are a tag bump. Pin
+The image is **immutable**. Upgrades are a tag bump. Pin
 `SBPP_IMAGE_TAG` in `.env` to a specific version for reproducible
 deploys:
 
@@ -277,9 +277,9 @@ docker compose -f docker-compose.prod.yml up -d
 ```
 
 The new container's entrypoint runs any pending updater migrations
-against the existing database (idempotent — every migration script
-in `web/updater/data/<N>.php` is forward-only and safe to re-run).
-The `dbdata` and `demos` volumes survive the swap unchanged.
+against the existing database. The migrations are idempotent: every
+script in `web/updater/data/<N>.php` is forward-only and safe to
+re-run. The `dbdata` and `demos` volumes survive the swap unchanged.
 
 Image tags:
 
@@ -290,10 +290,9 @@ Image tags:
 | `X.Y` | Floats forward across patch releases of `X.Y.*`. |
 | `X` | Floats forward across minor releases of `X.*.*`. |
 
-Only tagged release builds are published — there is no rolling
-`:main` or per-commit `:sha-<short>` tag. Self-hosters who want to
-test a yet-unreleased fix should `git checkout` the relevant ref and
-build the image locally with
+Only tagged release builds are published. There is no rolling
+`:main` or per-commit `:sha-<short>` tag. To test an unreleased fix,
+`git checkout` the relevant ref and build the image locally with
 `docker buildx build -f docker/Dockerfile.prod -t sbpp:dev .`.
 
 Every published tag is signed with Sigstore cosign in keyless mode.
@@ -310,7 +309,7 @@ cosign verify ghcr.io/sbpp/sourcebans-pp:1.7.0 \
 Every secret-shaped env var (`SB_SECRET_KEY`, `DB_PASS`,
 `DB_ROOT_PASS`, `STEAMAPIKEY`, `INITIAL_ADMIN_PASSWORD`) supports a
 sibling `_FILE` form that reads the value from a file path inside
-the container. This is the canonical Docker Swarm / Kubernetes
+the container. This is the standard Docker Swarm / Kubernetes
 secret-injection pattern.
 
 A worked Swarm example with two secrets:
@@ -353,23 +352,23 @@ deploy on those platforms by pointing the relevant service at the
 vars from `.env.example.prod`. The image already speaks the
 platform-conventional knobs:
 
-- **`PORT`** — the entrypoint rewrites Apache's `Listen` directive
-  to match. Render / Fly / Heroku-style injection works out of the
-  box.
+- **`PORT`**: the entrypoint rewrites Apache's `Listen` directive
+  to match. Render / Fly / Heroku-style injection works without
+  extra config.
 
   :::caution[Don't set `PORT` on the docker-compose deploy above]
   The `docker-compose.prod.yml` shipped in this repo hardcodes
-  `${SBPP_HOST_PORT}:80` — host port to container port 80. Setting
-  `PORT=8000` in `.env` would rewrite Apache's listen to `8000`
-  but compose would still map the host port to the container's
-  port `80` (which nothing is listening on), making the panel
+  `${SBPP_HOST_PORT}:80` (host port to container port 80). Setting
+  `PORT=8000` in `.env` would rewrite Apache's listen to `8000`,
+  but compose would still map the host port to the container's port
+  `80` (which nothing is listening on), making the panel
   unreachable. `PORT` is exclusively for the app-platform shape
   above; on compose deploys, `SBPP_HOST_PORT` is the host-side knob.
   :::
-- **`DATABASE_URL`** — parsed before the split `DB_*` vars get
+- **`DATABASE_URL`**: parsed before the split `DB_*` vars get
   applied. Railway / Render / Fly's "attached database" pattern
   works without extra config.
-- **`/health.php`** — DB-aware healthcheck. Point the platform's
+- **`/health.php`**: DB-aware healthcheck. Point the platform's
   health probe at this path.
 
 ## Troubleshooting
@@ -380,13 +379,13 @@ The first place to look is the container's stderr:
 docker compose -f docker-compose.prod.yml logs --tail=200 web
 ```
 
-Common failures + fixes:
+Common failures and fixes:
 
 | Symptom | Likely cause / fix |
 | --- | --- |
-| Boot stalls at `step 3: waiting for DB`. | The `db` service hasn't passed its healthcheck. `docker compose ... logs db` for the underlying MariaDB error — typically a wrong `DB_ROOT_PASS` on a re-deploy over an existing `dbdata` volume. |
+| Boot stalls at `step 3: waiting for DB`. | The `db` service hasn't passed its healthcheck. Run `docker compose ... logs db` to see the underlying MariaDB error. Usually a wrong `DB_ROOT_PASS` on a re-deploy over an existing `dbdata` volume. |
 | `step 4: minted fresh SB_SECRET_KEY` on every restart. | You haven't set `SB_SECRET_KEY` in `.env`. The first boot wrote a randomly-generated key into the writable layer's `config.php`, but a container recreation rebuilds the layer fresh. Set the env var to persist. |
-| Healthcheck flips to `unhealthy` repeatedly. | `curl https://<host>/health.php` to see the failure reason. If it's a DB connect error, the panel and DB containers have lost their network — `docker compose ... restart` typically resolves. |
+| Healthcheck flips to `unhealthy` repeatedly. | Run `curl https://<host>/health.php` to see the failure reason. If it's a DB connect error, the panel and DB containers have lost their network. `docker compose ... restart` usually resolves it. |
 | Panel renders but Steam OpenID login fails. | `STEAMAPIKEY` is empty or wrong. Set it in `.env`; bring the panel back with `docker compose ... up -d`. |
 | Apache logs `mod_remoteip` warnings about `RemoteIPInternalProxy`. | The `SBPP_TRUSTED_PROXIES` value isn't a valid CIDR. The entrypoint passes the value through verbatim; check for typos. |
 
@@ -403,7 +402,7 @@ apply identically to the Docker install:
   <LinkCard
     title="Driver not found"
     href="/troubleshooting/could-not-find-driver/"
-    description="If the plugin can't reach the database; rarely applies to the Docker image (it bundles pdo_mysql)."
+    description="If the plugin can't reach the database. Rarely applies to the Docker image, which bundles pdo_mysql."
   />
   <LinkCard
     title="Database errors"

--- a/docs/src/content/docs/getting-started/quickstart.mdx
+++ b/docs/src/content/docs/getting-started/quickstart.mdx
@@ -1,15 +1,15 @@
 ---
 title: Quickstart
-description: Install SourceBans++ end-to-end — database, web panel, plugin, first server.
+description: Install SourceBans++ end-to-end. Database, web panel, plugin, first server.
 sidebar:
   order: 3
 ---
 
 import { Tabs, TabItem, Aside, LinkCard, CardGrid, Steps } from '@astrojs/starlight/components';
 
-This guide walks you through a fresh SourceBans++ install from scratch.
-By the end you'll have a working panel, a connected database, and at
-least one game server reporting back to it.
+A fresh SourceBans++ install from scratch. By the end you'll have a
+working panel, a connected database, and at least one game server
+reporting back to it.
 
 If you haven't yet, the [Overview](/getting-started/overview/) is the
 2-minute background read.
@@ -30,7 +30,7 @@ Ubuntu host in a handful of commands.
 You'll also want:
 
 - The SteamID of the **account you want to make the first admin**
-  (it's you, probably). In `STEAM_0:0:12345678` form — see the
+  (probably you). In `STEAM_0:0:12345678` form. See the
   [SteamID tip](#admin-account-setup) below if you only know the
   numeric form.
 - A **Steam Web API key** from
@@ -42,7 +42,7 @@ You'll also want:
 Grab the latest release zip from the
 [Releases page](https://github.com/sbpp/sourcebans-pp/releases). You
 want the `sourcebans-pp-X.Y.Z.webpanel-only.zip` (web side) and the
-`sourcebans-pp-X.Y.Z.plugin-only.zip` (game side) — or the combined
+`sourcebans-pp-X.Y.Z.plugin-only.zip` (game side), or the combined
 zip if you prefer.
 
 ## Step 2 — Upload the web panel
@@ -68,18 +68,18 @@ host:
     `chown` the files to that user.
 
     ```sh
-    # config.php — the wizard appends DB credentials and the secret
+    # config.php: the wizard appends DB credentials and the secret
     # key to this file.
     sudo chmod 644 config.php
 
-    # demos/ — uploaded ban-evidence demos.
+    # demos/: uploaded ban-evidence demos.
     sudo chmod -R 644 demos
 
-    # themes_c/ — Smarty's template cache. The panel writes here on
+    # themes_c/: Smarty's template cache. The panel writes here on
     # every page render.
     sudo chmod -R 774 themes_c
 
-    # images/games/, images/maps/ — admin-uploaded thumbnails.
+    # images/games/, images/maps/: admin-uploaded thumbnails.
     sudo chmod -R 644 images/games
     sudo chmod -R 644 images/maps
     ```
@@ -110,12 +110,12 @@ host:
     directories. `themes_c/` may need **775**.
 
     If your host runs PHP under a different user and you don't have
-    suEXEC / suPHP, ask support to enable it — that's the proper
-    fix. World-writable (`666` / `777`) works as a last resort.
+    suEXEC / suPHP, ask support to enable it. World-writable (`666`
+    / `777`) works as a last resort.
   </TabItem>
 
   <TabItem label="Docker" icon="docker">
-    Our official `Dockerfile` handles this automatically — the
+    Our official `Dockerfile` handles this automatically. The
     webroot is owned by `www-data` inside the container and the
     wizard runs as that user.
 
@@ -125,9 +125,9 @@ host:
 </Tabs>
 
 <Aside type="tip">
-If the wizard complains a path isn't writable, that's working as
-intended — it refuses to proceed rather than leave you with a panel
-that fails mysteriously later. Fix the permissions and reload.
+If the wizard complains a path isn't writable, it's refusing to
+proceed rather than leave you with a panel that fails later. Fix the
+permissions and reload.
 </Aside>
 
 ## Step 3 — Run the install wizard
@@ -164,9 +164,9 @@ if PHP can't talk to MySQL at all.
 
 ### System check
 
-The wizard runs a final sanity check — PHP version, extensions,
-paths it needs to write to. Every row should be green. Fix any
-yellow / red rows before continuing.
+The wizard runs a final sanity check: PHP version, extensions, paths
+it needs to write to. Every row should be green. Fix any yellow or
+red rows before continuing.
 
 ### Table creation
 
@@ -175,12 +175,12 @@ and shows a success notification.
 
 ### Admin account setup
 
-This is the first admin account — that's you.
+The first admin account is you.
 
 <Aside type="tip" title="SteamID format">
 Use the **SteamID2** form: `STEAM_0:0:12345678`. Not the SteamID3
 (`[U:1:24691356]`) or numeric / SteamID64 form. Tools like
-[SteamID I/O](https://steamid.io/) convert between them — paste any
+[SteamID I/O](https://steamid.io/) convert between them. Paste any
 form in and copy the `STEAM_0:0:…` line back out.
 </Aside>
 
@@ -189,16 +189,16 @@ Fill it in and click **OK**. Your panel is now live at
 
 <Aside type="caution" title="Delete the install directory">
 After the wizard finishes, **delete the `install/` directory** from
-your webserver. The panel actively refuses to boot while
-`install/` exists — leaving it accessible would let anyone re-run
-the wizard and hijack your panel.
+your webserver. The panel refuses to boot while `install/` exists,
+since leaving it accessible would let anyone re-run the wizard and
+hijack your panel.
 </Aside>
 
 ## Step 4 — Register your first game server
 
 In the panel, navigate to **Admin Panel → Server Settings → Add new
 server**. Fill in the form (game, RCON password, IP, port), click
-**Add Server**, and note the **`ID` column** for the new row — that
+**Add Server**, and note the **`ID` column** for the new row. That
 number is the `ServerID` the plugin needs in the next step.
 
 Full walkthrough with screenshots:
@@ -232,10 +232,10 @@ section pointing at the same database the panel uses:
 
 <Aside type="caution">
 The web panel offers to generate this section for you, but treat
-that as a starting point, not a finished config — especially if
-your game server isn't on the same host as the database. If the
-two hosts are on different networks, you'll also need to allow
-the game server's IP in your database's user grant (see
+that as a starting point, especially if your game server isn't on
+the same host as the database. If the two hosts are on different
+networks, you'll also need to allow the game server's IP in your
+database's user grant (see
 [Database setup → Granting permission](/setup/mariadb/#granting-permission)).
 </Aside>
 
@@ -256,18 +256,18 @@ Back in the panel:
 
 - The **Servers** page should show your new server as **online** with
   the current map and player list within ~30 seconds.
-- Try banning a test player from in-game via SourceMod's admin menu —
-  the ban should appear on the panel's **Bans** page within seconds.
-- Try banning from the panel — the ban should kick the player from
+- Try banning a test player from in-game via SourceMod's admin menu.
+  The ban should appear on the panel's **Bans** page within seconds.
+- Try banning from the panel. The ban should kick the player from
   the game server.
 
 If something isn't working, the most useful starting points are:
 
-- [Server connection issues](/troubleshooting/debugging-connection/) —
-  the panel doesn't show your server's map / players.
-- [Driver not found](/troubleshooting/could-not-find-driver/) — the
+- [Server connection issues](/troubleshooting/debugging-connection/):
+  the panel doesn't show your server's map or players.
+- [Driver not found](/troubleshooting/could-not-find-driver/): the
   plugin can't talk to the database.
-- [Database errors](/troubleshooting/database-errors/) — anything else
+- [Database errors](/troubleshooting/database-errors/): anything else
   database-related.
 
 ## What's next?

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: SourceBans++
-description: Self-hostable ban management for Source-engine game servers — install, upgrade, operate.
+description: Self-hostable ban management for Source-engine game servers. Install, upgrade, operate.
 template: splash
 hero:
   tagline: |
@@ -55,14 +55,14 @@ day-to-day moderation work.
   </Card>
 
   <Card title="Already running it?" icon="approve-check">
-    See [Updating](/updating/) for the safe upgrade path — and the
+    See [Updating](/updating/) for the safe upgrade path, plus the
     dedicated [1.8.x → 2.0.x guide](/updating/1-8-to-2-0/) if you're
     crossing the v2.0 boundary.
   </Card>
 
   <Card title="Something broken?" icon="warning">
     The [Troubleshooting](/troubleshooting/panel-not-loading/)
-    section catalogs the usual culprits — database errors, missing
+    section covers the usual culprits: database errors, missing
     PHP extensions, blank pages, and server-connection issues.
   </Card>
 

--- a/docs/src/content/docs/integrations/discord-forward-setup.md
+++ b/docs/src/content/docs/integrations/discord-forward-setup.md
@@ -7,7 +7,7 @@ sidebar:
 ---
 
 If you want SourceBans++ to post a Discord message every time
-something happens in-game — a ban, a player report, a mute / gag —
+something happens in-game (a ban, a player report, a mute / gag),
 that's what
 [`sbpp/discord-forward`](https://github.com/sbpp/discord-forward) is
 for. It's a separate SourceMod plugin (not part of the SourceBans++
@@ -16,8 +16,8 @@ the regular plugin set.
 
 :::note
 The Discord forwarder posts only for **in-game** events. Bans
-applied from the web panel UI don't trigger Discord messages —
-that's a long-standing
+applied from the web panel UI don't trigger Discord messages.
+That's a long-standing
 [feature request](https://github.com/sbpp/discord-forward/issues).
 :::
 
@@ -32,9 +32,9 @@ You'll need:
   separate channels (one for bans, one for reports, etc.).
 
 - **Two SourceMod extensions** on each game server:
-  - [SteamWorks](http://users.alliedmods.net/~kyles/builds/SteamWorks/) —
+  - [SteamWorks](http://users.alliedmods.net/~kyles/builds/SteamWorks/):
     Steam Web API access from SourceMod.
-  - [SMJansson](https://forums.alliedmods.net/showthread.php?t=184604) —
+  - [SMJansson](https://forums.alliedmods.net/showthread.php?t=184604):
     JSON support for SourceMod.
 
   Both go in `addons/sourcemod/extensions/` on the game server.
@@ -73,7 +73,7 @@ that channel.
 | --- | --- |
 | `sbpp_discord_username` | username shown on the webhook message (default `Sourcebans++`) |
 | `sbpp_discord_pp_url` | URL to a profile picture for the webhook |
-| `sbpp_website_url` | base URL of your SourceBans++ panel — embeds link admin / player names back to it when set |
+| `sbpp_website_url` | base URL of your SourceBans++ panel; embeds link admin / player names back to it when set |
 | `sbpp_discord_roleid` | Discord role ID to mention when a report comes in; leave empty to disable the mention |
 
 After saving the config, reload the map so SourceMod re-reads the
@@ -89,7 +89,7 @@ If no message arrives:
 
 - **Check the SourceMod logs** for the plugin (`addons/sourcemod/logs/`).
   Failed webhook posts are logged there.
-- **Confirm both extensions are loaded** with `sm exts list` —
+- **Confirm both extensions are loaded** with `sm exts list`.
   SteamWorks and SMJansson should both show `Running`.
 - **Test the webhook URL with curl** to make sure Discord still
   accepts it:

--- a/docs/src/content/docs/setup/adding-server.md
+++ b/docs/src/content/docs/setup/adding-server.md
@@ -21,10 +21,10 @@ Before adding a server, have these on hand:
   startup config (`server.cfg` or similar) under `rcon_password`.
 - The **game / mod** the server runs (Team Fortress 2,
   Counter-Strike: Source, Garry's Mod, etc.). Each lives in its own
-  mod folder — `tf`, `cstrike`, `garrysmod`, …
+  mod folder: `tf`, `cstrike`, `garrysmod`, etc.
 
 If you have RCON disabled or don't know the password, set one in
-`server.cfg` and reload the server first — the panel can't manage
+`server.cfg` and reload the server first. The panel can't manage
 a server without RCON access.
 
 ## Register the server in the panel
@@ -36,10 +36,10 @@ a server without RCON access.
 
 3. Fill in:
 
-   - **Game** — pick the mod from the dropdown.
-   - **IP** — the server's public IP.
-   - **Port** — the server's port (`27015` if you didn't change it).
-   - **RCON password** — the password from `server.cfg`.
+   - **Game**: pick the mod from the dropdown.
+   - **IP**: the server's public IP.
+   - **Port**: the server's port (`27015` if you didn't change it).
+   - **RCON password**: the password from `server.cfg`.
 
 4. Click **Add server**.
 
@@ -48,9 +48,9 @@ a server without RCON access.
    write into the SourceMod plugin's config in the next step.
 
 The panel attempts an RCON connection right away to validate the
-details. If it can't reach the server, you'll see a warning — but
-the row still gets saved, so you can fix the issue (firewall, IP,
-password) and the panel will reconnect on the next poll.
+details. If it can't reach the server, you'll see a warning, but
+the row still gets saved. Fix the issue (firewall, IP, password)
+and the panel will reconnect on the next poll.
 
 ## Wire the plugin's `ServerID`
 
@@ -70,8 +70,8 @@ On the game server itself:
    the change.
 
 If you skip the `ServerID` step, the plugin will still try to write
-bans to the database but with no server-side identity — meaning the
-panel can't tell them apart from bans on other servers.
+bans to the database but with no server-side identity, so the panel
+can't tell them apart from bans on other servers.
 
 ## Verifying
 
@@ -84,18 +84,18 @@ Back in the panel's **Servers** page, your new server should show:
 If it doesn't:
 
 - The panel can probably reach the server but can't read the player
-  list back — see
+  list back. See
   [Server connection issues](/troubleshooting/debugging-connection/)
   for the firewall / `listip` / RCON checklist.
 
 - If you also can't ban from in-game, the plugin likely can't reach
-  the database — see [Driver not found](/troubleshooting/could-not-find-driver/)
+  the database. See [Driver not found](/troubleshooting/could-not-find-driver/)
   and [Database errors](/troubleshooting/database-errors/).
 
 :::tip
 Adding a second or third server later? Repeat the same two halves
 (panel registration + plugin `ServerID` edit) on each new server.
-Each server gets its own row in the panel and its own
-`ServerID` — the `databases.cfg` section stays the same across all
-servers as long as they share the same database.
+Each server gets its own row in the panel and its own `ServerID`.
+The `databases.cfg` section stays the same across all servers as
+long as they share the same database.
 :::

--- a/docs/src/content/docs/setup/admins-and-groups.md
+++ b/docs/src/content/docs/setup/admins-and-groups.md
@@ -16,15 +16,15 @@ SourceBans++ uses a two-layer model:
 
 - **Groups** are named bundles of permission flags (e.g. "Junior
   admin", "Moderator", "Senior admin", "Owner").
-- **Admins** are individuals — each has a SteamID, email, optional
+- **Admins** are individuals. Each has a SteamID, email, optional
   password, and is assigned to one or more groups.
 
 In practice most installs only ever edit groups: you set up three or
 four group templates that match your community's hierarchy, then
-each new admin just gets added to the right group. Per-admin
-permission overrides exist for edge cases.
+each new admin gets added to the right group. Per-admin permission
+overrides exist for edge cases.
 
-There are also **server groups**, separate from web groups — these
+There are also **server groups**, separate from web groups. These
 control which game servers an admin can use in-game. An admin who
 moderates Server A but not Server B gets added to a server group
 scoped to Server A.
@@ -38,15 +38,15 @@ scoped to Server A.
 
 3. Fill in:
 
-   - **Username** — what the panel displays.
-   - **SteamID** — the admin's SteamID in `STEAM_0:0:…` form.
+   - **Username**: what the panel displays.
+   - **SteamID**: the admin's SteamID in `STEAM_0:0:…` form.
      [SteamID I/O](https://steamid.io/) converts other formats.
-   - **Email** — the admin's email. Required if they'll use
+   - **Email**: the admin's email. Required if they'll use
      password login; optional if they'll use Steam OpenID only.
-   - **Password** — set one or leave empty to force Steam-only
+   - **Password**: set one or leave empty to force Steam-only
      login.
-   - **Web group** — which group's flags they get on the panel.
-   - **Server group(s)** — which game servers they can moderate
+   - **Web group**: which group's flags they get on the panel.
+   - **Server group(s)**: which game servers they can moderate
      in-game.
 
 4. Click **Add admin**.
@@ -61,27 +61,27 @@ Groups live under **Admin Panel → Groups**.
 
 ### Web groups
 
-Web groups control panel access — who can do what *inside the web
+Web groups control panel access: who can do what *inside the web
 UI*. Common flags:
 
-- **Owner** — full access to everything.
-- **Add ban** — can apply bans from the panel.
-- **Edit ban / Unban** — can lift or amend bans.
-- **Add admin** — can create new admin accounts.
-- **Web settings** — can edit panel settings.
-- **Settings → Servers / Mods / Groups** — granular admin-area
+- **Owner**: full access to everything.
+- **Add ban**: can apply bans from the panel.
+- **Edit ban / Unban**: can lift or amend bans.
+- **Add admin**: can create new admin accounts.
+- **Web settings**: can edit panel settings.
+- **Settings → Servers / Mods / Groups**: granular admin-area
   access.
 
 For a small community two or three groups is usually enough:
 
-- **Senior admin / Owner** — everything.
-- **Admin** — ban / unban / edit comms, add new admins, but no
+- **Senior admin / Owner**: everything.
+- **Admin**: ban / unban / edit comms, add new admins, but no
   settings access.
-- **Junior admin** — ban / unban only.
+- **Junior admin**: ban / unban only.
 
 ### Server groups
 
-Server groups control in-game permissions — who can use what
+Server groups control in-game permissions: who can use what
 SourceMod commands on which servers. These flags follow SourceMod's
 standard letter codes (`a`-`z`):
 
@@ -134,15 +134,15 @@ manually reload admins in-game with `sm_reloadadmins`.
 
 Each admin can sign in two ways:
 
-- **SteamID + password** — they enter their SteamID and the
+- **SteamID + password**: they enter their SteamID and the
   password you set, just like a normal login form.
-- **Steam OpenID** — they click "Sign in with Steam" and Steam
+- **Steam OpenID**: they click "Sign in with Steam" and Steam
   confirms their identity.
 
 The Steam OpenID flow has no password to forget or leak, so it's
 the recommended default for most communities. You can disable
 password login site-wide under **Admin Panel → Settings → Features
-→ Steam-only login**, but **think twice** — if you lose Steam access
+→ Steam-only login**, but **think twice**: if you lose Steam access
 later you'll need a database query to get back in (covered in the
 [FAQ](/faq/#i-locked-myself-out-by-enabling-steam-only-login)).
 
@@ -160,7 +160,7 @@ unexpected changed.
 ## Removing an admin
 
 Under **Admin Panel → Admins**, find the row and click the trash icon.
-You'll be asked for a reason — it goes into the audit log alongside
+You'll be asked for a reason. It goes into the audit log alongside
 the removal.
 
 Removed admins lose panel access immediately. In-game admin status
@@ -178,5 +178,5 @@ clears on the next map change.
   includes the relevant servers and flag `d`.
 
 - **Admin can ban from in-game but not the panel.** Mirror image of
-  the above — they're in a server group but no web group with the
+  the above: they're in a server group but no web group with the
   Add ban flag.

--- a/docs/src/content/docs/setup/mariadb.mdx
+++ b/docs/src/content/docs/setup/mariadb.mdx
@@ -15,15 +15,15 @@ self-host path) and creating the user and database the panel will use.
 If you already run MySQL or MariaDB and just need the user / grant
 syntax, jump straight to [Granting permission](#granting-permission).
 
-If you're on **shared hosting** (cPanel, Plesk, DirectAdmin, …) you
-don't need any of this — your control panel has a "Create database"
-wizard that gives you the host, name, user, and password. Use those
-values directly in the SourceBans++ install wizard.
+If you're on **shared hosting** (cPanel, Plesk, DirectAdmin, etc.)
+you don't need any of this. Your control panel has a "Create
+database" wizard that gives you the host, name, user, and password.
+Use those values directly in the SourceBans++ install wizard.
 
 ## Why MariaDB?
 
 MariaDB is a drop-in MySQL replacement maintained by the original
-MySQL authors. SourceBans++ supports both engines equally — we just
+MySQL authors. SourceBans++ supports both engines equally. We
 recommend MariaDB by default because:
 
 - It's what our dev stack and CI run against.
@@ -38,7 +38,7 @@ If your host already provides MySQL, that's perfectly fine.
 
 <Tabs syncKey="db">
   <TabItem label="MariaDB (Ubuntu repo)" icon="seti:db">
-    The simplest path on Ubuntu 22.04 / 24.04 — the distro repo
+    The simplest path on Ubuntu 22.04 / 24.04. The distro repo
     carries a recent enough MariaDB:
 
     ```sh
@@ -76,7 +76,7 @@ If your host already provides MySQL, that's perfectly fine.
     ```
 
     The [Granting permission](#granting-permission) syntax differs
-    slightly on MySQL 8+ — see the tabs in that section.
+    slightly on MySQL 8+; see the tabs in that section.
   </TabItem>
 </Tabs>
 
@@ -91,7 +91,7 @@ sudo mysql_secure_installation
 
 Accept the defaults unless you have a specific reason not to. The
 root password it sets is for the **database root account**, not your
-OS root — pick something different from your sudo password.
+OS root. Pick something different from your sudo password.
 
 ## Configure for remote connections
 
@@ -150,10 +150,10 @@ Enter the root password you set during `mysql_secure_installation`.
 
 Decide on three values:
 
-- A **username** — by convention, `sourcebans`.
-- A **password** — pick a strong one; the panel saves it in
+- A **username**: by convention, `sourcebans`.
+- A **password**: pick a strong one; the panel saves it in
   `config.php` and the SourceMod plugins save it in `databases.cfg`.
-- A **source host** — `localhost` if everything's on the same
+- A **source host**: `localhost` if everything's on the same
   machine, the IP of the other host, or `%` to allow any source IP
   (paired with a firewall rule, please).
 
@@ -201,7 +201,7 @@ Then create the database, the user, and grant access:
   </TabItem>
 </Tabs>
 
-The `utf8mb4` charset is required — SourceBans++ won't insert player
+The `utf8mb4` charset is required. SourceBans++ won't insert player
 names with emoji or some CJK characters into a 3-byte `utf8` table.
 
 ## Done

--- a/docs/src/content/docs/setup/plugin-setup.md
+++ b/docs/src/content/docs/setup/plugin-setup.md
@@ -1,6 +1,6 @@
 ---
 title: Plugin setup
-description: Wire up the SourceMod side of SourceBans++ — databases.cfg, sourcebans.cfg, and the optional companion plugins.
+description: Wire up the SourceMod side of SourceBans++. databases.cfg, sourcebans.cfg, and the optional companion plugins.
 sidebar:
   order: 2
 ---
@@ -41,27 +41,27 @@ lists every database any plugin on the server can talk to. Add a
 
 :::caution
 The web panel offers to generate this block for you, but treat it as
-a starting point — review every value before pasting. The panel
+a starting point. Review every value before pasting. The panel
 guesses based on its own config, which is often wrong for game
 servers on a different host.
 
 If the panel and the game server live on **different networks**,
 your DB will also need to allow the game server's IP in the user
-grant — see
+grant. See
 [Database setup → Granting permission](/setup/mariadb/#granting-permission).
 :::
 
 ### `sourcebans.cfg`
 
 `addons/sourcemod/configs/sourcebans/sourcebans.cfg` is the per-server
-config. The single most important field is **`ServerID`** — the
+config. The single most important field is **`ServerID`**: the
 numeric ID the panel assigned when you
 [added the server](/setup/adding-server/). Without a correct
 `ServerID`, bans applied from in-game won't show up against the right
 server in the panel.
 
 The rest of the file controls in-game admin menu behaviour (ban
-durations, default reasons, immunity flags, …). The defaults are
+durations, default reasons, immunity flags, etc.). The defaults are
 sensible; tweak as you go.
 
 After editing either file, **reload the map or restart the game
@@ -74,9 +74,9 @@ is mandatory; the others are opt-in based on what you want:
 
 | Plugin                | What it does | Most installs want it? |
 | --------------------- | ------------ | ---------------------- |
-| `sbpp_main.smx`       | The core. Ban / unban, in-game admin menu, panel write-back. | **Yes** — required. |
+| `sbpp_main.smx`       | The core. Ban / unban, in-game admin menu, panel write-back. | **Yes**, required. |
 | `sbpp_comms.smx`      | Communication blocks (mute / gag). | Yes if you care about voice / text moderation. |
-| `sbpp_checker.smx`    | Re-checks every connecting client against the panel's ban list — catches bans issued while the player was offline. | Yes — closes a real loophole. |
+| `sbpp_checker.smx`    | Re-checks every connecting client against the panel's ban list. Catches bans issued while the player was offline. | Yes. Closes a real loophole. |
 | `sbpp_report.smx`     | In-game `!report` command for players. | Up to you. |
 | `sbpp_sleuth.smx`     | Detects alt accounts by recording IP / SteamID associations. | Useful for larger communities. |
 | `sbpp_admcfg.smx`     | Loads admin / group / override definitions from the panel into SourceMod. Replaces SourceMod's stock `admin-flatfile.smx` and pre-1.6 `sb_admcfg.smx`. | Yes if you want panel-managed admins. |
@@ -104,9 +104,9 @@ After your first ban from in-game (or from the panel), check:
 
 If any of these don't happen:
 
-- **Plugin can't reach the database** — see
+- **Plugin can't reach the database**: see
   [Driver not found](/troubleshooting/could-not-find-driver/).
-- **Database is reachable but queries fail** — see
+- **Database is reachable but queries fail**: see
   [Database errors](/troubleshooting/database-errors/).
-- **Panel doesn't show the server's player list** — see
+- **Panel doesn't show the server's player list**: see
   [Server connection issues](/troubleshooting/debugging-connection/).

--- a/docs/src/content/docs/setup/ports.md
+++ b/docs/src/content/docs/setup/ports.md
@@ -9,22 +9,22 @@ sidebar:
 For the web panel to manage a game server it has to reach two things
 on that server: the **query port** (UDP, to read the map and player
 list) and the **RCON port** (TCP, to push admin commands). On a stock
-Source server those are the same number — usually `27015`.
+Source server those are the same number, usually `27015`.
 
 ## What needs to be open
 
 From the **web panel's perspective**:
 
-- **Outgoing UDP** to each game server's port — the panel sends an
+- **Outgoing UDP** to each game server's port: the panel sends an
   `A2S_INFO` query and waits for the reply.
-- **Outgoing TCP** to each game server's port — the panel opens an
+- **Outgoing TCP** to each game server's port: the panel opens an
   RCON session to push commands.
 
 From the **game server's perspective**:
 
-- **Incoming UDP** on its port — for the panel's query and for
+- **Incoming UDP** on its port: for the panel's query and for
   players joining.
-- **Incoming TCP** on its port — for the panel's RCON connection.
+- **Incoming TCP** on its port: for the panel's RCON connection.
 
 On a typical setup these are all the **same port** (`27015` by
 default), just two different protocols. If your firewall lets you
@@ -46,6 +46,6 @@ If your panel shows the server as offline or with no player list,
 the most common cause is a firewall blocking one of these ports.
 
 The walkthrough is in
-[Server connection issues](/troubleshooting/debugging-connection/) —
-it includes a small `sb_debug_connection.php` tool you can run from
+[Server connection issues](/troubleshooting/debugging-connection/).
+It includes a small `sb_debug_connection.php` tool you can run from
 the panel host to test the UDP and RCON sides independently.

--- a/docs/src/content/docs/sponsor.mdx
+++ b/docs/src/content/docs/sponsor.mdx
@@ -15,25 +15,24 @@ servers and networks.
 Sponsorships fund the work that keeps the panel healthy across
 SourceMod versions, MariaDB and PHP releases, and the long tail of
 Source-engine games people still run today. They also pay for the
-infrastructure that supports development — the docs site, test
+infrastructure that supports development: the docs site, test
 servers used for cross-version compatibility runs, and the time it
-takes to land the modernization work that's been shipping across the
-v2.x line.
+takes to land the modernization work shipping across the v2.x line.
 
 <Sponsors />
 
 ## Where the money goes
 
-- **Maintainer time** — code review, release cuts, security
+- **Maintainer time**: code review, release cuts, security
   triage, and the back-and-forth on `#help-support` in Discord. The
   more sustainable this is, the faster fixes land.
-- **Infrastructure** — the docs site, the screenshot capture stack,
+- **Infrastructure**: the docs site, the screenshot capture stack,
   and the test fleet used to verify panel + plugin builds against
   SourceMod 1.10 / 1.11 / 1.12 and the MariaDB / MySQL versions in
   the wild.
-- **Modernization** — finishing the rolling cleanup that's been
-  landing across the v2.x line (legacy PHP and JS removal, schema
-  hygiene, accessibility, container-friendly deployment).
+- **Modernization**: finishing the rolling cleanup landing across
+  the v2.x line (legacy PHP and JS removal, schema hygiene,
+  accessibility, container-friendly deployment).
 
 ## Other ways to help
 
@@ -41,13 +40,13 @@ Money is one way; there are others. The project always welcomes:
 
 - **Bug reports with reproduction details** on
   [GitHub Issues](https://github.com/sbpp/sourcebans-pp/issues).
-- **Pull requests** — see
+- **Pull requests**: see
   [`CONTRIBUTING.md`](https://github.com/sbpp/sourcebans-pp/blob/main/CONTRIBUTING.md)
   for the guide. PRs that touch the web panel ride a
   [Contributor License Agreement](https://github.com/sbpp/sourcebans-pp/blob/main/CLA.md);
   the CLA bot leaves one-line sign instructions on your first such
   PR.
-- **Translation help** — see
+- **Translation help**: see
   [Translating](/customization/translating/) for the per-locale
   workflow.
 - **Answering questions** in `#help-support` on the
@@ -56,7 +55,7 @@ Money is one way; there are others. The project always welcomes:
   there is.
 
 :::note
-**Game-server hosts and SourceBans++-as-a-feature providers** —
+**Game-server hosts and SourceBans++-as-a-feature providers**:
 production / commercial use of the web panel is covered by a
 separate commercial license. Reach out via the contact link on
 the platform of your choice above or via Discord.

--- a/docs/src/content/docs/troubleshooting/could-not-find-driver.md
+++ b/docs/src/content/docs/troubleshooting/could-not-find-driver.md
@@ -121,5 +121,5 @@ After the fix, restart the relevant service:
 
 If you're still stuck, drop into `#help-support` on our
 [Discord](https://discord.gg/tzqYqmAtF5) with the output of
-`php -m | grep pdo` (web) or `sm exts list` (plugin) — that
+`php -m | grep pdo` (web) or `sm exts list` (plugin). That
 narrows it down quickly.

--- a/docs/src/content/docs/troubleshooting/database-errors.md
+++ b/docs/src/content/docs/troubleshooting/database-errors.md
@@ -1,16 +1,16 @@
 ---
 title: Database errors
-description: Common MySQL / MariaDB errors during install or runtime — and how to fix them.
+description: Common MySQL / MariaDB errors during install or runtime, and how to fix them.
 sidebar:
   order: 3
 ---
 
 The most common database errors SourceBans++ users hit, with the
-fix that usually resolves each. They're ordered roughly by how
-often they show up.
+fix that usually resolves each. Ordered roughly by how often they
+show up.
 
 If the panel reports `Could not find driver` instead of one of the
-errors below, it's not a SQL error — PHP can't load the MySQL driver
+errors below, it's not a SQL error: PHP can't load the MySQL driver
 at all. Jump to [Driver not found](/troubleshooting/could-not-find-driver/).
 
 ## Access denied
@@ -48,7 +48,7 @@ Usually one of:
 - **The TCP port is blocked** by a firewall or port-blocking
   service. The default is `3306`.
 - **Wrong host / port** in `config.php`. `localhost` and `127.0.0.1`
-  are not always equivalent on Unix — `localhost` typically routes
+  are not always equivalent on Unix: `localhost` typically routes
   through a socket file, while `127.0.0.1` uses TCP.
 
 If the panel and database are on the same host, the **socket path**
@@ -70,7 +70,7 @@ almost always it.
 
 More rarely, the **initial connection** times out. If your
 `connect_timeout` is set to only a few seconds, bump it to ten or
-more — useful on slow long-distance connections.
+more. Useful on slow long-distance connections.
 
 ## MySQL server has gone away
 
@@ -119,8 +119,8 @@ https://example.com/updater/
 ```
 
 Watch the output for errors. If a specific migration step fails,
-the page will say which one and why — share that in
-`#help-support` if you can't decipher it.
+the page will say which one and why. Share that in `#help-support`
+if you can't decipher it.
 
 ## Incorrect string value
 
@@ -141,7 +141,7 @@ ALTER TABLE `_bans` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
 -- (etc. for every panel table)
 ```
 
-Back up your database before running these — `CONVERT TO` rewrites
+Back up your database before running these. `CONVERT TO` rewrites
 every row.
 
 ## Anything else

--- a/docs/src/content/docs/troubleshooting/debugging-connection.md
+++ b/docs/src/content/docs/troubleshooting/debugging-connection.md
@@ -6,8 +6,8 @@ sidebar:
   label: Server connection
 ---
 
-When the panel shows a game server as offline — or as online but
-with an empty player list — it can't reach the server's query
+When the panel shows a game server as offline (or as online but
+with an empty player list), it can't reach the server's query
 (UDP) or RCON (TCP) port. This page walks through the checks in
 order, from "is the server actually online?" to "test it with the
 diagnostic tool."
@@ -59,13 +59,13 @@ If everything's wired right, it'll print the server's info (map,
 hostname, player count), the result of the RCON handshake (if you
 filled in a password), and the player list.
 
-If something fails, it'll tell you which step — that maps directly
+If something fails, it'll tell you which step. That maps directly
 to the sections below.
 
 :::caution
 The diagnostic tool exposes server info and (if you filled it in)
 the RCON password. **Delete `sb_debug_connection.php` when you're
-done** — don't leave it on a production install.
+done.** Don't leave it on a production install.
 :::
 
 ## UDP errors
@@ -73,7 +73,7 @@ done** — don't leave it on a production install.
 > The panel can't read server info / player list back from the game
 > server.
 
-UDP is the protocol Source uses for its A2S queries — the panel
+UDP is the protocol Source uses for its A2S queries: the panel
 sends a small "tell me about yourself" packet and waits for the
 reply.
 

--- a/docs/src/content/docs/troubleshooting/panel-not-loading.md
+++ b/docs/src/content/docs/troubleshooting/panel-not-loading.md
@@ -1,14 +1,14 @@
 ---
 title: Panel won't load
-description: The panel hangs, shows a blank page, or doesn't respond — checklist for the usual causes.
+description: The panel hangs, shows a blank page, or doesn't respond. A checklist for the usual causes.
 sidebar:
   order: 1
 ---
 
-If the panel won't paint — blank tab, spinning forever, "this site
-can't be reached", or a half-rendered page that never finishes — the
-cause is almost always one of a small handful of things. This page
-walks through the checks in order from easiest to most involved.
+If the panel won't paint (blank tab, spinning forever, "this site
+can't be reached", or a half-rendered page that never finishes), the
+cause is usually one of a handful of things. This page walks through
+the checks in order from easiest to most involved.
 
 ## 1. Server-level errors (blank white page)
 
@@ -24,13 +24,13 @@ locations:
   log
 - Docker / our dev stack: `./sbpp.sh logs web`
 
-Open the most recent entry. It'll be specific — typically a missing
+Open the most recent entry. It'll be specific: usually a missing
 PHP extension, a syntax error in `config.php`, or a memory-limit hit
 on a heavy page.
 
 If you can't find the log file, set `display_errors = On` in `php.ini`
 **temporarily**, reload the page, and read the error in the browser.
-Set it back to `Off` immediately after — leaving error display on in
+Set it back to `Off` immediately after. Leaving error display on in
 production leaks internal paths and stack traces.
 
 ## 2. Database connection problems
@@ -44,8 +44,8 @@ If PHP loads but reports "could not find driver", see
 ## 3. The page paints but JavaScript doesn't run
 
 If the panel renders content (you see the layout, sidebar, and so
-on) but interactive elements don't respond — buttons don't click,
-modals don't open, the command palette doesn't appear — JavaScript
+on) but interactive elements don't respond (buttons don't click,
+modals don't open, the command palette doesn't appear), JavaScript
 is failing to execute somewhere. Common causes:
 
 ### A reverse proxy is rewriting the JavaScript
@@ -75,7 +75,7 @@ recently added any of these, try disabling them first.
 
 Aggressive ad/script blockers (uBlock Origin with custom rules,
 NoScript, Privacy Badger) can block the panel's own scripts. Open
-the page in a private window with extensions disabled — if it works
+the page in a private window with extensions disabled. If it works
 there, your extension is the cause.
 
 ### The browser cache is stale after an upgrade
@@ -102,7 +102,7 @@ This is rare on a current panel but worth diagnosing:
 6. Click **Save profile** (Firefox) or **Save** (Chrome).
 
 Then drop into our [Discord](https://discord.gg/tzqYqmAtF5)
-`#help-support` channel and share the trace — it'll tell us
+`#help-support` channel and share the trace. It'll tell us
 whether the hang is in our JS, an upstream library, or your
 browser environment.
 

--- a/docs/src/content/docs/updating/1-8-to-2-0.mdx
+++ b/docs/src/content/docs/updating/1-8-to-2-0.mdx
@@ -10,8 +10,8 @@ import { Aside } from '@astrojs/starlight/components';
 SourceBans++ 2.0.0 is a major version bump. This page covers what
 changes between 1.8.x and 2.0.x and the prep work an admin should do
 **before** running the panel updater. The general upgrade flow
-(back up, upload, visit `/updater/`) is the same as any other version —
-see [Updating SourceBans++](/updating/) for that.
+(back up, upload, visit `/updater/`) is the same as any other version.
+See [Updating SourceBans++](/updating/) for that.
 
 The four things to know about the v2.0 upgrade:
 
@@ -34,19 +34,19 @@ v2.0.0 raises the PHP requirement to **8.5** (up from 1.8.x's 8.2)
 and pulls in several new Composer dependencies. A 1.8.x install that
 has a `vendor/` directory left over from a prior `composer install`
 will pass the panel's autoload check but fatal at runtime the first
-time v2.0 code references a class the old `vendor/` doesn't have —
-usually mid-page, with the `Class "…" not found` line buried in your
+time v2.0 code references a class the old `vendor/` doesn't have.
+Usually mid-page, with the `Class "…" not found` line buried in your
 PHP error log.
 
 What's new:
 
-- `php >= 8.5` — **upgrade your host's PHP before uploading the v2.0
+- `php >= 8.5`: **upgrade your host's PHP before uploading the v2.0
   files.** A panel on PHP 8.4 or earlier won't boot.
-- `symfony/mailer ^7.2` — replaced 1.8.x's PHPMailer.
-- `league/commonmark ^2.5` — added so admin-authored Markdown on the
+- `symfony/mailer ^7.2`: replaced 1.8.x's PHPMailer.
+- `league/commonmark ^2.5`: added so admin-authored Markdown on the
   dashboard intro text renders safely.
-- `lcobucci/jwt ^5.0` — major-bumped from 1.8.x.
-- `smarty/smarty ^v5.4` — major-bumped from 1.8.x.
+- `lcobucci/jwt ^5.0`: major-bumped from 1.8.x.
+- `smarty/smarty ^v5.4`: major-bumped from 1.8.x.
 
 ### Tarball install (the easy path)
 
@@ -70,7 +70,7 @@ state without losing data.
 
 ## Theme reset
 
-v2.0.0 is a complete chrome rewrite — new typed View DTOs, new admin
+v2.0.0 is a complete chrome rewrite: new typed View DTOs, new admin
 sidebar layout, every template signature changed, MooTools and xajax
 are gone, the `openTab()` JS helper is deleted. A fork theme
 inherited from a 1.8.x install **does not have the templates v2.0
@@ -86,7 +86,7 @@ If you maintain a fork theme:
 
 1. After upgrading, the panel will be on `default`.
 
-2. Port your fork against the v2.0 default theme — diff
+2. Port your fork against the v2.0 default theme. Diff
    `web/themes/default/` between the 1.8.x and 2.0 trees to see what
    changed. The new conventions live in
    [`AGENTS.md`](https://github.com/sbpp/sourcebans-pp/blob/main/AGENTS.md)
@@ -96,12 +96,12 @@ If you maintain a fork theme:
 
 3. Once your fork ships v2.0-shaped templates, re-select it from
    **Admin Panel → Settings → Themes**. The DB-side reset is a
-   one-shot at upgrade time — the panel won't flip back to `default`
+   one-shot at upgrade time. The panel won't flip back to `default`
    on its own.
 
-Your fork directory under `web/themes/<fork>/` is left in place —
+Your fork directory under `web/themes/<fork>/` is left in place;
 only the `:prefix_settings.config.theme` row is rewritten. Your work
-isn't lost; the panel just stops trying to render against templates
+isn't lost. The panel just stops trying to render against templates
 that don't exist (yet).
 
 ## Anonymous telemetry
@@ -116,14 +116,14 @@ Once per day per install, the panel sends an anonymous JSON payload
 to a SourceBans++ Cloudflare Worker. The payload covers four
 categories:
 
-- **panel** — version, short git SHA, dev flag, theme name (only
-  `default` or `custom` is reported — fork theme **names are never
+- **panel**: version, short git SHA, dev flag, theme name (only
+  `default` or `custom` is reported; fork theme **names are never
   sent**).
-- **env** — PHP `major.minor`, DB engine + `major.minor`, web server
+- **env**: PHP `major.minor`, DB engine + `major.minor`, web server
   family, OS family.
-- **scale** — counts of admins, enabled servers, active and total
+- **scale**: counts of admins, enabled servers, active and total
   bans / comm blocks, 30-day submission / protest counts.
-- **features** — every checkbox under
+- **features**: every checkbox under
   **Admin Panel → Settings → Features**, plus three derived booleans:
   SMTP-configured, Steam API key set, GeoIP DB present.
 
@@ -164,8 +164,8 @@ WHERE setting = 'telemetry.endpoint';
 
 Setting the value to the empty string disables network calls
 without flipping the user-facing toggle. There's no UI for this
-knob — it's a debug / escape-hatch surface. The Worker source lives
-at [sbpp/cf-analytics](https://github.com/sbpp/cf-analytics) for
+knob; it's a debug escape hatch. The Worker source lives at
+[sbpp/cf-analytics](https://github.com/sbpp/cf-analytics) for
 operators who want to inspect or fork the collector.
 
 ### Performance impact
@@ -177,8 +177,8 @@ On PHP-FPM, `fastcgi_finish_request()` closes the user's TCP
 socket **before** the cURL POST runs, so a panel response time of
 N ms remains N ms regardless of telemetry. The cURL call has
 3-second connect / 5-second total timeouts and is silent on
-failure — telemetry can never hard-fail a panel page or a JSON
-API request.
+failure. Telemetry can never hard-fail a panel page or a JSON API
+request.
 
 ## Project announcements feed
 
@@ -192,18 +192,17 @@ panels. Anonymous viewers and non-admin users never see the strip.
 
 This is a **second always-on outbound channel** in addition to
 telemetry. Like telemetry, it ships on by default and is
-opt-out-by-config. The two channels are intentionally separate:
-telemetry is a write-only push (panel → collector), announcements
-is a read-only pull (panel ← static JSON). Neither can affect the
-other; opting out of one leaves the other running.
+opt-out-by-config. The two channels are separate: telemetry is a
+write-only push (panel → collector), announcements is a read-only
+pull (panel ← static JSON). Neither can affect the other; opting
+out of one leaves the other running.
 
 ### What's sent
 
 The GET request carries:
 
-- `User-Agent: SourceBans++/<version> (announcements)` — same
-  shape as the existing `system.check_version` release-check
-  fetch.
+- `User-Agent: SourceBans++/<version> (announcements)`: same shape
+  as the existing `system.check_version` release-check fetch.
 - Standard HTTP headers added by PHP's stream wrapper.
 
 Specifically **not** sent:
@@ -243,5 +242,5 @@ The announcements tick runs in `register_shutdown_function`.
 the upstream fetch runs, so the user-perceived response time
 is unaffected. The fetch has a 5-second total timeout, a 256 KiB
 hard cap on the response body, stale-while-error caching, and
-is silent on failure — a flapping `sbpp.github.io` can never
+is silent on failure. A flapping `sbpp.github.io` can never
 hard-fail a panel page.

--- a/docs/src/content/docs/updating/index.md
+++ b/docs/src/content/docs/updating/index.md
@@ -1,6 +1,6 @@
 ---
 title: Updating SourceBans++
-description: Safely upgrade an existing SourceBans++ install — web panel and plugin.
+description: Safely upgrade an existing SourceBans++ install. Web panel and plugin.
 sidebar:
   order: 1
 ---
@@ -11,7 +11,7 @@ This page covers the safe upgrade path for both halves.
 
 :::tip
 Upgrading from **1.8.x to 2.0.x**? Read
-[Upgrading from 1.8.x to 2.0.x](/updating/1-8-to-2-0/) first — v2.0
+[Upgrading from 1.8.x to 2.0.x](/updating/1-8-to-2-0/) first. v2.0
 raises the PHP version floor, resets the active theme, and ships
 default-on anonymous telemetry.
 :::
@@ -66,7 +66,7 @@ want the `sourcebans-pp-X.Y.Z.webpanel-only.zip` for the web side and
 
 :::caution
 Leaving `install/` or `updater/` accessible after an upgrade is a
-foot-gun — anyone who can reach the panel can re-run them. The
+foot-gun: anyone who can reach the panel can re-run them. The
 panel guards against `install/` automatically; the `updater/`
 directory has no such guard, so it's on you to remove it.
 :::
@@ -77,7 +77,7 @@ directory has no such guard, so it's on you to remove it.
    to your game server's root.
 
 2. **Review the plugin config files** at
-   `addons/sourcemod/configs/sourcebans/` — new versions sometimes
+   `addons/sourcemod/configs/sourcebans/`. New versions sometimes
    add new options. Defaults are sensible if you don't touch them.
 
 3. **Reload the map or restart the game server** so SourceMod picks
@@ -90,7 +90,7 @@ directory has no such guard, so it's on you to remove it.
 
 ### Upgrading from 1.8.x to 2.0.x
 
-The biggest jump SourceBans++ has shipped — PHP 8.5 requirement,
+The biggest jump SourceBans++ has shipped: PHP 8.5 requirement,
 chrome rewrite, default-on telemetry. The full breakdown lives in
 [Upgrading from 1.8.x to 2.0.x](/updating/1-8-to-2-0/).
 
@@ -108,9 +108,9 @@ need that value generated before they can log in.
 3. **Set the JWT signing secret by hand.** SourceBans++ 1.7 moved the
    panel's session-signing key into `config.php` as `SB_SECRET_KEY`.
    Older releases shipped an `upgrade.php` helper that wrote it for
-   you, but it was removed in 2.0
-   ([#903](https://github.com/sbpp/sourcebans-pp/issues/903)) because
-   of a security issue — set the value manually instead.
+   you, but it was removed in 2.0 for security reasons
+   ([#903](https://github.com/sbpp/sourcebans-pp/issues/903)). Set
+   the value manually instead.
 
    Skip the rest of this step if your existing `config.php` already
    contains a `define('SB_SECRET_KEY', '…')` line (anyone who ran
@@ -156,7 +156,7 @@ cleanly.
 
 If you're on an install older than 1.6.x and the pages above don't
 cover your starting point, drop into our
-[Discord](https://discord.gg/tzqYqmAtF5) `#help-support` channel —
+[Discord](https://discord.gg/tzqYqmAtF5) `#help-support` channel and
 we'll walk you through it.
 
 ## After the upgrade
@@ -179,9 +179,9 @@ A quick smoke test once everything's uploaded:
 
 If anything looks off, the most useful starting points are:
 
-- [Panel not loading](/troubleshooting/panel-not-loading/) — blank
+- [Panel not loading](/troubleshooting/panel-not-loading/): blank
   page or hanging tab after upgrade.
-- [Database errors](/troubleshooting/database-errors/) — if the
+- [Database errors](/troubleshooting/database-errors/): if the
   panel reports a SQL or table error.
-- [Driver not found](/troubleshooting/could-not-find-driver/) — if
+- [Driver not found](/troubleshooting/could-not-find-driver/): if
   the plugin can't talk to the DB after the plugin upgrade.

--- a/web/themes/default/box_admin_bans_search.tpl
+++ b/web/themes/default/box_admin_bans_search.tpl
@@ -77,7 +77,7 @@
     <div class="card__header">
         <div>
             <h3>Advanced search</h3>
-            <p>Each row is its own search criterion &mdash; the &laquo;Search&raquo; button on the right submits using just that row's value.</p>
+            <p>Each row is its own search criterion. The &laquo;Search&raquo; button on the right submits using just that row's value.</p>
         </div>
     </div>
 

--- a/web/themes/default/box_admin_comms_search.tpl
+++ b/web/themes/default/box_admin_comms_search.tpl
@@ -74,7 +74,7 @@
     <div class="card__header">
         <div>
             <h3>Advanced search</h3>
-            <p>Each row is its own search criterion &mdash; the &laquo;Search&raquo; button on the right submits using just that row's value.</p>
+            <p>Each row is its own search criterion. The &laquo;Search&raquo; button on the right submits using just that row's value.</p>
         </div>
     </div>
 

--- a/web/themes/default/install/page_admin.tpl
+++ b/web/themes/default/install/page_admin.tpl
@@ -6,9 +6,9 @@
 {include file="install/_chrome.tpl"}
 
 <p class="lead">
-    Create the first administrator account. This account has the
-    <strong>Owner</strong> permission flag &mdash; it can do
-    everything in the panel, including creating other admins.
+    Create the first administrator account. This account gets the
+    <strong>Owner</strong> permission flag, which can do everything in
+    the panel, including creating other admins.
 </p>
 
 {if $error !== ''}

--- a/web/themes/default/install/page_database.tpl
+++ b/web/themes/default/install/page_database.tpl
@@ -6,10 +6,9 @@
 {include file="install/_chrome.tpl"}
 
 <p class="lead">
-    Tell the wizard how to reach your MySQL or MariaDB database.
-    Create the database first via your hosting control panel
-    (phpMyAdmin, cPanel "MySQL Databases", &hellip;), then come back
-    here with the credentials.
+    Enter your MySQL or MariaDB connection details. Create the database
+    first in your hosting control panel (phpMyAdmin, cPanel "MySQL
+    Databases"), then come back here with the credentials.
 </p>
 
 {if $error !== ''}
@@ -91,7 +90,7 @@
                        value="{$val_database}"
                        data-testid="install-database-database"
                        required>
-                <p class="text-xs text-muted">Must already exist &mdash; the wizard fills it.</p>
+                <p class="text-xs text-muted">Must already exist. The wizard fills it.</p>
             </div>
 
             <div>
@@ -111,7 +110,7 @@
     </div>
 
     <div class="install-section">
-        <h2>Optional &mdash; Steam &amp; admin email</h2>
+        <h2>Optional: Steam &amp; admin email</h2>
         <div class="install-grid">
             <div>
                 <label class="label" for="install-database-apikey">Steam API key</label>
@@ -122,11 +121,11 @@
                        value="{$val_apikey}"
                        data-testid="install-database-apikey">
                 <p class="text-xs text-muted">
-                    Powers profile lookups + the Steam OpenID login.
-                    Get one from
+                    Used for Steam profile lookups and OpenID login. Get
+                    one from
                     <a href="https://steamcommunity.com/dev/apikey"
                        target="_blank" rel="noopener">steamcommunity.com</a>.
-                    Can be added later in <em>Admin &rarr; Settings</em>.
+                    Optional, can be added later in <em>Admin &rarr; Settings</em>.
                 </p>
             </div>
 
@@ -139,8 +138,7 @@
                        value="{$val_email}"
                        data-testid="install-database-email">
                 <p class="text-xs text-muted">
-                    Sender address for password resets and ban
-                    notifications. Can be configured later.
+                    Sender address for password resets and ban notifications. Optional.
                 </p>
             </div>
         </div>

--- a/web/themes/default/install/page_done.tpl
+++ b/web/themes/default/install/page_done.tpl
@@ -43,10 +43,9 @@
              role="status"
              data-testid="install-done-local-warning"
              style="margin-top:0.75rem">
-            <strong>Heads up:</strong> you used <code>localhost</code>
-            for the database host. That's fine for the panel itself,
-            but gameservers on a different machine need a hostname or
-            IP they can route to &mdash; update the
+            You used <code>localhost</code> for the database host. That
+            works for the panel, but gameservers on another machine
+            need a routable hostname or IP. Update the
             <code>"host"</code> value above for those.
         </div>
     {/if}
@@ -69,11 +68,10 @@
 {/if}
 
 <div class="install-section">
-    <h2>{if $config_writable}3{else}4{/if}. Optional &mdash; import AMXBans</h2>
+    <h2>{if $config_writable}3{else}4{/if}. Optional: import AMXBans</h2>
     <p>
-        If you're migrating from AMXBans, the next step copies your
-        existing bans into SourceBans++. You can also skip this and
-        log in now.
+        Migrating from AMXBans? The next step copies your existing bans
+        into SourceBans++. Skip it to log in now.
     </p>
 </div>
 

--- a/web/themes/default/install/page_handoff.tpl
+++ b/web/themes/default/install/page_handoff.tpl
@@ -28,7 +28,7 @@
 
             <noscript>
                 <p class="text-sm text-muted" style="margin-bottom:1rem">
-                    JavaScript is disabled &mdash; click the button to continue.
+                    JavaScript is disabled. Click the button to continue.
                 </p>
             </noscript>
 

--- a/web/themes/default/install/page_license.tpl
+++ b/web/themes/default/install/page_license.tpl
@@ -6,9 +6,8 @@
 {include file="install/_chrome.tpl"}
 
 <p class="lead">
-    To use this web panel you have to read and accept the license
-    below. If you don't agree, you can't install the panel.
-    A plain-language explanation of the license lives at
+    You need to accept the license below to install the panel.
+    A plain-language summary is at
     <a href="https://creativecommons.org/licenses/by-nc-sa/3.0/"
        target="_blank" rel="noopener">creativecommons.org</a>.
 </p>
@@ -17,7 +16,7 @@
     <div class="card__header">
         <div>
             <h2 style="margin:0;font-size:0.95rem;font-weight:600">
-                Creative Commons &mdash; Attribution-NonCommercial-ShareAlike 3.0
+                Creative Commons Attribution-NonCommercial-ShareAlike 3.0
             </h2>
         </div>
     </div>

--- a/web/themes/default/install/page_requirements.tpl
+++ b/web/themes/default/install/page_requirements.tpl
@@ -6,15 +6,15 @@
 {include file="install/_chrome.tpl"}
 
 <p class="lead">
-    Quick environment check before we touch your database.
+    Environment check before we touch your database.
     {if $errors > 0}
         <strong>{$errors} blocking issue{if $errors != 1}s{/if}</strong>
         must be fixed before continuing.
     {elseif $warnings > 0}
-        <strong>{$warnings} warning{if $warnings != 1}s{/if}</strong>
-        &mdash; you can continue, but some features may not work.
+        <strong>{$warnings} warning{if $warnings != 1}s{/if}</strong>.
+        You can continue, but some features may not work.
     {else}
-        Everything looks good!
+        Everything looks good.
     {/if}
 </p>
 

--- a/web/themes/default/install/page_schema.tpl
+++ b/web/themes/default/install/page_schema.tpl
@@ -14,9 +14,8 @@
     <div class="install-alert install-alert--ok"
          role="status"
          data-testid="install-schema-success">
-        Created <strong>{$tables_created}</strong> table{if $tables_created != 1}s{/if}
-        successfully. Continue to the next step to create your admin
-        account.
+        Created <strong>{$tables_created}</strong> table{if $tables_created != 1}s{/if}.
+        Continue to create your admin account.
     </div>
 {else}
     <div class="install-alert install-alert--error"
@@ -24,9 +23,8 @@
          data-testid="install-schema-error">
         <strong>Schema creation failed.</strong>
         {$errors_text}
-        Go back to the database step and double-check the credentials
-        + permissions for your DB user (it needs CREATE / ALTER /
-        INDEX / INSERT).
+        Go back to the database step and check the DB user's
+        credentials and permissions (CREATE, ALTER, INDEX, INSERT).
     </div>
 {/if}
 

--- a/web/themes/default/page_admin_admins_list.tpl
+++ b/web/themes/default/page_admin_admins_list.tpl
@@ -201,7 +201,7 @@
         <form method="dialog" data-testid="admins-delete-form">
             <h2 id="admins-delete-dialog-title" style="font-size:var(--fs-lg);font-weight:600;margin:0 0 0.25rem">Delete admin</h2>
             <p class="text-sm text-muted m-0" style="margin-bottom:0.75rem">
-                You're about to permanently delete <strong data-testid="admins-delete-target">this admin</strong>. This cannot be undone &mdash; their server access is revoked immediately and any rehash queue is flushed.
+                You're about to permanently delete <strong data-testid="admins-delete-target">this admin</strong>. This cannot be undone. Their server access is revoked immediately and any rehash queue is flushed.
             </p>
             <label class="label" for="admins-delete-reason">Reason (optional)</label>
             {* aria-required (not the native `required`) parity with the

--- a/web/themes/default/page_admin_mods_list.tpl
+++ b/web/themes/default/page_admin_mods_list.tpl
@@ -175,7 +175,7 @@
         <form method="dialog" data-testid="mod-delete-form">
             <h2 id="mod-delete-dialog-title" style="font-size:var(--fs-lg);font-weight:600;margin:0 0 0.25rem">Delete mod</h2>
             <p class="text-sm text-muted m-0" style="margin-bottom:0.75rem">
-                You're about to permanently delete <strong data-testid="mod-delete-target">this mod</strong>. This cannot be undone &mdash; historical bans + comm blocks that were recorded against this mod will keep their rows but their game-association becomes orphaned (the banlist will read &ldquo;Unknown&rdquo; in the Server / Mod column for those entries).
+                You're about to permanently delete <strong data-testid="mod-delete-target">this mod</strong>. This cannot be undone. Historical bans and comm blocks recorded against this mod keep their rows but lose their game association, so the banlist will show &ldquo;Unknown&rdquo; in the Server / Mod column for those entries.
             </p>
             <label class="label" for="mod-delete-reason">Reason (optional)</label>
             {* aria-required (not the native `required`) parity with the

--- a/web/themes/default/page_admin_settings_features.tpl
+++ b/web/themes/default/page_admin_settings_features.tpl
@@ -201,23 +201,9 @@
                                     <span class="text-sm font-medium">Anonymous telemetry</span>
                                 </label>
                                 <p class="settings-fieldset__help" id="telemetry_enabled_help" data-testid="setting-help-telemetry.enabled">
-                                    Sends one anonymous ping per day to a SourceBans++ collector
-                                    so maintainers can see what versions, environments, and feature
-                                    toggles are in real-world use. The payload covers four categories:
-                                    panel (version, git SHA, dev flag, theme — <code>default</code> or
-                                    <code>custom</code>); environment (PHP <code>major.minor</code>,
-                                    DB engine + <code>major.minor</code>, web server family, OS family);
-                                    scale (counts of admins, enabled servers, active and total bans /
-                                    comms, and 30-day submissions / protests); and feature toggles
-                                    (every checkbox above plus SMTP-configured / Steam-API-key-set /
-                                    GeoIP-present yes/no). A random per-install ID is included so
-                                    pings can be deduplicated; <strong>no</strong> hostnames, IPs,
-                                    admin names, SteamIDs, or ban reasons are ever sent.
-                                    <a href="https://sbpp.github.io/updating/1.8-to-2.0/#telemetry" target="_blank" rel="noopener noreferrer">
-                                        Read more on the docs site
-                                    </a>.
-                                    Disabling clears the random ID, so re-enabling later issues
-                                    a fresh one.
+                                    Sends one anonymous ping per day with panel version, PHP / DB / OS family, counts (admins, servers, bans, comms, 30-day submissions / protests), and which features are turned on. <strong>No</strong> hostnames, IPs, admin names, SteamIDs, or ban reasons are sent. A random install ID is included so pings can be deduplicated.
+                                    <a href="https://sbpp.github.io/updating/1.8-to-2.0/#telemetry" target="_blank" rel="noopener noreferrer">See the full payload</a>.
+                                    Disabling clears the random ID; turning it back on issues a fresh one.
                                 </p>
                             </div>
                         </div>

--- a/web/themes/default/page_admin_settings_settings.tpl
+++ b/web/themes/default/page_admin_settings_settings.tpl
@@ -110,7 +110,7 @@
                                 <p class="settings-fieldset__help"
                                    id="template_logo_help"
                                    data-testid="setting-help-template.logo">
-                                    Path to the brand mark image rendered in the sidebar and sign-in card, resolved relative to the active theme directory (<code class="font-mono">themes/&lt;theme&gt;/</code>). Default: <code class="font-mono">images/favicon.svg</code> &mdash; the SourceBans++ shield from the favicon set. Any theme-relative SVG / PNG works; <code class="font-mono">logos/sbpp_logo.png</code> ships as a 512&times;512 PNG render of the same shield for installs that need a raster brand mark.
+                                    Path to the sidebar and sign-in logo, relative to the theme directory (<code class="font-mono">themes/&lt;theme&gt;/</code>). Defaults to <code class="font-mono">images/favicon.svg</code>. A 512&times;512 raster version sits at <code class="font-mono">logos/sbpp_logo.png</code>.
                                 </p>
                             </div>
                             <div data-testid="setting-row" data-key="config.password.minlength">

--- a/web/themes/default/page_comms.tpl
+++ b/web/themes/default/page_comms.tpl
@@ -405,7 +405,7 @@
                                     <i data-lucide="search-x" style="width:18px;height:18px"></i>
                                 </span>
                                 <h2 class="empty-state__title">No comm blocks match those filters</h2>
-                                <p class="empty-state__body">Try a different search term, server, or time range &mdash; or clear the active filters to see every recorded mute / gag.</p>
+                                <p class="empty-state__body">Try a different search term, server, or time range, or clear the active filters to see every recorded mute / gag.</p>
                                 <div class="empty-state__actions">
                                     <a class="btn btn--secondary btn--sm"
                                        href="?p=commslist"

--- a/web/themes/default/page_submitban.tpl
+++ b/web/themes/default/page_submitban.tpl
@@ -31,8 +31,7 @@
     <header class="mb-6">
         <h1 style="font-size:var(--fs-2xl);font-weight:600;margin:0">Submit a ban request</h1>
         <p class="text-sm text-muted m-0 mt-2">
-            Report a player for cheating, harassment, or other rule violations. Fill in as much detail as
-            you can &mdash; demos and screenshots help admins act faster.
+            Report a player for cheating, harassment, or other rule violations. Demos and screenshots help admins act faster.
         </p>
     </header>
 
@@ -172,8 +171,7 @@
                           aria-describedby="submitban-reason-help"
                           data-testid="submitban-reason">{$ban_reason}</textarea>
                 <p id="submitban-reason-help" class="text-xs text-muted m-0 mt-2">
-                    Be specific. &ldquo;hacking&rdquo; is not enough &mdash; describe what you saw,
-                    when, and on which server.
+                    Be specific. &ldquo;hacking&rdquo; is not enough. Describe what you saw, when, and on which server.
                 </p>
             </div>
         </div>


### PR DESCRIPTION
## Summary

Sweep through the user-facing docs (Starlight site + README) and the
panel templates that installers / admins read, replacing em-dashed
asides, redundant qualifiers, and over-explained paragraphs with
plain sentences. No behavior changes, no testid / Smarty / PHP
edits — text-only audit.

**Marquee case.** The `template.logo` setting help text was four
sentences explaining what a brand-mark image is and what the SVG +
PNG fallbacks look like. Trimmed to one line that says where the
path is resolved from and where the raster fallback lives:

> Path to the sidebar and sign-in logo, relative to the theme directory (`themes/<theme>/`). Defaults to `images/favicon.svg`. A 512×512 raster version sits at `logos/sbpp_logo.png`.

That replaced:

> Path to the brand mark image rendered in the sidebar and sign-in card, resolved relative to the active theme directory (`themes/<theme>/`). Default: `images/favicon.svg` — the SourceBans++ shield from the favicon set. Any theme-relative SVG / PNG works; `logos/sbpp_logo.png` ships as a 512×512 PNG render of the same shield for installs that need a raster brand mark.

## Surfaces touched

**Panel templates** (`web/themes/default/`):

- `install/page_{admin,database,done,handoff,license,requirements,schema}.tpl` — every wizard step's lead paragraph + several help texts.
- `page_admin_settings_features.tpl` — `telemetry.enabled` help collapsed to one sentence + "See the full payload" link.
- `page_admin_settings_settings.tpl` — `template.logo` rewrite (marquee case).
- `page_admin_{admins,mods}_list.tpl` — delete-confirm dialogs.
- `box_admin_{bans,comms}_search.tpl` — advanced-search lead.
- `page_comms.tpl` — filtered empty-state body.
- `page_submitban.tpl` — public submission lead + reason help.

**Docs site** (`docs/src/content/docs/`):

- `index.mdx`, `getting-started/*`, `setup/*`, `customization/*`, `integrations/discord-forward-setup.md`, `troubleshooting/*`, `updating/*`, `faq/index.md`, `configuring/announcements.mdx`, `sponsor.mdx`.
- `README.md` (project root).

The pattern across the diff: em-dashed continuations become periods
(or colons in list items), "Heads up:" / "Read more on the docs site"
become inline links or get dropped, and several "X — Y, …" structures
become "X. Y." or "X (Y)." A few longer paragraphs that re-stated
what the surrounding context already implied were collapsed to a
single sentence.

## Test plan

- [x] `npm run build` in `docs/` clean.
- [x] `npm run check` (Astro type check) clean in `docs/`.
- [x] Grepped `web/tests/` for the original verbose phrases; no test
      asserts against any of the touched copy.
- [x] Only template / docs content modified — no PHP / Smarty tag /
      `data-testid` / `aria-*` / link target edits, so unit + e2e
      coverage is unaffected.