### PR TITLE
fix(1448): require base `btn` token alongside every `btn--*` modifier

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -965,6 +965,35 @@ enum.
 - **Do not** reintroduce MooTools, React, or a runtime bundler.
  Self-hosters install by unzipping the release tarball.
 
+### Button class chains (`class="btn btn--ghost btn--icon"`)
+
+Every `<button>` / `<a>` chrome affordance that pulls the panel's
+button styling MUST carry the base `btn` token alongside any
+`btn--*` modifier:
+
+- `class="btn btn--primary"` ✓
+- `class="btn btn--ghost btn--icon"` ✓
+- `class="btn btn--secondary btn--sm"` ✓
+- `class="btn--ghost btn--icon"` ✗ — no `btn` base; `<button>`
+ falls back to UA-default chrome (visible grey 1px-border pill).
+
+Only `.btn` carries the load-bearing `background` / `color` /
+`border` / `display: inline-flex` / `padding` / `height`
+declarations — every modifier (colour or sizing) sets CSS
+custom properties + (for `.btn--sm` / `.btn--icon` / `.btn--xs`)
+adds a thin layer of geometry on top, but nothing applies the
+chrome without `.btn`. Order: base first, modifiers after. Pinned
+by `web/tests/integration/ButtonClassChainTest.php` (#1448);
+canonical anti-pattern entry under "Anti-patterns" with the
+user-reported regression details.
+
+The same rule applies to button strings emitted at runtime by
+`web/themes/default/js/theme.js`'s
+`renderDrawerBody()` / `renderDrawerLoading()` /
+`renderToast()` / `renderNotePane()` paths — the gate scans
+`*.js` too, so a copy-paste of the pre-#1448 broken shape into a
+new chrome surface fails CI at PR time.
+
 ### Loading state on action buttons (`window.SBPP.setBusy`)
 
 Every action button that fires `sb.api.call(...)` from a click handler
@@ -2448,6 +2477,51 @@ contacting every contributor individually.
  to defend the path. New popup-upload surfaces wire through
  `UploadHandler::handle()`; never `move_uploaded_file()`
  directly.
+- `class="btn--ghost btn--icon"` (or any other modifier-only chain
+ of `.btn--*` classes without the base `btn` token) on a `<button>`
+ / `<a>` chrome affordance → always ship `class="btn btn--ghost
+ btn--icon"` (base token first, modifiers after). The base `.btn`
+ rule in `theme.css` is the load-bearing site that declares the
+ `--btn-bg` / `--btn-color` / `--btn-border` / `--btn-bg-hover`
+ custom-property defaults AND applies them as `background` /
+ `color` / `border` / `display: inline-flex` / `padding` /
+ `height` declarations. The colour-modifier rules (`.btn--ghost`,
+ `.btn--primary`, `.btn--secondary`, `.btn--danger`) are pure
+ custom-property overrides — they set `--btn-bg` / `--btn-color`
+ / `--btn-border` / `--btn-bg-hover` and that's all. The sizing
+ modifiers (`.btn--sm`, `.btn--icon`, `.btn--xs`) layer geometry
+ on top (`width` / `height` / `padding` / `font-size`) but still
+ don't carry the load-bearing `background` / `color` / `border`
+ / `display: inline-flex` declarations — those live exclusively
+ on `.btn`. Without `.btn` in the same class chain the variables
+ get set but nothing reads them, so the `<button>` falls back to
+ the user-agent default chrome (typically a visible grey
+ 1px-border pill). The marquee user-reported regression: pre-#1448
+ `core/title.tpl`'s mobile burger menu shipped
+ `class="btn--ghost btn--icon"`, which on mobile (where
+ `[data-mobile-menu]` flips from `display: none` to `display:
+ inline-flex` at `<=1024px`) rendered a glaring grey square in
+ the top-left of the topbar, fighting the dark theme's near-black
+ background (#1448's screenshot). Sister sites swept in the same
+ PR: `core/footer.tpl`'s palette `Esc` button (live bug — same
+ wrong-chrome shape as the burger button), and the
+ `partials/player-drawer.tpl` reference template (documentation
+ sync — the live drawer chrome is rendered by
+ `web/themes/default/js/theme.js`, which always shipped the
+ correct three-class chain). Regression guard:
+ `web/tests/integration/ButtonClassChainTest.php` (parser-style
+ sweep across `web/themes/`, `web/pages/`, `web/includes/View/`,
+ `web/install/`, `web/updater/`, `web/api/handlers/`, AND
+ `web/scripts/` + `web/themes/default/js/` for `*.tpl` / `*.php`
+ / `*.js` — every `class="..."` attribute carrying a `btn--*`
+ modifier MUST also carry the base `btn`). Class attributes
+ containing `{` (Smarty-conditional shapes) are skipped — the
+ gate doesn't expand templates, so it can't validate which branch
+ a given token came from. False negatives are bounded to chains
+ with NO base in any branch (e.g.
+ `class="{if $x}btn--primary{else}btn--ghost{/if}"`); none in
+ the codebase today, would surface as a visible UA-default render
+ whenever the conditional path runs.
 - `btn.disabled = true` (or any other manual `disabled` flip) inside
  a confirm-modal submit handler or any other action button that
  fires `sb.api.call(...)` from a click handler without an immediate
@@ -3943,6 +4017,7 @@ contacting every contributor individually.
 | Trap PHP 8.1 null-into-scalar deprecations at runtime (the bits PHPStan can't see) | `web/tests/integration/Php82DeprecationsTest.php` (#1273) — process-isolated render harness with a stub Smarty + `set_error_handler` that promotes `E_DEPRECATED` / `E_USER_DEPRECATED` to `\ErrorException`. Mirrors the LostPasswordChromeTest stub-Smarty pattern; each test method runs in a separate process because the page handlers declare top-level helpers (`setPostKey()` etc.) that PHP can't redeclare in one process. Add a marquee route here whenever a new high-traffic page handler ships, especially if it reads nullable `:prefix_*` columns or `$_POST` / `$_GET` lookups. |
 | Pin the "every `:name` PDO placeholder needs as many `bind()` calls as occurrences" contract under native prepares | `web/tests/integration/SrvAdminsPdoParamTest.php` (#1314) — two methods. `testReusedNamedPlaceholderUnderNativePreparesIsRejected` issues a tiny `SELECT 1 ... WHERE aid = :sid OR aid = :sid` against `Sbpp\Db\Database` with one `bind()` and asserts it throws `HY093`; this is the contract pin (also a regression guard if anyone re-flips `EMULATE_PREPARES` back to `true`). `testAdminSrvadminsPageRendersWithoutPdoException` is the page-level regression guard for the actual #1314 fatal — process-isolated `require` of `pages/admin.srvadmins.php` with `?id=0` asserting no `PDOException` escapes. Mirrors the Php82DeprecationsTest stub-Smarty + process-isolation shape. |
 | Pin "dead v1.x JS call sites + their server-side feeders stay deleted" (the `<script>LoadServerHost(...)</script>` / `$data['unban_link']` / `$info['popup']` shapes the v2.0.0 `sourcebans.js` cutover left without a JS landing site) | `web/tests/integration/DeadJsCallSitesTest.php` (#1404) — three methods, 12 assertions. Per-file forbidden-substring map (`page.banlist.php` / `page.commslist.php` / `page.home.php` / `admin.admins.php` / `admin.groups.php`) scanned against the **comment-stripped** source of each handler via `php_strip_whitespace()`, so the cleanup's own `// #1404 — ...` explanatory comments (and pre-existing historical-context comments that name the dead helpers in passing) don't false-fire the gate. The Smarty half (`{$server_script nofilter}`, the `<div id="servers_{$group.gid}">` hydration slot, the "Servers populate via the legacy LoadServerHostPlayersList hook." placeholder copy) is pinned by `testDeadTemplateSidesStayDropped` (also comment-stripped via `{* *}`-regex). The View-DTO side (`Sbpp\View\AdminAdminsAddView::server_script` orphan property) is pinned independently by `testAdminAdminsAddViewDoesNotCarryServerScriptProperty` so the failure points at the View directly instead of cascading through SmartyTemplateRule. Pure file scanning — extends `PHPUnit\Framework\TestCase` (no DB / session / Smarty bring-up). Sister #1402 (rewire dead JS handlers) and #1403 (ShowBox→`window.SBPP.showToast` rewrite) extend the per-file forbidden-substring map as their PRs land. |
+| Pin "every `class="btn--*"` modifier carries the base `btn` token" structural contract | `web/tests/integration/ButtonClassChainTest.php` (#1448) — single-method parser-style sweep across `web/themes/`, `web/pages/`, `web/includes/View/`, `web/install/`, `web/updater/`, `web/api/handlers/`, AND `web/scripts/` + `web/themes/default/js/` for `*.tpl` / `*.php` / `*.js`. Strips Smarty `{* … *}` (default delimiters) and `-{* … *}-` (the non-default-delimiter shape used by `page_login.tpl` / `page_blockit.tpl` / `page_kickit.tpl` / `page_admin_servers_rcon.tpl`), PHP comments via `php_strip_whitespace()`, and JS `/* */` + `//` comments. Extracts every `class="…"` / `class='…'` attribute body (negative lookbehind on the `class` keyword skips name-prefixed `data-class=` / `aria-class=` shapes), splits on whitespace, and asserts every chain carrying a `btn--*` modifier also carries `btn`. Class attributes containing `{` (Smarty-conditional shapes) are skipped — the gate doesn't expand templates. Sanity-check assertions guard against `ROOT` / `scanRoots()` typos that would silently scan zero files. Sister gate to `DeadJsCallSitesTest`; same pure-file-scanning shape. The JS-side coverage (`web/themes/default/js/theme.js`'s `renderDrawerBody()` / `renderDrawerLoading()` / toast / Notes-pane delete chrome, plus the `web/scripts/sb.js` legacy `'btn ok'` button factory) is what makes the gate's "panel chrome" coverage actually structural — that file ships seven `<button class="btn btn--ghost btn--icon[ btn--xs]">` strings via runtime concatenation, and the regression guard would be papering over the live bug surface without it. |
 | Add an E2E spec                        | `web/tests/e2e/specs/<smoke|flows|a11y|responsive>/...` + `web/tests/e2e/pages/...` |
 | Add a route to the screenshot gallery  | `web/tests/e2e/specs/_screenshots.spec.ts` (`ROUTES` array) |
 | Tweak mobile (<=768px) chrome layout   | `web/themes/default/css/theme.css` — see the `#1207` `@media (max-width: 768px)` blocks for the canonical shapes (icon-only topbar search, full-width drawer + scroll lock). Sub-paged admin routes (servers / mods / groups / comms / settings / admins / bans) use the `<details open>` accordion in the `#1259` `@media (min-width: 1024px)` block (sidebar inline at `<1024px`, sticky 14rem rail at `>=1024px`); see "Sub-paged admin routes" in Conventions. |

--- a/web/tests/integration/ButtonClassChainTest.php
+++ b/web/tests/integration/ButtonClassChainTest.php
@@ -1,0 +1,361 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sbpp\Tests\Integration;
+
+use PHPUnit\Framework\TestCase;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+
+/**
+ * Issue #1448: pin the "every `class="btn--*"` modifier carries the
+ * base `btn` token" structural contract across every panel-chrome
+ * surface that emits HTML — Smarty templates, page handlers, view
+ * DTOs, AND the runtime HTML emitter at
+ * `web/themes/default/js/theme.js` (the load-bearing site that
+ * actually paints the live drawer / toast / Notes-pane chrome).
+ *
+ * Background
+ * ----------
+ *
+ * The panel's button rule (`web/themes/default/css/theme.css`):
+ *
+ *   .btn {
+ *     --btn-bg: var(--zinc-900);
+ *     --btn-color: white;
+ *     --btn-border: transparent;
+ *     --btn-bg-hover: var(--zinc-800);
+ *     display: inline-flex; align-items: center; justify-content: center;
+ *     ...;
+ *     background: var(--btn-bg); color: var(--btn-color);
+ *     border: 1px solid var(--btn-border);
+ *   }
+ *
+ * is the load-bearing site. It declares the `--btn-*` custom-property
+ * defaults AND applies them as `background` / `color` / `border` /
+ * `display: inline-flex` / `padding` / `height`.
+ *
+ * The modifier rules — `.btn--ghost`, `.btn--primary`, `.btn--secondary`,
+ * `.btn--danger` — are colour-variable overrides only:
+ *
+ *   .btn--ghost {
+ *     --btn-bg: transparent;
+ *     --btn-color: var(--text-muted);
+ *     --btn-border: transparent;
+ *     --btn-bg-hover: var(--bg-muted);
+ *   }
+ *
+ * The sizing modifiers — `.btn--sm`, `.btn--icon`, `.btn--xs` — are
+ * variable overrides PLUS a thin layer of geometry on top
+ * (`width` / `height` / `padding` / `font-size`). They still don't
+ * carry the load-bearing `background` / `color` / `border` /
+ * `display: inline-flex` declarations — those live exclusively on
+ * `.btn`. Without the base in the class chain, the `--btn-*`
+ * variables are SET but never READ, and the `<button>` falls back
+ * to the user-agent default chrome (typically a grey 1px-border
+ * pill).
+ *
+ * The bug presents most visibly on the mobile viewport's burger
+ * menu (the user-reported regression in #1448 — "Mobile view -
+ * Burger menu background is grey"), but it's structurally identical
+ * on the drawer-close `X` and the palette-close `Esc` button. The
+ * fix at #1448 prepends `btn ` to the offending sites; this test
+ * pins the contract so a future copy-paste doesn't re-open the bug
+ * class.
+ *
+ * Implementation
+ * --------------
+ *
+ * Parser-style sweep, not literal-substring grep:
+ *
+ *   1. Walk every `*.tpl`, `*.php`, and `*.js` under the documented
+ *      scan roots.
+ *   2. Strip Smarty `{* … *}` comments (default delimiters) AND
+ *      `-{* … *}-` (the non-default delimiter shape used by
+ *      `page_login.tpl` / `page_blockit.tpl` / `page_kickit.tpl` /
+ *      `page_admin_servers_rcon.tpl`); strip PHP and JS line
+ *      comments. The strip pass is what stops this test's own
+ *      explanatory comments — and the AGENTS.md-style reminders
+ *      next to the three fixed sites — from false-matching the
+ *      gate. Without the strip, the literal substring
+ *      `btn--ghost btn--icon` quoted inside a `{* ... *}` comment
+ *      block would fire the gate every run.
+ *   3. Extract every `class="…"` / `class='…'` attribute body. The
+ *      regex uses a negative lookbehind to skip name-prefixed
+ *      attributes like `data-class=`.
+ *   4. Split on whitespace, classify tokens as `btn` (the base) /
+ *      `btn--<x>` (a modifier) / other.
+ *   5. If any token is a `btn--<x>` modifier and no `btn` token is
+ *      present, the file fails the gate.
+ *
+ * Smarty-conditional class chains (`class="btn{if $foo} btn--primary{/if}"`)
+ * are skipped — the gate doesn't expand templates, so it can't
+ * validate which branch a given token came from. False negatives
+ * are bounded to chains with NO base in any branch (e.g.
+ * `class="{if $x}btn--primary{else}btn--ghost{/if}"`); none present
+ * in the codebase today, and would surface as a visible UA-default
+ * render whenever the conditional path runs. A fuller fix would
+ * build a per-branch tokenizer; deferred until a real bypass
+ * appears.
+ *
+ * Pure file scanning. No DB / session / Smarty bring-up. Extends
+ * `PHPUnit\Framework\TestCase` directly so test discovery + CI
+ * scheduling stay cheap (mirrors `DeadJsCallSitesTest`).
+ */
+final class ButtonClassChainTest extends TestCase
+{
+    /**
+     * Roots scanned by the gate. Each entry is `[path, recursive]`
+     * — recursive directories use the iterator, single files map
+     * straight onto `collectFiles()`.
+     *
+     * Coverage rationale:
+     *
+     * - `themes/`           — every Smarty template plus the rare
+     *                         PHP view-helper. Includes the install
+     *                         wizard chrome under
+     *                         `themes/default/install/`.
+     * - `themes/default/js/` — the runtime HTML emitter. The drawer
+     *                         close-X, the toast close button, the
+     *                         Notes-pane delete button, and the
+     *                         row-level copy buttons all live here
+     *                         and ship `<button class="btn btn--ghost
+     *                         btn--icon">` strings. Without this
+     *                         scan root the gate would only protect
+     *                         server-rendered chrome and miss the
+     *                         most actively-edited surface.
+     * - `pages/`            — page handlers occasionally render
+     *                         inline HTML.
+     * - `includes/View/`    — view DTOs are pure value objects;
+     *                         scan is preventive.
+     * - `install/`          — wizard chrome (`recovery.php`,
+     *                         `already-installed.php`, etc.).
+     *                         Wizard surfaces today don't use the
+     *                         panel `.btn` chain (they ship their
+     *                         own self-contained inline CSS) but a
+     *                         future maintainer reaching for
+     *                         `<button class="btn--primary">` here
+     *                         would silently regress without this.
+     * - `updater/`          — `web/updater/index.php` lives outside
+     *                         the themes tree.
+     * - `api/handlers/`     — JSON-emitting handlers; preventive
+     *                         coverage for any future error-page
+     *                         render that leaks inline HTML.
+     * - `scripts/`          — public JS at the panel root (sb.js,
+     *                         banlist.js, comment-actions.js,
+     *                         server-tile-hydrate.js, etc.). Same
+     *                         emit-HTML rationale as the theme JS.
+     *
+     * @return list<string>
+     */
+    private static function scanRoots(): array
+    {
+        return [
+            ROOT . 'themes',
+            ROOT . 'pages',
+            ROOT . 'includes/View',
+            ROOT . 'install',
+            ROOT . 'updater',
+            ROOT . 'api/handlers',
+            ROOT . 'scripts',
+        ];
+    }
+
+    /**
+     * Strip comments before scanning so explanatory blocks that
+     * quote literal `class="btn--*"` strings (this test's own
+     * docblock + the AGENTS.md-style reminders next to the three
+     * #1448 fixes are the canonical references) don't false-match
+     * the gate.
+     *
+     * Per file extension:
+     *
+     * - `*.php` — `php_strip_whitespace()`. Native PHP tokenizer;
+     *             handles every comment shape PHP supports.
+     * - `*.tpl` — Smarty `{* … *}` (default delimiters) plus
+     *             `-{* … *}-` (the non-default delimiter shape used
+     *             by `page_login.tpl` / `page_blockit.tpl` /
+     *             `page_kickit.tpl` / `page_admin_servers_rcon.tpl`,
+     *             documented under "Templates + View DTOs" in
+     *             AGENTS.md). Then C-style block comments and `//`
+     *             line comments inside `<script>` blocks the
+     *             template embeds.
+     * - `*.js`  — C-style block comments and `//` line comments.
+     *             A regex pass — fine for the way `theme.js` is
+     *             written (no embedded templated code, no
+     *             single-line `//` inside string literals at
+     *             column 0). A future complex JS file with
+     *             string-literal-inside-comment edge cases would
+     *             want the JS tokenizer; defer until needed.
+     */
+    private static function stripCommentsForScan(string $path, string $contents): string
+    {
+        if (str_ends_with($path, '.php')) {
+            return php_strip_whitespace($path);
+        }
+        if (str_ends_with($path, '.tpl')) {
+            $contents = (string) preg_replace('/\{\*.*?\*\}/s', '', $contents);
+            $contents = (string) preg_replace('/-\{\*.*?\*\}-/s', '', $contents);
+            $contents = (string) preg_replace('!/\*.*?\*/!s', '', $contents);
+            $contents = (string) preg_replace('!(^|[^:])//[^\n]*!', '$1', $contents);
+            return $contents;
+        }
+        if (str_ends_with($path, '.js')) {
+            $contents = (string) preg_replace('!/\*.*?\*/!s', '', $contents);
+            $contents = (string) preg_replace('!(^|[^:])//[^\n]*!', '$1', $contents);
+            return $contents;
+        }
+        return $contents;
+    }
+
+    /**
+     * Walk a directory tree and return every `*.tpl` / `*.php` /
+     * `*.js` file path under it, sorted for deterministic output.
+     *
+     * @return list<string>
+     */
+    private static function collectFiles(string $root): array
+    {
+        if (!is_dir($root)) {
+            return [];
+        }
+        $iter = new RecursiveIteratorIterator(new RecursiveDirectoryIterator($root, RecursiveDirectoryIterator::SKIP_DOTS));
+        $files = [];
+        foreach ($iter as $entry) {
+            if (!$entry->isFile()) {
+                continue;
+            }
+            $path = $entry->getPathname();
+            if (
+                !str_ends_with($path, '.tpl')
+                && !str_ends_with($path, '.php')
+                && !str_ends_with($path, '.js')
+            ) {
+                continue;
+            }
+            $files[] = $path;
+        }
+        sort($files);
+        return $files;
+    }
+
+    /**
+     * Extract every `class="..."` / `class='...'` attribute body.
+     * The lookbehind `(?<![-_\w])` guards against name-prefixed
+     * attributes like `data-class=`, `aria-class=`, or
+     * `someClass=` JS-style — only an unprefixed `class` keyword
+     * matches.
+     *
+     * The attribute matcher is intentionally simple — quoted-string
+     * boundaries on the value, no embedded escaping. HTML + Smarty
+     * + the JS string literals in `theme.js` don't carry embedded
+     * same-quote characters inside an attribute value, so the
+     * simple match is correct.
+     *
+     * Returns the raw bodies (NOT split into tokens) so the caller
+     * can run conditional-detection logic before splitting.
+     *
+     * @return list<string>
+     */
+    private static function extractClassAttributes(string $contents): array
+    {
+        $matches = [];
+        if (preg_match_all('/(?<![-_\w])class\s*=\s*"([^"]*)"/', $contents, $double)) {
+            foreach ($double[1] as $body) {
+                $matches[] = $body;
+            }
+        }
+        if (preg_match_all("/(?<![-_\\w])class\\s*=\\s*'([^']*)'/", $contents, $single)) {
+            foreach ($single[1] as $body) {
+                $matches[] = $body;
+            }
+        }
+        return $matches;
+    }
+
+    /**
+     * Single-method pin: every `class="..."` attribute carrying a
+     * `btn--*` modifier token MUST also carry the base `btn` token.
+     * Smarty-conditional class chains (the `{if $x} btn--primary{/if}`
+     * shape) are skipped — the gate's output then surfaces only the
+     * structural-bug shape this test exists to catch.
+     *
+     * Captures a sanity-check counter alongside the hits so the
+     * test fails loudly if the scan ever ends up touching zero
+     * files (the failure shape if `ROOT` resolves wrong, or if a
+     * future refactor of `scanRoots()` lands an unreadable path).
+     * Thresholds are deliberately loose — the point is "scope is
+     * non-empty," not "this exact number." The current codebase
+     * touches ~750 files / extracts ~3500 class attributes;
+     * `> 100` files and `> 200` attribute bodies leaves headroom
+     * for half the panel templates being stripped without a
+     * false-fail.
+     *
+     * The literal expected hit count is `0`. Failure messages name
+     * the file path + the offending class chain so a regression
+     * triages directly to the call site.
+     */
+    public function testEveryBtnModifierCarriesTheBaseBtnToken(): void
+    {
+        $hits = [];
+        $filesScanned = 0;
+        $classAttrsExtracted = 0;
+
+        foreach (self::scanRoots() as $root) {
+            foreach (self::collectFiles($root) as $path) {
+                $filesScanned++;
+                $raw = (string) file_get_contents($path);
+                $stripped = self::stripCommentsForScan($path, $raw);
+                foreach (self::extractClassAttributes($stripped) as $body) {
+                    $classAttrsExtracted++;
+                    if (str_contains($body, '{')) {
+                        continue;
+                    }
+                    $tokens = preg_split('/\s+/', trim($body)) ?: [];
+                    $hasBase = false;
+                    $modifiers = [];
+                    foreach ($tokens as $tok) {
+                        if ($tok === 'btn') {
+                            $hasBase = true;
+                            continue;
+                        }
+                        if (str_starts_with($tok, 'btn--')) {
+                            $modifiers[] = $tok;
+                        }
+                    }
+                    if ($modifiers !== [] && !$hasBase) {
+                        $rel = str_starts_with($path, ROOT) ? substr($path, strlen(ROOT)) : $path;
+                        $hits[] = sprintf(
+                            '%s: class="%s" carries %s but not the base `btn`',
+                            $rel,
+                            $body,
+                            implode(' / ', $modifiers),
+                        );
+                    }
+                }
+            }
+        }
+
+        $this->assertGreaterThan(
+            100,
+            $filesScanned,
+            "Sanity check: scan touched only {$filesScanned} files, expected > 100. "
+                . 'A `ROOT` typo or an unreadable scan root will produce a false-pass; this assertion '
+                . 'fails loudly so the gate cannot silently de-cover.',
+        );
+        $this->assertGreaterThan(
+            200,
+            $classAttrsExtracted,
+            "Sanity check: scan extracted only {$classAttrsExtracted} `class=\"…\"` attribute bodies, "
+                . 'expected > 200. A regex regression in `extractClassAttributes()` would surface here.',
+        );
+
+        $this->assertSame(
+            0,
+            count($hits),
+            "One or more `class=\"btn--*\"` attributes are missing the base `btn` token. Without `.btn`, the modifier rules set CSS custom properties (`--btn-bg`, `--btn-color`, …) and (for sizing modifiers) layer geometry on top — but nothing reads the `--btn-*` variables and nothing carries the load-bearing `background` / `color` / `border` / `display: inline-flex` declarations except `.btn` itself. Buttons render with the user-agent default chrome instead of the panel's button styling. See #1448 for the canonical reproduction (mobile burger menu) and AGENTS.md \"Anti-patterns\" for the rule.\n\nOffending sites:\n - "
+                . implode("\n - ", $hits),
+        );
+    }
+}

--- a/web/themes/default/core/footer.tpl
+++ b/web/themes/default/core/footer.tpl
@@ -179,8 +179,9 @@
                placeholder="Search players, SteamIDs, pages…"
                aria-label="Search players, SteamIDs, pages"
                data-testid="palette-input">
+        {* #1448: keep `btn` first — only `.btn` carries the load-bearing chrome declarations; modifiers set CSS custom properties + (for sizing) geometry on top. See AGENTS.md "Anti-patterns". *}
         <button type="button"
-                class="btn--ghost btn--icon"
+                class="btn btn--ghost btn--icon"
                 data-palette-close
                 data-testid="palette-close"
                 aria-label="Close command palette"

--- a/web/themes/default/core/title.tpl
+++ b/web/themes/default/core/title.tpl
@@ -19,8 +19,9 @@
 *}
 <div class="main">
     <header class="topbar" data-testid="topbar">
+        {* #1448: keep `btn` first — only `.btn` carries the load-bearing `background` / `color` / `border` / `display: inline-flex` declarations; the modifiers set CSS custom properties + (for sizing) geometry on top. See AGENTS.md "Anti-patterns" → modifier-only `btn--*` chains. *}
         <button type="button"
-                class="btn--ghost btn--icon"
+                class="btn btn--ghost btn--icon"
                 data-mobile-menu
                 data-testid="mobile-menu-toggle"
                 aria-label="Open navigation menu"

--- a/web/themes/default/partials/player-drawer.tpl
+++ b/web/themes/default/partials/player-drawer.tpl
@@ -45,7 +45,8 @@
         <div class="text-xs text-faint" style="text-transform:uppercase;letter-spacing:0.06em">Ban #{$detail.bid}</div>
         <h2 class="font-semibold" style="margin:0.125rem 0 0;font-size:1.125rem">{$detail.player.name}</h2>
     </div>
-    <button class="btn--ghost btn--icon" type="button" data-drawer-close aria-label="Close">
+    {* #1448: keep `btn` first — only `.btn` carries the load-bearing chrome declarations; modifiers set CSS custom properties + (for sizing) geometry on top. See AGENTS.md "Anti-patterns". This template is the canonical reference shape; the live drawer is rendered by `theme.js`'s `renderDrawerBody()` and friends — those sites also carry the three-class chain. *}
+    <button class="btn btn--ghost btn--icon" type="button" data-drawer-close aria-label="Close">
         <i data-lucide="x"></i>
     </button>
 </header>


### PR DESCRIPTION
## Summary

Fixes #1448 — the mobile-viewport burger button rendered with the user-agent default grey 1px-border chrome instead of the panel's ghost-button styling.

The button in `web/themes/default/core/title.tpl` shipped `class="btn--ghost btn--icon"` — modifier-only, no base `btn`. In `theme.css`:

- `.btn` is the load-bearing rule: it declares the `--btn-bg` / `--btn-color` / `--btn-border` defaults AND applies them as `background` / `color` / `border` / `display: inline-flex` / `padding` / `height`.
- `.btn--ghost` / `.btn--primary` / `.btn--secondary` / `.btn--danger` are pure custom-property overrides — they SET the variables but don't apply them.
- `.btn--sm` / `.btn--icon` / `.btn--xs` layer geometry on top but still don't carry the chrome declarations.

Without `.btn` in the chain, the variables get set but nothing reads them — `<button>` falls back to UA-default chrome (visible grey pill that fights the topbar's dark background on mobile, where `[data-mobile-menu]` flips from `display: none` to `display: inline-flex` at `<=1024px`).

### Sister sites swept in the same PR

- **`core/footer.tpl`** — the palette `Esc` close button shipped the same modifier-only chain. Same live wrong-chrome shape behind the `<kbd>Esc</kbd>` child.
- **`partials/player-drawer.tpl`** — drawer-close `X` button. **Reference template, not live render path** — the live drawer chrome is rendered by `web/themes/default/js/theme.js`'s `renderDrawerBody()` / `renderDrawerLoading()` (which always shipped the correct three-class chain). Documentation sync, not a behaviour fix.

### Regression guard

New test `web/tests/integration/ButtonClassChainTest.php` — single-method parser-style sweep across:

- `web/themes/` (every Smarty template + the install wizard chrome)
- `web/themes/default/js/` (the runtime HTML emitter)
- `web/scripts/` (panel-side JS)
- `web/pages/` (page handlers)
- `web/includes/View/` (view DTOs)
- `web/install/`, `web/updater/`, `web/api/handlers/` (preventive coverage for any future inline-HTML emission)

For `*.tpl`, `*.php`, AND `*.js`. Every `class="…"` / `class='…'` attribute body carrying a `btn--*` modifier MUST also carry the base `btn` token. The JS-side coverage is what makes the gate's "panel chrome" protection structural — `theme.js` ships seven runtime `<button class="btn btn--ghost btn--icon[ btn--xs]">` strings via template concatenation; without scanning them the gate would paper over the live bug surface.

Implementation details:

- Strips Smarty `{* *}` comments (default + `-{* *}-` non-default delimiters used by `page_login.tpl` / `page_blockit.tpl` / `page_kickit.tpl` / `page_admin_servers_rcon.tpl`), PHP comments via `php_strip_whitespace()`, and JS `/* */` + `//` comments so AGENTS.md-style explanatory blocks don't false-match.
- Negative lookbehind `(?<![-_\w])` on the `class` keyword skips `data-class=` / `aria-class=` siblings.
- Sanity-check assertions (`>100 files scanned`, `>200 attribute bodies extracted`) guard against silent zero-scan if `ROOT` / `scanRoots()` ever drift.
- Smarty-conditional class chains (anything containing `{`) are skipped; false negatives bounded to chains with NO base in any branch (none in the codebase today).

I deliberately introduced a regression in `theme.js` during development to verify the gate fires; it caught the bug at the right line with the right message.

### AGENTS.md changes

- New "Anti-patterns" entry documenting the bug class with the user-reported regression details, sister-site rationale, and regression-guard scope.
- New "Button class chains" Conventions block (positive-shape contract paired with the anti-pattern).
- New "Where to find what" row pointing at the regression guard.

### Adversarial review trail

Spawned an adversarial reviewer subagent on the initial diff. It surfaced:

- `theme.js` runtime-emitted button strings were outside the scan scope (MAJOR — fixed by extending `scanRoots` + adding JS comment stripping).
- The "PURE CSS-variable overrides" claim was technically wrong for sizing modifiers (MAJOR — tightened wording across all five sites).
- Missing "Where to find what" row (MAJOR — added).
- The drawer-template framing as a "live sister bug" was misleading (MAJOR — clarified in the AGENTS.md entry; the JS scan extension also makes the framing structurally honest now since the gate covers both halves).
- Several MINOR / NIT findings around docstring honesty, scan scope completeness, regex edge cases, and template-comment bloat — all addressed in this commit.

## Test plan

- [x] `./sbpp.sh phpstan` passes (level 5, baseline unchanged)
- [x] `./sbpp.sh ts-check` passes
- [x] `./sbpp.sh composer api-contract` is in sync (no diff)
- [x] `./sbpp.sh test` — full suite passes (891 tests, 3338 assertions, including the 3-assertion regression guard)
- [x] Test catches a fresh regression — verified by intentionally breaking `theme.js`'s `renderDrawerLoading()` button, watching the gate fire, then reverting
- [x] Visual verification via Playwright on mobile viewport (iPhone 13-like 390×844, light + dark themes, before-and-after screenshots) — burger button now renders with the panel ghost-button chrome instead of UA-default grey

CLA: I have read the CLA Document and I hereby sign the CLA