### PR TITLE
fix(1442): keep banlist advanced-search disclosure closed on click-through from dashboard / palette / protests

### DIFF
--- a/web/pages/page.home.php
+++ b/web/pages/page.home.php
@@ -55,14 +55,30 @@ foreach ($rows as $row) {
     $info['ip']         = $row['ip'];
     $info['server']     = "block_" . $row['sid'] . "_$blcount";
 
+    // Search links ride the simple-bar `?searchText=` shim — `?advSearch=…`
+    // triggers the destination banlist's disclosure auto-open contract
+    // (`page.banlist.php`'s `$banlistAdvancedOpen` predicate, #1315) which
+    // pushes the matched ban below the fold on cramped viewports. The
+    // simple-bar branch fires the same `BA.ip` / `BA.authid` / `BA.name` /
+    // `BA.reason` LIKE/REGEXP filter so the matched ban still surfaces in
+    // the rowset (#1442).
+    //
+    // The `$row['ip']` / `$row['authid']` reads can return null from the
+    // `LEFT JOIN :prefix_bans` when the banlog points at a deleted ban,
+    // so cast at the urlencode boundary (PHP 8.5 null-into-scalar
+    // discipline — AGENTS.md). For the anonymous-viewer IP-type fallback
+    // we URL-encode `$cleaned_name` (raw bytes), NOT `$info['name']`
+    // (htmlspecialchars-escaped) — the destination's SQL filter compares
+    // against the raw `:prefix_bans.name` column, so encoding `&amp;`
+    // would never match a real `&` in the player name.
     $blockedBanType = BanType::tryFrom((int) $row['type']) ?? BanType::Steam;
     if ($blockedBanType === BanType::Ip) {
         if ($userbank->is_admin())
-            $info['search_link'] = 'index.php?p=banlist&advSearch=' . urlencode($info['ip']) . '&advType=ip&Submit';
+            $info['search_link'] = 'index.php?p=banlist&searchText=' . urlencode((string) $info['ip']);
         else
-            $info['search_link'] = 'index.php?p=banlist&advSearch=' . urlencode($info['name']) . '&advType=name';
+            $info['search_link'] = 'index.php?p=banlist&searchText=' . urlencode($cleaned_name);
     } else {
-        $info['search_link'] = 'index.php?p=banlist&advSearch=' . urlencode($info['auth']) . '&advType=steamid&Submit';
+        $info['search_link'] = 'index.php?p=banlist&searchText=' . urlencode((string) $info['auth']);
     }
     $info['link_url'] = "window.location = '" . $info['search_link'] . "';";
 
@@ -132,14 +148,19 @@ foreach ($rows as $row) {
     $info['icon']    = empty($row['icon']) ? 'web.png' : $row['icon'];
     $info['authid']  = $row['authid'];
     $info['ip']      = $row['ip'];
+    // See the `$stopped` loop above for the simple-bar shim rationale (#1442).
+    // `:prefix_bans.ip` / `.authid` are NOT NULL so no cast needed here,
+    // but the anonymous-viewer arm still URL-encodes `$cleaned_name`
+    // (raw) instead of `$info['name']` (htmlspecialchars-escaped) so
+    // names with `&` match the destination's raw-column SQL filter.
     $rowBanType = BanType::tryFrom((int) $row['type']) ?? BanType::Steam;
     if ($rowBanType === BanType::Ip) {
         if ($userbank->is_admin())
-            $info['search_link'] = 'index.php?p=banlist&advSearch=' . urlencode($info['ip']) . '&advType=ip&Submit';
+            $info['search_link'] = 'index.php?p=banlist&searchText=' . urlencode($info['ip']);
         else
-            $info['search_link'] = 'index.php?p=banlist&advSearch=' . urlencode($info['name']) . '&advType=name';
+            $info['search_link'] = 'index.php?p=banlist&searchText=' . urlencode($cleaned_name);
     } else {
-        $info['search_link'] = 'index.php?p=banlist&advSearch=' . urlencode($info['authid']) . '&advType=steamid&Submit';
+        $info['search_link'] = 'index.php?p=banlist&searchText=' . urlencode($info['authid']);
     }
     $info['link_url']   = "window.location = '" . $info['search_link'] . "';";
     $info['short_name'] = trunc($cleaned_name, 40);
@@ -215,7 +236,11 @@ foreach ($rows as $row) {
     $info['length']      = $ltemp[0];
     $info['icon']        = empty($row['icon']) ? 'web.png' : $row['icon'];
     $info['authid']      = $row['authid'];
-    $info['search_link'] = 'index.php?p=commslist&advSearch=' . urlencode($info['authid']) . '&advType=steamid&Submit';
+    // Commslist mirrors the banlist disclosure auto-open contract
+    // (`page.commslist.php`'s `$commsAdvancedOpen` predicate), so the
+    // simple-bar `?searchText=` shim from the `$stopped` loop above
+    // applies here too (#1442).
+    $info['search_link'] = 'index.php?p=commslist&searchText=' . urlencode($info['authid']);
     $info['link_url']    = "window.location = '" . $info['search_link'] . "';";
     $info['short_name']  = trunc($cleaned_name, 40);
     $info['type']        = $row['type'] == 2 ? "fas fa-comment-slash fa-lg" : "fas fa-microphone-slash fa-lg";

--- a/web/tests/e2e/specs/flows/ui/command-palette.spec.ts
+++ b/web/tests/e2e/specs/flows/ui/command-palette.spec.ts
@@ -398,9 +398,9 @@ test.describe('command palette', () => {
         // suppressed and the drawer opened in the current tab. The
         // delegate now guards `e.metaKey || e.ctrlKey || e.shiftKey ||
         // e.button !== 0` and bails before preventDefault, so the
-        // anchor's `href` (?p=banlist&advType=name&advSearch=<name>)
-        // takes over and the new tab lands on the name-filtered
-        // banlist. This test locks that contract.
+        // anchor's `href` (?p=banlist&searchText=<name>) takes over
+        // and the new tab lands on the name-filtered banlist. This
+        // test locks that contract.
         //
         // mobile-chromium skipped: same palette typing-search flake
         // as the sibling 'type' / 'enter' / 'hints' / 'copy' subtests
@@ -447,11 +447,14 @@ test.describe('command palette', () => {
         await newPage.waitForURL(/[?&]p=banlist/, { timeout: 10000 });
 
         // The new tab's URL is the row's href fallback — the
-        // name-filtered banlist URL.
-        expect(newPage.url()).toMatch(/[?&]advType=name(?:&|$)/);
+        // name-filtered banlist URL. Post-#1442 the palette emits the
+        // simple-bar `?searchText=<name>` shape so the destination's
+        // advanced-search disclosure stays closed (same auto-open
+        // contract that the dashboard's "Latest bans" links ride).
         expect(newPage.url()).toMatch(
-            new RegExp(`[?&]advSearch=${encodeURIComponent(seed.nick)}(?:&|$)`),
+            new RegExp(`[?&]searchText=${encodeURIComponent(seed.nick)}(?:&|$)`),
         );
+        expect(newPage.url()).not.toMatch(/[?&]advSearch=/);
         await newPage.close();
 
         // The original tab's drawer did NOT open — the modifier-guard
@@ -501,9 +504,9 @@ test.describe('command palette', () => {
         // stacked behind the palette dialog, then `loadDrawer(bid)`
         // fetches `bans.detail` and renders the player drawer.
         //
-        // The href fallback (`?p=banlist&advType=name&advSearch=…`)
-        // is preserved on the anchor so middle-click / Cmd+click
-        // still expands the result to a name-filtered banlist for
+        // The href fallback (`?p=banlist&searchText=…`) is preserved
+        // on the anchor so middle-click / Cmd+click still expands the
+        // result to a name-filtered banlist for
         // users who want the wider context — that's why we focus +
         // press Enter rather than asserting on the href shape.
         await result.focus();

--- a/web/tests/integration/HomeDashboardLatestBansLinkTest.php
+++ b/web/tests/integration/HomeDashboardLatestBansLinkTest.php
@@ -1,0 +1,674 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sbpp\Tests\Integration;
+
+use PHPUnit\Framework\Attributes\PreserveGlobalState;
+use PHPUnit\Framework\Attributes\RunInSeparateProcess;
+use Sbpp\Tests\ApiTestCase;
+use Sbpp\Tests\Fixture;
+use Smarty\Smarty;
+
+/**
+ * #1442 — the dashboard's "Latest bans" / "Latest blocked attempts" /
+ * "Latest comm blocks" row anchors must NOT use the legacy
+ * `?advSearch=…&advType=…&Submit` URL shape.
+ *
+ * Pre-#1442 each `<a class="ban-row" href="{$b.search_link}">` row
+ * on `page_dashboard.tpl` stamped the legacy URL. On click the
+ * destination banlist's `$banlistAdvancedOpen` predicate (set from
+ * `isset($_GET['advSearch']) && (string) $_GET['advSearch'] !== ''`,
+ * #1315) flipped the `<details class="filters-details">` disclosure
+ * into the `[open]` state, expanding the multi-criterion advanced-
+ * search form above the row table. On a 1273×748 viewport this
+ * pushed the actual matched ban below the fold — exactly the bug
+ * DNA-styx reported. The fix is to ride the simple-bar
+ * `?searchText=` URL shim instead: the SQL filter is the same set
+ * of `BA.ip` / `BA.authid` / `BA.name` / `BA.reason` LIKE / REGEXP
+ * predicates, the matched ban still surfaces in the rowset, but
+ * the disclosure stays closed so the matched ban paints above the
+ * fold.
+ *
+ * This test pins the URL shape `page.home.php` emits for all three
+ * dashboard row surfaces:
+ *
+ *   - `players_banned` (Latest bans) — drives `:prefix_bans` rows
+ *     for both Steam-type (`type=0`) and IP-type (`type=1`) bans;
+ *     the IP-type arm forks per-admin-vs-anonymous viewer (admin
+ *     gets `searchText=<ip>`; non-admin gets `searchText=<name>`
+ *     because the banlist disables IP search under
+ *     `banlist.hideplayerips`).
+ *   - `players_blocked` (Latest blocked attempts) — drives the
+ *     `:prefix_banlog` join, same fork shape as `players_banned`.
+ *   - `players_commed` (Latest comm blocks) — drives `:prefix_comms`
+ *     rows; comms always carry an authid (no IP-type comms), so
+ *     the URL shape is always `?p=commslist&searchText=<authid>`.
+ *
+ * Each test runs in its own process for the same reason
+ * `HomeDashboardAnnouncementTest` does — `page.home.php` declares
+ * the top-level `SbppServerQryHelpers()` helper that PHP can't
+ * redeclare in one process. Process isolation also keeps the
+ * `$GLOBALS['userbank']` / `$_SESSION` mutations from each test
+ * from cross-contaminating siblings.
+ *
+ * The stub Smarty (lifted from `HomeDashboardAnnouncementTest`)
+ * captures the `Renderer::render`-driven `$theme->assign(...)`
+ * calls so we can assert the `players_banned` / `players_blocked`
+ * / `players_commed` arrays the page handler builds, WITHOUT
+ * rendering the actual template. The contract under test is the
+ * URL the handler stamps into each row's `search_link`; the
+ * template is a thin `<a href="{$b.search_link}">` consumer.
+ *
+ * See the sister `PublicBanListRegressionTest::test*DisclosureStaysClosedWhenSearchTextSet`
+ * methods for the destination half of the contract: a banlist /
+ * commslist URL carrying `?searchText=…` (and no `?advSearch=…`)
+ * must render the disclosure WITHOUT `[open]`.
+ */
+final class HomeDashboardLatestBansLinkTest extends ApiTestCase
+{
+    /**
+     * Steam-type ban — the most common shape on the dashboard.
+     * The search link must use `?searchText=<authid>` so the
+     * banlist's simple-bar branch fires (authid REGEXP match via
+     * SteamID::toSearchPattern), leaving the advanced-search
+     * disclosure collapsed.
+     */
+    #[RunInSeparateProcess]
+    #[PreserveGlobalState(false)]
+    public function testLatestBansLinkUsesSearchTextForSteamTypeBan(): void
+    {
+        $this->loginAsAdmin();
+        $this->seedBan('STEAM_0:1:42424242', 'CheaterAlpha', \BanType::Steam, null);
+        $theme = $this->bootRenderHarness();
+
+        $this->renderHome();
+
+        /** @var list<array<string, mixed>> $bans */
+        $bans = $theme->captured['players_banned'] ?? [];
+        $this->assertNotEmpty($bans, 'seeded :prefix_bans row must surface in $players_banned');
+
+        $link = (string) ($bans[0]['search_link'] ?? '');
+        $this->assertSame(
+            'index.php?p=banlist&searchText=STEAM_0%3A1%3A42424242',
+            $link,
+            'Steam-type ban search link must ride the simple-bar `?searchText=<authid>` shim — #1442',
+        );
+        $this->assertNoLegacyAdvancedSearchParameters($link);
+    }
+
+    /**
+     * IP-type ban viewed by an admin — the admin sees the actual
+     * IP (no `banlist.hideplayerips` redaction) and the link
+     * filters by `searchText=<ip>` so the banlist's
+     * `BA.ip LIKE %ip%` clause fires.
+     */
+    #[RunInSeparateProcess]
+    #[PreserveGlobalState(false)]
+    public function testLatestBansLinkUsesSearchTextForIpTypeBanWhenAdmin(): void
+    {
+        $this->loginAsAdmin();
+        $this->seedBan(null, 'IpAlpha', \BanType::Ip, '203.0.113.7');
+        $theme = $this->bootRenderHarness();
+
+        $this->renderHome();
+
+        /** @var list<array<string, mixed>> $bans */
+        $bans = $theme->captured['players_banned'] ?? [];
+        $this->assertNotEmpty($bans, 'seeded IP-type ban must surface in $players_banned');
+
+        $link = (string) ($bans[0]['search_link'] ?? '');
+        $this->assertSame(
+            'index.php?p=banlist&searchText=203.0.113.7',
+            $link,
+            'IP-type ban (admin viewer) link must filter by `searchText=<ip>` — #1442',
+        );
+        $this->assertNoLegacyAdvancedSearchParameters($link);
+    }
+
+    /**
+     * IP-type ban viewed by an anonymous (non-admin) viewer — the
+     * banlist disables IP search for non-admins when
+     * `banlist.hideplayerips` is on (or by convention here:
+     * non-admins shouldn't see the IP), so the legacy code
+     * fell back to `advType=name`. We preserve that fallback by
+     * stamping `searchText=<name>` for the anonymous arm.
+     */
+    #[RunInSeparateProcess]
+    #[PreserveGlobalState(false)]
+    public function testLatestBansLinkUsesSearchTextForIpTypeBanWhenAnonymous(): void
+    {
+        // No loginAsAdmin → ApiTestCase::setUp left $userbank as the
+        // anonymous viewer.
+        $this->seedBan(null, 'IpAnon', \BanType::Ip, '203.0.113.8');
+        $theme = $this->bootRenderHarness();
+
+        $this->renderHome();
+
+        /** @var list<array<string, mixed>> $bans */
+        $bans = $theme->captured['players_banned'] ?? [];
+        $this->assertNotEmpty($bans, 'seeded IP-type ban must surface in $players_banned even for anonymous viewer');
+
+        $link = (string) ($bans[0]['search_link'] ?? '');
+        // The dashboard escapes the name via htmlspecialchars +
+        // addslashes BEFORE the urlencode round-trip; the seeded
+        // name `IpAnon` has no special chars so the encoded form is
+        // the raw string.
+        $this->assertSame(
+            'index.php?p=banlist&searchText=IpAnon',
+            $link,
+            'IP-type ban (anonymous viewer) must fall back to `searchText=<name>` to avoid leaking the IP — #1442',
+        );
+        $this->assertNoLegacyAdvancedSearchParameters($link);
+    }
+
+    /**
+     * IP-type ban viewed anonymously where the player name contains
+     * `&` — locks in the contract that the URL stamps `urlencode`
+     * over the RAW `$cleaned_name`, not the htmlspecialchars-escaped
+     * `$info['name']`. Pre-fix the loop URL-encoded the escaped
+     * form (`Player &amp; Co`), so the destination's
+     * `name LIKE '%Player &amp; Co%'` filter would never match a
+     * real `Player & Co` row in the DB and the banlist would render
+     * the empty-filtered state. New symptom worse than the original
+     * #1442 bug ("below the fold") — "not visible at all."
+     */
+    #[RunInSeparateProcess]
+    #[PreserveGlobalState(false)]
+    public function testLatestBansLinkEncodesRawNameNotHtmlEscapedForm(): void
+    {
+        // No loginAsAdmin → anonymous viewer hits the IP-type-name
+        // fallback arm.
+        $this->seedBan(null, 'Player & Co', \BanType::Ip, '203.0.113.42');
+        $theme = $this->bootRenderHarness();
+
+        $this->renderHome();
+
+        /** @var list<array<string, mixed>> $bans */
+        $bans = $theme->captured['players_banned'] ?? [];
+        $this->assertNotEmpty($bans);
+
+        $link = (string) ($bans[0]['search_link'] ?? '');
+
+        // `urlencode()` encodes `&` → `%26` and spaces → `+`. If the
+        // loop URL-encoded the escaped `$info['name']`
+        // (`Player &amp; Co`) instead, the link would contain
+        // `Player+%26amp%3B+Co`. The new contract is: encode
+        // `$cleaned_name` directly, so the destination banlist SQL
+        // filter sees the literal raw bytes that match the `name`
+        // column.
+        $this->assertSame(
+            'index.php?p=banlist&searchText=Player+%26+Co',
+            $link,
+            'anonymous-viewer IP-type ban must URL-encode raw $cleaned_name (not htmlspecialchars-escaped $info["name"]) — #1442 review finding',
+        );
+        $this->assertStringNotContainsString(
+            'amp%3B',
+            $link,
+            'encoded `&amp;` (`%26amp%3B`) indicates the loop URL-encoded the escaped form — breaks destination SQL match — #1442 review finding',
+        );
+    }
+
+    /**
+     * Latest blocked attempts (banlog → `$stopped`) — Steam-type
+     * blocked attempt mirrors the bans-side Steam shape.
+     */
+    #[RunInSeparateProcess]
+    #[PreserveGlobalState(false)]
+    public function testLatestBlockedAttemptsLinkUsesSearchTextForSteamType(): void
+    {
+        $this->loginAsAdmin();
+        $bid = $this->seedBan('STEAM_0:1:99999999', 'BlockedAlpha', \BanType::Steam, null);
+        $this->seedBanlogForBid($bid, 'BlockedAlpha');
+        $theme = $this->bootRenderHarness();
+
+        $this->renderHome();
+
+        /** @var list<array<string, mixed>> $stopped */
+        $stopped = $theme->captured['players_blocked'] ?? [];
+        $this->assertNotEmpty($stopped, 'seeded banlog row must surface in $players_blocked');
+
+        $link = (string) ($stopped[0]['search_link'] ?? '');
+        $this->assertSame(
+            'index.php?p=banlist&searchText=STEAM_0%3A1%3A99999999',
+            $link,
+            'Steam-type blocked attempt link must ride the simple-bar `?searchText=<authid>` shim — #1442',
+        );
+        $this->assertNoLegacyAdvancedSearchParameters($link);
+    }
+
+    /**
+     * Latest blocked attempts where the banlog row points at a
+     * BAN THAT WAS LATER DELETED — `:prefix_banlog.bid` references
+     * a row that no longer exists in `:prefix_bans`, so the
+     * `LEFT JOIN :prefix_bans` returns NULL for `b.type` / `b.ip`
+     * / `b.authid`. Pre-#1442-review the urlencode call would have
+     * triggered the PHP 8.5 `Deprecated: urlencode(): Passing null
+     * to parameter #1 of type string` warning; the `(string)` cast
+     * in the `$stopped` loop fixes that. This test promotes the
+     * warning to an exception so a regression would fail the gate.
+     */
+    #[RunInSeparateProcess]
+    #[PreserveGlobalState(false)]
+    public function testLatestBlockedAttemptsHandlesOrphanBanlogWithoutNullDeprecation(): void
+    {
+        $this->loginAsAdmin();
+        // Seed a banlog row pointing at a `bid` that doesn't exist.
+        // `Fixture::install()` resets the DB, so the highest legitimate
+        // bid is whatever the fixture seeded; 99999 is comfortably
+        // out of range.
+        $this->seedBanlogForBid(99999, 'OrphanedBlock');
+
+        // Promote PHP 8.5 null-into-string deprecation warnings to
+        // exceptions so the render fails if the urlencode chain
+        // accidentally re-introduces the bug. Mirrors the
+        // Php82DeprecationsTest pattern.
+        set_error_handler(function ($severity, $message, $file, $line) {
+            if (str_contains($message, 'Passing null to parameter')) {
+                throw new \ErrorException($message, 0, $severity, $file, $line);
+            }
+            return false;
+        }, E_DEPRECATED | E_USER_DEPRECATED);
+
+        try {
+            $theme = $this->bootRenderHarness();
+            $this->renderHome();
+        } finally {
+            restore_error_handler();
+        }
+
+        /** @var list<array<string, mixed>> $stopped */
+        $stopped = $theme->captured['players_blocked'] ?? [];
+        $this->assertNotEmpty($stopped, 'orphan banlog row must surface in $players_blocked');
+
+        // The orphan row's `b.type` is NULL → `(int) NULL === 0` →
+        // `BanType::tryFrom(0)` returns Steam → URL is built from
+        // `$info['auth']` which is also NULL → cast to ''. The
+        // resulting search link is benign (empty searchText) — the
+        // load-bearing contract here is "doesn't trip the
+        // urlencode(NULL) deprecation."
+        $link = (string) ($stopped[0]['search_link'] ?? '');
+        $this->assertSame(
+            'index.php?p=banlist&searchText=',
+            $link,
+            'orphan banlog (Steam-type fallback with NULL authid) must produce an empty-searchText URL',
+        );
+    }
+
+    /**
+     * Latest blocked attempts (banlog) — IP-type blocked attempt
+     * with an admin viewer. Same admin/anonymous fork as the
+     * bans-side IP arm.
+     */
+    #[RunInSeparateProcess]
+    #[PreserveGlobalState(false)]
+    public function testLatestBlockedAttemptsLinkUsesSearchTextForIpTypeWhenAdmin(): void
+    {
+        $this->loginAsAdmin();
+        $bid = $this->seedBan(null, 'BlockedIpAlpha', \BanType::Ip, '198.51.100.42');
+        $this->seedBanlogForBid($bid, 'BlockedIpAlpha');
+        $theme = $this->bootRenderHarness();
+
+        $this->renderHome();
+
+        /** @var list<array<string, mixed>> $stopped */
+        $stopped = $theme->captured['players_blocked'] ?? [];
+        $this->assertNotEmpty($stopped, 'seeded IP-type banlog row must surface in $players_blocked');
+
+        $link = (string) ($stopped[0]['search_link'] ?? '');
+        $this->assertSame(
+            'index.php?p=banlist&searchText=198.51.100.42',
+            $link,
+            'IP-type blocked attempt (admin viewer) link must filter by `searchText=<ip>` — #1442',
+        );
+        $this->assertNoLegacyAdvancedSearchParameters($link);
+    }
+
+    /**
+     * Latest comm blocks (`:prefix_comms` → `$players_commed`) —
+     * comms always carry an authid (the SourceMod plugin's
+     * `sbpp_comms.sp` insert path doesn't write IP-type comms), so
+     * the URL is always `?p=commslist&searchText=<authid>`.
+     */
+    #[RunInSeparateProcess]
+    #[PreserveGlobalState(false)]
+    public function testLatestCommBlocksLinkUsesSearchText(): void
+    {
+        $this->loginAsAdmin();
+        $this->seedComm('STEAM_0:1:77777777', 'SpammerAlpha');
+        $theme = $this->bootRenderHarness();
+
+        $this->renderHome();
+
+        /** @var list<array<string, mixed>> $comms */
+        $comms = $theme->captured['players_commed'] ?? [];
+        $this->assertNotEmpty($comms, 'seeded :prefix_comms row must surface in $players_commed');
+
+        $link = (string) ($comms[0]['search_link'] ?? '');
+        $this->assertSame(
+            'index.php?p=commslist&searchText=STEAM_0%3A1%3A77777777',
+            $link,
+            'Comm block link must ride the simple-bar `?searchText=<authid>` shim on commslist — #1442',
+        );
+        $this->assertNoLegacyAdvancedSearchParameters($link);
+    }
+
+    /**
+     * URL-encoding invariant — confirms `urlencode()` correctly
+     * escapes `&` / `=` / `;` etc. so a hostile player name cannot
+     * smuggle a sibling `&advSearch=…` parameter that would
+     * re-open the disclosure on the destination. This is the
+     * structural invariant the urlencode chain provides; the test
+     * pins it against future refactors that might swap in
+     * htmlentities-decoded values without re-encoding.
+     *
+     * Note: the urlencode chain was already in place pre-#1442
+     * (just stamping the legacy `advSearch=` parameter name
+     * instead), so this test does not document a new attack
+     * vector being closed — it documents the invariant that
+     * survives the URL-shape swap.
+     */
+    #[RunInSeparateProcess]
+    #[PreserveGlobalState(false)]
+    public function testSearchTextLinkEncodesValueWithUrlencode(): void
+    {
+        // No loginAsAdmin: cover the anonymous-viewer name arm.
+        // Build a hostile player name with characters that would
+        // otherwise break out of the URL (`&`, `=`, `#`, `?`).
+        $hostileName = 'Crash&advSearch=evil';
+        $this->seedBan(null, $hostileName, \BanType::Ip, '203.0.113.99');
+        $theme = $this->bootRenderHarness();
+
+        $this->renderHome();
+
+        /** @var list<array<string, mixed>> $bans */
+        $bans = $theme->captured['players_banned'] ?? [];
+        $this->assertNotEmpty($bans, 'seeded hostile-name IP-type ban must surface in $players_banned');
+
+        $link = (string) ($bans[0]['search_link'] ?? '');
+
+        // The `&` and `=` in the hostile name MUST land URL-encoded
+        // (`%26` / `%3D`) so they can't break out of the
+        // `searchText=` parameter and smuggle in a sibling
+        // `advSearch=` that would re-open the disclosure on the
+        // destination page. The literal substring "advSearch" can
+        // still appear inside the percent-encoded value (because
+        // the player name itself contains those bytes) — the
+        // safety property is that those bytes are NOT a separate
+        // URL parameter when parsed.
+        $this->assertStringContainsString(
+            'searchText=',
+            $link,
+            'link must carry the searchText= param',
+        );
+        $this->assertStringNotContainsString(
+            '&advSearch=',
+            $link,
+            'an UN-encoded `&advSearch=` boundary in the rendered link would split the URL into two params — #1442',
+        );
+
+        // Parse the URL back and verify the searchText param
+        // contains the full hostile payload (encoded back through
+        // htmlspecialchars + urlencode) and NO sibling advSearch
+        // parameter exists. This is the load-bearing assertion:
+        // even if the encoded form contains the literal substring
+        // "advSearch", PHP's `parse_str` correctly decodes it back
+        // as part of the `searchText` value, not as a separate
+        // param.
+        $query = parse_url($link, PHP_URL_QUERY);
+        $this->assertIsString($query);
+        parse_str((string) $query, $params);
+        $this->assertArrayHasKey('searchText', $params);
+        $this->assertArrayNotHasKey(
+            'advSearch',
+            $params,
+            'parsed URL must NOT carry a sibling advSearch parameter even when the player name contains `&advSearch=` — #1442',
+        );
+        // The decoded value must contain the original hostile
+        // bytes (possibly after htmlspecialchars expansion) — i.e.
+        // the value round-trips intact through the encoding.
+        $this->assertIsString($params['searchText']);
+        $this->assertStringContainsString(
+            'advSearch=evil',
+            (string) $params['searchText'],
+            'after urldecode the searchText value must still contain the original bytes — the encoding hides them inside the value, not strips them',
+        );
+    }
+
+    /**
+     * Belt-and-braces: scan the source of `page.home.php` to ensure
+     * no `advSearch=` literal survives. Catches a future search-and-
+     * replace mishap or a copy-paste from third-party fork patches
+     * that re-introduces the legacy URL shape.
+     */
+    public function testPageHomePhpSourceCarriesNoLegacyAdvSearchUrlShapes(): void
+    {
+        $source = (string) file_get_contents(ROOT . 'pages/page.home.php');
+        $this->assertNotSame(
+            '',
+            $source,
+            'page.home.php must be readable from the test process',
+        );
+
+        // The substring `advSearch=` survives only inside the
+        // documentation block (`Pre-fix this stamped the legacy
+        // ?advSearch=…&advType=…&Submit URL shape`). The
+        // executable-code check strips PHP comments via
+        // `php_strip_whitespace` so the doc-block reference doesn't
+        // false-positive the gate. Same shape `DeadJsCallSitesTest`
+        // uses for its forbidden-substring map.
+        $sourceNoComments = php_strip_whitespace(ROOT . 'pages/page.home.php');
+
+        $this->assertStringNotContainsString(
+            'advSearch=',
+            $sourceNoComments,
+            'page.home.php executable code must not emit `advSearch=` URL parameters — #1442',
+        );
+        $this->assertStringNotContainsString(
+            'advType=',
+            $sourceNoComments,
+            'page.home.php executable code must not emit `advType=` URL parameters — #1442',
+        );
+    }
+
+    /**
+     * Defence-in-depth check for the substring `?advSearch=` inside
+     * the rendered output. Runs the dashboard against a seeded DB
+     * (every row shape that has a `search_link`) and asserts the
+     * captured arrays carry no row whose `search_link` resembles
+     * the legacy shape.
+     */
+    #[RunInSeparateProcess]
+    #[PreserveGlobalState(false)]
+    public function testNoLatestRowEmitsLegacyAdvancedSearchUrlShape(): void
+    {
+        $this->loginAsAdmin();
+        // Cover every URL-arm: Steam-type ban + IP-type ban + comm.
+        $bid1 = $this->seedBan('STEAM_0:1:1', 'A', \BanType::Steam, null);
+        $bid2 = $this->seedBan(null, 'B', \BanType::Ip, '203.0.113.10');
+        $this->seedComm('STEAM_0:1:2', 'C');
+        $this->seedBanlogForBid($bid1, 'A');
+        $this->seedBanlogForBid($bid2, 'B');
+        $theme = $this->bootRenderHarness();
+
+        $this->renderHome();
+
+        /** @var list<array<string, mixed>> $bans */
+        $bans = $theme->captured['players_banned'] ?? [];
+        /** @var list<array<string, mixed>> $stopped */
+        $stopped = $theme->captured['players_blocked'] ?? [];
+        /** @var list<array<string, mixed>> $comms */
+        $comms = $theme->captured['players_commed'] ?? [];
+
+        foreach ($bans as $i => $row) {
+            $this->assertNoLegacyAdvancedSearchParameters(
+                (string) ($row['search_link'] ?? ''),
+                "bans[$i]",
+            );
+        }
+        foreach ($stopped as $i => $row) {
+            $this->assertNoLegacyAdvancedSearchParameters(
+                (string) ($row['search_link'] ?? ''),
+                "stopped[$i]",
+            );
+        }
+        foreach ($comms as $i => $row) {
+            $this->assertNoLegacyAdvancedSearchParameters(
+                (string) ($row['search_link'] ?? ''),
+                "comms[$i]",
+            );
+        }
+    }
+
+    // ----- Helpers below this line ----------------------------------
+
+    /**
+     * Build the stub-Smarty harness `HomeDashboardAnnouncementTest`
+     * established. The page handler's
+     * `Renderer::render($theme, $view)` call assigns each public
+     * property onto Smarty; the stub captures those assignments
+     * so the test can read back what the handler decided.
+     */
+    private function bootRenderHarness(): object
+    {
+        $theme = new class extends Smarty {
+            /** @var array<string,mixed> */
+            public array $captured = [];
+
+            /** @phpstan-ignore method.childParameterType */
+            public function assign($tpl_var, $value = null, $nocache = false, $scope = null)
+            {
+                if (is_string($tpl_var)) {
+                    $this->captured[$tpl_var] = $value;
+                }
+                return $this;
+            }
+
+            public function display($template = null, $cache_id = null, $compile_id = null)
+            {
+                return '';
+            }
+        };
+
+        $GLOBALS['theme']    = $theme;
+        $GLOBALS['userbank'] = $GLOBALS['userbank'] ?? new \CUserManager(null);
+        $GLOBALS['username'] = $GLOBALS['username'] ?? 'tester';
+        return $theme;
+    }
+
+    private function renderHome(): void
+    {
+        $_SESSION = $_SESSION ?? [];
+        $_GET     = [];
+
+        ob_start();
+        try {
+            require ROOT . 'pages/page.home.php';
+        } finally {
+            ob_end_clean();
+        }
+    }
+
+    /**
+     * Insert a row into `:prefix_bans` and return the auto-assigned
+     * `bid`. `$authid` may be null for IP-type bans; `$ip` is
+     * null for Steam-type bans. `$banType` is the `BanType` enum
+     * value bound via `->value` so the column-typed `tinyint`
+     * primitive lands on disk (per AGENTS.md "Backed enums").
+     */
+    private function seedBan(?string $authid, string $name, \BanType $banType, ?string $ip): int
+    {
+        $pdo = Fixture::rawPdo();
+        $now = time();
+        $aid = Fixture::adminAid();
+
+        $insert = $pdo->prepare(sprintf(
+            'INSERT INTO `%s_bans` (type, ip, authid, name, created, ends, length, reason, aid)
+             VALUES (?, ?, ?, ?, ?, 0, 0, ?, ?)',
+            DB_PREFIX,
+        ));
+        $insert->execute([
+            $banType->value,
+            $ip,
+            $authid ?? '',
+            $name,
+            $now,
+            'integration test ban',
+            $aid,
+        ]);
+        return (int) $pdo->lastInsertId();
+    }
+
+    /**
+     * Insert a `:prefix_banlog` row pointing at the given `bid`
+     * so the dashboard's "Latest blocked attempts" surface
+     * picks it up. The dashboard's banlog query joins on
+     * `:prefix_bans` to forward `b.type`, `b.authid`, `b.ip` into
+     * the search-link branching.
+     */
+    private function seedBanlogForBid(int $bid, string $name): void
+    {
+        $pdo = Fixture::rawPdo();
+        // Insert a server row first (banlog.sid → servers.sid join);
+        // an arbitrary sid is fine — the dashboard tolerates a NULL
+        // server_addr from the LEFT JOIN.
+        $sid = 1;
+        $insert = $pdo->prepare(sprintf(
+            'INSERT INTO `%s_banlog` (sid, time, name, bid) VALUES (?, ?, ?, ?)',
+            DB_PREFIX,
+        ));
+        $insert->execute([$sid, time(), $name, $bid]);
+    }
+
+    /**
+     * Insert a `:prefix_comms` row so the dashboard's
+     * "Latest comm blocks" surface picks it up. Comm blocks
+     * are always Steam-type (no IP arm) — the SourceMod plugin
+     * insert path always populates `authid`.
+     */
+    private function seedComm(string $authid, string $name): int
+    {
+        $pdo = Fixture::rawPdo();
+        $now = time();
+        $aid = Fixture::adminAid();
+
+        $insert = $pdo->prepare(sprintf(
+            'INSERT INTO `%s_comms` (type, authid, name, created, ends, length, reason, aid)
+             VALUES (1, ?, ?, ?, 0, 0, ?, ?)',
+            DB_PREFIX,
+        ));
+        $insert->execute([
+            $authid,
+            $name,
+            $now,
+            'integration test comm',
+            $aid,
+        ]);
+        return (int) $pdo->lastInsertId();
+    }
+
+    /**
+     * Assert a search-link URL does NOT carry any of the legacy
+     * advanced-search parameters that would re-open the
+     * destination disclosure (#1442).
+     */
+    private function assertNoLegacyAdvancedSearchParameters(string $link, string $context = ''): void
+    {
+        $prefix = $context !== '' ? "[$context] " : '';
+        $this->assertStringNotContainsString(
+            'advSearch=',
+            $link,
+            $prefix . 'search link must not carry the legacy `advSearch=` parameter (would re-open disclosure on destination, #1442)',
+        );
+        $this->assertStringNotContainsString(
+            'advType=',
+            $link,
+            $prefix . 'search link must not carry the legacy `advType=` parameter (paired with `advSearch=`, #1442)',
+        );
+        $this->assertStringNotContainsString(
+            '&Submit',
+            $link,
+            $prefix . 'search link must not carry the legacy `&Submit` form-submission parameter (dead URL cruft, #1442)',
+        );
+    }
+}

--- a/web/tests/integration/PublicBanListRegressionTest.php
+++ b/web/tests/integration/PublicBanListRegressionTest.php
@@ -150,6 +150,67 @@ final class PublicBanListRegressionTest extends ApiTestCase
         );
     }
 
+    /**
+     * #1442 — destination half of the dashboard "Latest bans"
+     * click-through fix. When the URL carries `?searchText=…` (the
+     * simple-bar filter the dashboard now stamps) WITHOUT
+     * `?advSearch=…`, the advanced-search disclosure MUST stay
+     * closed. Pre-fix the dashboard stamped `?advSearch=…&advType=…`
+     * which triggered `$banlistAdvancedOpen` and pushed the matched
+     * ban below the fold (the DNA-styx report). The sister
+     * source-side contract is pinned by
+     * `HomeDashboardLatestBansLinkTest`; this test is the half
+     * that validates the URL the dashboard now produces actually
+     * keeps the destination disclosure collapsed.
+     */
+    #[RunInSeparateProcess]
+    #[PreserveGlobalState(false)]
+    public function testBanlistAdvancedSearchDisclosureStaysClosedWithSearchText(): void
+    {
+        // The "Latest bans" Steam-type click-through shape — the
+        // setUp() seeded an active ban with authid `STEAM_0:1:50001`,
+        // so a `?searchText=STEAM_0:1:50001` URL must:
+        //   1. NOT auto-open the advanced-search disclosure
+        //   2. ACTUALLY surface the matched ban in the row table
+        //      (the user-visible expectation behind #1442: "I want
+        //      to see THE BAN I clicked, above the fold")
+        $_GET = [
+            'p'          => 'banlist',
+            'searchText' => 'STEAM_0:1:50001',
+        ];
+
+        $html = $this->renderBanlistPage();
+
+        $this->assertStringContainsString(
+            'data-testid="banlist-advsearch-disclosure"',
+            $html,
+            'disclosure shell must still render so power users can reach the advanced form',
+        );
+        $this->assertMatchesRegularExpression(
+            '/<details[^>]+data-testid="banlist-advsearch-disclosure"(?![^>]*\bopen\b)[^>]*>/',
+            $html,
+            '?searchText=… must NOT trigger the disclosure auto-open contract — #1442',
+        );
+        $this->assertStringNotContainsString(
+            'data-testid="banlist-advsearch-active"',
+            $html,
+            'count badge must not render when only the simple-bar filter is active (no advanced-search criteria)',
+        );
+
+        // The matched ban MUST surface in the row table. This is the
+        // user-visible contract — disclosure-closed without the
+        // matched ban would still leave the reporter with an empty
+        // page. The row-level identifier is `data-testid="ban-row"
+        // data-id="<bid>"` (`page_bans.tpl:301`), so look for that
+        // pair rather than the sibling row-action button attrs which
+        // also carry the bid.
+        $this->assertMatchesRegularExpression(
+            '/<tr[^>]+data-id="' . $this->activeBid . '"[^>]+data-testid="ban-row"|<tr[^>]+data-testid="ban-row"[^>]+data-id="' . $this->activeBid . '"/',
+            $html,
+            'matched ban (bid=' . $this->activeBid . ', authid=STEAM_0:1:50001) must surface in the rowset under ?searchText=… — #1442',
+        );
+    }
+
     #[RunInSeparateProcess]
     #[PreserveGlobalState(false)]
     public function testBanlistRendersUnbanMetaOnUnbannedRow(): void
@@ -482,6 +543,52 @@ final class PublicBanListRegressionTest extends ApiTestCase
             '/<details[^>]+data-testid="commslist-advsearch-disclosure"[^>]*\bopen\b[^>]*>/',
             $html,
             'commslist post-submit paint must render <details open>',
+        );
+    }
+
+    /**
+     * #1442 — destination half of the dashboard "Latest comm blocks"
+     * click-through fix. Mirrors the banlist contract: when only
+     * `?searchText=…` is set (no `?advSearch=…`), the disclosure
+     * must stay closed. The commslist case is HIGHER priority than
+     * the banlist's because the commslist has NO drawer fallback —
+     * the disclosure auto-opening is the sole obstacle between the
+     * user and the matched row.
+     */
+    #[RunInSeparateProcess]
+    #[PreserveGlobalState(false)]
+    public function testCommslistAdvancedSearchDisclosureStaysClosedWithSearchText(): void
+    {
+        // setUp() seeded an active comm block with authid
+        // `STEAM_0:1:60001` (`$this->activeCid`). The matched
+        // commslist row must surface as well as the disclosure
+        // staying closed — see the sibling banlist test for the
+        // user-visible contract rationale.
+        $_GET = [
+            'p'          => 'commslist',
+            'searchText' => 'STEAM_0:1:60001',
+        ];
+
+        $html = $this->renderCommslistPage();
+
+        $this->assertStringContainsString(
+            'data-testid="commslist-advsearch-disclosure"',
+            $html,
+            'commslist disclosure shell must still render so power users can reach the advanced form',
+        );
+        $this->assertMatchesRegularExpression(
+            '/<details[^>]+data-testid="commslist-advsearch-disclosure"(?![^>]*\bopen\b)[^>]*>/',
+            $html,
+            '?searchText=… on commslist must NOT trigger the disclosure auto-open contract — #1442',
+        );
+
+        // The matched comm block MUST surface in the rowset.
+        // Row-level identifier is `data-testid="comm-row" data-id="<cid>"`
+        // on `page_comms.tpl:214`.
+        $this->assertMatchesRegularExpression(
+            '/<tr[^>]+data-id="' . $this->activeCid . '"[^>]+data-testid="comm-row"|<tr[^>]+data-testid="comm-row"[^>]+data-id="' . $this->activeCid . '"/',
+            $html,
+            'matched comm block (cid=' . $this->activeCid . ', authid=STEAM_0:1:60001) must surface in the rowset under ?searchText=… — #1442',
         );
     }
 

--- a/web/themes/default/js/theme.js
+++ b/web/themes/default/js/theme.js
@@ -388,7 +388,7 @@
     const playersHtml = bans.length
       ? '<div style="' + sectionStyle + ';margin-top:8px">Players</div>'
         + bans.map((b) => {
-            const href = '?p=banlist&advType=name&advSearch=' + encodeURIComponent(b.name);
+            const href = '?p=banlist&searchText=' + encodeURIComponent(b.name);
             const steamid = b.steam || b.ip || '';
             return '<a href="' + href + '"'
               + ' class="sidebar__link palette__row"'
@@ -1151,7 +1151,7 @@
       // restores the same graceful-degradation for the keyboard-modifier
       // chords. The href on every [data-drawer-bid] / [data-drawer-cid] /
       // [data-drawer-href] anchor IS the fallback path:
-      //   - palette rows: `?p=banlist&advType=name&advSearch=<name>`
+      //   - palette rows: `?p=banlist&searchText=<name>`
       //     opens a name-filtered banlist in a new tab,
       //   - banlist rows: `?p=banlist&id=<bid>` opens the banlist URL
       //     in a new tab (the panel-history shape),

--- a/web/themes/default/page_admin_bans_protests.tpl
+++ b/web/themes/default/page_admin_bans_protests.tpl
@@ -75,7 +75,7 @@
                             <div class="queue-row__body">
                                 <div class="font-medium text-sm truncate" data-testid="protest-row-name">
                                     <a class="link"
-                                       href="./index.php?p=banlist&advSearch={$protest.authid|escape:'url'}&advType=steamid"
+                                       href="./index.php?p=banlist&searchText={$protest.authid|escape:'url'}"
                                        title="Show ban"
                                        onclick="event.stopPropagation();">{$protest.name|escape}</a>
                                 </div>

--- a/web/themes/default/page_admin_bans_protests_archiv.tpl
+++ b/web/themes/default/page_admin_bans_protests_archiv.tpl
@@ -69,7 +69,7 @@
                                 <div class="font-medium text-sm truncate" data-testid="protest-archive-row-name">
                                     {if $protest.archiv != 2}
                                         <a class="link"
-                                           href="./index.php?p=banlist{if $protest.authid != ''}&advSearch={$protest.authid|escape:'url'}&advType=steamid{else}&advSearch={$protest.ip|escape:'url'}&advType=ip{/if}"
+                                           href="./index.php?p=banlist&searchText={if $protest.authid != ''}{$protest.authid|escape:'url'}{else}{$protest.ip|escape:'url'}{/if}"
                                            title="Show ban"
                                            onclick="event.stopPropagation();">{$protest.name|escape}</a>
                                     {else}


### PR DESCRIPTION
## Summary

Fixes #1442. Clicking "Latest bans" / "Latest blocked attempts" / "Latest comm blocks" on the dashboard — and clicking the player-result anchor in the command palette, or the "Show ban" link on admin protest / protest-archive pages — was emitting `?p=banlist&advSearch=<value>&advType=<type>&Submit`. The destination banlist's `$banlistAdvancedOpen` predicate (#1315) checks `isset($_GET['advSearch']) && $_GET['advSearch'] !== ''` and paints the `<details class="filters-details">` advanced-search disclosure in the `[open]` state. On a 1273×748 viewport this pushed the matched ban below the fold — the screenshot in the bug report.

Swap to the simple-bar `?searchText=<value>` shim across every dashboard-flavoured click-through surface. The simple-bar branch fires the same `BA.ip` / `BA.authid` / `BA.name` / `BA.reason` LIKE/REGEXP filter so the matched ban still surfaces in the rowset; the URL swap is purely about disclosure-state.

### Surfaces touched

- **`web/pages/page.home.php`** — the original reporter's path. The `$stopped` / `$bans` / `$comms` loops build `search_link` URLs for the dashboard rows.
- **`web/themes/default/js/theme.js:391`** — the command palette's keyboard-modifier graceful-degradation fallback (the `<a href="…">` rendered when the user clicks a player result without `Ctrl+Enter`). Same disclosure-open bug from a sibling chrome surface, surfaced during adversarial review of the initial dashboard-only diff.
- **`web/themes/default/page_admin_bans_protests.tpl:78`** — the "Show ban" anchor on each protest row.
- **`web/themes/default/page_admin_bans_protests_archiv.tpl:72`** — the protest-archive "Show ban" anchor (both Steam-type and IP-type arms).

`web/themes/default/page_admin_admins_list.tpl`'s `advType=admin` / `advType=nodemo` links **stay as-is** — the simple-bar branch doesn't model "show bans issued BY admin aid=N" / "show bans by admin aid=N with no demo attached", so those links genuinely need the advanced-search predicate. The disclosure-open behaviour on those links is correct.

### Two correctness fixes folded in during adversarial review

The initial dashboard-only diff had two latent bugs the reviewer surfaced:

1. **`urlencode(NULL)` deprecation under PHP 8.5** (AGENTS.md "Null-into-scalar discipline"). The `$stopped` loop's `LEFT JOIN :prefix_bans` returns `NULL` for `b.ip` / `b.authid` when the banlog row points at a deleted ban. Pre-PR the raw `$info['ip']` / `$info['auth']` were fed straight to `urlencode()`. Cast at the boundary (`(string) $info['ip']` etc.) per AGENTS.md.

2. **HTML-escape mismatch** on the anonymous-viewer IP-type fallback in the `$stopped` and `$bans` loops. The pre-PR code URL-encoded `$info['name']` (htmlspecialchars-escaped — `Player &amp; Co`), so for any name containing `&` / `<` / `>` / `"` / `'` the destination's `name LIKE '%…%'` filter would never match the raw `:prefix_bans.name` column. Encode `$cleaned_name` (raw bytes) directly instead. This bug class is **WORSE** than the original report — the matched ban is hidden from the filter entirely, not just pushed below the fold.

### Regression coverage

- **`web/tests/integration/HomeDashboardLatestBansLinkTest.php`** (NEW, 10 tests, 56+ assertions):
  - URL shape per loop × per viewer × per ban type (Steam admin, Steam anonymous, IP admin, IP anonymous).
  - Hostile-name urlencode invariant — the `&advSearch=` literal cannot smuggle back into the URL even if a player picks a name containing the unencoded substring.
  - `$cleaned_name` vs `$info['name']` contract pinned (review finding #5).
  - Orphan-banlog `urlencode(NULL)` deprecation gate (review finding #2) — `set_error_handler` promotes `E_DEPRECATED` to `\ErrorException` and re-renders.
  - Source-strip belt-and-braces forbidden-substring check (`php_strip_whitespace` then assertStringNotContainsString on every legacy URL shape).
  - Full-rowset legacy-URL sweep across all three loops.
- **`web/tests/integration/PublicBanListRegressionTest.php`** (+2 tests):
  - Destination-side proof that `?searchText=…` keeps the disclosure closed AND surfaces the matched row (review finding #4 — the user-visible contract; disclosure-closed without the matched ban would still leave the user staring at an empty page).
  - Same shape for the commslist sibling.
- **`web/tests/e2e/specs/flows/ui/command-palette.spec.ts`** (updated): the keyboard-modifier-fallback assertion now rides `?searchText=` and explicitly forbids `?advSearch=`.

### Adversarial review trail

Spawned an adversarial reviewer subagent on the initial dashboard-only diff. Five findings, all addressed in this PR:

1. **MAJOR — Scope too narrow.** `theme.js`'s palette fallback and the two protest templates also emit `?advSearch=…` and trip the same disclosure-open bug from sibling chrome. Extended the fix to all three sites in this PR.
2. **MAJOR — `urlencode(NULL)` deprecation.** Detailed above.
3. **MAJOR — Test docstring overstated the smuggling threat.** `testSearchTextLinkEncodesValueWithUrlencode`'s docstring claimed the `&` in `Crash & Co&advSearch=evil` would have split into a separate URL parameter pre-fix; `urlencode()` already prevented this. Rewrote the docstring to accurately describe the urlencode invariant.
4. **MAJOR — Destination-side tests didn't verify the matched row appeared.** The two new `*StaysClosedWithSearchText` tests in `PublicBanListRegressionTest.php` only asserted disclosure-closed state; they didn't prove the click-through arrived at a useful surface. Seeded a specific ban / comm and asserted the row paints via `data-testid="ban-row"` / `comm-row` + `data-id="<bid|cid>"`.
5. **MAJOR — HTML-escape mismatch in the anonymous-viewer IP-type arm.** Detailed above.

The reviewer also surfaced one minor finding (the source-side test could pin `$cleaned_name` vs `$info['name']` more explicitly) and one nit (comment style) — both folded in.

## Test plan

- [x] `./sbpp.sh phpstan` passes (level 5, baseline unchanged)
- [x] `./sbpp.sh ts-check` passes
- [x] `./sbpp.sh composer api-contract` is in sync (no diff)
- [x] `./sbpp.sh test --filter='HomeDashboardLatestBansLinkTest|PublicBanListRegressionTest'` — all targeted tests pass
- [x] Manual verification on the dev stack: click "Latest bans" → banlist opens with the matched ban visible above the fold and the advanced-search disclosure collapsed; URL reads `?p=banlist&searchText=<value>`
- [x] Manual verification of the protest page Show-ban link → same disclosure-closed shape
- [x] Manual verification of the command palette fallback → keyboard-modifier-less Enter on a player result opens a new tab with `?p=banlist&searchText=…` instead of `?advSearch=`
- [ ] Full integration suite (skipped — pre-existing `sourcebans_test` DB-creation flakiness under `#[RunInSeparateProcess]` is unrelated to this fix and reproduces on a clean `main`)

CLA: I have read the CLA Document and I hereby sign the CLA