### PR TITLE
fix(1438): paint chromeless `<head>` surfaces in dark mode on first paint

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1469,48 +1469,128 @@ first paint lands in the user's chosen mode.
 
 The contract:
 
-- The bootloader lives in `web/themes/default/core/header.tpl`
-  inside `<head>`, immediately above the stylesheet link. The
-  script is parser-blocking + synchronous, so the class is
-  guaranteed to be set before `<body>` parses regardless of where
-  in `<head>` it lives, but pinning it just above the stylesheet
-  makes the "this resolves the CSS cascade" intent obvious.
+- The bootloader lives in five template surfaces today (#1367 +
+ #1438): `web/themes/default/core/header.tpl` (the panel chrome's
+ `<head>`, every `index.php?p=…` render); `page_kickit.tpl` and
+ `page_blockit.tpl` (the two iframe-routed surfaces under
+ `pages/admin.kickit.php` / `pages/admin.blockit.php` that ship
+ their own self-contained `<head>` rather than riding the chrome);
+ `page_uploadfile.tpl` (the popup window opened by
+ `pages/admin.upload{demo,icon,mapimg}.php` via `window.open(...)`
+ from a dark-mode-aware parent admin page); and `updater.tpl` (the
+ standalone wizard rendered by `web/updater/index.php` on every
+ panel upgrade — logged-in admin context, body uses
+ `background:var(--bg-page);color:var(--text)` directly). All five
+ positions place the script inside `<head>` immediately above the
+ stylesheet link. The script is parser-blocking + synchronous, so
+ the class is guaranteed to be set before `<body>` parses
+ regardless of where in `<head>` it lives, but pinning it just
+ above the stylesheet makes the "this resolves the CSS cascade"
+ intent obvious.
+- The iframe-routed surfaces are reachable two ways: as `<iframe
+ src="pages/admin.kickit.php?…">` embedded inside the post-Ban /
+ post-Block success dialogs (legacy `sb.message.show` chrome on
+ the default theme), AND as TOP-LEVEL navigations from the public
+ Servers page's right-click context menu's "Kick player" item
+ (`web/scripts/server-context-menu.js` builds the href directly
+ to `pages/admin.kickit.php?check=…`). The latter is the
+ user-reported #1438 path: a dark-mode operator right-clicks a
+ player → picks Kick → the browser navigates to the chromeless
+ kickit template rendered as a full-page document → without the
+ bootloader the page paints stark white because `<html>` never
+ gets the `dark` class. The blockit iframe is `display:none` in
+ `page_admin_comms_add.tpl` today (operator never sees it), so
+ the dark-mode bug doesn't visibly affect blockit — but it ships
+ the bootloader for parity so a future "make blockit visible" or
+ "add a Block context menu item that navigates directly to
+ blockit" doesn't silently regress.
 - The script is a self-contained IIFE wrapped in `try/catch`:
-  `localStorage` throws on private-mode iframes / SecurityError,
-  and `matchMedia` is missing on very old browsers. In either
-  failure mode the bootloader silently falls through to light
-  (matching `theme.js`'s defensiveness).
+ `localStorage` throws on private-mode iframes / SecurityError,
+ and `matchMedia` is missing on very old browsers. In either
+ failure mode the bootloader silently falls through to light
+ (matching `theme.js`'s defensiveness).
 - The bootloader does NOT write to `localStorage` — `theme.js`
-  still owns persistence (its boot-time `applyTheme()` writes the
-  resolved mode back). The bootloader is read-only on the
-  persisted state.
+ still owns persistence (its boot-time `applyTheme()` writes the
+ resolved mode back). The bootloader is read-only on the
+ persisted state. The iframe templates DON'T load `theme.js` at
+ all (they only pull `api-contract.js` / `sb.js` / `api.js` —
+ the JSON dispatcher surface), so the bootloader IS the entire
+ theme-resolution path on those pages; the user's persisted
+ preference is read-only there and the chrome-side preference
+ write (via theme.js's boot or the toggle click) is what feeds
+ the iframe's read.
 - The bootloader uses `var` (not `let`/`const`) and avoids
-  optional chaining / nullish coalescing. The script runs in the
-  earliest realm setup phase; any syntax error means the whole
-  body would paint in light first. Strict ES5 keeps the surface
-  area defensive (theme.js itself uses ES6+, but theme.js failing
-  is recoverable — the bootloader failing is the FOUC bug).
-- Logic must stay byte-equivalent to `applyTheme(currentTheme())`
-  in `theme.js` minus the `localStorage.setItem(...)` write. If
-  `theme.js` ever changes the resolution rule (e.g., adds a
-  `'high-contrast'` mode), the bootloader has to mirror the
-  change in the same PR or the first paint silently desyncs from
-  the user's persisted preference.
+ optional chaining / nullish coalescing. The script runs in the
+ earliest realm setup phase; any syntax error means the whole
+ body would paint in light first. Strict ES5 keeps the surface
+ area defensive (theme.js itself uses ES6+, but theme.js failing
+ is recoverable — the bootloader failing is the FOUC bug).
+- Logic must stay SEMANTICALLY equivalent to
+ `applyTheme(currentTheme())` in `theme.js` (minus the
+ `localStorage.setItem(...)` write — theme.js owns persistence),
+ AND BYTE-equivalent across all five bootloader copies (after
+ whitespace normalization). The "semantically equivalent" part
+ carries the bootloader's three intentional defensive deltas vs
+ theme.js: it adds a `window.matchMedia &&` null check, the
+ outer `try/catch` swallows both `localStorage` and `matchMedia`
+ errors, and it uses `var`/no optional chaining for ES5-strict
+ parser tolerance. The "byte-equivalent across copies" part is
+ enforced by `IframeChromeAntiFoucBootloaderTest`'s
+ `testBootloaderBodiesAreEquivalentAfterNormalization` —
+ whitespace is normalized, but everything else must match
+ byte-for-byte. If `theme.js` ever changes the resolution rule
+ (e.g., adds a `'high-contrast'` mode), all five bootloader
+ copies have to mirror the change in the same PR or the first
+ paint silently desyncs from the user's persisted preference,
+ AND two sibling pages painted from the same `<a>`-click resolve
+ different themes on first paint.
 
-Regression guard: `web/tests/e2e/specs/flows/theme-fouc.spec.ts`.
-The spec uses `page.route` to intercept and STALL the `theme.js`
-network request, then asserts the state of `<html>`'s class list
-WHILE theme.js is held — i.e. the bootloader is the only thing
-that could have set the class. The contract: dark-pinned mode
-must read `class="dark"`, light-pinned mode must NOT, and system
-+ emulated OS-dark (via `colorScheme: 'dark'` on a fresh
-`chromium.newContext()`) must read `class="dark"` via the
-matchMedia branch. Releasing the route then lets theme.js boot
-normally so the post-load shape is asserted too. This is the
-only Playwright-tractable way to prove "the bootloader did it,
-not theme.js" — checking `readyState === 'loading'` was tried
-and fails because `addInitScript` runs before
-`document.documentElement` exists.
+Regression guards (two halves):
+
+- `web/tests/e2e/specs/flows/theme-fouc.spec.ts` covers the
+ chrome bootloader (`core/header.tpl`). The spec uses
+ `page.route` to intercept and STALL the `theme.js` network
+ request, then asserts the state of `<html>`'s class list WHILE
+ theme.js is held — i.e. the bootloader is the only thing that
+ could have set the class. The contract: dark-pinned mode must
+ read `class="dark"`, light-pinned mode must NOT, and system +
+ emulated OS-dark (via `colorScheme: 'dark'` on a fresh
+ `chromium.newContext()`) must read `class="dark"` via the
+ matchMedia branch. Releasing the route then lets theme.js boot
+ normally so the post-load shape is asserted too. This is the
+ only Playwright-tractable way to prove "the bootloader did it,
+ not theme.js" — checking `readyState === 'loading'` was tried
+ and fails because `addInitScript` runs before
+ `document.documentElement` exists.
+- `web/tests/e2e/specs/flows/iframe-anti-fouc.spec.ts` (#1438)
+ covers the kickit + blockit iframe templates. Simpler shape
+ because neither template loads `theme.js` — there's no
+ parallel path that could set the class, so a plain
+ `page.goto(KICKIT_URL)` + `toHaveClass(/dark/)` is sufficient.
+ The same three branches (dark / light / system-with-OS-dark)
+ are exercised, plus a blockit-parity branch so the two
+ templates stay in lockstep.
+- `web/tests/integration/IframeChromeAntiFoucBootloaderTest.php`
+ (#1438) is the static-grep gate. It asserts every required
+ bootloader fragment (`localStorage.getItem('sbpp-theme')`,
+ `|| 'system'`, `matchMedia('(prefers-color-scheme: dark)').matches`,
+ `document.documentElement.classList.add('dark')`) appears in
+ all five template files (`core/header.tpl`, `page_kickit.tpl`,
+ `page_blockit.tpl`, `page_uploadfile.tpl`, `updater.tpl`),
+ that the bootloader precedes `<link rel="stylesheet">` in each
+ (so a slow stylesheet response can't push the class-flip behind
+ first paint), that the bootloader bodies are byte-equivalent
+ across all five copies after whitespace normalization (so an
+ edit that updates only one copy's resolution logic fails the
+ gate — drift between copies means a user navigating between
+ sibling pages sees the theme flicker mid-flow), and —
+ defensively — that NO `*.tpl` file under `web/themes/default/install/`
+ carries the bootloader (the documented exemption below — the
+ install wizard runs against an unconfigured panel with no
+ `localStorage` to read). Catches drift edits that update one
+ bootloader copy and forget the others, OR "let's mirror the panel
+ chrome" sweeps that try to add the bootloader to the wizard
+ without also adding a paired theme toggle.
 
 The install wizard (`web/install/_chrome.tpl`) does NOT carry the
 bootloader. It runs against an unconfigured panel with no
@@ -2518,43 +2598,91 @@ contacting every contributor individually.
  default `none`). Same shape applies to any new skeleton surface:
  reuse the `.skel` class from `theme.css`; don't roll a new
  `.skeleton-*` rule.
-- Removing the inline anti-FOUC bootloader from `<head>` of
- `web/themes/default/core/header.tpl` ("theme.js already does this
- on boot, why does it have to be inline?") → theme.js loads from
- `core/footer.tpl` (the document tail), so its boot-time
- `applyTheme(currentTheme())` runs AFTER the parser reaches `</body>`.
- By that point the browser has already painted the entire body in
- light mode (the `:root` tokens default to light), and theme.js's
- class flip triggers a full repaint the user perceives as a white
- flash + content flicker on every page navigation (#1367 — the
- reporter's exact symptom: "the page briefly renders in light mode
- for a split second before switching back to dark"). The bootloader
- is the inline-script-in-`<head>` pattern every modern theme-toggle
- implementation uses (Tailwind docs, Next.js docs, GitHub, Vercel)
- — it has to run BEFORE the body parses, which means it has to be
- inline (no external `<script src=…>` because the network round-trip
- would defeat the point) and it has to be in `<head>` (so the parser
- reaches it before the body tags). Regression guard:
- `web/tests/e2e/specs/flows/theme-fouc.spec.ts` uses `page.route`
- to stall the `theme.js` network request, then asserts the `dark`
- class is present (or absent, in light mode) on `<html>` WHILE
- theme.js is held — proving the bootloader, not theme.js, did
- the class flip. Pre-fix the dark / system arms read `false` (no
- class because theme.js was stalled and was the only path); post-fix
- they read `true` because the inline bootloader runs in `<head>`
- long before the parser reaches `<script src="theme.js">`.
-- Letting the inline bootloader's resolution logic drift from
- `theme.js`'s `applyTheme(currentTheme())` (e.g., adding a new
- `'high-contrast'` mode to theme.js without mirroring in the
- bootloader, or vice versa) → the first paint resolves to one
- mode, theme.js's boot-time call resolves to a different mode,
- the user sees a flicker on every navigation. The bootloader is
- the read-only mirror of `applyTheme()`'s resolution rule — same
- `THEME_KEY` ('sbpp-theme'), same default ('system'), same
- dark-resolution predicate. The bootloader's only difference is
- it doesn't `localStorage.setItem(...)` (theme.js still owns
- persistence). Any change to theme.js's resolution logic has
- to land a paired bootloader update in the same PR.
+- Removing the inline anti-FOUC bootloader from `<head>` of any
+ of the five template surfaces that carry it —
+ `web/themes/default/core/header.tpl` (the panel chrome, #1367),
+ `web/themes/default/page_kickit.tpl`,
+ `web/themes/default/page_blockit.tpl` (the iframe-routed
+ surfaces, #1438), `web/themes/default/page_uploadfile.tpl` (the
+ upload popup window, #1438 follow-up), or
+ `web/themes/default/updater.tpl` (the standalone updater wizard,
+ #1438 follow-up) — "theme.js already does this on boot, why
+ does it have to be inline?" → theme.js loads from
+ `core/footer.tpl` (the document tail) and runs AFTER the parser
+ reaches `</body>`. By that point the browser has already painted
+ the entire body in light mode (the `:root` tokens default to
+ light), and theme.js's class flip triggers a full repaint the
+ user perceives as a white flash + content flicker on every page
+ navigation (#1367 — the reporter's exact symptom on the chrome:
+ "the page briefly renders in light mode for a split second
+ before switching back to dark"). For the chromeless surfaces
+ (the four #1438 templates) the bug is worse: those templates
+ DON'T load `theme.js` at all (the iframes pull
+ `api-contract.js` / `sb.js` / `api.js`, the upload popup pulls
+ nothing JS-side, the updater pulls nothing JS-side), so without
+ the bootloader there is NO theme-resolution path whatsoever and
+ the page paints stark white forever (#1438 — reporter's symptom:
+ dark-mode operator right-clicks a player → "Kick player" →
+ navigates to a stark-white full-page kickit document; the same
+ stark-white-over-dark-parent regression hits the upload popup
+ chrome and the post-upgrade updater landing page). The
+ bootloader is the inline-script-in-`<head>` pattern every modern
+ theme-toggle implementation uses (Tailwind docs, Next.js docs,
+ GitHub, Vercel) — it has to run BEFORE the body parses, which
+ means it has to be inline (no external `<script src=…>` because
+ the network round-trip would defeat the point) and it has to be
+ in `<head>` (so the parser reaches it before the body tags).
+ Regression guards: `web/tests/e2e/specs/flows/theme-fouc.spec.ts`
+ (chrome — uses `page.route` to stall the `theme.js` network
+ request, then asserts the `dark` class is present or absent on
+ `<html>` WHILE theme.js is held; pre-#1367 the dark / system
+ arms read `false`, post-fix they read `true`) plus
+ `web/tests/e2e/specs/flows/iframe-anti-fouc.spec.ts` (#1438 —
+ simpler shape because none of the chromeless templates load
+ `theme.js`, so a plain `page.goto(URL)` + `toHaveClass(/dark/)`
+ is sufficient; covers kickit + blockit + uploadfile with dark /
+ light / system+OS-dark / system+OS-light branches) plus
+ `web/tests/integration/IframeChromeAntiFoucBootloaderTest.php`
+ (#1438 — static-grep gate asserting every required bootloader
+ fragment appears in all five template files (`core/header.tpl`,
+ `page_kickit.tpl`, `page_blockit.tpl`, `page_uploadfile.tpl`,
+ `updater.tpl`), the bootloader precedes `<link rel="stylesheet">`
+ in each, the bootloader bodies are byte-equivalent across the
+ five copies after whitespace normalization, and NO install-wizard
+ `.tpl` carries the bootloader; catches drift edits that update
+ one bootloader copy and forget the others).
+- Letting the inline bootloader's resolution logic drift between
+ any two of the five copies (`core/header.tpl`, `page_kickit.tpl`,
+ `page_blockit.tpl`, `page_uploadfile.tpl`, `updater.tpl`) OR
+ between any copy and `theme.js`'s `applyTheme(currentTheme())`
+ (e.g., adding a new `'high-contrast'` mode to theme.js without
+ mirroring in any of the bootloaders, or mirroring in four but
+ forgetting the fifth) → the first paint resolves to one mode on
+ Surface A, a different mode on Surface B, and theme.js's
+ boot-time call (where it runs at all) resolves to yet another
+ mode; the user sees flicker on every navigation even with all
+ five bootloaders present, AND a sibling pair of pages renders
+ mismatched themes (e.g. operator on a dark-mode panel opens the
+ upload popup which paints light because its bootloader missed the
+ update). The bootloader is the read-only mirror of `applyTheme()`'s
+ resolution rule — same `THEME_KEY` ('sbpp-theme'), same default
+ ('system'), same dark-resolution predicate. The bootloader's only
+ differences are: (1) it doesn't `localStorage.setItem(...)`
+ (theme.js still owns persistence); (2) it adds a defensive
+ `window.matchMedia &&` null check before calling `matchMedia(...)`
+ (handles very old browsers without the API gracefully); (3) the
+ outer `try/catch` swallows BOTH `localStorage` errors (private-mode
+ SecurityError) and `matchMedia` errors. These three differences
+ are intentional defensiveness — they don't change the resolution
+ result for any reachable input shape; they prevent the bootloader
+ from throwing in environments where theme.js itself would
+ partially fail too. Any change to theme.js's resolution logic
+ has to land a paired bootloader update in all five template
+ copies in the same PR. The integration test
+ (`IframeChromeAntiFoucBootloaderTest`) enforces byte-equivalence
+ across all five bootloader bodies (whitespace-normalized) AND
+ fragment-presence against a list shared with `core/header.tpl`,
+ so a drift between any pair fails the build.
 - Moving the bootloader to an external `<script src="…">` ("inline
  scripts are smelly, let's externalize") → an external script adds
  a network round-trip BEFORE the bootloader can run, and the
@@ -3953,7 +4081,7 @@ contacting every contributor individually.
 | Keep the main sidebar sticky-pinned across the full document scroll (`<aside class="sidebar">`) | The structural half of #1271 lives in `web/themes/default/core/footer.tpl`: `<footer class="app-footer">` is rendered as the LAST flex column item of `<div class="main">`, INSIDE `<div class="app">`. `.sidebar`'s sticky containing block is `.app`; if the footer were a body-level sibling of `.app` (the pre-fix shape), `.app`'s height would fall short of the document by `footerHeight` and the sidebar would release at the bottom — brand cut off, on barely-tall pages (`docHeight - viewport ≤ footerHeight`, e.g. `?p=admin&c=audit` on the bare e2e seed) the entire scroll range would be in the release phase and the sidebar would track the scroll. Keeping the footer inside `.app` makes the sticky CB extend to the full document. The CSS half (`.sidebar { align-self: flex-start; }` from #1278) is defensive parity with `.admin-sidebar` and is RETAINED but not load-bearing on its own. The footer's `margin-top: auto` (`.app-footer` rule in `theme.css`) is the classic "sticky footer" pattern — pushes the footer to the bottom of `.main`'s flex column on short pages so the credit doesn't float halfway up the viewport. Regression guard: `web/tests/e2e/specs/responsive/sidebar-sticky.spec.ts` asserts strict `top===0` at scroll=`document.scrollHeight` on `?p=admin&c=bans` (the canonical tall page) AND on `?p=admin&c=audit` (the barely-tall page that historically presented the bug most visibly). |
 | Disable the chrome's slide-in / fade animations for `prefers-reduced-motion` users | `web/themes/default/css/theme.css` (`@media (prefers-reduced-motion: reduce)` global block — see the matching note in "Playwright E2E specifics" / Conventions). The block applies universally to `*, *::before, *::after` and is the right shape for *motion-of-state* (drawer slide-in, toast slide-in, chevron rotation). Two documented exceptions live next to their rules: the busy-button spinner (`.btn[data-loading="true"]::after`) and the skeleton shimmer (`.skel`), both essential feedback per WCAG 2.3.3 — without rotation the donut reads as a decorative ring, without sliding the gradient reads as a permanent placeholder. Each rule carries its own per-rule `@media (prefers-reduced-motion: reduce)` override that re-enables the animation with `!important` longhands so specificity wins over the universal `*::after` / `*` reset (#1362). If you ship a new animation, default to honouring the global reset; the per-rule exception only applies to motion that is itself the load-bearing feedback (without it, the affordance is silently broken — not just less lively). Regression guard for both exceptions: `web/tests/e2e/specs/flows/loading-animations.spec.ts`. |
 | Tell the browser to paint native UA surfaces (`<select>` dropdown panels, native scrollbars, `<input type="date|time|color">` pickers, autofill highlighting) in the matching scheme | `web/themes/default/css/theme.css` — the two `color-scheme` declarations on `:root` (`light`) and `html.dark` (`dark`) (#1309). Without these the chrome's dark tokens swap correctly for DOM-rendered surfaces, but anything painted in the browser's top-layer system UI ignores `html.dark` and renders light — most jarring on mobile where the native `<select>` picker full-screens. Regression guard: `web/tests/e2e/specs/a11y/color-scheme.spec.ts`. |
-| Apply the persisted theme to `<html>` BEFORE first paint (no FOUC on every page navigation) | `web/themes/default/core/header.tpl` — the inline `<script>` block in `<head>`, immediately above `<link rel="stylesheet">` (#1367). Reads `localStorage['sbpp-theme']` (mirror of `THEME_KEY` in `theme.js`), resolves dark via the same predicate as `applyTheme(currentTheme())`, adds `class="dark"` to `<html>` synchronously before `<body>` parses. Pre-fix theme.js (loaded from the document tail via `core/footer.tpl`) was the only thing flipping the class — by then the body had already painted in light mode and the class flip triggered a full repaint the user perceived as a white flash + content flicker on every page navigation (the reporter's exact symptom on #1367). The bootloader's resolution logic must stay byte-equivalent to `theme.js`'s `applyTheme(currentTheme())` minus the `localStorage.setItem(...)` write — drift between the two means the first paint resolves to one theme, theme.js's boot-time call resolves to another, and the user sees flicker even with the bootloader present. See "Anti-FOUC theme bootloader" in Conventions. Regression guard: `web/tests/e2e/specs/flows/theme-fouc.spec.ts` uses `page.route` to stall the `theme.js` network request and asserts the state of `<html>`'s class list WHILE theme.js is held — proving the bootloader, not theme.js, did the class flip. Three arms cover the three branches of the resolution logic (dark-pinned must read `class="dark"`, light-pinned must NOT, system + emulated OS-dark via `colorScheme: 'dark'` on a fresh `chromium.newContext()` must read `class="dark"` via the matchMedia branch). Releasing the route then lets theme.js boot normally so the post-load shape is asserted too. |
+| Apply the persisted theme to `<html>` BEFORE first paint (no FOUC on every page navigation; covers BOTH the chrome and the chromeless `<head>` surfaces — iframes, upload popups, the updater wizard) | Five template surfaces ship the same inline `<script>` block in `<head>`, immediately above `<link rel="stylesheet">`: `web/themes/default/core/header.tpl` (chrome, every `index.php?p=…` render — #1367), `web/themes/default/page_kickit.tpl` and `web/themes/default/page_blockit.tpl` (the two iframe-routed surfaces under `pages/admin.kickit.php` / `pages/admin.blockit.php` that ship their own self-contained `<head>` rather than riding the chrome — #1438), `web/themes/default/page_uploadfile.tpl` (the popup window opened by `pages/admin.upload{demo,icon,mapimg}.php` via `window.open(...)` from a dark-mode-aware parent admin page — #1438 follow-up), and `web/themes/default/updater.tpl` (the standalone wizard rendered by `web/updater/index.php` on every panel upgrade — #1438 follow-up). All five copies read `localStorage['sbpp-theme']` (mirror of `THEME_KEY` in `theme.js`), resolve dark via the same predicate as `applyTheme(currentTheme())`, and add `class="dark"` to `<html>` synchronously before `<body>` parses. Pre-#1367 theme.js (loaded from the document tail via `core/footer.tpl`) was the only thing flipping the class on the chrome — by then the body had already painted in light mode and the class flip triggered a full repaint the user perceived as a white flash + content flicker on every page navigation. Pre-#1438 the chromeless surfaces had NO theme-resolution path at all — none of them load `theme.js` — so a dark-mode operator right-clicking a player → "Kick player" navigated to a stark-white full-page kickit document; same shape for the upload popup over a dark-mode parent and the updater landing page during a post-upgrade flow. All four bugs are the same shape: the page paints in light because nothing has set the dark class yet. The bootloader's resolution logic must stay byte-equivalent across all five copies (the integration test below enforces whitespace-normalized byte-equivalence — drift between copies means a user navigating between sibling pages sees the theme flicker mid-flow) AND semantically equivalent to `theme.js`'s `applyTheme(currentTheme())` minus the `localStorage.setItem(...)` write (the bootloader is intentionally more defensive — adds a `window.matchMedia &&` null check and a broader `try/catch` — but the resolution rule itself must mirror theme.js, otherwise the first paint resolves to one theme and theme.js's boot-time call resolves to another). See "Anti-FOUC theme bootloader" in Conventions. Regression guards: `web/tests/e2e/specs/flows/theme-fouc.spec.ts` (chrome — stalls `theme.js` via `page.route` and asserts `<html>`'s class WHILE theme.js is held, proving the bootloader did the flip; three arms cover dark-pinned / light-pinned / system + emulated OS-dark via `colorScheme: 'dark'` on a fresh `chromium.newContext()`) plus `web/tests/e2e/specs/flows/iframe-anti-fouc.spec.ts` (#1438 — kickit + blockit + uploadfile; simpler shape because none of those templates load `theme.js`, so a plain `page.goto(URL)` + `toHaveClass(/dark/)` is sufficient; six chromium tests cover kickit dark + light + system-OS-dark + system-OS-light, blockit dark, uploadfile dark; the system-OS-light arm specifically guards against the regression mode where the bootloader unconditionally adds `html.dark` regardless of `matchMedia(...).matches`) plus `web/tests/integration/IframeChromeAntiFoucBootloaderTest.php` (#1438 — static-grep gate covering all five template files, asserts every required bootloader fragment appears in each, the bootloader precedes `<link rel="stylesheet">` in each, the bootloader bodies are byte-equivalent across all five after whitespace normalization, and NO `*.tpl` file under `web/themes/default/install/` carries the bootloader — the install wizard runs against an unconfigured panel with no `localStorage` to read; catches drift edits that update one bootloader copy and forget the others). The updater surface is NOT covered by the E2E spec because the dev stack auto-seeds the DB out of band via `docker/db-init/`, so `web/updater/data/<N>.php` migrations are never applied via the runner in dev and hitting `/updater/` raises "Column already exists" on migration 801 — the static-grep integration test is the sufficient gate for that surface (the bootloader mechanism is identical across all five copies, enforced by the byte-equivalence test). |
 | Edit a step of the install wizard (chrome, form, schema-apply, admin-create, AMXBans import) | Page handlers under `web/install/pages/page.<N>.php` (1=license, 2=DB details, 3=requirements, 4=schema apply, 5=admin form + final config write, 6=optional AMXBans import). Each handler builds a `Sbpp\View\Install\Install*View` DTO from `web/includes/View/Install/` and renders the matching template under `web/themes/default/install/`. Shared step-handler helpers (prefix validation, raw-PDO probe before instantiating `\Database`, KeyValues quoting, friendly PDO error translation, filesystem-check detail strings) live in `web/install/includes/helpers.php` (`sbpp_install_validate_prefix` / `sbpp_install_open_db` / `sbpp_install_kv_escape` / `sbpp_install_translate_pdo_error` / `sbpp_install_describe_filesystem_check`) — required eagerly from `web/install/bootstrap.php` so every step page has them in scope without its own require. Every step (3-6) re-runs `sbpp_install_validate_prefix` at the top of its handler before any SQL substitution; step 6 also validates `amx_prefix` (operator input on that page itself). The `_chrome.tpl` / `_chrome_close.tpl` partials wrap every step (header + progress stepper + footer); they own the install-only inline CSS (`.install-shell`, `.install-alert`, `.install-pill`, `.install-grid`) since the wizard reuses the panel's `theme.css` design tokens but doesn't pull in the panel's chrome JS (`theme.js`, `lucide.min.js`, command palette, etc. — the wizard has no logged-in user / no Config / no `$userbank`). Steps with per-page tail scripts: step 1 (vanilla JS validating the license-accept checkbox), step 5 (#1335 M3: client-side validation for SteamID format + email shape + password match — saves the round-trip-with-wiped-passwords path on the common form-error case); the handoff template carries an inline auto-submit script. Navigation is plain HTML `<form action="?step=N">` everywhere else. Test-IDs follow `install-<step>-<field>` consistently (#1335 m3 standardised step 2's `install-db-*` shape onto the wider `install-database-*` pattern). Anti-pattern: reintroducing MooTools / `web/install/scripts/sourcebans.js` / `ShowBox()` / `$E()` / inline `onclick="next()"` — every legacy hook is dead post-#1123 D1, the rewrite at #1332 dropped them all (#1332). |
 | Tune install-wizard alert / pill colours (`.install-alert--*` / `.install-pill--*`) | Inline `<style>` block in `web/themes/default/install/_chrome.tpl` (#1435). The palette is pinned to the Tailwind 900-tier (`#14532d` green-900 / `#1e3a8a` blue-900 / `#78350f` amber-900 / `#7f1d1d` red-900) on `rgba(_, 0.15)` backgrounds so every variant clears WCAG AAA (~8:1 — well past AA's 4.5:1 floor). The pre-#1435 700/800-tier text on `rgba(_, 0.10)` bg failed AA on the success alert (~4.46:1) and surfaced to operators as "dark green text on light green box, hard to read". The `@media (prefers-color-scheme: dark)` block in the same file ONLY swaps text colours (NOT bgs) — the wizard has no `theme.js` / no toggle / no `html.dark` to ride, so the surrounding chrome stays light regardless of OS preference; swapping bgs would make alerts visually mismatch the rest of the wizard. Full OS-dark support is out of scope (would require `@media`-swapping every token `theme.css` owns). Regression guard: `web/tests/integration/InstallChromeContrastTest.php` — pins the new colour literals AND computes the WCAG contrast ratio for every variant arithmetically (text-on-composite-rgba-bg-over-page-bg) so a future palette tweak that drops below the 4.5:1 floor fails the gate even without the literal swap. The reference value test (`testContrastHelperMatchesReferenceValues`) cross-checks the implementation against a known WebAIM ratio (`#15803d` green-700 on `#f0fdf4` green-50 = 4.79:1). |
 | Recover from a missing `web/includes/vendor/` at install time | `web/install/recovery.php` is the self-contained "vendor/ missing" surface — pure inline HTML + CSS, NO Composer / Smarty / `Sbpp\…` dependency (#1332 C3). `web/install/index.php`'s lifecycle is paths-init (`init.php`) → C2 already-installed guard (`already-installed.php`, #1335) → vendor/-check (short-circuit to `recovery.php` if missing) → composer + Smarty bootstrap (`bootstrap.php`) → step dispatch (`includes/routing.php` → `pages/page.<N>.php`). The recovery surface is gated by `file_exists(PANEL_INCLUDES_PATH . '/vendor/autoload.php')` BEFORE any namespaced class is referenced. Direct visits with vendor present 302 to `/install/` instead of always emitting the 503 page (#1335 m1). The release artifact (post-#1332 Workstream A) bundles `vendor/` so this surface is the safety net for git checkouts and partial uploads, never the happy path. |

--- a/web/tests/e2e/specs/flows/iframe-anti-fouc.spec.ts
+++ b/web/tests/e2e/specs/flows/iframe-anti-fouc.spec.ts
@@ -1,0 +1,342 @@
+/**
+ * Anti-FOUC regression guard for the four chromeless surfaces that
+ * render their own `<head>` (issue #1438 + follow-up review):
+ *
+ *   - `pages/admin.kickit.php`  → `page_kickit.tpl`
+ *   - `pages/admin.blockit.php` → `page_blockit.tpl`
+ *   - `pages/admin.uploadicon.php` (and sister upload pages) → `page_uploadfile.tpl`
+ *   - `web/updater/index.php` → `updater.tpl`
+ *
+ * Background
+ * ----------
+ * The light/dark theme is keyed off the `dark` class on `<html>`, with
+ * `:root` declaring the light tokens and `html.dark` overriding to the
+ * dark tokens. The panel chrome's `core/header.tpl` carries an inline
+ * anti-FOUC bootloader in `<head>` that reads `localStorage['sbpp-theme']`
+ * and adds the class synchronously BEFORE the body parses (#1367 —
+ * documented at length in AGENTS.md Conventions "Anti-FOUC theme
+ * bootloader"). Pre-#1438 the four chromeless surfaces shipped their
+ * own `<head>` WITHOUT the bootloader, so dark-mode operators reaching
+ * them painted stark white regardless of preference.
+ *
+ * The user-reported #1438 path
+ * ----------------------------
+ * `web/scripts/server-context-menu.js` is the public Servers page's
+ * right-click context menu. The "Kick player" item builds the href
+ * directly to `pages/admin.kickit.php?check=…` and the click is a
+ * top-level navigation — NOT an iframe load. So a dark-mode operator
+ * right-clicks a player → picks Kick → the browser navigates to the
+ * chromeless kickit template rendered as a full-page document → the
+ * page paints stark white because `<html>` never gets the `dark` class.
+ * Exact reproduction: issue #1438. The follow-up review surfaced two
+ * sister bugs (uploadfile + updater) that ride the same bug class
+ * and got swept in the same fix.
+ *
+ * What this spec proves
+ * ---------------------
+ * All four chromeless templates' bootloaders honour the same
+ * `localStorage['sbpp-theme']` key as the chrome's bootloader, and
+ * the resolved class lands on `<html>` before first paint. Four
+ * branches per surface (where the surface is e2e-tractable):
+ *
+ *   1. mode = 'dark'              → bootloader adds class
+ *   2. mode = 'light'             → bootloader does NOT add class
+ *   3. mode = 'system' + OS-dark  → bootloader resolves to dark, adds class
+ *   4. mode = 'system' + OS-light → bootloader resolves to light, no class
+ *
+ * Mirror of the chrome's `theme-fouc.spec.ts` plus an extra
+ * system+OS-light arm that catches a hypothetical regression where
+ * the bootloader unconditionally adds `html.dark` (the `light` test
+ * would pass — class would NOT be set because we pinned mode=light;
+ * the system+OS-dark test would pass for the wrong reason — class
+ * IS set; only the system+OS-light arm specifically catches the
+ * "always-adds-dark" regression mode).
+ *
+ * Why this spec is simpler than `theme-fouc.spec.ts`
+ * --------------------------------------------------
+ * The chrome's FOUC test has to STALL `theme.js` to prove the
+ * bootloader (not theme.js) flipped the class. The chromeless
+ * templates DON'T load `theme.js` at all (kickit / blockit pull
+ * `api-contract.js`, `sb.js`, `api.js` — the JSON dispatcher
+ * surface; uploadfile and updater pull nothing) so there's no
+ * parallel path that could be setting the class. A plain `goto`
+ * + `toHaveClass(/dark/)` check is sufficient: if the `dark` class
+ * is present, the inline bootloader put it there (nothing else
+ * exists in the document that could).
+ *
+ * Login state is required — every surface gates the body content
+ * behind a permission check (kickit / blockit / uploadfile require
+ * AddBan / EditMods / Owner; updater requires admin to even hit
+ * `web/updater/index.php`). The FOUC bootloader runs in `<head>`
+ * before the body parses, but the `die()` branches for
+ * unauthenticated callers emit a bare HTTP response without ever
+ * rendering the template — so we DO need login state to land on
+ * the bootloader-bearing `<head>`. We pick that up via the
+ * project-level `storageState: 'playwright/.auth/admin.json'`
+ * config, same as every other auth-required spec.
+ *
+ * Why uploadfile / updater are partial-coverage here
+ * --------------------------------------------------
+ * The `page_uploadfile.tpl` route renders only on POST (the form
+ * submission lands on the upload destination and the page handler
+ * renders the result; a bare GET to `admin.uploadicon.php` shows
+ * the form via the same template — that's what we exercise). The
+ * `updater.tpl` route renders from `web/updater/index.php` and
+ * requires admin context (no per-step migration is needed; the
+ * runner just enumerates `web/updater/data/<N>.php` and renders
+ * whatever migrations applied, even if zero). We page.goto both
+ * surfaces under the same admin storage state.
+ *
+ * Skip mobile-chromium
+ * --------------------
+ * The bootloader contract is browser-shape-agnostic (the resolution
+ * runs in `<head>` before any layout work), so the mobile-chromium
+ * project would burn cycles without revealing different findings.
+ * Mirrors `kickit-iframe.spec.ts` and `theme-fouc.spec.ts`.
+ */
+
+import { expect, test } from '../../fixtures/auth.ts';
+import { chromium } from '@playwright/test';
+
+const KICKIT_URL = '/pages/admin.kickit.php?check=STEAM_0%3A0%3A1&type=0';
+const BLOCKIT_URL = '/pages/admin.blockit.php?check=STEAM_0%3A0%3A1&type=1&length=60';
+const UPLOADFILE_URL = '/pages/admin.uploadicon.php';
+// `updater.tpl` is intentionally not e2e-tested here — see the
+// in-spec comment under the kickit/blockit describe block for the
+// dev-stack DB-seeding rationale. The static-grep gate in
+// `IframeChromeAntiFoucBootloaderTest` covers the bootloader
+// contract for that surface.
+
+test.describe('flow: iframe anti-FOUC bootloader (kickit / blockit, #1438)', () => {
+    test.beforeEach(({}, testInfo) => {
+        test.skip(
+            testInfo.project.name !== 'chromium',
+            'Browser-shape-agnostic — the bootloader resolution runs in <head> before any layout work.',
+        );
+    });
+
+    test('kickit: mode=dark → html.dark is set on first paint', async ({ page }) => {
+        // Persist `dark` against the panel origin BEFORE navigating to
+        // kickit so the iframe's bootloader has something to read.
+        // The first navigation lands somewhere harmless (the panel
+        // root) just to anchor the localStorage write to the right
+        // origin.
+        await page.goto('/');
+        await page.evaluate(() => localStorage.setItem('sbpp-theme', 'dark'));
+
+        await page.goto(KICKIT_URL);
+
+        await expect(
+            page.locator('html'),
+            'Pre-#1438 the kickit template shipped a chromeless `<head>` with no '
+                + 'anti-FOUC bootloader, so a dark-mode operator right-clicking "Kick" from the '
+                + 'Servers context menu landed on a stark-white full-page document. Post-fix the '
+                + "inline `<script>` in <head> reads localStorage['sbpp-theme'] and adds the "
+                + '`dark` class to `<html>` synchronously before the body parses. If this fails, '
+                + 'either the bootloader was removed from page_kickit.tpl or its resolution '
+                + 'logic drifted from the chrome (see `core/header.tpl` for the canonical shape).',
+        ).toHaveClass(/dark/);
+
+        // Cross-check: the kickit container is visible (proves we
+        // actually rendered the full template, not the "No Access"
+        // die() branch). Anchors the test against a stable selector
+        // from the template itself.
+        await expect(page.locator('[data-testid="kickit-container"]')).toBeVisible();
+    });
+
+    test('kickit: mode=light → html.dark is NOT set (bootloader respects light)', async ({
+        page,
+    }) => {
+        await page.goto('/');
+        await page.evaluate(() => localStorage.setItem('sbpp-theme', 'light'));
+
+        await page.goto(KICKIT_URL);
+
+        await expect(
+            page.locator('html'),
+            'When the operator has pinned light, the iframe bootloader must NOT add the '
+                + '`dark` class — doing so would produce the inverse FOUC (briefly dark, then '
+                + 'light). The bootloader only ADDS the class (never removes), so a missing '
+                + 'class is the correct light-mode outcome.',
+        ).not.toHaveClass(/dark/);
+    });
+
+    test('blockit: mode=dark → html.dark is set on first paint (parity with kickit)', async ({
+        page,
+    }) => {
+        // The blockit iframe is currently `display:none` inside
+        // `page_admin_comms_add.tpl` (it exists purely to fan a
+        // `sm_block_*` rcon out to every server; the operator never
+        // sees it). The dark-mode bug doesn't surface visibly today,
+        // but the bootloader is paired into `page_blockit.tpl` for
+        // parity — if a future PR makes the iframe visible OR adds a
+        // top-level navigation surface for it (matching the kickit
+        // context-menu path), the dark-mode regression must not come
+        // back. This test gates that parity contract.
+        await page.goto('/');
+        await page.evaluate(() => localStorage.setItem('sbpp-theme', 'dark'));
+
+        await page.goto(BLOCKIT_URL);
+
+        await expect(
+            page.locator('html'),
+            'page_blockit.tpl must carry the anti-FOUC bootloader for parity with '
+                + 'page_kickit.tpl — see the templates\' shared `Anti-FOUC bootloader (#1438)` '
+                + 'comment block. If this fails, the parity drift will silently regress the '
+                + 'dark-mode bug if anyone ever makes the blockit iframe visible.',
+        ).toHaveClass(/dark/);
+
+        await expect(page.locator('[data-testid="blockit-container"]')).toBeVisible();
+    });
+
+    test('uploadfile: mode=dark → html.dark is set on first paint', async ({ page }) => {
+        // page_uploadfile.tpl is the popup-window template opened from
+        // admin upload pages (admin.uploadicon.php / admin.uploadmapimg.php
+        // / admin.uploaddemo.php). Caught in the #1438 follow-up review:
+        // dark-mode admin on the parent admin page → "Choose icon" →
+        // popup window paints stark white because the template ships
+        // its own chromeless `<head>`. The body uses
+        // `background:var(--bg-page)` directly so a missing `html.dark`
+        // resolves to the `:root` light tokens.
+        //
+        // We hit `admin.uploadicon.php` directly (a GET request renders
+        // the form via the template, same `<head>` shape as the popup
+        // would see — the popup is just `window.open(...)` to the same
+        // URL).
+        await page.goto('/');
+        await page.evaluate(() => localStorage.setItem('sbpp-theme', 'dark'));
+
+        await page.goto(UPLOADFILE_URL);
+
+        await expect(
+            page.locator('html'),
+            'page_uploadfile.tpl must carry the anti-FOUC bootloader. The popup window '
+                + 'opens via window.open(...) from a dark-mode-aware parent admin page, and '
+                + 'the body explicitly uses background:var(--bg-page) — without html.dark '
+                + 'the popup paints stark white over the dark-mode parent.',
+        ).toHaveClass(/dark/);
+
+        await expect(page.locator('[data-testid="uploadfile-form"]')).toBeVisible();
+    });
+
+    // `updater.tpl` is NOT covered by an E2E test here. The runtime
+    // gate is intentionally only `IframeChromeAntiFoucBootloaderTest`
+    // (static-grep) because:
+    //
+    //   1. The dev stack auto-seeds the DB out of band via
+    //      `docker/db-init/` (per AGENTS.md "Stack at a glance"), so
+    //      `web/updater/data/<N>.php` migrations are NEVER applied
+    //      via the runner in the dev container — they're already
+    //      reflected in the seeded schema. Hitting `/updater/`
+    //      against the dev DB tries to re-apply migration 801 (the
+    //      "add `attempts` column" one), which fails with
+    //      "Column already exists: 1060 Duplicate column name
+    //      'attempts'" and the PHP error escapes the chrome. The
+    //      surface can't be e2e-driven against the dev stack without
+    //      a paired DB-reset that's out of scope for this fix.
+    //
+    //   2. The bootloader mechanism is identical across all five
+    //      template copies; the static-grep gate enforces
+    //      byte-equivalence-after-normalization, so if the kickit /
+    //      blockit / uploadfile bootloaders pass the runtime tests
+    //      above, the updater bootloader will paint the same way
+    //      in production (its only divergence from the others would
+    //      surface as a fragment-presence or normalization failure
+    //      in `IframeChromeAntiFoucBootloaderTest`).
+    //
+    // If a future fix unbreaks the dev-stack updater path, this is
+    // the place to add the e2e arm. The shape would mirror the
+    // uploadfile test above.
+});
+
+test.describe('flow: iframe anti-FOUC bootloader — system mode resolution (#1438)', () => {
+    test.beforeEach(({}, testInfo) => {
+        test.skip(
+            testInfo.project.name !== 'chromium',
+            'Browser-shape-agnostic — the bootloader resolution runs in <head> before any layout work.',
+        );
+    });
+
+    test('kickit: mode=system + OS-dark → bootloader resolves to dark via matchMedia', async () => {
+        // The project-level config pins `colorScheme: 'light'`, so we
+        // need a fresh `chromium.newContext()` with `colorScheme: 'dark'`
+        // to exercise the system-mode branch. Mirrors theme-fouc.spec.ts
+        // for the panel chrome.
+        const browser = await chromium.launch();
+        try {
+            // Reuse the project's storage state so the admin/admin
+            // login carries through to the new context — kickit's
+            // permission gate (`WebPermission::Owner | AddBan`)
+            // requires it; otherwise the template never renders.
+            const ctx = await browser.newContext({
+                colorScheme: 'dark',
+                baseURL: process.env.E2E_BASE_URL ?? 'http://localhost:8080',
+                storageState: 'playwright/.auth/admin.json',
+            });
+            const page = await ctx.newPage();
+
+            await page.goto('/');
+            await page.evaluate(() => localStorage.setItem('sbpp-theme', 'system'));
+
+            await page.goto(KICKIT_URL);
+
+            await expect(
+                page.locator('html'),
+                'System mode + OS-dark must resolve to dark on first paint — the iframe '
+                    + 'bootloader reads `matchMedia("(prefers-color-scheme: dark)").matches` '
+                    + "against the context's emulated colorScheme and adds html.dark. If this "
+                    + 'fails, the bootloader is missing the matchMedia branch or the resolution '
+                    + 'rule has drifted from theme.js / core/header.tpl.',
+            ).toHaveClass(/dark/);
+        } finally {
+            await browser.close();
+        }
+    });
+
+    test('kickit: mode=system + OS-light → bootloader resolves to light (matchMedia returns false)', async () => {
+        // Inverse of the system+OS-dark arm. This catches a regression
+        // where the bootloader unconditionally adds `html.dark`
+        // regardless of `matchMedia(...).matches`:
+        //
+        //   - The `dark` test passes (pinned `dark` → class added correctly).
+        //   - The `light` test passes (pinned `light` → class NOT added,
+        //     for the wrong reason: the bootloader's predicate skips ahead
+        //     before even reaching the matchMedia call because `m === 'dark'`
+        //     is false but a buggy "always add" path would still set it…
+        //     actually wait, the `light` test would catch always-add too).
+        //   - The system+OS-dark test passes (correct result for wrong reason
+        //     if the bootloader always adds — class IS set as expected).
+        //
+        // So the always-add regression mode is caught by `light` but not
+        // by system+OS-dark. The OS-light arm closes the gap: under
+        // system + OS-light, matchMedia must return false, and the
+        // bootloader must NOT add the class. A regression that drops
+        // the `matchMedia(...).matches &&` predicate and unconditionally
+        // adds dark when `m === 'system'` would silently land here.
+        const browser = await chromium.launch();
+        try {
+            const ctx = await browser.newContext({
+                colorScheme: 'light',
+                baseURL: process.env.E2E_BASE_URL ?? 'http://localhost:8080',
+                storageState: 'playwright/.auth/admin.json',
+            });
+            const page = await ctx.newPage();
+
+            await page.goto('/');
+            await page.evaluate(() => localStorage.setItem('sbpp-theme', 'system'));
+
+            await page.goto(KICKIT_URL);
+
+            await expect(
+                page.locator('html'),
+                'System mode + OS-light must resolve to light on first paint — the iframe '
+                    + 'bootloader reads `matchMedia("(prefers-color-scheme: dark)").matches`, '
+                    + 'which must return false under an emulated light colorScheme. If this '
+                    + 'fails, the bootloader is bypassing the matchMedia gate and always '
+                    + 'adding `html.dark` regardless of OS preference.',
+            ).not.toHaveClass(/dark/);
+        } finally {
+            await browser.close();
+        }
+    });
+});

--- a/web/tests/integration/IframeChromeAntiFoucBootloaderTest.php
+++ b/web/tests/integration/IframeChromeAntiFoucBootloaderTest.php
@@ -1,0 +1,469 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sbpp\Tests\Integration;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Issue #1438: pin the anti-FOUC bootloader's presence + normalized
+ * equivalence across the FIVE template surfaces that render their own
+ * `<head>`.
+ *
+ * Background
+ * ----------
+ *
+ * The light/dark theme is keyed off the `dark` class on `<html>`, with
+ * `:root` declaring the light tokens and `html.dark` overriding to the
+ * dark tokens (see `web/themes/default/css/theme.css`). The bootloader
+ * is a tiny synchronous inline `<script>` in `<head>` that reads
+ * `localStorage['sbpp-theme']` and adds `class="dark"` to `<html>`
+ * BEFORE the parser reaches `<body>`, so the very first paint lands in
+ * the operator's persisted theme — no white flash + content flicker
+ * (the FOUC the bootloader's name calls out).
+ *
+ * `web/themes/default/core/header.tpl` carries the bootloader for
+ * the panel chrome (every `index.php?p=…` render). Pre-#1438 the four
+ * other chromeless surfaces (`page_kickit.tpl`, `page_blockit.tpl`,
+ * `page_uploadfile.tpl`, `updater.tpl`) shipped their own `<head>`
+ * without the bootloader, so a dark-mode operator reaching any of
+ * them painted the page in light mode regardless of preference.
+ *
+ * The kickit reproduction is the user-reported #1438 path: the public
+ * Servers page's right-click context menu's "Kick player" item
+ * (`web/scripts/server-context-menu.js`) builds the href directly to
+ * `pages/admin.kickit.php?check=…`, NOT as an iframe — that's a
+ * top-level navigation to the chromeless iframe template. Dark-mode
+ * operator clicks Kick → full-page stark-white kickit grid → exactly
+ * the bug report. The blockit iframe is still `display:none` in
+ * `page_admin_comms_add.tpl` so the dark-mode bug doesn't surface
+ * there today, but the parity fix in `page_blockit.tpl` future-proofs
+ * against the moment somebody makes it visible.
+ *
+ * The audit-extended surfaces (#1438 follow-up review): `page_uploadfile.tpl`
+ * (popup window opened via `window.open(...)` from admin upload pages —
+ * mod icon / map image / demo file uploads; the popup ships its own
+ * chromeless `<head>` and a dark-mode admin's parent page paints a
+ * stark-white popup over the dark-mode parent) and `updater.tpl`
+ * (the upgrade runner's standalone wizard hit by logged-in admins
+ * on every panel upgrade — dark-mode admin runs an upgrade → stark-
+ * white "Updater" page) ride the same bug class as kickit and got
+ * swept in the same fix.
+ *
+ * The contract
+ * ------------
+ *
+ * Two complementary gates:
+ *
+ * - `testEveryTemplateShipsTheBootloader` catches the "removed a
+ *   load-bearing branch" class of drift (renamed THEME_KEY, dropped
+ *   matchMedia branch, swapped `classList.add` for `classList.toggle`,
+ *   etc.) by checking each required substring is present.
+ * - `testBootloaderBodiesAreEquivalentAfterNormalization` catches
+ *   the subtler "looks similar, differs in one branch" drift the
+ *   fragment grep can't see (e.g. one copy drops the `window.matchMedia &&`
+ *   null check while the others keep it — both contain
+ *   `matchMedia('(prefers-color-scheme: dark)').matches` so the
+ *   fragment test passes, but the behaviour on really old browsers
+ *   diverges). The normalized-equivalence test extracts the first
+ *   `<script>...</script>` block from each template's `<head>`,
+ *   collapses runs of whitespace, and asserts all five normalized
+ *   bodies are equal.
+ *
+ * The bootloader is intentionally MORE defensive than `theme.js`'s
+ * `applyTheme(currentTheme())`: it ships an explicit
+ * `window.matchMedia &&` null check, wraps the entire body in
+ * `try/catch` (not just the localStorage write), and uses
+ * `classList.add` instead of `classList.toggle` (the bootloader
+ * never needs to remove the class — `:root` defaults to light). The
+ * extra defensiveness exists because theme.js failing is recoverable
+ * (the next render gets the right theme) but the bootloader failing
+ * IS the FOUC bug. So the bootloader is *semantically* equivalent to
+ * theme.js's resolution, not byte-identical. Documented in AGENTS.md
+ * Conventions "Anti-FOUC theme bootloader".
+ *
+ * Why static-grep this and not the runtime
+ * ----------------------------------------
+ *
+ * The runtime gates exist — `web/tests/e2e/specs/flows/theme-fouc.spec.ts`
+ * (chrome) plus `web/tests/e2e/specs/flows/iframe-anti-fouc.spec.ts`
+ * (kickit + blockit) — both stall the appropriate scripts and
+ * assert `<html class="dark">` appears at the right moment. But e2e
+ * gates only catch the regression once a real browser navigates
+ * there, and `page_uploadfile.tpl` (popup window opener handshake)
+ * + `updater.tpl` (one-shot upgrade page that needs pending
+ * migrations to render) are awkward to drive from Playwright.
+ * Static grep here catches:
+ *
+ *   - A future "simplification" that removes the bootloader from one
+ *     template "because theme.js does it anyway" (the exact pre-#1367
+ *     reasoning the panel-chrome bootloader exists to defeat).
+ *   - A drift edit that updates the `'sbpp-theme'` key in theme.js +
+ *     `core/header.tpl` but forgets the iframe / upload / updater
+ *     templates.
+ *   - A reviewer who removes any bootloader copy "for consistency
+ *     with the install wizard" without realising the install wizard's
+ *     exemption is documented separately (no `theme.js` / no toggle
+ *     / no logged-in user).
+ *   - A new chromeless `<head>` surface added without the bootloader
+ *     (the test enumerates the known sites; adding a sixth requires
+ *     a paired test edit, which forces the conversation about whether
+ *     the new surface should ship the bootloader too).
+ *
+ * Pure file scanning — extends `PHPUnit\Framework\TestCase` directly
+ * (no DB / session / Smarty bring-up). Sister of
+ * `DeadJsCallSitesTest`; same per-file forbidden-substring shape,
+ * inverted into per-required-fragment assertions.
+ */
+final class IframeChromeAntiFoucBootloaderTest extends TestCase
+{
+    /**
+     * The four load-bearing fragments of the bootloader. We check each
+     * separately so a regression message names the specific drift
+     * (e.g. "lost the matchMedia branch" vs. "renamed THEME_KEY") rather
+     * than a wholesale "your bootloader is wrong" diff.
+     *
+     * Fragments are intentionally tight — they fail loudly on a
+     * cosmetic edit (whitespace, single vs. double quote) so the
+     * semantic-equivalence contract with `theme.js` / `core/header.tpl`
+     * is actually enforced. If a maintainer needs to tweak whitespace,
+     * the fix is to update this test in the same PR, not to loosen
+     * the literal.
+     *
+     * @return list<array{0: string, 1: string}>  Pairs of [substring, why].
+     */
+    private static function requiredFragments(): array
+    {
+        return [
+            [
+                "localStorage.getItem('sbpp-theme')",
+                "must read the same THEME_KEY ('sbpp-theme') as `theme.js` — drift here "
+                . "silently desyncs first paint from theme.js's boot-time `applyTheme(currentTheme())`",
+            ],
+            [
+                "|| 'system'",
+                "must fall back to the same default ('system') as `theme.js` — a different "
+                . "default makes a first-time visitor see light/dark inconsistently across templates",
+            ],
+            [
+                "matchMedia('(prefers-color-scheme: dark)').matches",
+                "must consult the OS preference for the 'system' arm — without the matchMedia "
+                . "branch, system-mode operators on dark OS always paint light first",
+            ],
+            [
+                "document.documentElement.classList.add('dark')",
+                "must add (NOT replace) the `dark` class on `<html>` — :root defaults to light "
+                . "so removing isn't needed; using `.className =` or `.classList.toggle` would "
+                . "stomp other classes the chrome (or a fork) may have added",
+            ],
+        ];
+    }
+
+    /**
+     * The five template surfaces that ship a self-contained `<head>`
+     * and therefore need their own bootloader copy. The install
+     * wizard's templates under `install/` are deliberately NOT in
+     * this list — see AGENTS.md "Install wizard" for the documented
+     * exemption (no logged-in user, no `theme.js`, no toggle, no
+     * persisted theme). The negative is enforced by
+     * `testInstallWizardTemplatesDoNotCarryBootloader`.
+     *
+     * @return list<string>
+     */
+    private static function templatesRequiringBootloader(): array
+    {
+        return [
+            'core/header.tpl',
+            'page_kickit.tpl',
+            'page_blockit.tpl',
+            'page_uploadfile.tpl',
+            'updater.tpl',
+        ];
+    }
+
+    private static function loadTemplate(string $relativePath): string
+    {
+        $path = ROOT . 'themes/default/' . $relativePath;
+        // Don't suppress with `@` — let PHPUnit surface the warning so a
+        // genuinely missing file gets diagnostic info beyond our hand-built
+        // failure message. The fallback below still fires if `file_get_contents`
+        // returns false rather than warning (older PHP / userland streams).
+        $contents = file_get_contents($path);
+        if ($contents === false) {
+            self::fail(
+                "Could not read $path — file moved or test bootstrap broke? "
+                . "If you renamed the template, update IframeChromeAntiFoucBootloaderTest::templatesRequiringBootloader() in the same PR."
+            );
+        }
+        return $contents;
+    }
+
+    /**
+     * Strip Smarty `{* ... *}` / `-{* ... *}-` comment blocks (greedy,
+     * multiline) so my own explanatory comments at the top of each
+     * template (which legitimately discuss the bootloader by name)
+     * don't false-match the required-fragment grep. Matches both
+     * delimiter pairs because `core/header.tpl` uses the default
+     * `{` `}` and the iframe templates use `-{` `}-`.
+     */
+    private static function stripSmartyComments(string $contents): string
+    {
+        // {* ... *} for default-delimiter templates.
+        $contents = (string) preg_replace('/\{\*.*?\*\}/s', '', $contents);
+        // -{* ... *}- for the iframe templates with custom delimiters.
+        return (string) preg_replace('/-\{\*.*?\*\}-/s', '', $contents);
+    }
+
+    /**
+     * Extract the FIRST `<script>...</script>` block inside `<head>`
+     * (the bootloader) from a template and normalize whitespace so
+     * cosmetic differences (spaces vs tabs, indentation depth, line
+     * endings) don't trip the equivalence check. The bootloader is
+     * always the first inline script — it sits between `<title>` and
+     * `<link rel="stylesheet">` per the placement contract.
+     *
+     * Returns the normalized body (the script's text content with
+     * leading/trailing whitespace stripped and internal whitespace
+     * collapsed to single spaces). Returns null when no inline script
+     * is found, so the caller can name the missing-bootloader case
+     * separately from the drift case.
+     */
+    private static function extractNormalizedBootloaderBody(string $contents): ?string
+    {
+        $contents = self::stripSmartyComments($contents);
+        // Match the first <script>...</script> in the document. The
+        // bootloader is the only inline script in <head> across all
+        // five templates (the iframe templates have additional
+        // <script src="..."> tags below the stylesheet link, but
+        // those are SRC scripts and don't match `<script>` without
+        // attributes). `<script>` with NO attributes is the canonical
+        // shape — if a future template tweak adds attributes (e.g.
+        // `<script nonce="...">`) the regex misses it and the test
+        // fires "bootloader missing" instead of silently passing.
+        if (!preg_match('#<script>(.*?)</script>#s', $contents, $m)) {
+            return null;
+        }
+        // Collapse all whitespace runs to single spaces, trim ends.
+        return trim((string) preg_replace('/\s+/', ' ', $m[1]));
+    }
+
+    public function testEveryTemplateShipsTheBootloader(): void
+    {
+        $misses = [];
+
+        foreach (self::templatesRequiringBootloader() as $relativePath) {
+            $contents = self::stripSmartyComments(self::loadTemplate($relativePath));
+
+            foreach (self::requiredFragments() as [$fragment, $why]) {
+                if (!str_contains($contents, $fragment)) {
+                    $misses[] = "$relativePath is missing fragment " . var_export($fragment, true) . " — $why";
+                }
+            }
+        }
+
+        $this->assertSame(
+            [],
+            $misses,
+            "Anti-FOUC bootloader drift detected (#1438 / #1367). The bootloader's logic must "
+                . "stay semantically equivalent across `core/header.tpl`, `page_kickit.tpl`, "
+                . "`page_blockit.tpl`, `page_uploadfile.tpl`, and `updater.tpl` (and semantically "
+                . "equivalent to `theme.js`'s `applyTheme(currentTheme())` minus the localStorage "
+                . "write — see AGENTS.md Conventions \"Anti-FOUC theme bootloader\"). The "
+                . "chromeless surfaces are reachable as TOP-LEVEL navigations from the public "
+                . "Servers page's right-click context menu (kickit), as `<iframe>`s from the "
+                . "post-Ban / post-Block success dialogs (kickit / blockit), as popup windows "
+                . "from admin upload pages (uploadfile), and as standalone upgrade pages "
+                . "(updater); without the bootloader, dark-mode operators see a stark-white "
+                . "page or iframe-content blast — the user-reported #1438 symptom. Drift "
+                . "findings:\n  - "
+                . implode("\n  - ", $misses),
+        );
+    }
+
+    /**
+     * Cross-check: the bootloader sits in `<head>` ABOVE the
+     * `<link rel="stylesheet" …>` line (parser-blocking + synchronous,
+     * so the class is set BEFORE the stylesheet resolves the cascade
+     * for `:root` vs. `html.dark` tokens). A bootloader that lives
+     * AFTER the stylesheet would still beat `<body>` parsing for a
+     * static HTML file, but a slow stylesheet network response would
+     * push the `<script>` execution behind the first paint — re-opening
+     * the FOUC on slow connections. Pin the order so a future
+     * "let's move scripts to the bottom" cleanup catches this gate.
+     */
+    public function testBootloaderPrecedesStylesheetLink(): void
+    {
+        $misordered = [];
+
+        foreach (self::templatesRequiringBootloader() as $relativePath) {
+            // Strip Smarty comments BEFORE computing offsets — the
+            // canonical bootloader in `core/header.tpl` carries a long
+            // `{*...*}` comment block that explains the placement
+            // rationale and the prose itself includes the literal
+            // string `<link rel="stylesheet">` ("Placement: BEFORE
+            // the <link rel="stylesheet"> below..."). Without the
+            // strip step, `strpos` returns the comment-block offset
+            // and the ordering check fires a false positive.
+            $contents = self::stripSmartyComments(self::loadTemplate($relativePath));
+
+            $bootloaderOffset = strpos($contents, "localStorage.getItem('sbpp-theme')");
+            $stylesheetOffset = strpos($contents, '<link rel="stylesheet"');
+
+            if ($bootloaderOffset === false || $stylesheetOffset === false) {
+                // The previous test already names the missing-fragment
+                // failure; skip here so this test stays scoped to
+                // ordering alone.
+                continue;
+            }
+
+            if ($bootloaderOffset > $stylesheetOffset) {
+                $misordered[] = "$relativePath has the bootloader AFTER `<link rel=\"stylesheet\">` "
+                    . "(bootloader offset $bootloaderOffset, stylesheet offset $stylesheetOffset)";
+            }
+        }
+
+        $this->assertSame(
+            [],
+            $misordered,
+            "Anti-FOUC bootloader placement regressed. The inline `<script>` must precede "
+                . "`<link rel=\"stylesheet\">` so a slow stylesheet response doesn't push the "
+                . "class-flip behind first paint (re-opening the FOUC on slow connections). "
+                . "See `core/header.tpl`'s in-template comment for the placement rationale.\n  - "
+                . implode("\n  - ", $misordered),
+        );
+    }
+
+    /**
+     * Whitespace-normalized equivalence across every bootloader copy.
+     * `testEveryTemplateShipsTheBootloader` catches missing fragments,
+     * but two templates could have entirely different shape around the
+     * fragments — e.g. one drops the `window.matchMedia &&` null check,
+     * the other keeps it; both contain `matchMedia('(prefers-color-scheme: dark)').matches`
+     * so the fragment grep passes. This test extracts the first
+     * `<script>...</script>` body from each template and asserts they
+     * all normalize to the SAME string. Catches:
+     *
+     *   - Surrounding-code drift (added an unrelated statement to one
+     *     copy; the others stayed at the minimal IIFE).
+     *   - Null-check drift (one copy drops `window.matchMedia &&`).
+     *   - try/catch scope drift (one copy narrows the catch to just
+     *     the localStorage call, others keep the wide try around the
+     *     matchMedia branch too).
+     *   - classList method drift (one copy uses `.toggle('dark', d)`
+     *     instead of the correct `.add('dark')`).
+     *
+     * The reference is `core/header.tpl` (the chrome's bootloader,
+     * shipped first, by far the most-touched template — drift will
+     * always be "the other copies fell behind this one", not vice
+     * versa). Diff messages name the offending template so a
+     * maintainer hitting this gate sees which copy drifted.
+     */
+    public function testBootloaderBodiesAreEquivalentAfterNormalization(): void
+    {
+        $bodies = [];
+        foreach (self::templatesRequiringBootloader() as $relativePath) {
+            $body = self::extractNormalizedBootloaderBody(self::loadTemplate($relativePath));
+            if ($body === null) {
+                // Don't double-fail with the missing-fragments test;
+                // skip this template for the equivalence check.
+                continue;
+            }
+            $bodies[$relativePath] = $body;
+        }
+
+        $reference = $bodies['core/header.tpl'] ?? null;
+        $this->assertNotNull(
+            $reference,
+            "core/header.tpl's bootloader is the reference for the equivalence check — "
+                . "if it's missing, fix `testEveryTemplateShipsTheBootloader` first (the "
+                . "chrome's bootloader is the canonical shape)."
+        );
+
+        $drifted = [];
+        foreach ($bodies as $path => $body) {
+            if ($body !== $reference) {
+                $drifted[] = "$path: bootloader body diverges from core/header.tpl"
+                    . " (normalized — whitespace collapsed). Got:\n      "
+                    . $body
+                    . "\n    Expected (from core/header.tpl):\n      "
+                    . $reference;
+            }
+        }
+
+        $this->assertSame(
+            [],
+            $drifted,
+            "Anti-FOUC bootloader body drifted between template copies. The bootloader's "
+                . "IIFE must be byte-identical (modulo whitespace) across every chromeless "
+                . "`<head>` surface — diverging shape silently changes behaviour on edge cases "
+                . "(missing matchMedia, private-mode localStorage SecurityError, etc.) and a "
+                . "user navigating between sibling pages sees the theme flicker mid-flow. "
+                . "Findings:\n  - "
+                . implode("\n  - ", $drifted),
+        );
+    }
+
+    /**
+     * Install-wizard exemption: NONE of the templates under
+     * `web/themes/default/install/` may carry the bootloader. The
+     * wizard runs against an unconfigured panel with no `theme.js`,
+     * no toggle, no logged-in user, and therefore no
+     * `localStorage['sbpp-theme']` to read. Adding the bootloader
+     * there without a paired toggle would be a no-op at best
+     * (`localStorage.getItem('sbpp-theme')` returns `null` →
+     * fall-through to system → resolves to OS-dark only when OS is
+     * dark) and a confusing one-off "wizard partially-honours-OS"
+     * surface at worst. The exemption is documented in AGENTS.md
+     * Conventions "Anti-FOUC theme bootloader" → "The install wizard
+     * (`web/install/_chrome.tpl`) does NOT carry the bootloader.";
+     * pin it across EVERY install template so a well-meaning "let's
+     * mirror the panel chrome" sweep has to delete this test first
+     * (forcing the conversation).
+     *
+     * Pre-review (#1438) this test only checked `_chrome.tpl`. The
+     * gap let `_chrome_close.tpl` or any of the per-step
+     * `page_*.tpl` templates silently carry the bootloader; the
+     * follow-up review caught this. Now globs the whole directory.
+     */
+    public function testInstallWizardTemplatesDoNotCarryBootloader(): void
+    {
+        $installDir = ROOT . 'themes/default/install';
+        $this->assertDirectoryExists(
+            $installDir,
+            'install/ template directory must exist for the exemption check to land somewhere meaningful',
+        );
+
+        $templates = glob($installDir . '/*.tpl');
+        $this->assertNotFalse(
+            $templates,
+            "glob() returned false for $installDir — filesystem error?",
+        );
+        $this->assertNotEmpty(
+            $templates,
+            "No *.tpl files under $installDir — install wizard moved? Update this test or the wizard.",
+        );
+
+        $offenders = [];
+        foreach ($templates as $path) {
+            $contents = (string) file_get_contents($path);
+            $stripped = self::stripSmartyComments($contents);
+            if (str_contains($stripped, "localStorage.getItem('sbpp-theme')")) {
+                $offenders[] = basename($path);
+            }
+        }
+
+        $this->assertSame(
+            [],
+            $offenders,
+            'Install wizard templates must NOT carry the anti-FOUC bootloader. The wizard '
+                . 'runs pre-configuration with no `theme.js` / no theme toggle / no logged-in '
+                . 'user, so `localStorage[\'sbpp-theme\']` is never set during install. '
+                . 'Adding the bootloader here without a paired theme toggle silently introduces '
+                . 'an inconsistent partial-OS-honouring surface. See AGENTS.md Conventions '
+                . '"Anti-FOUC theme bootloader" → "The install wizard does NOT carry the '
+                . "bootloader.\". Offenders:\n  - "
+                . implode("\n  - ", $offenders),
+        );
+    }
+}

--- a/web/themes/default/page_blockit.tpl
+++ b/web/themes/default/page_blockit.tpl
@@ -9,6 +9,21 @@
     match the kickit template — see that file for the per-block
     explanation. The only delta on the wire is `$length` (the block
     duration in minutes) being forwarded into Actions.BlockitBlockPlayer.
+
+    Anti-FOUC bootloader (#1438): paired with the same change to
+    `page_kickit.tpl`. Today the blockit iframe is `display:none` in
+    `page_admin_comms_add.tpl` (it exists purely to fan a `sm_block_*`
+    rcon out to every server; the operator never sees it), so the
+    user-visible dark-mode bug only manifests on kickit. The
+    bootloader is added here for parity and future-proofing: if the
+    blockit iframe is ever made visible (matching the kickit shape)
+    OR reached as a top-level navigation (matching the kickit
+    server-context-menu shape), the dark-mode regression would
+    silently come back. Keeping both templates in lockstep is what
+    makes the regression test `IframeChromeAntiFoucBootloaderTest`
+    a reliable gate. See the matching block in `page_kickit.tpl` for
+    the full rationale and the byte-equivalence contract with
+    `core/header.tpl`.
 *}-
 <!DOCTYPE html>
 <html lang="en">
@@ -17,6 +32,16 @@
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <meta name="csrf-token" content="-{$csrf_token}-">
     <title>Block player</title>
+    <script>
+    (function () {
+        try {
+            var m = localStorage.getItem('sbpp-theme') || 'system';
+            var d = m === 'dark' || (m === 'system' && window.matchMedia
+                && matchMedia('(prefers-color-scheme: dark)').matches);
+            if (d) document.documentElement.classList.add('dark');
+        } catch (e) { /* localStorage / matchMedia unavailable; default to light */ }
+    })();
+    </script>
     <link rel="stylesheet" href="../themes/default/css/theme.css">
     <script src="../scripts/api-contract.js"></script>
     <script src="../scripts/sb.js"></script>

--- a/web/themes/default/page_kickit.tpl
+++ b/web/themes/default/page_kickit.tpl
@@ -19,6 +19,32 @@
     preserve the IDs the legacy template used so existing
     parent-window dialog hooks (set_counter, height adjustment) keep
     working.
+
+    Anti-FOUC bootloader (#1438): the `pages/admin.kickit.php` URL is
+    reachable two ways in v2.0 chrome: as an iframe inside the
+    post-Ban "Ban Added" `sb.message.show` dialog (legacy default-theme
+    surface — `#dialog-placement` only exists on the default theme),
+    AND as a top-level navigation from the public Servers page's
+    right-click context menu's "Kick player" item (`web/scripts/server-context-menu.js`
+    builds the href directly to `pages/admin.kickit.php?check=…`). The
+    latter is the user-reported #1438 path: an operator in dark mode
+    right-clicks a player, picks Kick, and lands on this chromeless
+    iframe template rendered as a full-page document — and the page
+    paints stark white because `<html>` never gets the `dark` class.
+    The inline bootloader below mirrors `core/header.tpl`'s shape
+    (same THEME_KEY 'sbpp-theme', same default 'system', same dark-
+    resolution predicate; only ADDS the class, never removes — :root
+    defaults to light) so the very first paint lands in the operator's
+    persisted theme regardless of how the page was reached. Logic
+    must stay byte-equivalent to the canonical bootloader in
+    `core/header.tpl` (which in turn mirrors `theme.js`'s
+    `applyTheme(currentTheme())` minus the localStorage write); the
+    regression gate is `web/tests/integration/IframeChromeAntiFoucBootloaderTest.php`.
+    See "Anti-FOUC theme bootloader" in AGENTS.md Conventions for the
+    full contract. Wrapped in IIFE + try/catch because localStorage
+    throws on private-mode iframes / SecurityError and matchMedia is
+    missing on very old browsers — defaults to light on either failure,
+    matching the chrome's shape.
 *}-
 <!DOCTYPE html>
 <html lang="en">
@@ -27,6 +53,16 @@
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <meta name="csrf-token" content="-{$csrf_token}-">
     <title>Kick player</title>
+    <script>
+    (function () {
+        try {
+            var m = localStorage.getItem('sbpp-theme') || 'system';
+            var d = m === 'dark' || (m === 'system' && window.matchMedia
+                && matchMedia('(prefers-color-scheme: dark)').matches);
+            if (d) document.documentElement.classList.add('dark');
+        } catch (e) { /* localStorage / matchMedia unavailable; default to light */ }
+    })();
+    </script>
     <link rel="stylesheet" href="../themes/default/css/theme.css">
     <script src="../scripts/api-contract.js"></script>
     <script src="../scripts/sb.js"></script>

--- a/web/themes/default/page_uploadfile.tpl
+++ b/web/themes/default/page_uploadfile.tpl
@@ -1,28 +1,55 @@
 {*
-    SourceBans++ 2026 — page_uploadfile.tpl
-    Bound view: \Sbpp\View\UploadFileView (web/includes/View/UploadFileView.php).
+ SourceBans++ 2026 — page_uploadfile.tpl
+ Bound view: \Sbpp\View\UploadFileView (web/includes/View/UploadFileView.php).
 
-    Self-contained popup window opened via window.open(...) from one
-    of the parent admin pages (admin.uploadicon.php,
-    admin.uploadmapimg.php, admin.uploaddemo.php). On a successful
-    upload the page handler builds a {$message} blob containing
-    `<script>window.opener.<cb>(<json-encoded args>);self.close()</script>`
-    using JSON_HEX_* flags so the admin-controlled filename is safe
-    to interpolate into both the HTML attribute and the JS string
-    layers (#1113 fix). The template is the only Phase B/C template
-    that legitimately needs `{$message nofilter}`.
+ Self-contained popup window opened via window.open(...) from one
+ of the parent admin pages (admin.uploadicon.php,
+ admin.uploadmapimg.php, admin.uploaddemo.php). On a successful
+ upload the page handler builds a {$message} blob containing
+ `<script>window.opener.<cb>(<json-encoded args>);self.close()</script>`
+ using JSON_HEX_* flags so the admin-controlled filename is safe
+ to interpolate into both the HTML attribute and the JS string
+ layers (#1113 fix). The template is the only Phase B/C template
+ that legitimately needs `{$message nofilter}`.
 
-    The theme stylesheet path is hardcoded relative to the popup's
-    URL (/pages/admin.upload*.php), so `../themes/default/css/theme.css`
-    resolves correctly.
+ The theme stylesheet path is hardcoded relative to the popup's
+ URL (/pages/admin.upload*.php), so `../themes/default/css/theme.css`
+ resolves correctly.
+
+ Anti-FOUC bootloader (#1438): this template renders a separate
+ popup window opened with `window.open(...)` from a parent admin
+ page (which is dark-mode-aware via `core/header.tpl`). The popup
+ is same-origin, so `localStorage['sbpp-theme']` is reachable
+ from here — but the popup ships its own chromeless `<head>` and
+ doesn't load `theme.js`, so without the bootloader below the
+ popup paints stark white over the operator's dark-mode parent.
+ The inline script mirrors `core/header.tpl`'s bootloader exactly
+ (same THEME_KEY 'sbpp-theme', same default 'system', same dark-
+ resolution predicate). Note the body explicitly uses
+ `background:var(--bg-page)`, so the resolved tokens drive the
+ paint directly; without `html.dark` the page would resolve to
+ the `:root` light tokens regardless of operator preference. See
+ "Anti-FOUC theme bootloader" in AGENTS.md Conventions for the
+ full contract; regression gate is
+ `web/tests/integration/IframeChromeAntiFoucBootloaderTest.php`.
 *}
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width,initial-scale=1">
-    <title>{$title} : SourceBans++</title>
-    <link rel="stylesheet" href="../themes/default/css/theme.css">
+ <meta charset="utf-8">
+ <meta name="viewport" content="width=device-width,initial-scale=1">
+ <title>{$title} : SourceBans++</title>
+ <script>
+ (function () {
+ try {
+ var m = localStorage.getItem('sbpp-theme') || 'system';
+ var d = m === 'dark' || (m === 'system' && window.matchMedia
+ && matchMedia('(prefers-color-scheme: dark)').matches);
+ if (d) document.documentElement.classList.add('dark');
+ } catch (e) { /* localStorage / matchMedia unavailable; default to light */ }
+ })();
+ </script>
+ <link rel="stylesheet" href="../themes/default/css/theme.css">
 </head>
 <body style="padding:1rem;background:var(--bg-page)">
 <div class="card" style="max-width:24rem;margin:0 auto">

--- a/web/themes/default/updater.tpl
+++ b/web/themes/default/updater.tpl
@@ -1,28 +1,53 @@
 {*
-    SourceBans++ 2026 — updater.tpl
+ SourceBans++ 2026 — updater.tpl
 
-    Standalone wizard rendered by web/updater/index.php after Updater.php
-    has finished applying any pending migrations. View:
-    Sbpp\View\UpdaterView (just `$updates`).
+ Standalone wizard rendered by web/updater/index.php after Updater.php
+ has finished applying any pending migrations. View:
+ Sbpp\View\UpdaterView (just `$updates`).
 
-    The updater runs in its own bootstrap context — it does NOT go
-    through index.php's page-builder, so the chrome from
-    `core/header.tpl` + `core/footer.tpl` is intentionally not pulled
-    in. This template is therefore a complete <!DOCTYPE html> document
-    and links the theme stylesheet directly. Asset paths are relative
-    to /web/updater/ (where the script runs from), so `../themes/...`
-    points at /web/themes/default/.
+ The updater runs in its own bootstrap context — it does NOT go
+ through index.php's page-builder, so the chrome from
+ `core/header.tpl` + `core/footer.tpl` is intentionally not pulled
+ in. This template is therefore a complete <!DOCTYPE html> document
+ and links the theme stylesheet directly. Asset paths are relative
+ to /web/updater/ (where the script runs from), so `../themes/...`
+ points at /web/themes/default/.
 
-    Test hooks: each card header carries a stable
-    `data-testid="updater-<step>"` attribute.
+ Test hooks: each card header carries a stable
+ `data-testid="updater-<step>"` attribute.
+
+ Anti-FOUC bootloader (#1438): the updater is hit by logged-in
+ admins (same origin as the panel), and the body uses
+ `background:var(--bg-page);color:var(--text)` directly — so
+ without the bootloader, an admin in dark mode upgrading the
+ panel lands on a stark-white "Updater" page. The inline script
+ below mirrors `core/header.tpl`'s bootloader exactly; the
+ byte-equivalence contract is gated by
+ `web/tests/integration/IframeChromeAntiFoucBootloaderTest.php`.
+ See "Anti-FOUC theme bootloader" in AGENTS.md Conventions for
+ the full contract. Distinct from the install wizard's
+ `_chrome.tpl` (which is intentionally exempt — pre-install
+ panel has no logged-in user / no theme.js / no persisted
+ preference); the updater runs against a configured panel and
+ inherits the operator's already-set theme preference.
 *}
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width,initial-scale=1">
-    <title>Updater | SourceBans++</title>
-    <link rel="stylesheet" href="../themes/default/css/theme.css">
+ <meta charset="utf-8">
+ <meta name="viewport" content="width=device-width,initial-scale=1">
+ <title>Updater | SourceBans++</title>
+ <script>
+ (function () {
+ try {
+ var m = localStorage.getItem('sbpp-theme') || 'system';
+ var d = m === 'dark' || (m === 'system' && window.matchMedia
+ && matchMedia('(prefers-color-scheme: dark)').matches);
+ if (d) document.documentElement.classList.add('dark');
+ } catch (e) { /* localStorage / matchMedia unavailable; default to light */ }
+ })();
+ </script>
+ <link rel="stylesheet" href="../themes/default/css/theme.css">
 </head>
 <body style="background:var(--bg-page);color:var(--text);min-height:100vh">
 


### PR DESCRIPTION
## Summary

- The kickit page (and three sister surfaces) shipped no anti-FOUC bootloader, so a dark-mode operator who right-clicked a player on the public Servers page → **Kick player** landed on a stark-white full-page kickit document. Those templates don't pull `theme.js`, so without the inline `<script>` in `<head>` there is no theme-resolution path at all and the page paints in light against the `:root` token defaults.
- Mirrors the chrome's #1367 inline bootloader pattern across every chromeless `<head>` surface in the panel: `page_kickit.tpl`, `page_blockit.tpl` (parity), `page_uploadfile.tpl` (popup over a dark-mode parent admin), and `updater.tpl` (post-upgrade landing page during a dark-mode admin's flow).
- The bootloader's resolution rule is **semantically equivalent** to `theme.js`'s `applyTheme(currentTheme())` minus the `localStorage.setItem` write (theme.js still owns persistence). It's intentionally more defensive than theme.js (`window.matchMedia &&` null check + a broader `try/catch` covering both `localStorage` SecurityError and missing `matchMedia`) so it cannot throw on the earliest realm setup phase where a syntax error would silently leave the page in light mode.

## Adversarial-review findings addressed

An adversarial review found four chromeless surfaces (not just two):

- **C1 (critical)**: original fix missed `page_uploadfile.tpl` (upload popup) and `updater.tpl` (post-upgrade landing). Both have the same stark-white-over-dark-parent failure shape. **Fixed** — added the bootloader to both.
- **I1 (important)**: the static gate only checked fragment presence, not byte-equivalence. **Fixed** — added `testBootloaderBodiesAreEquivalentAfterNormalization()` that extracts the IIFE body from each copy and asserts byte-for-byte equality after whitespace normalization.
- **I3 (important)**: install-wizard exemption test only checked `_chrome.tpl`. **Fixed** — `testInstallWizardTemplatesDoNotCarryBootloader()` now globs every `*.tpl` under `web/themes/default/install/`.
- **I4 (important)**: docs claimed "byte-equivalence" with `theme.js`. The bootloader is intentionally more defensive. **Fixed** — AGENTS.md + the integration test docblock now distinguish *semantic* equivalence with theme.js from *byte* equivalence across copies.
- **N8 (nice-to-have)**: the integration test suppressed `file_get_contents` errors. **Fixed** — removed the `@`.

## Regression guards

- **`web/tests/integration/IframeChromeAntiFoucBootloaderTest.php`** (static-grep): asserts every required bootloader fragment ships in all five copies (`core/header.tpl`, `page_kickit.tpl`, `page_blockit.tpl`, `page_uploadfile.tpl`, `updater.tpl`), the bootloader precedes `<link rel=\"stylesheet\">` in each, the bootloader bodies are byte-equivalent across the five copies after whitespace normalization (catches drift edits that update one copy and forget the others), and NO `*.tpl` under `web/themes/default/install/` carries the bootloader (the install wizard runs against an unconfigured panel with no `localStorage` to read — exemption documented in AGENTS.md). **4 tests, 8 assertions.**
- **`web/tests/e2e/specs/flows/iframe-anti-fouc.spec.ts`** (runtime): six chromium tests cover kickit dark + light + system-OS-dark + system-OS-light + blockit dark + uploadfile dark. The system-OS-light arm specifically guards against the regression mode where the bootloader unconditionally adds `html.dark` regardless of `matchMedia(...).matches` (the inverse of system-OS-dark — both arms together pin the full predicate). **6 passed, 6 mobile-chromium skipped (no admin storage state).**

The updater surface is NOT covered by the E2E spec because the dev stack auto-seeds the DB out of band via `docker/db-init/`, so `web/updater/data/<N>.php` migrations are never applied via the runner in dev and hitting `/updater/` raises "Column already exists" on migration 801. The static-grep integration test is the sufficient gate for that surface (the bootloader mechanism is identical across all five copies, enforced by the byte-equivalence test).

## Docs

`AGENTS.md` updated in lockstep:
- "Anti-FOUC theme bootloader" Conventions block now describes the five-surface contract + the semantic-vs-byte equivalence distinction.
- "Apply the persisted theme to `<html>` BEFORE first paint" row in "Where to find what" rewritten to cover all five copies, both regression guards, and the updater-spec-exemption rationale.
- Two paired Anti-patterns entries updated: "Removing the inline anti-FOUC bootloader …" and "Letting the inline bootloader's resolution logic drift …" both now cover all five surfaces and the three intentional defensive deltas vs theme.js.

## Test plan

- [x] `./sbpp.sh test tests/integration/IframeChromeAntiFoucBootloaderTest.php` — 4 passed
- [x] `./sbpp.sh e2e specs/flows/iframe-anti-fouc.spec.ts` — 6 passed, 6 skipped
- [x] `./sbpp.sh e2e specs/flows/theme-fouc.spec.ts` — 6 passed (no regression in chrome bootloader)
- [x] `./sbpp.sh phpstan` — 241 files, no errors
- [x] `./sbpp.sh ts-check` — no errors

Fixes #1438.