### PR TITLE
fix(1443): drop misleading row-wide `cursor: pointer` on data tables

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3645,6 +3645,44 @@ contacting every contributor individually.
   every keyboard / screen-reader user. New surfaces add visible
   buttons in the same shape as `.queue-row` (admin moderation
   queue) or the comms-list desktop table (`web/themes/default/page_comms.tpl`).
+- Row-wide `cursor: pointer` on `.table tbody tr` (or any other
+  `tbody tr` / `tr.ban-row` / `tr[data-testid="ban-row"]` /
+  `tr[data-testid="comm-row"]` selector) → the `<tr>` element is
+  NOT a click target on any list page. The v2.0 chrome delegates
+  interaction to specific *child* elements: the player-name `<a>`
+  carries `[data-drawer-bid]` / `[data-drawer-cid]` /
+  `[data-drawer-href]` for the drawer; row-action buttons carry
+  `data-action="…"` for delete / unban / unmute / re-apply / copy;
+  the per-row comments toggle via its native `<summary>`. The row
+  itself has no click handler. Painting `cursor: pointer` on the
+  row falsely advertised every pixel as clickable, so users would
+  click on dead cells (steam id, IP, reason, status, server,
+  admin, length, banned timestamp) and nothing would happen — the
+  reporter's exact symptom on #1443. The fix dropped the
+  declaration from `.table tbody tr` (`web/themes/default/css/theme.css`);
+  native cursors on the inner `<a>` / `<button>` / `<summary>`
+  elements already paint correctly without help, so removing the
+  row-wide declaration restored honest affordance ("pointer only
+  where clicking does something"). The hover-background rule
+  (`.table tbody tr:hover { background: var(--bg-muted); }`) is
+  intentionally retained — it's a scanning aid for tracking which
+  row the mouse is on, not a clickability claim, mirroring the
+  Linear / Notion / GitHub / Vercel data-table convention of
+  hover-bg-without-pointer-cursor. Regression guard:
+  `web/tests/integration/TableRowCursorPointerRegressionTest.php`
+  pins three contracts — the bare `.table tbody tr` rule carries
+  no `cursor: pointer`, the hover-bg rule survives, AND no other
+  selector silently re-applies `cursor: pointer` to any
+  table-row scope (the "fail closed" arm catches a future
+  copy-paste from a tooltip / popover demo or a well-meaning
+  "rows feel clickable, let me make them clickable" PR). If a
+  future list page genuinely needs row-wide click delegation,
+  gate the cursor behind a specific class on the table
+  (`.table--clickable-rows tbody tr { cursor: pointer; }`) AND
+  wire a real click handler on the `<tr>` AND update the
+  regression test's allowlist — never restore the bare
+  `.table tbody tr { cursor: pointer; }` shape (it would lie on
+  every other table on the panel).
 - Viewport-based `@media` queries for hiding `.table` columns
   (`@media (max-width: 1535px) { .col-tier-2 { display: none; } }`
   shape) → use `@container tablescroll (max-width: …)` rules

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3645,44 +3645,81 @@ contacting every contributor individually.
   every keyboard / screen-reader user. New surfaces add visible
   buttons in the same shape as `.queue-row` (admin moderation
   queue) or the comms-list desktop table (`web/themes/default/page_comms.tpl`).
-- Row-wide `cursor: pointer` on `.table tbody tr` (or any other
-  `tbody tr` / `tr.ban-row` / `tr[data-testid="ban-row"]` /
-  `tr[data-testid="comm-row"]` selector) → the `<tr>` element is
-  NOT a click target on any list page. The v2.0 chrome delegates
-  interaction to specific *child* elements: the player-name `<a>`
-  carries `[data-drawer-bid]` / `[data-drawer-cid]` /
-  `[data-drawer-href]` for the drawer; row-action buttons carry
-  `data-action="…"` for delete / unban / unmute / re-apply / copy;
-  the per-row comments toggle via its native `<summary>`. The row
-  itself has no click handler. Painting `cursor: pointer` on the
-  row falsely advertised every pixel as clickable, so users would
-  click on dead cells (steam id, IP, reason, status, server,
-  admin, length, banned timestamp) and nothing would happen — the
+- Row-wide `cursor: pointer` on the bare `.table tbody tr` (or any
+  other `tbody tr` / `tbody > tr` / `.table tr` / `tr.ban-row` /
+  `tr[data-testid="ban-row"]` / `tr[data-testid="comm-row"]` /
+  `[role="row"]` selector that lands the cursor on a row scope) →
+  the `<tr>` element is NOT a click target on the bans list, the
+  comms list, the admin admins / mods / groups / overrides /
+  servers tables, the kickit / blockit iframes, the bans-groups
+  list, or admin-edit-group / admin-edit-admins-perms. The v2.0
+  chrome on those surfaces delegates interaction to specific
+  *child* elements: the player-name `<a>` carries
+  `[data-drawer-bid]` / `[data-drawer-cid]` / `[data-drawer-href]`
+  for the drawer; row-action buttons carry `data-action="…"` for
+  delete / unban / unmute / re-apply / copy; the per-row comments
+  toggle via its native `<summary>`. The row itself has no click
+  handler. Painting `cursor: pointer` on the row falsely
+  advertised every pixel as clickable, so users would click on
+  dead cells (steam id, IP, reason, status, server, admin,
+  length, banned timestamp) and nothing would happen — the
   reporter's exact symptom on #1443. The fix dropped the
-  declaration from `.table tbody tr` (`web/themes/default/css/theme.css`);
-  native cursors on the inner `<a>` / `<button>` / `<summary>`
-  elements already paint correctly without help, so removing the
-  row-wide declaration restored honest affordance ("pointer only
-  where clicking does something"). The hover-background rule
+  declaration from the bare `.table tbody tr` rule
+  (`web/themes/default/css/theme.css`); native cursors on the
+  inner `<a>` / `<button>` / `<summary>` elements already paint
+  correctly without help, so removing the row-wide declaration
+  restored honest affordance ("pointer only where clicking does
+  something"). The hover-background rule
   (`.table tbody tr:hover { background: var(--bg-muted); }`) is
   intentionally retained — it's a scanning aid for tracking which
   row the mouse is on, not a clickability claim, mirroring the
   Linear / Notion / GitHub / Vercel data-table convention of
-  hover-bg-without-pointer-cursor. Regression guard:
+  hover-bg-without-pointer-cursor.
+
+  **The one in-tree surface where the `<tr>` IS the click target**
+  is the System Log table (`web/themes/default/page_admin_settings_logs.tpl`).
+  Each row carries `onclick="toggleLogRow(this)"` that flips a
+  sibling detail row's `hidden` attribute (the template's
+  `<p>Click a row to expand.</p>` instruction makes the
+  affordance contract explicit). For that case — and any future
+  surface that genuinely wires a row-wide click handler — the
+  opt-in `.table.table--clickable-rows tbody tr { cursor: pointer; }`
+  modifier in `theme.css` is the documented escape hatch. Apply
+  it to the `<table>` element (NOT individual `<tr>`s) so it
+  composes cleanly with the column-tier classes
+  (`.col-tier-2` / `.col-tier-3`) and any future table-scoped
+  variant. The System Log row ALSO carries `role="button"` +
+  `tabindex="0"` + `aria-expanded` + an `onkeydown` handler that
+  dispatches Enter / Space to the same toggle path — bare
+  `<tr onclick>` chrome with no role / tabindex / key handling
+  is a sibling anti-pattern (the affordance becomes mouse-only,
+  excluding keyboard and AT users).
+
+  Regression guards:
   `web/tests/integration/TableRowCursorPointerRegressionTest.php`
-  pins three contracts — the bare `.table tbody tr` rule carries
-  no `cursor: pointer`, the hover-bg rule survives, AND no other
-  selector silently re-applies `cursor: pointer` to any
-  table-row scope (the "fail closed" arm catches a future
-  copy-paste from a tooltip / popover demo or a well-meaning
-  "rows feel clickable, let me make them clickable" PR). If a
+  pins five contracts — (1) the bare `.table tbody tr` rule
+  carries no `cursor: pointer`, (2) the hover-bg rule survives,
+  (3) the `.table.table--clickable-rows tbody tr` opt-in rule
+  exists and DOES carry `cursor: pointer`, (4) no OTHER selector
+  silently re-applies `cursor: pointer` to any table-row scope
+  (the "fail closed" arm catches a future copy-paste from a
+  tooltip / popover demo, a search-and-replace mishap, or a
+  well-meaning "rows feel clickable, let me make them clickable"
+  PR — covers bare `tr`, `tbody > tr` child combinator, attribute
+  selectors, ARIA `[role="row"]`), and (5) the System Log
+  template sets the opt-in class on its `<table>` AND its rows
+  carry the keyboard a11y triple (`role="button"` + `tabindex="0"`
+  + `onkeydown` Enter/Space handler) so the regression that
+  motivated the opt-in pattern stays caught end-to-end. If a
   future list page genuinely needs row-wide click delegation,
-  gate the cursor behind a specific class on the table
-  (`.table--clickable-rows tbody tr { cursor: pointer; }`) AND
-  wire a real click handler on the `<tr>` AND update the
-  regression test's allowlist — never restore the bare
+  set `class="table table--clickable-rows"` on the `<table>` AND
+  wire a real `<tr>`-level click handler AND ship the same
+  keyboard a11y triple AND update the regression test's
+  allowlist with the new opt-in variant — never restore the bare
   `.table tbody tr { cursor: pointer; }` shape (it would lie on
-  every other table on the panel).
+  every other table on the panel) and never ship a row-wide
+  `onclick` without `role="button"` + `tabindex="0"` + `onkeydown`
+  (it would exclude keyboard users from the affordance).
 - Viewport-based `@media` queries for hiding `.table` columns
   (`@media (max-width: 1535px) { .col-tier-2 { display: none; } }`
   shape) → use `@container tablescroll (max-width: …)` rules

--- a/web/tests/integration/TableRowCursorPointerRegressionTest.php
+++ b/web/tests/integration/TableRowCursorPointerRegressionTest.php
@@ -1,0 +1,182 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sbpp\Tests\Integration;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Issue #1443: the desktop `.table tbody tr` rule in
+ * `web/themes/default/css/theme.css` carried `cursor: pointer` from
+ * the initial v2.0 vendor handoff (#1123 A1, commit 7c8bb9d6) — an
+ * artifact of an early design where the whole table row was meant
+ * to be clickable. The final v2.0 chrome wires interaction to
+ * specific *child* elements instead (the player-name `<a>` carries
+ * `[data-drawer-bid]` / `[data-drawer-cid]` / `[data-drawer-href]`
+ * for the drawer; row-actions buttons carry `data-action="…"`; the
+ * per-row comments toggle via its native `<summary>`). The `<tr>`
+ * itself has no click handler.
+ *
+ * Painting `cursor: pointer` on the row therefore lied to every
+ * user hovering over a non-anchor cell (steam id, IP, reason,
+ * status, server, admin, length, banned timestamp) — the hand
+ * cursor advertised clickability, the click did nothing, and the
+ * panel read as broken. The reporter's exact symptom on #1443.
+ *
+ * The fix drops the `cursor: pointer` declaration from the
+ * `.table tbody tr` selector. Native cursors on the inner
+ * `<a>` / `<button>` / `<summary>` elements already paint
+ * correctly (browsers default `cursor: pointer` for links and
+ * carry it for interactive widgets), so removing the row-wide
+ * declaration restores honest affordance: pointer only where
+ * clicking does something.
+ *
+ * The hover-background rule survives — it's a scanning aid for
+ * tracking which row the mouse is on, not a clickability claim.
+ * Every modern data table (Linear, Notion, GitHub, Vercel)
+ * leans on the same row-hover-background-without-cursor-pointer
+ * convention.
+ *
+ * This suite is the static gate against re-introducing the rule.
+ * A copy-paste from a future tooltip / popover demo, a search-
+ * and-replace mishap, or a well-meaning "rows feel clickable, let
+ * me make them clickable" PR would all silently re-open the bug.
+ */
+final class TableRowCursorPointerRegressionTest extends TestCase
+{
+    private string $css;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $cssPath = ROOT . 'themes/default/css/theme.css';
+        $css     = file_get_contents($cssPath);
+        if ($css === false) {
+            self::fail("setUp could not read theme.css at {$cssPath}");
+        }
+        $this->css = $css;
+    }
+
+    /**
+     * The load-bearing assertion: the `.table tbody tr` selector
+     * must NOT carry `cursor: pointer`. Match the whole rule body
+     * (selector through closing brace) so a future refactor that
+     * splits the rule onto multiple lines doesn't accidentally
+     * sneak `cursor: pointer` back in.
+     */
+    public function testTableRowSelectorHasNoCursorPointer(): void
+    {
+        if (preg_match('/\.table\s+tbody\s+tr\s*\{[^}]*\}/', $this->css, $m) !== 1) {
+            self::fail(
+                'Could not locate the `.table tbody tr { … }` rule in theme.css. '
+                . 'If the selector was renamed, update this regression guard in the '
+                . 'same PR — #1443 is about row-wide cursor pointer being misleading, '
+                . 'not about the selector shape itself.'
+            );
+        }
+        $ruleBody = $m[0];
+
+        $this->assertDoesNotMatchRegularExpression(
+            '/cursor\s*:\s*pointer/',
+            $ruleBody,
+            "The `.table tbody tr { … }` rule must NOT declare `cursor: pointer`. "
+            . "The `<tr>` element is not a click target on any list page (banlist, "
+            . "commslist, admin admins, mods, groups, overrides, servers, logs, "
+            . "kickit, blockit, bans groups, admin edit group, admin edit admins perms). "
+            . "Painting pointer on the row falsely advertises every pixel of the row "
+            . "as clickable while clicks on non-interactive cells (steam id, IP, "
+            . "reason, status, server, admin, length, banned timestamp) actually "
+            . "do nothing — the #1443 user-reported regression. Native cursors on "
+            . "the inner `<a>` / `<button>` / `<summary>` elements already paint "
+            . "correctly without help. Leave them alone."
+        );
+    }
+
+    /**
+     * The row hover-background is intentional and stays — it's a
+     * scanning aid for tracking which row the mouse is on, not a
+     * clickability claim. Hover-bg-without-cursor-pointer is the
+     * Linear / Notion / GitHub convention for data tables. Drop
+     * this affordance by accident and rows become harder to
+     * visually track.
+     */
+    public function testTableRowHoverBackgroundSurvives(): void
+    {
+        $this->assertMatchesRegularExpression(
+            '/\.table\s+tbody\s+tr:hover\s*\{[^}]*background\s*:\s*var\(--bg-muted\)/',
+            $this->css,
+            "The `.table tbody tr:hover { background: var(--bg-muted); }` rule must "
+            . "survive — it's a scanning aid that helps users track which row they're "
+            . "hovering over. The hover background is NOT a clickability claim (the "
+            . "Linear / Notion / GitHub convention is hover-bg-without-pointer-cursor); "
+            . "removing it would make data-table rows visually harder to track without "
+            . "fixing the #1443 cursor problem the way dropping `cursor: pointer` did."
+        );
+    }
+
+    /**
+     * Defense-in-depth: assert no OTHER selector in theme.css
+     * silently re-applies `cursor: pointer` to `tbody tr` or
+     * `.table` rows. A future utility class like
+     * `.clickable-rows tbody tr { cursor: pointer; }` would be
+     * the right shape if a list page genuinely wired row-wide
+     * click delegation, but until that's true the codebase
+     * should NOT carry such a selector. This test fails closed
+     * — if you genuinely need a future row-wide click affordance,
+     * gate it behind a specific class on the table (not a bare
+     * `tbody tr` selector) AND update this test to allowlist the
+     * new shape.
+     */
+    public function testNoOtherSelectorReintroducesRowWideCursorPointer(): void
+    {
+        // Strip CSS block comments so our scan doesn't false-positive
+        // on documentation comments that legitimately mention the
+        // forbidden shape (e.g. the explanatory comment above the
+        // `.table tbody tr` rule itself, which says "Painting
+        // `cursor: pointer` on the row falsely advertised…"). The
+        // `/s` flag makes `.` match newlines so multi-line comments
+        // collapse correctly; the `U` flag makes the quantifier
+        // non-greedy so we don't accidentally eat across `*/...*/`
+        // boundaries.
+        $stripped = preg_replace('#/\*.*?\*/#s', '', $this->css);
+        if (!is_string($stripped)) {
+            self::fail('Failed to strip CSS comments before scanning.');
+        }
+
+        // Match any rule whose selector ends in `tbody tr`,
+        // `tr.ban-row`, or `tr[data-testid="(ban|comm)-row"]` and
+        // whose body contains `cursor: pointer`. Bare
+        // `tr { cursor: pointer; }` would be even more catastrophic
+        // so we catch that too via the `^tr` anchor (start-of-line
+        // under the `/m` flag).
+        //
+        // Selector regex matches: one or more "selector chars" plus
+        // a row-scope token, then optional further selector chars
+        // (e.g. `:hover`, `.foo`), then the `{...}` body.
+        $forbiddenSelectorBodies = [];
+        $pattern = '/(?:^|[\n,])[^{}]*\b(?:tbody\s+tr|tr\.ban-row|tr\[data-testid="(?:ban|comm)-row"\])[^{}]*\{[^}]*\}/m';
+        if (preg_match_all($pattern, $stripped, $matches) > 0) {
+            foreach ($matches[0] as $rule) {
+                if (preg_match('/cursor\s*:\s*pointer/', $rule) === 1) {
+                    $forbiddenSelectorBodies[] = trim($rule);
+                }
+            }
+        }
+
+        $this->assertSame(
+            [],
+            $forbiddenSelectorBodies,
+            "theme.css must NOT carry any selector that applies `cursor: pointer` "
+            . "to a table-row scope (`tbody tr`, `tr.ban-row`, "
+            . "`tr[data-testid=\"ban-row\"]`, `tr[data-testid=\"comm-row\"]`). "
+            . "The `<tr>` element is not a click target — the v2.0 "
+            . "chrome delegates interaction to specific child elements (drawer "
+            . "trigger anchor, row-action buttons, comments details summary). "
+            . "Painting row-wide pointer cursor on non-clickable rows is #1443's "
+            . "regression class. Found rule(s): \n"
+            . implode("\n---\n", $forbiddenSelectorBodies)
+        );
+    }
+}

--- a/web/tests/integration/TableRowCursorPointerRegressionTest.php
+++ b/web/tests/integration/TableRowCursorPointerRegressionTest.php
@@ -7,45 +7,67 @@ namespace Sbpp\Tests\Integration;
 use PHPUnit\Framework\TestCase;
 
 /**
- * Issue #1443: the desktop `.table tbody tr` rule in
+ * Issue #1443: the bare `.table tbody tr` rule in
  * `web/themes/default/css/theme.css` carried `cursor: pointer` from
  * the initial v2.0 vendor handoff (#1123 A1, commit 7c8bb9d6) — an
  * artifact of an early design where the whole table row was meant
  * to be clickable. The final v2.0 chrome wires interaction to
- * specific *child* elements instead (the player-name `<a>` carries
- * `[data-drawer-bid]` / `[data-drawer-cid]` / `[data-drawer-href]`
- * for the drawer; row-actions buttons carry `data-action="…"`; the
- * per-row comments toggle via its native `<summary>`). The `<tr>`
- * itself has no click handler.
+ * specific *child* elements on every list page EXCEPT the System
+ * Log table (`page_admin_settings_logs.tpl`, which legitimately
+ * carries an `onclick="toggleLogRow"` on the `<tr>` to flip a
+ * sibling detail row): the player-name `<a>` carries
+ * `[data-drawer-bid]` / `[data-drawer-cid]` /
+ * `[data-drawer-href]` for the drawer; row-actions buttons carry
+ * `data-action="…"`; the per-row comments toggle via its native
+ * `<summary>`. The `<tr>` itself has no click handler on those
+ * pages.
  *
- * Painting `cursor: pointer` on the row therefore lied to every
+ * Painting `cursor: pointer` on every row therefore lied to every
  * user hovering over a non-anchor cell (steam id, IP, reason,
  * status, server, admin, length, banned timestamp) — the hand
  * cursor advertised clickability, the click did nothing, and the
  * panel read as broken. The reporter's exact symptom on #1443.
  *
- * The fix drops the `cursor: pointer` declaration from the
- * `.table tbody tr` selector. Native cursors on the inner
- * `<a>` / `<button>` / `<summary>` elements already paint
- * correctly (browsers default `cursor: pointer` for links and
- * carry it for interactive widgets), so removing the row-wide
- * declaration restores honest affordance: pointer only where
- * clicking does something.
+ * The fix drops the `cursor: pointer` declaration from the bare
+ * `.table tbody tr` selector and adds an opt-in
+ * `.table.table--clickable-rows tbody tr { cursor: pointer; }`
+ * modifier for the one in-tree surface that needs it. The System
+ * Log table opts in by setting `class="table table--clickable-rows"`
+ * on the `<table>`. Native cursors on inner `<a>` / `<button>` /
+ * `<summary>` elements already paint correctly on every other
+ * surface (browsers default `cursor: pointer` for links and
+ * interactive widgets).
  *
  * The hover-background rule survives — it's a scanning aid for
  * tracking which row the mouse is on, not a clickability claim.
  * Every modern data table (Linear, Notion, GitHub, Vercel)
- * leans on the same row-hover-background-without-cursor-pointer
- * convention.
+ * leans on the same hover-bg-without-cursor-pointer convention
+ * for non-clickable rows.
  *
  * This suite is the static gate against re-introducing the rule.
  * A copy-paste from a future tooltip / popover demo, a search-
  * and-replace mishap, or a well-meaning "rows feel clickable, let
  * me make them clickable" PR would all silently re-open the bug.
+ *
+ * The contracts pinned in five tests:
+ *
+ *   1. The bare `.table tbody tr` rule must NOT declare
+ *      `cursor: pointer`.
+ *   2. The hover-background rule must survive (scanning aid).
+ *   3. The opt-in `.table.table--clickable-rows tbody tr` rule
+ *      must exist and DOES declare `cursor: pointer` (so any
+ *      future row-wide click surface has a working idiom to
+ *      reach for).
+ *   4. No OTHER selector silently re-applies `cursor: pointer`
+ *      to a table-row scope (the "fail closed" arm).
+ *   5. The System Log template `page_admin_settings_logs.tpl`
+ *      sets the opt-in class on its table (so the regression
+ *      that motivated the opt-in pattern stays caught).
  */
 final class TableRowCursorPointerRegressionTest extends TestCase
 {
     private string $css;
+    private string $logsTemplate;
 
     protected function setUp(): void
     {
@@ -57,20 +79,34 @@ final class TableRowCursorPointerRegressionTest extends TestCase
             self::fail("setUp could not read theme.css at {$cssPath}");
         }
         $this->css = $css;
+
+        $logsPath = ROOT . 'themes/default/page_admin_settings_logs.tpl';
+        $logs     = file_get_contents($logsPath);
+        if ($logs === false) {
+            self::fail("setUp could not read system-log template at {$logsPath}");
+        }
+        $this->logsTemplate = $logs;
     }
 
     /**
-     * The load-bearing assertion: the `.table tbody tr` selector
-     * must NOT carry `cursor: pointer`. Match the whole rule body
-     * (selector through closing brace) so a future refactor that
-     * splits the rule onto multiple lines doesn't accidentally
-     * sneak `cursor: pointer` back in.
+     * The load-bearing assertion: the bare `.table tbody tr`
+     * selector must NOT carry `cursor: pointer`. Match the whole
+     * rule body (selector through closing brace) so a future
+     * refactor that splits the rule onto multiple lines doesn't
+     * accidentally sneak `cursor: pointer` back in. The selector
+     * pattern carries `(?![^{]*table--clickable-rows)` so we don't
+     * accidentally match the sibling opt-in rule.
      */
-    public function testTableRowSelectorHasNoCursorPointer(): void
+    public function testBareTableRowSelectorHasNoCursorPointer(): void
     {
-        if (preg_match('/\.table\s+tbody\s+tr\s*\{[^}]*\}/', $this->css, $m) !== 1) {
+        // Locate the bare `.table tbody tr { ... }` rule (NOT the
+        // sibling `.table.table--clickable-rows tbody tr { ... }`
+        // opt-in rule). We do this by finding a rule whose selector
+        // line STARTS with `.table tbody tr` and has no modifier
+        // class before `tbody`.
+        if (preg_match('/(?:^|[\n;\}])\s*\.table\s+tbody\s+tr\s*\{[^}]*\}/', $this->css, $m) !== 1) {
             self::fail(
-                'Could not locate the `.table tbody tr { … }` rule in theme.css. '
+                'Could not locate the bare `.table tbody tr { … }` rule in theme.css. '
                 . 'If the selector was renamed, update this regression guard in the '
                 . 'same PR — #1443 is about row-wide cursor pointer being misleading, '
                 . 'not about the selector shape itself.'
@@ -81,16 +117,19 @@ final class TableRowCursorPointerRegressionTest extends TestCase
         $this->assertDoesNotMatchRegularExpression(
             '/cursor\s*:\s*pointer/',
             $ruleBody,
-            "The `.table tbody tr { … }` rule must NOT declare `cursor: pointer`. "
-            . "The `<tr>` element is not a click target on any list page (banlist, "
-            . "commslist, admin admins, mods, groups, overrides, servers, logs, "
-            . "kickit, blockit, bans groups, admin edit group, admin edit admins perms). "
-            . "Painting pointer on the row falsely advertises every pixel of the row "
-            . "as clickable while clicks on non-interactive cells (steam id, IP, "
-            . "reason, status, server, admin, length, banned timestamp) actually "
-            . "do nothing — the #1443 user-reported regression. Native cursors on "
-            . "the inner `<a>` / `<button>` / `<summary>` elements already paint "
-            . "correctly without help. Leave them alone."
+            "The bare `.table tbody tr { … }` rule must NOT declare `cursor: pointer`. "
+            . "The `<tr>` element is not a click target on banlist, commslist, admin "
+            . "admins / mods / groups / overrides / servers, kickit, blockit, "
+            . "bans-groups, admin-edit-group, or admin-edit-admins-perms. Painting "
+            . "pointer on the row falsely advertises every pixel as clickable while "
+            . "clicks on non-interactive cells (steam id, IP, reason, status, server, "
+            . "admin, length, banned timestamp) actually do nothing — the #1443 "
+            . "user-reported regression. Native cursors on the inner `<a>` / "
+            . "`<button>` / `<summary>` elements already paint correctly without "
+            . "help. For genuinely row-clickable surfaces (currently only the System "
+            . "Log table), set `class=\"table table--clickable-rows\"` on the "
+            . "`<table>` — see `testClickableRowsModifierExists()` for the opt-in "
+            . "selector contract."
         );
     }
 
@@ -98,8 +137,8 @@ final class TableRowCursorPointerRegressionTest extends TestCase
      * The row hover-background is intentional and stays — it's a
      * scanning aid for tracking which row the mouse is on, not a
      * clickability claim. Hover-bg-without-cursor-pointer is the
-     * Linear / Notion / GitHub convention for data tables. Drop
-     * this affordance by accident and rows become harder to
+     * Linear / Notion / GitHub / Vercel convention for data tables.
+     * Drop this affordance by accident and rows become harder to
      * visually track.
      */
     public function testTableRowHoverBackgroundSurvives(): void
@@ -117,17 +156,43 @@ final class TableRowCursorPointerRegressionTest extends TestCase
     }
 
     /**
+     * The opt-in `.table.table--clickable-rows tbody tr` rule must
+     * exist AND carry `cursor: pointer`. This is the documented
+     * escape hatch for tables where the `<tr>` IS a click target
+     * (currently only the System Log table). Without this idiom,
+     * future authors would either re-introduce the bare rule (the
+     * #1443 regression) or invent another opt-in shape (theme
+     * fragmentation).
+     */
+    public function testClickableRowsModifierExists(): void
+    {
+        $this->assertMatchesRegularExpression(
+            '/\.table\.table--clickable-rows\s+tbody\s+tr\s*\{[^}]*cursor\s*:\s*pointer/',
+            $this->css,
+            "The `.table.table--clickable-rows tbody tr { cursor: pointer; }` opt-in "
+            . "rule must exist in theme.css — it's the documented escape hatch for "
+            . "tables where the `<tr>` IS a click target (currently only the System "
+            . "Log table). Without this idiom, future authors would either re-"
+            . "introduce the bare `.table tbody tr { cursor: pointer; }` rule (the "
+            . "#1443 regression class) or invent another opt-in shape (theme "
+            . "fragmentation). The modifier must be applied to the `<table>` element "
+            . "(not the individual `<tr>`s) so it composes cleanly with future "
+            . "table-scoped variants."
+        );
+    }
+
+    /**
      * Defense-in-depth: assert no OTHER selector in theme.css
-     * silently re-applies `cursor: pointer` to `tbody tr` or
-     * `.table` rows. A future utility class like
-     * `.clickable-rows tbody tr { cursor: pointer; }` would be
-     * the right shape if a list page genuinely wired row-wide
-     * click delegation, but until that's true the codebase
-     * should NOT carry such a selector. This test fails closed
-     * — if you genuinely need a future row-wide click affordance,
-     * gate it behind a specific class on the table (not a bare
-     * `tbody tr` selector) AND update this test to allowlist the
-     * new shape.
+     * silently re-applies `cursor: pointer` to a table-row scope.
+     * This is the "fail closed" arm — any new selector that
+     * targets `tr` (in any shape) and declares `cursor: pointer`
+     * fails the test, and the contract is "if you genuinely need
+     * a new row-wide click affordance, gate it behind
+     * `.table--clickable-rows` AND wire a real `<tr>` click
+     * handler AND update this test's allowlist". The bare `tr`
+     * selector and every plausible variant (child combinator,
+     * tbody-less, attribute-selector, ARIA role) all get caught
+     * by this gate.
      */
     public function testNoOtherSelectorReintroducesRowWideCursorPointer(): void
     {
@@ -137,30 +202,76 @@ final class TableRowCursorPointerRegressionTest extends TestCase
         // `.table tbody tr` rule itself, which says "Painting
         // `cursor: pointer` on the row falsely advertised…"). The
         // `/s` flag makes `.` match newlines so multi-line comments
-        // collapse correctly; the `U` flag makes the quantifier
-        // non-greedy so we don't accidentally eat across `*/...*/`
-        // boundaries.
+        // collapse correctly. `.*?` is non-greedy so we don't
+        // accidentally eat across `*/...*/` boundaries.
         $stripped = preg_replace('#/\*.*?\*/#s', '', $this->css);
         if (!is_string($stripped)) {
             self::fail('Failed to strip CSS comments before scanning.');
         }
 
-        // Match any rule whose selector ends in `tbody tr`,
-        // `tr.ban-row`, or `tr[data-testid="(ban|comm)-row"]` and
-        // whose body contains `cursor: pointer`. Bare
-        // `tr { cursor: pointer; }` would be even more catastrophic
-        // so we catch that too via the `^tr` anchor (start-of-line
-        // under the `/m` flag).
-        //
-        // Selector regex matches: one or more "selector chars" plus
-        // a row-scope token, then optional further selector chars
-        // (e.g. `:hover`, `.foo`), then the `{...}` body.
+        // Walk every rule body and extract the `(selector) { body }`
+        // pair, then test:
+        //   1. Does the body declare `cursor: pointer`?
+        //   2. Does the selector touch a table-row scope?
+        //   3. Is the selector the documented opt-in?
+        // We use a depth-zero CSS parser since theme.css is flat
+        // (no @-rules nesting selectors). The split is by `}` after
+        // a top-level `{`.
         $forbiddenSelectorBodies = [];
-        $pattern = '/(?:^|[\n,])[^{}]*\b(?:tbody\s+tr|tr\.ban-row|tr\[data-testid="(?:ban|comm)-row"\])[^{}]*\{[^}]*\}/m';
-        if (preg_match_all($pattern, $stripped, $matches) > 0) {
-            foreach ($matches[0] as $rule) {
-                if (preg_match('/cursor\s*:\s*pointer/', $rule) === 1) {
-                    $forbiddenSelectorBodies[] = trim($rule);
+
+        // Allowlisted selectors — exact substring match.
+        $allowlist = [
+            '.table.table--clickable-rows tbody tr',
+        ];
+
+        // The rule-extraction loop: find every `{ ... }` body and
+        // pair it with the selector portion that precedes it.
+        $offset = 0;
+        while (preg_match('/(?<sel>[^{}]+)\{(?<body>[^{}]*)\}/s', $stripped, $m, PREG_OFFSET_CAPTURE, $offset) === 1) {
+            $sel    = trim($m['sel'][0]);
+            $body   = $m['body'][0];
+            $next   = $m[0][1] + strlen($m[0][0]);
+            $offset = $next;
+
+            // Skip rules whose body doesn't declare cursor: pointer.
+            if (preg_match('/cursor\s*:\s*pointer/', $body) !== 1) {
+                continue;
+            }
+
+            // Walk every selector in the comma-separated list and
+            // flag any that touches a `tr` scope.
+            foreach (preg_split('/\s*,\s*/', $sel) as $oneSel) {
+                $oneSel = trim($oneSel);
+                if ($oneSel === '') {
+                    continue;
+                }
+
+                // Allowlisted?
+                $isAllowlisted = false;
+                foreach ($allowlist as $allowed) {
+                    if (str_contains($oneSel, $allowed)) {
+                        $isAllowlisted = true;
+                        break;
+                    }
+                }
+                if ($isAllowlisted) {
+                    continue;
+                }
+
+                // Touches a `tr` scope? Cover every plausible shape:
+                //   - bare `tr`                              (catastrophic)
+                //   - any descendant or child combinator ending in `tr`
+                //     (`tbody tr`, `tbody > tr`, `.table tr`)
+                //   - `tr` with class / id / attribute / pseudo
+                //     (`tr.x`, `tr#x`, `tr[…]`, `tr:hover`)
+                //   - `[role="row"]` (ARIA equivalent)
+                $touchesRowScope = (bool) preg_match(
+                    '/(?:^|[\s>+~])tr(?:[\s.:#\[]|$)|\[role\s*=\s*["\']?row["\']?\]/',
+                    $oneSel,
+                );
+
+                if ($touchesRowScope) {
+                    $forbiddenSelectorBodies[] = $oneSel . ' { ' . trim($body) . ' }';
                 }
             }
         }
@@ -169,14 +280,92 @@ final class TableRowCursorPointerRegressionTest extends TestCase
             [],
             $forbiddenSelectorBodies,
             "theme.css must NOT carry any selector that applies `cursor: pointer` "
-            . "to a table-row scope (`tbody tr`, `tr.ban-row`, "
-            . "`tr[data-testid=\"ban-row\"]`, `tr[data-testid=\"comm-row\"]`). "
-            . "The `<tr>` element is not a click target — the v2.0 "
-            . "chrome delegates interaction to specific child elements (drawer "
+            . "to a table-row scope (any descendant of / child of / direct match on "
+            . "`tr`, including ARIA-equivalent `[role=\"row\"]`). The `<tr>` element "
+            . "is not a click target on any list page outside the System Log — the "
+            . "v2.0 chrome delegates interaction to specific child elements (drawer "
             . "trigger anchor, row-action buttons, comments details summary). "
             . "Painting row-wide pointer cursor on non-clickable rows is #1443's "
-            . "regression class. Found rule(s): \n"
+            . "regression class. If you're adding a new row-wide click affordance, "
+            . "gate it behind the existing `.table.table--clickable-rows` opt-in "
+            . "(currently the only allowlisted shape — see the `\$allowlist` array "
+            . "above) AND wire a real `<tr>` click handler AND update this test's "
+            . "allowlist to add the new opt-in variant. Found offending rule(s): \n"
             . implode("\n---\n", $forbiddenSelectorBodies)
+        );
+    }
+
+    /**
+     * The System Log template must apply the
+     * `table--clickable-rows` modifier to its `<table>` — without
+     * the opt-in, the `<tr onclick="toggleLogRow">` rows lose
+     * their cursor affordance (the row stays clickable but reads
+     * as inert, the exact "click works but cursor lies" inversion
+     * of #1443 the opt-in pattern exists to prevent). The
+     * template's `<p>Click a row to expand.</p>` instruction makes
+     * the affordance gap especially user-visible.
+     */
+    public function testSystemLogTableOptsIntoClickableRowsModifier(): void
+    {
+        $this->assertMatchesRegularExpression(
+            '/<table\b[^>]*\bclass="[^"]*\btable--clickable-rows\b[^"]*"[^>]*\bdata-testid="logs-table"/',
+            $this->logsTemplate,
+            "`page_admin_settings_logs.tpl` must set "
+            . "`class=\"table table--clickable-rows\"` on its `<table data-testid=\"logs-table\">` "
+            . "so the legitimately row-wide-clickable rows (each carries "
+            . "`onclick=\"toggleLogRow(this)\"`) keep their cursor affordance after "
+            . "#1443 stripped the bare-rule cursor on every other table. The opt-in "
+            . "is the documented contract — without it, the System Log row stays "
+            . "clickable but reads as inert (cursor stays default arrow, even though "
+            . "the template's `<p>Click a row to expand.</p>` instruction tells the "
+            . "user to click). See the `.table.table--clickable-rows tbody tr` rule "
+            . "in `theme.css`."
+        );
+    }
+
+    /**
+     * The System Log row must carry `role="button"` + `tabindex="0"`
+     * + `aria-expanded` + a matching `onkeydown` handler so the
+     * disclosure works for keyboard-only and AT users. Pre-#1443
+     * the row was a bare `<tr onclick="toggleLogRow">` — no role,
+     * no tabindex, no key handling — so the only way to expand a
+     * log row was a mouse click. Fixing #1443 (cursor-on-clickable
+     * surface) without paying the a11y cost on the same surface
+     * would be the wrong shape.
+     */
+    public function testSystemLogRowIsKeyboardReachable(): void
+    {
+        $this->assertMatchesRegularExpression(
+            '/<tr\b[^>]*\bdata-testid="log-row"[^>]*\brole="button"[^>]*\btabindex="0"[^>]*\baria-expanded="false"[^>]*\baria-controls="log-detail-\{\$log\.lid\}"/',
+            $this->logsTemplate,
+            "`page_admin_settings_logs.tpl`'s log-row `<tr>` must carry "
+            . "`role=\"button\"` + `tabindex=\"0\"` + `aria-expanded=\"false\"` + "
+            . "`aria-controls=\"log-detail-{\$log.lid}\"` so the row is "
+            . "keyboard-reachable and announced as an expandable disclosure to "
+            . "screen-reader users. The matching `<tr data-detail-for=\"…\">` "
+            . "row must carry the matching `id=\"log-detail-…\"` for "
+            . "`aria-controls` to resolve."
+        );
+
+        $this->assertStringContainsString(
+            'onkeydown="if(event.key===\'Enter\'||event.key===\' \'){event.preventDefault();toggleLogRow(this);}"',
+            $this->logsTemplate,
+            "`page_admin_settings_logs.tpl`'s log-row `<tr>` must carry an "
+            . "`onkeydown` handler that dispatches Enter / Space to "
+            . "`toggleLogRow(this)` — otherwise the `role=\"button\"` + "
+            . "`tabindex=\"0\"` chrome paints the affordance but the key press "
+            . "doesn't fire the toggle. AT users would hear \"button, collapsed\" "
+            . "but pressing Enter / Space would do nothing."
+        );
+
+        $this->assertMatchesRegularExpression(
+            '/<tr\b[^>]*\bdata-detail-for="\{\$log\.lid\}"[^>]*\bid="log-detail-\{\$log\.lid\}"/',
+            $this->logsTemplate,
+            "`page_admin_settings_logs.tpl`'s detail row `<tr>` must carry "
+            . "`id=\"log-detail-{\$log.lid}\"` so the summary row's "
+            . "`aria-controls=\"log-detail-{\$log.lid}\"` resolves to a real "
+            . "element. Without the `id`, screen readers can't follow the "
+            . "disclosure relationship."
         );
     }
 }

--- a/web/themes/default/css/theme.css
+++ b/web/themes/default/css/theme.css
@@ -1118,25 +1118,40 @@ html.dark .table thead tr { background: rgb(255 255 255 / 0.02); }
 .table th { text-align: left; font-size: 0.625rem; font-weight: 600; letter-spacing: 0.06em; text-transform: uppercase; color: var(--text-muted); padding: 0.625rem 0.75rem; }
 .table th:first-child, .table td:first-child { padding-left: 1.25rem; }
 .table th:last-child, .table td:last-child { padding-right: 1.25rem; }
-/* #1443: NO `cursor: pointer` on the row itself. The `<tr>` is not
-   a click target — every list-page table in the panel delegates
-   interaction to specific child elements (the player-name anchor
-   carries `[data-drawer-bid]` / `[data-drawer-cid]` / `[data-drawer-href]`
-   for the drawer; row-actions buttons carry `data-action="…"`; the
+/* #1443: NO `cursor: pointer` on the bare `.table tbody tr`. On
+   every list page where the table-row is NOT itself a click target
+   — banlist, commslist, admin admins / mods / groups / overrides /
+   servers, kickit, blockit, bans-groups, admin-edit-group,
+   admin-edit-admins-perms — interaction is delegated to specific
+   *child* elements (the player-name anchor carries
+   `[data-drawer-bid]` / `[data-drawer-cid]` / `[data-drawer-href]`
+   for the drawer; row-action buttons carry `data-action="…"`; the
    per-row comments `<details>` toggles via its native `<summary>`).
    Painting `cursor: pointer` on the row falsely advertised every
    pixel of the row as clickable, so users would click on dead cells
    (steam id, IP, reason, status, server, admin, length, banned
-   timestamp) and nothing would happen — the reporter's exact
-   symptom on #1443. Native cursors on the inner anchors / buttons /
-   summaries already paint correctly without help, so dropping the
-   rule restores honest affordance: pointer only where clicking does
-   something. Hover-bg stays — it's a scanning aid, not a
-   clickability claim (every modern data table from Linear / Notion /
-   GitHub leans on the same row-hover-background-without-cursor-
-   pointer convention). */
+   timestamp) and nothing would happen — the reporter's exact symptom
+   on #1443. Native cursors on the inner `<a>` / `<button>` /
+   `<summary>` elements already paint correctly without help, so
+   dropping the row-wide declaration restores honest affordance:
+   pointer only where clicking does something. Hover-bg stays — it's
+   a scanning aid for tracking which row the mouse is on, not a
+   clickability claim (Linear / Notion / GitHub / Vercel all converge
+   on hover-bg-without-pointer-cursor for data tables where the row
+   is not itself clickable).
+
+   The opt-in `.table--clickable-rows` modifier below restores the
+   row-wide cursor on the one in-tree surface that legitimately needs
+   it: the System Log table (`page_admin_settings_logs.tpl`) where
+   the row's `onclick="toggleLogRow(this)"` flips a hidden sibling
+   detail row. Any future surface that genuinely wires a row-wide
+   click handler MUST add the modifier class to the `<table>` AND
+   wire the real handler on the `<tr>` AND update the regression
+   test's allowlist (see
+   `web/tests/integration/TableRowCursorPointerRegressionTest.php`). */
 .table tbody tr { border-bottom: 1px solid var(--border); }
 .table tbody tr:hover { background: var(--bg-muted); }
+.table.table--clickable-rows tbody tr { cursor: pointer; }
 .table td { padding: 0.75rem; vertical-align: middle; }
 /* #1207 ADM-5: row actions are *always* visible — the previous
    `opacity: 0 → 1 on tr:hover` treatment was a discoverability dead

--- a/web/themes/default/css/theme.css
+++ b/web/themes/default/css/theme.css
@@ -1118,7 +1118,24 @@ html.dark .table thead tr { background: rgb(255 255 255 / 0.02); }
 .table th { text-align: left; font-size: 0.625rem; font-weight: 600; letter-spacing: 0.06em; text-transform: uppercase; color: var(--text-muted); padding: 0.625rem 0.75rem; }
 .table th:first-child, .table td:first-child { padding-left: 1.25rem; }
 .table th:last-child, .table td:last-child { padding-right: 1.25rem; }
-.table tbody tr { border-bottom: 1px solid var(--border); cursor: pointer; }
+/* #1443: NO `cursor: pointer` on the row itself. The `<tr>` is not
+   a click target — every list-page table in the panel delegates
+   interaction to specific child elements (the player-name anchor
+   carries `[data-drawer-bid]` / `[data-drawer-cid]` / `[data-drawer-href]`
+   for the drawer; row-actions buttons carry `data-action="…"`; the
+   per-row comments `<details>` toggles via its native `<summary>`).
+   Painting `cursor: pointer` on the row falsely advertised every
+   pixel of the row as clickable, so users would click on dead cells
+   (steam id, IP, reason, status, server, admin, length, banned
+   timestamp) and nothing would happen — the reporter's exact
+   symptom on #1443. Native cursors on the inner anchors / buttons /
+   summaries already paint correctly without help, so dropping the
+   rule restores honest affordance: pointer only where clicking does
+   something. Hover-bg stays — it's a scanning aid, not a
+   clickability claim (every modern data table from Linear / Notion /
+   GitHub leans on the same row-hover-background-without-cursor-
+   pointer convention). */
+.table tbody tr { border-bottom: 1px solid var(--border); }
 .table tbody tr:hover { background: var(--bg-muted); }
 .table td { padding: 0.75rem; vertical-align: middle; }
 /* #1207 ADM-5: row actions are *always* visible — the previous

--- a/web/themes/default/page_admin_settings_logs.tpl
+++ b/web/themes/default/page_admin_settings_logs.tpl
@@ -70,7 +70,16 @@
                         </div>
 
                         {if count($log_items) > 0}
-                            <table class="table" data-testid="logs-table">
+                            {* #1443: this is the in-tree canonical surface where
+                               the table-row IS the click target — `onclick="toggleLogRow"`
+                               flips a sibling detail row. `.table--clickable-rows`
+                               opts the rows into the row-wide `cursor: pointer`
+                               affordance from `theme.css`. New surfaces that want
+                               the same shape add the modifier class AND wire a
+                               real `<tr>`-level click handler AND update the
+                               regression test's allowlist; see the comment above
+                               the `.table tbody tr` rule in `theme.css`. *}
+                            <table class="table table--clickable-rows" data-testid="logs-table">
                                 <thead>
                                     <tr>
                                         <th style="width:6rem">Type</th>
@@ -81,7 +90,22 @@
                                 </thead>
                                 <tbody>
                                     {foreach from=$log_items item="log"}
-                                        <tr data-testid="log-row" data-id="{$log.lid}" onclick="toggleLogRow(this);">
+                                        {* #1443 a11y: `role="button"` + `tabindex="0"` +
+                                           `aria-expanded` + matching keydown handler make
+                                           the row keyboard-reachable AND screen-reader-
+                                           announced as an expandable disclosure. Pre-fix
+                                           the only affordance was the `onclick` attribute
+                                           — a bare `<tr>` with no role / tabindex / key
+                                           handling — so keyboard-only and AT users had no
+                                           way to expand a log row. *}
+                                        <tr data-testid="log-row"
+                                            data-id="{$log.lid}"
+                                            role="button"
+                                            tabindex="0"
+                                            aria-expanded="false"
+                                            aria-controls="log-detail-{$log.lid}"
+                                            onclick="toggleLogRow(this);"
+                                            onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();toggleLogRow(this);}">
                                             <td>
                                                 {if $log.type == 'm'}
                                                     <span class="pill pill--online"><i data-lucide="info" style="width:0.75rem;height:0.75rem"></i> Info</span>
@@ -97,7 +121,7 @@
                                             <td class="font-mono text-xs">{$log.user}</td>
                                             <td class="font-mono text-xs tabular-nums">{$log.date_str}</td>
                                         </tr>
-                                        <tr data-detail-for="{$log.lid}" hidden>
+                                        <tr data-detail-for="{$log.lid}" id="log-detail-{$log.lid}" hidden>
                                             <td colspan="4" style="background:var(--bg-muted)">
                                                 <dl class="grid gap-2 text-xs" style="grid-template-columns:8rem 1fr;margin:0">
                                                     <dt class="text-muted">Details</dt>
@@ -134,6 +158,12 @@
      * are emitted with data-detail-for="<lid>", so a click on the summary
      * row finds its sibling by id and flips the `hidden` attribute. No
      * accordion library, no jQuery, no global state.
+     *
+     * #1443 a11y: also flips the summary row's `aria-expanded` so AT users
+     * hear the disclosure state. The summary row carries
+     * `role="button" tabindex="0" aria-controls="log-detail-<lid>"` so it's
+     * keyboard-reachable; the inline `onkeydown` handler dispatches Enter /
+     * Space to the same toggle path.
      */
     window.toggleLogRow = function (row) {
         if (!row || !row.dataset || !row.dataset.id) return;
@@ -141,8 +171,10 @@
         if (!detail) return;
         if (detail.hasAttribute('hidden')) {
             detail.removeAttribute('hidden');
+            row.setAttribute('aria-expanded', 'true');
         } else {
             detail.setAttribute('hidden', '');
+            row.setAttribute('aria-expanded', 'false');
         }
     };
 


### PR DESCRIPTION
## Summary

Fixes [#1443](https://github.com/sbpp/sourcebans-pp/issues/1443) — the
hand (pointer) cursor was painted on every `<tr>` of every panel data
table, but on every list page except the System Log the `<tr>` element
isn't a click target. Interaction is delegated to specific *child*
elements: the player-name `<a>` carries `[data-drawer-*]` for the
drawer; row-action buttons carry `data-action="…"`; the per-row
comments toggle via its native `<summary>`. Clicking on dead cells
(steam id, IP, reason, status, server, admin, length, banned
timestamp) did nothing — the panel read as broken to the reporter.

The bare `.table tbody tr` rule in `theme.css` (vintage v2.0 vendor
handoff, commit 7c8bb9d6) now drops `cursor: pointer`. The
hover-background rule survives — it's a scanning aid for tracking which
row the mouse is on, not a clickability claim (Linear / Notion /
GitHub / Vercel all converge on hover-bg-without-pointer-cursor for
data tables where the row is not itself clickable).

The **one in-tree surface where the `<tr>` IS a click target** is the
System Log table (`page_admin_settings_logs.tpl`) where each row's
\`onclick=\"toggleLogRow\"\` flips a sibling detail row. A new opt-in
modifier (\`.table.table--clickable-rows tbody tr { cursor: pointer; }\`)
restores the row-wide cursor on that surface AND establishes the
documented pattern for any future row-wide click surface.

This PR went through one full adversarial review cycle in-conversation
— the initial commit (`4c4269f1`) only dropped the cursor, missing the
System Log regression. The second commit (`d998ee82`) added the opt-in
modifier, restored the System Log affordance, ALSO paid the keyboard
a11y cost on the same surface (the System Log's pre-existing
\`<tr onclick=…>\` had no \`role\` / \`tabindex\` / key handling, so
keyboard + AT users had no way to expand a log row), and rewrote the
test suite + docs to match.

### Changes

- **\`web/themes/default/css/theme.css\`** — drop \`cursor: pointer\`
  from the bare \`.table tbody tr\` rule; add the opt-in
  \`.table.table--clickable-rows tbody tr { cursor: pointer; }\`
  modifier. Comment block documents the rationale and points to the
  System Log as the opt-in's canonical consumer.
- **\`web/themes/default/page_admin_settings_logs.tpl\`** —
  \`class=\"table table--clickable-rows\"\` on the \`<table>\` so the
  row-wide cursor affordance survives the bare-rule strip. Summary
  rows now carry \`role=\"button\"\` + \`tabindex=\"0\"\` +
  \`aria-expanded=\"false\"\` + \`aria-controls=\"log-detail-{lid}\"\`
  + a matching \`onkeydown\` Enter/Space handler. Detail rows carry
  the paired \`id=\"log-detail-{lid}\"\` so \`aria-controls\` resolves.
  \`toggleLogRow\` flips \`aria-expanded\` alongside the \`hidden\`
  attribute so AT users hear the disclosure state.
- **\`web/tests/integration/TableRowCursorPointerRegressionTest.php\`**
  — NEW. Six contracts (3 → 6 across the review cycle):
  1. Bare \`.table tbody tr\` carries no \`cursor: pointer\`.
  2. Hover-bg rule survives (scanning aid).
  3. \`.table.table--clickable-rows tbody tr\` opt-in rule exists AND
     carries \`cursor: pointer\` (escape hatch can't silently vanish).
  4. No OTHER selector re-applies \`cursor: pointer\` to a table-row
     scope — full CSS-rule walker catches bare \`tr\`, \`tbody > tr\`,
     \`.table tr\`, \`tr.X\`, \`tr[data-testid=…]\`, \`[role=\"row\"]\`,
     and any future variant. The opt-in is the only allowlisted shape.
  5. System Log template applies the opt-in class to its \`<table>\`.
  6. System Log row carries the keyboard-a11y triple
     (\`role=\"button\"\` + \`tabindex=\"0\"\` + \`aria-expanded\` +
     \`aria-controls\` + matching \`onkeydown\` handler + paired \`id\`
     on the detail row).
- **\`AGENTS.md\`** — anti-pattern entry rewritten to acknowledge the
  System Log as the legitimate exception (the prior text falsely
  claimed \`<tr>\` is "NOT a click target on any list page") AND to
  document the opt-in pattern + the keyboard-a11y triple as the
  contract for any future surface that genuinely wires a row-wide
  click handler.

### User-visible effect

Before:

- Cursor turns into a hand over every cell of every row on the
  banlist / commslist / admin lists. Clicks on non-interactive cells
  (steam id, IP, reason, status) silently do nothing.
- System Log rows show the hand on hover (which was correct), and a
  mouse click expands the detail — but no keyboard / AT path to the
  same affordance.

After:

- Cursor stays the default arrow over non-interactive cells on every
  list page. Cursor still turns into a hand over the inner \`<a>\` /
  \`<button>\` / \`<summary>\` elements that ARE click targets —
  honest affordance everywhere.
- System Log rows keep the hand cursor (opt-in class) AND are now
  keyboard-reachable (Tab focuses the row, Enter / Space expands).

## Test plan

- [x] \`./sbpp.sh test --filter TableRowCursorPointerRegressionTest\` —
      6/6 pass, 8 assertions.
- [x] \`./sbpp.sh test\` — full suite green: **896 tests, 3343
      assertions**.
- [x] \`./sbpp.sh phpstan\` — clean (0 errors, 241 files).
- [x] \`./sbpp.sh ts-check\` — clean.
- [x] \`./sbpp.sh composer api-contract\` — no diff (unchanged).
- [ ] **Manual check (request reviewer)**: load the dev panel, hover
      over banlist / commslist / admin admins / admin mods / admin
      servers / admin groups rows — cursor should stay the default
      arrow over non-interactive cells but turn into a hand over the
      player-name link, action buttons, and the per-row comments
      summary.
- [ ] **Manual check (request reviewer)**: load
      \`?p=admin&c=settings&section=logs\` — cursor should turn into
      a hand over every row (opt-in class), AND Tab / Enter / Space
      should expand the focused row.

## Adversarial review

This PR includes the response to a full adversarial review cycle. The
review flagged one blocking issue (System Log regression), one
blocking documentation accuracy issue (the "any list page" claim was
false), and three concerns (test regex too narrow, missing System Log
test coverage, missing keyboard a11y on the System Log). All five are
addressed in commit \`d998ee82\`.