### PR TITLE
fix(1444): give toast notifications time to be read (and screenshotted)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1236,16 +1236,23 @@ timers, but the redirect is gated on the user's explicit X-click
 on the persistent toast. (No in-tree caller emits a mixed queue
 today; the contract is conservative for future surfaces.)
 
-Duration semantics (#1409):
+Duration semantics (#1409, default bumped to 6000ms in #1444):
 
 `$duration_ms` is optional and OMITTED from the wire format when
 the caller didn't pass an override — the chrome's `showToast`
 falls through to its `SHOWTOAST_DEFAULT_DURATION` constant
-(`4000` in `theme.js`). Three values are meaningful:
+(`6000` in `theme.js` post-#1444; was `4000` in the v2 RC chrome
+— the bump addressed the user-reported regression "notification
+appear top right and disappears very quickly" in issue #1444 by
+landing in the modern industry sweet spot, sitting alongside
+Bootstrap 5 Toast's 5000ms default and Material Design's
+~5500ms snackbar guideline for medium-length messages). Three
+values are meaningful:
 
 - `null` (default) — omit the field. The toast auto-dismisses
-  after `SHOWTOAST_DEFAULT_DURATION` (~4000ms). The right
-  choice for every routine info / success / warn confirmation.
+  after `SHOWTOAST_DEFAULT_DURATION` (~6000ms post-#1444). The
+  right choice for every routine info / success / warn
+  confirmation.
 - `0` — persistent. The chrome does NOT schedule an auto-dismiss
   timer at all; the only way the toast disappears is the user
   clicking the X button. Reserved for severe-error
@@ -1270,13 +1277,19 @@ worst-of-both outcome).
 
 `SHOWTOAST_DEFAULT_DURATION` lives in `theme.js`'s TOASTS
 block — single source for the chrome-side default. Don't
-mirror the literal `4000` into other tests or call sites;
+mirror the literal `6000` into other tests or call sites;
 reference the PHP-side `null` default and trust the chrome.
-The 4000ms default is itself a constant the project doesn't
-tune lightly — see the "Passing duration_ms = 0 for routine
-info / success toasts" Anti-patterns entry for the
-counter-direction (don't reach for `0` to dodge the timer
-on casual confirmations).
+The default is a constant the project doesn't tune lightly
+— #1444 bumped it from 4000ms to 6000ms after a user
+reported "notification appear top right and disappears
+very quickly", landing within the industry-norm 5000-6000ms
+band. The matching E2E spec (`toast-persistent-duration.spec.ts`)
+hardcodes timing thresholds derived from this constant; any
+future tweak MUST update both halves in the same commit
+(see the spec's docblock for the lockstep rationale). The
+counter-direction is "Passing duration_ms = 0 for routine
+info / success toasts" (Anti-patterns) — don't reach for
+`0` to dodge the timer on casual confirmations.
 
 The consumer-side gate in `flushPendingToasts` is
 `typeof data.duration_ms === 'number'`. A hostile / malformed
@@ -1288,6 +1301,95 @@ The typeof gate keeps the chrome's behaviour deterministic
 regardless of upstream noise; the encoder side already
 enforces an `int|null` PHP type so the only way a non-number
 lands on the wire is a hand-rolled malformed payload.
+
+Pause-on-hover / pause-on-focus (#1444):
+
+The auto-dismiss timer in `showToast` pauses when the mouse
+hovers the painted toast OR keyboard focus lands inside it,
+and resumes (from where it paused — NOT from the original
+full duration) when the user leaves the toast. The pair of
+contracts that make this work:
+
+- **Mouse arm**: `mouseenter` and `mouseleave` listeners on
+  the toast element. `mouseenter` clears the dismiss
+  `setTimeout` and records `remainingMs = duration - elapsed`.
+  `mouseleave` schedules a fresh `setTimeout` for
+  `remainingMs`.
+- **Keyboard arm**: `focusin` and `focusout` (the BUBBLING
+  pair — `focus` / `blur` don't bubble, so a tab landing on
+  the inner X button wouldn't fire them on the outer toast
+  element). Same pause / resume math as the mouse arm.
+
+Why both arms: the issue (#1444) was the user couldn't get
+a screenshot of the notification. The 4000ms → 6000ms bump
+covers the "I missed it entirely" case, but even 6s is
+tight for a screenshot (the user has to find the screenshot
+shortcut). Pause-on-hover gives the user unlimited time to
+read or capture; pause-on-focus extends the same affordance
+to keyboard / screen-reader users who Tab into the toast
+(they get the same "let me read this without scrambling"
+escape hatch the mouse user gets via hover).
+
+**Independent `hovered` and `focused` state** (#1444 review
+M-1): the pause/resume helpers track each input modality
+separately. `resumeIfIdle()` only restarts the dismiss
+timer when BOTH `hovered` AND `focused` are false.
+Collapsing them into a single "is the timer paused?" signal
+silently breaks multi-modal users: someone using mouse +
+keyboard simultaneously who tabs to the X button, then
+hovers in to read, then moves the cursor off while keeping
+focus on the X — the toast would auto-dismiss out from
+under them even though they're clearly still engaged.
+Real users hit this (Windows Narrator + mouse, JAWS + mouse,
+anyone running two input devices). Don't simplify the
+helpers back to a single-signal model.
+
+**Pause math runs on `performance.now()`** (#1444 review
+m-4): monotonic time. `Date.now()` (wall-clock) would
+clamp `remainingMs` to 0 after an NTP step-forward, a
+laptop suspend/resume mid-hover, a daylight-savings
+transition, or virtualisation clock skew — the next
+resume would schedule `setTimeout(..., 0)` and the toast
+would dismiss on the next tick. `performance.now()` is
+the right tool for measuring elapsed durations; the
+`Math.max(0, ...)` clamp stays defensively but is no
+longer the load-bearing fix.
+
+**X-button click cancels the timer explicitly** (#1444
+review m-3): `showToast` wires a per-toast click handler
+on the `[data-toast-close]` button that clears the
+in-flight timer and detaches the pause/resume listeners
+BEFORE removing the element. Without the explicit
+teardown, the click's focus-shift fires `focusout` on
+the (now-detached) toast, which calls `resumeIfIdle()`
+and schedules a fresh `setTimeout` whose closure pins
+the detached subtree until the timer fires (~remainingMs
+of transient memory per X-click; the eventual
+`el.remove()` on a detached node is a no-op so it's a
+code smell more than a leak). The document-level
+`data-toast-close` delegate stays as defence-in-depth
+for third-party themes that strip the per-toast wiring.
+
+Persistent toasts (`duration_ms: 0`) skip the hover hooks
+entirely — there's no timer to pause, and adding the
+hooks would be dead code. The chrome's `if (durationMs >
+0)` guard wraps the entire pause/resume scaffolding for
+the same reason. Don't reach for "let's add focus-pause
+to persistent toasts too" — the X-button is the only
+escape hatch on a persistent toast by design (#1409), and
+focus-pause without an auto-dismiss timer is a no-op.
+
+Regression guard: `web/tests/e2e/specs/flows/toast-hover-pause.spec.ts`
+covers both the mouse arm (hover for 7500ms — past the
+6000ms default — assert visible; unhover, wait 6500ms,
+assert dismissed) and the keyboard arm (focus the X
+button, same timing dance, assert pause / resume work).
+
+The contract has the same lockstep relationship with
+`SHOWTOAST_DEFAULT_DURATION` as the persistent-toast spec
+does: bumping the default ALSO requires bumping the spec's
+hover-wait threshold above the new default — see the
+spec's docblock for the math.
 
 ARIA role contract (#1409 review):
 
@@ -1384,8 +1486,8 @@ Regression guards:
   `commslist-getfallback-toast.spec.ts`, `admin-edit-comms-toast.spec.ts`,
   `toast-persistent-duration.spec.ts` (#1409 — drives a NOT-*
   branch's wire-format payload through the chrome and asserts
-  the toast is STILL visible past the default ~4000ms window;
-  the X-button dismiss is the only way out).
+  the toast is STILL visible past the default ~6000ms window
+  post-#1444; the X-button dismiss is the only way out).
 
 ### Loading state on drawers + lazy panes (`.skel` shimmer)
 
@@ -2972,7 +3074,7 @@ contacting every contributor individually.
   comes up empty because the read-the-message-first contract
   was burned through routine overuse). The contract:
   - **Default** (no 5th arg): chrome's `SHOWTOAST_DEFAULT_DURATION`
-    (~4000ms). The right choice for every routine path.
+    (~6000ms post-#1444). The right choice for every routine path.
   - `0`: severe-error branches ONLY. The five NOT-* sites today
     are the entire set; adding a sixth requires the same
     "destructive operation failed mid-flight, audit log already
@@ -2988,16 +3090,26 @@ contacting every contributor individually.
   / `testNotStarBranchesPassPersistentDurationMs` plus the
   `toast-persistent-duration.spec.ts` E2E that asserts the
   NOT-* toast survives past `SHOWTOAST_DEFAULT_DURATION`.
-- Mirroring the literal `4000` into a new caller or test
-  ("the default is 4 seconds, let me hard-code it") → the
+- Mirroring the literal `6000` into a new caller or test
+  ("the default is 6 seconds, let me hard-code it") → the
   default lives in `theme.js`'s `SHOWTOAST_DEFAULT_DURATION`
   constant — single source. Reference it as `null` on the
   PHP side (`Toast::emit(...)` with no 5th arg) and trust the
-  chrome to fill in the value. The 4000ms number is one
-  reduce-this-to-3000ms tweak away from desynchronising every
-  hard-coded mirror; the chrome's constant + omission-on-wire
-  is what keeps the contract single-source. The matching
-  consumer-side gate
+  chrome to fill in the value. On the JS-test side, read it
+  at runtime from `window.SBPP.SHOWTOAST_DEFAULT_DURATION`
+  (exposed for exactly this lockstep purpose, #1444 review
+  M-2) — derive every wait threshold from the read value
+  instead of hardcoding `6500` or `5500` or other literal-
+  derived numbers. Hardcoded mirrors silently pass for the
+  wrong reason when the constant moves: a `await
+  page.waitForTimeout(5500)` followed by "still visible"
+  passes whether the default is 6000ms OR 8000ms, because
+  5500ms is inside both windows. The 6000ms number is one
+  reduce-this-to-4000ms tweak away from desynchronising
+  every hard-coded mirror (and the bump from 4000 to 6000
+  in #1444 is itself evidence that the constant moves over
+  time); the chrome's constant + omission-on-wire +
+  runtime-exposure is what keeps the contract single-source. The matching consumer-side gate
   (`if (typeof data.duration_ms === 'number') opts.durationMs = data.duration_ms;`)
   is what makes "field absent → use default" work — a future
   refactor that always serialises `duration_ms` (even when
@@ -4168,7 +4280,7 @@ contacting every contributor individually.
 | Add visible row actions to a table-rendered admin list (Edit / Unmute / Remove buttons + responsive mobile-card mirror) | `web/themes/default/page_comms.tpl` (#1207 ADM-5) is the canonical reference: `<button class="btn btn--secondary btn--sm">` / `<a class="btn btn--ghost btn--sm">` inside a `.row-actions` cell, plus `.ban-card__actions` row of identical-data-action buttons in the mobile card. Wire destructive / state-changing buttons via `data-action="…"` + `data-bid` + `data-fallback-href`; the inline page-tail JS calls `sb.api.call(Actions.PascalName)` and falls back to the GET URL if the JSON dispatcher is absent. The public banlist (`web/themes/default/page_bans.tpl`) follows the same shape — same chrome (Lucide icon + visible text label inside `.btn--ghost` / `.btn--secondary btn--sm`), same `.ban-card__actions` mobile row, same `data-action` / `data-fallback-href` wiring (`bans-unban` / `bans-delete`). The Remove affordance points at the legacy GET handler (`?p=banlist&a=delete&id=…&key=…` at the top of `page.banlist.php`) because no JSON `bans.delete` action exists yet — the inline JS `confirm()`-prompts then navigates, mirroring commslist's flow without adding a new handler / snapshot / permission-matrix entry. |
 | Wire a comment-delete trash icon on any of the four comment-rendering surfaces (banlist, commslist, admin.bans protests, admin.bans submissions) | `web/scripts/comment-actions.js` (#1402). Single document-level dispatcher loaded from `core/footer.tpl` (`<script src="./scripts/comment-actions.js" defer>`) that picks up every `[data-action="comment-delete"]` click, `window.confirm`s the destructive intent, then `sb.api.call(Actions.BansRemoveComment, { cid, ctype, page })`. The four call sites emit the trigger with `data-cid="<int>"` + `data-ctype="<B|C|S|P>"` + `data-page="<int>"` (the page number for client-side row-hide / paginator-aware redirect; `data-page="-1"` is the sentinel for unpaginated moderation queues). The `ctype` letter matches `:prefix_comments.type` (B=ban, C=comm-block, S=submission, P=protest); `api_bans_remove_comment`'s `ctype` arm consumes all four. Don't duplicate the dispatcher inline per page — the single mount point is the contract, otherwise a future bug-fix has to land in four places. |
 | Add a confirm + reason modal for an irreversible row-level action (unban, lift comm block, delete admin, delete mod, …) | `web/themes/default/page_bans.tpl` (`#bans-unban-dialog`, `Actions.BansUnban`) and `web/themes/default/page_comms.tpl` (`#comms-unblock-dialog`, `Actions.CommsUnblock`) are the canonical reference (#1301), with `web/themes/default/page_admin_admins_list.tpl` (`#admins-delete-dialog`, `Actions.AdminsRemove`, #1352) and `web/themes/default/page_admin_mods_list.tpl` (`#mod-delete-dialog`, `Actions.ModsRemove`, #1397) as the third and fourth references for the optional-reason variant. Shape: a `<dialog hidden>` with a `<form method="dialog">` carrying a `<textarea aria-required="true">` (or `aria-required="false"` for the optional-reason variant — see admins-delete / mod-delete) (NOT the native `required` — that lets the browser block the form submit before our handler runs, swallowing the inline-error UX), a Cancel button, and a Confirm submit button. The page-tail JS opens the dialog via `showModal()` on `[data-action]` clicks, validates the trimmed reason on submit (load-bearing gate is server-side), forwards `ureason` to the JSON action, and on success flips the row in place via the same `flipRowToUnbanned`/`flipRowToUnmuted` helper the legacy single-click flow used (or removes the row outright + decrements the count badge for the admins-delete / mod-delete variants where there's no "now-unbanned" state to render). The legacy GET fallback (`?p=banlist&a=unban&id=…&key=…&ureason=…` / `?p=commslist&a=ungag…&ureason=…`) is the no-JS / hand-edited-URL path; both halves now reject empty `ureason` server-side so the audit log carries the *why*. The admins-delete and mod-delete variants have no legacy GET handler — `RemoveAdmin()` / `RemoveMod()` always went through the JSON dispatcher pre-#1123 D1 — so their `data-fallback-href` lands the operator back at the list page as a graceful no-op when the JSON dispatcher is missing entirely (third-party theme stripping `api.js`); the audit-log "Reason: …" suffix is only emitted when `ureason` is non-empty (vs always-emitted on the bans / comms variants where reason is required). **Do not** put `onclick="event.stopPropagation()"` on the trigger button — `document.addEventListener('click')` is how the dialog opener picks the click up, and stopPropagation would silently swallow it (the action button isn't inside any `[data-drawer-href]` ancestor anyway, so the defensiveness was a copy-paste from the row-name anchor that doesn't apply here). The submit button MUST flip through `setBusy(submitBtn, true)` BEFORE `sb.api.call(...)` leaves the page and clear via `setBusy(submitBtn, false)` on every non-navigating response branch — see "Loading state on action buttons" in Conventions for the contract, the inline-script local wrapper shape, and the regression guard. |
-| Emit a toast from a server-side branch (lostpassword reset success, banlist GET-fallback unban result, admin.edit.* not-found guard, …) | `\Sbpp\View\Toast::emit($kind, $title, $body, ?$redirect, ?$duration_ms)` (`web/includes/View/Toast.php`). Stashes the payload in a `<script type="application/json" class="sbpp-pending-toast">…</script>` block that `theme.js`'s `flushPendingToasts` picks up on `DOMContentLoaded`. Always FQN at call sites (no `use Sbpp\View\Toast;` shim). The chrome JS renders the body through `escapeHtml`; the PHP JSON encoder uses `JSON_HEX_TAG \| JSON_HEX_AMP \| JSON_HEX_APOS \| JSON_HEX_QUOT \| JSON_INVALID_UTF8_SUBSTITUTE \| JSON_THROW_ON_ERROR` so a `</script>` in body cannot break out AND malformed UTF-8 in player names (the #1108 / #765 Latin-1-on-utf8 shape) substitutes to U+FFFD instead of throwing. Multi-toast safe: emit calls stack cleanly; the first non-empty `$redirect` wins (chrome navigates ~1500ms after the toast paints so the user can read it). The optional 5th arg `$duration_ms` (#1409) overrides the chrome's `SHOWTOAST_DEFAULT_DURATION` (~4000ms) — `null` (default) keeps the chrome timing, `0` makes the toast persistent (no auto-dismiss; user must click the X button), `> 0` is an explicit ms override. The 5 NOT-* destructive-action-failed branches in `page.banlist.php` / `page.commslist.php` ("Player NOT Unbanned", "Ban NOT Deleted", "Player NOT UnGagged" × 2, "Ban NOT Deleted") pass `0` so severe-error confirmations don't auto-dismiss before the operator finishes reading. Negative `$duration_ms` throws `\InvalidArgumentException` (Fail closed; see "Duration semantics" in Conventions). Persistent + redirect are mutually exclusive (#1409): pass `null` for `$redirect` when emitting `duration_ms: 0` — the chrome's auto-redirect would otherwise navigate ~1500ms after paint, tearing down the persistent toast before the operator can acknowledge it. The chrome ALSO carries a whole-drain inhibit (`flushPendingToasts` skips the redirect setTimeout entirely when any block had `duration_ms: 0`) as defence-in-depth, but the call-site half (`$redirect=null`) is the primary contract pinned by `testNotStarBranchesPassPersistentDurationMs`'s strict regex (which disambiguates the two `Player NOT UnGagged` sites in `page.commslist.php` by body substring + asserts each site's call shape with `assertSame($expected_count, …)`). Painted ARIA role is kind-aware (#1409 review): `role="alert"` for `kind === 'error'` (assertive — screen readers interrupt to surface), `role="status"` for every other kind (polite). Persistent error toasts especially benefit from `alert` because the screen-reader user is the population least likely to notice a visual change without an auditory cue. Pair with `PageDie()` (or `exit`) whenever the handler's "render the page body" path is no longer meaningful — pre-#1403 the legacy `<script>ShowBox(...)</script>` shape carried its own `window.location` and beat the page render to the user; the lifted helper relies on the explicit redirect + the 1500ms settle. See "Server-side toast emission" in Conventions for the full contract (the "ARIA role contract" subsection covers the kind-aware role rationale). Pinned by `web/tests/integration/ToastEmitRegressionTest.php` (static grep + wire-format + JSON-escape + UTF-8-substitute + FIRST-wins-redirect + `duration_ms` omitted/set/negative/escape contracts + the 5 NOT-* call sites pass `duration_ms: 0` AND `$redirect=null` + call-site contract) and the six marquee E2E specs (`lostpassword-toast.spec.ts`, `protest-toast.spec.ts`, `banlist-getfallback-toast.spec.ts`, `commslist-getfallback-toast.spec.ts`, `admin-edit-comms-toast.spec.ts`, `toast-persistent-duration.spec.ts`). The lostpassword spec seeds the dev stack's mailpit and asserts the password-reset email lands at the right address — the marquee user-reported regression from the audit. The persistent-duration spec (#1409) drives a NOT-* branch payload and asserts the toast is STILL visible past the default ~4000ms window; its sister regression-guard test drives `window.SBPP.showToast(...)` directly (no page-flow / redirect dependency, post-review reshape) and asserts a routine toast auto-dismisses inside the ~4000-5000ms window so a regression bumping or zeroing the default duration fails loudly. |
+| Emit a toast from a server-side branch (lostpassword reset success, banlist GET-fallback unban result, admin.edit.* not-found guard, …) | `\Sbpp\View\Toast::emit($kind, $title, $body, ?$redirect, ?$duration_ms)` (`web/includes/View/Toast.php`). Stashes the payload in a `<script type="application/json" class="sbpp-pending-toast">…</script>` block that `theme.js`'s `flushPendingToasts` picks up on `DOMContentLoaded`. Always FQN at call sites (no `use Sbpp\View\Toast;` shim). The chrome JS renders the body through `escapeHtml`; the PHP JSON encoder uses `JSON_HEX_TAG \| JSON_HEX_AMP \| JSON_HEX_APOS \| JSON_HEX_QUOT \| JSON_INVALID_UTF8_SUBSTITUTE \| JSON_THROW_ON_ERROR` so a `</script>` in body cannot break out AND malformed UTF-8 in player names (the #1108 / #765 Latin-1-on-utf8 shape) substitutes to U+FFFD instead of throwing. Multi-toast safe: emit calls stack cleanly; the first non-empty `$redirect` wins (chrome navigates ~1500ms after the toast paints so the user can read it). The optional 5th arg `$duration_ms` (#1409) overrides the chrome's `SHOWTOAST_DEFAULT_DURATION` (~6000ms post-#1444; was ~4000ms in the v2 RC chrome) — `null` (default) keeps the chrome timing, `0` makes the toast persistent (no auto-dismiss; user must click the X button), `> 0` is an explicit ms override. The 5 NOT-* destructive-action-failed branches in `page.banlist.php` / `page.commslist.php` ("Player NOT Unbanned", "Ban NOT Deleted", "Player NOT UnGagged" × 2, "Ban NOT Deleted") pass `0` so severe-error confirmations don't auto-dismiss before the operator finishes reading. Negative `$duration_ms` throws `\InvalidArgumentException` (Fail closed; see "Duration semantics" in Conventions). Persistent + redirect are mutually exclusive (#1409): pass `null` for `$redirect` when emitting `duration_ms: 0` — the chrome's auto-redirect would otherwise navigate ~1500ms after paint, tearing down the persistent toast before the operator can acknowledge it. The chrome ALSO carries a whole-drain inhibit (`flushPendingToasts` skips the redirect setTimeout entirely when any block had `duration_ms: 0`) as defence-in-depth, but the call-site half (`$redirect=null`) is the primary contract pinned by `testNotStarBranchesPassPersistentDurationMs`'s strict regex (which disambiguates the two `Player NOT UnGagged` sites in `page.commslist.php` by body substring + asserts each site's call shape with `assertSame($expected_count, …)`). Painted ARIA role is kind-aware (#1409 review): `role="alert"` for `kind === 'error'` (assertive — screen readers interrupt to surface), `role="status"` for every other kind (polite). Persistent error toasts especially benefit from `alert` because the screen-reader user is the population least likely to notice a visual change without an auditory cue. Pair with `PageDie()` (or `exit`) whenever the handler's "render the page body" path is no longer meaningful — pre-#1403 the legacy `<script>ShowBox(...)</script>` shape carried its own `window.location` and beat the page render to the user; the lifted helper relies on the explicit redirect + the 1500ms settle. See "Server-side toast emission" in Conventions for the full contract (the "ARIA role contract" subsection covers the kind-aware role rationale). Pinned by `web/tests/integration/ToastEmitRegressionTest.php` (static grep + wire-format + JSON-escape + UTF-8-substitute + FIRST-wins-redirect + `duration_ms` omitted/set/negative/escape contracts + the 5 NOT-* call sites pass `duration_ms: 0` AND `$redirect=null` + call-site contract) and the six marquee E2E specs (`lostpassword-toast.spec.ts`, `protest-toast.spec.ts`, `banlist-getfallback-toast.spec.ts`, `commslist-getfallback-toast.spec.ts`, `admin-edit-comms-toast.spec.ts`, `toast-persistent-duration.spec.ts`). The lostpassword spec seeds the dev stack's mailpit and asserts the password-reset email lands at the right address — the marquee user-reported regression from the audit. The persistent-duration spec (#1409, thresholds updated in #1444) drives a NOT-* branch payload and asserts the toast is STILL visible past the default ~6000ms window; its sister regression-guard test drives `window.SBPP.showToast(...)` directly (no page-flow / redirect dependency, post-review reshape) and asserts a routine toast auto-dismisses inside the ~6000-8000ms window so a regression bumping or zeroing the default duration fails loudly. |
 | Add a loading indicator to an action button that fires `sb.api.call(...)` without a page refresh | `window.SBPP.setBusy(btn, busy)` (`web/themes/default/js/theme.js`) writes the `data-loading="true"` + `aria-busy="true"` + `disabled` triple atomically; the CSS spinner lives in `web/themes/default/css/theme.css` under `.btn[data-loading="true"]` + the `sbpp-btn-spin` keyframe. Inline page-tail scripts inside `.tpl` files define a local `setBusy(btn, busy)` wrapper that delegates to `window.SBPP.setBusy` when present and falls back to `btn.disabled = busy` so third-party themes that strip `theme.js` still gate against double-clicks. Canonical reference shapes: the three confirm-dialog flows (`page_comms.tpl` / `page_bans.tpl` / `page_admin_admins_list.tpl`), the form-submit flows (`page_admin_groups_list.tpl` / `page_admin_groups_add.tpl` / `page_admin_bans_add.tpl` / `page_admin_bans_email.tpl` / `page_youraccount.tpl` / `page_lostpassword.tpl` / `page_login.tpl`), the row-action flows (`page_admin_servers_list.tpl` / `page_admin_bans_protests.tpl` / `page_admin_bans_protests_archiv.tpl` / `page_admin_bans_submissions.tpl` / `page_admin_bans_submissions_archiv.tpl`), and the drawer Notes paths (`theme.js`'s `submitNoteForm` / `deleteNote`). Comment edit on the banlist (`web/scripts/banlist.js`) carries the same pattern for the `sb.api.call(BansEditComment)` round-trip. Regression guards: `web/tests/e2e/specs/flows/action-loading-indicator.spec.ts` (stalls `Actions.CommsUnblock` via `page.route`, asserts the busy-attribute triple on the submit button while in flight, releases the route, and confirms the row flips in-place; the second test counts requests to prove the disabled gate blocks a double-click) **plus** `web/tests/e2e/specs/flows/loading-animations.spec.ts` (#1362 — samples `getComputedStyle(::after).transform` at multiple frame boundaries under both `reducedMotion: 'reduce'` AND `'no-preference'`, asserts the matrix values change across samples; catches the v2.0 RC1 regression where the global `prefers-reduced-motion: reduce` reset froze the spinner under reduced motion). |
 | Add a loading indicator to the player drawer or one of its lazy panes (so the chrome doesn't read as blank while the JSON action is in flight) | `renderDrawerLoading()` (header skeleton for the in-flight `bans.detail`) and `renderPaneSkeleton()` (placeholder for History / Comms / Notes activation) in `web/themes/default/js/theme.js`. Both lean on the `.skel` CSS rule in `theme.css` (linear-gradient + `shimmer` keyframe + dark-mode override + the `@media (prefers-reduced-motion: reduce)` per-rule override that keeps the shimmer sliding even under reduced motion, #1362). The header skeleton carries `[data-testid="drawer-loading"]` + `aria-busy="true"` + per-block `[data-skeleton]` (terminal markers under `#drawer-root[data-loading="true"]`); the lazy-pane skeleton carries `[data-pane-empty]` + `aria-busy="true"` and deliberately omits `[data-skeleton]` because the panel parent's `hidden` attribute doesn't compose into `[data-skeleton]:not([hidden])` and a nested marker would stall every page-load waiter that runs after the drawer opens. Class name is `.skel` (singular) — NOT `.skeleton`; the pre-fix `class="skeleton"` typo had no matching rule and the shimmer rows rendered as transparent zero-background divs (the user-visible "drawer is blank" regression). Regression guards: `web/tests/e2e/specs/flows/drawer-loading-indicator.spec.ts` (stalls `bans.detail` then `bans.player_history` via `page.route`, asserts the skeleton header is visible + the `.skel` block paints a `linear-gradient` background via `getComputedStyle(el).backgroundImage`, releases the routes, and confirms the drawer flips to `renderDrawerBody` / the pane fills with content) **plus** `web/tests/e2e/specs/flows/loading-animations.spec.ts` (#1362 — samples `getComputedStyle(.skel).backgroundPositionX` at multiple frame boundaries under both `reducedMotion: 'reduce'` AND `'no-preference'`, asserts the values change across samples; catches the v2.0 RC1 regression where the global reset froze the shimmer alongside the spinner). |
 | Surface unban-reason / removed-by inline on a public-list row (admin-lifted bans / comms — banlist-ureason or commslist-ureason inline) | `web/themes/default/page_bans.tpl` + `web/themes/default/page_comms.tpl` (#1315). Reason cell on the desktop table emits a `<div class="text-xs text-faint mt-1" data-testid="ban-unban-meta">` (or `comm-unban-meta` for comms) with "Unbanned by `<admin>`: `<reason>`" when `$ban.state == 'unbanned'` (or `$comm.state == 'unmuted'`); mobile cards mirror with the `-mobile` testid suffix. Always gated on `!$hideadminname` so anonymous viewers under a hidden-admins config don't get the admin name leaked. The `ureason` / `removedby` row fields come from the page handler's existing data path (`page.banlist.php` lines 635-643, `page.commslist.php` lines 626-635) — read-only render, no write-side overlap with #1301 / #1323's unban-reason flow. The commslist surface is higher-priority than the banlist (no drawer fallback on `<tr data-testid="comm-row">`); banlist users have the drawer as the canonical detail view. |

--- a/web/includes/View/Toast.php
+++ b/web/includes/View/Toast.php
@@ -89,7 +89,9 @@ namespace Sbpp\View;
  * the caller didn't pass an override — the chrome consumer's
  * `flushPendingToasts` reads `data.duration_ms` only when present
  * and otherwise falls through to `showToast`'s
- * `SHOWTOAST_DEFAULT_DURATION` (~4000ms). Three values are
+ * `SHOWTOAST_DEFAULT_DURATION` (~6000ms post-#1444; was ~4000ms in
+ * the v2 RC chrome — the bump addressed the user-reported regression
+ * "notification appear top right and disappears very quickly"). Three values are
  * meaningful: `null` (omit the field, default chrome timing — the
  * common case for routine info / success / warn toasts), `0`
  * (persistent — the toast does NOT auto-dismiss; the user has to
@@ -182,7 +184,8 @@ final class Toast
      *
      *   - `null` (default) — omit the field from the wire format;
      *     the chrome consumer falls through to
-     *     `SHOWTOAST_DEFAULT_DURATION` in `theme.js` (~4000ms).
+     *     `SHOWTOAST_DEFAULT_DURATION` in `theme.js` (~6000ms
+     *     post-#1444; was ~4000ms in the v2 RC chrome).
      *     The right choice for every routine info / success / warn
      *     confirmation.
      *   - `0` — persistent. The chrome does NOT schedule an
@@ -225,7 +228,7 @@ final class Toast
             throw new \InvalidArgumentException(
                 sprintf(
                     'Toast::emit: $duration_ms must be null, 0, or a positive integer; got %d. '
-                    . 'Pass null for the chrome\'s default ~4000ms timer, 0 for a persistent '
+                    . 'Pass null for the chrome\'s default ~6000ms timer (post-#1444), 0 for a persistent '
                     . 'toast (user must dismiss via the X button), or a positive ms count for '
                     . 'an explicit override.',
                     $duration_ms,

--- a/web/scripts/globals.d.ts
+++ b/web/scripts/globals.d.ts
@@ -186,9 +186,10 @@ interface Window {
          * `{kind?, title, body?, durationMs?}`. `durationMs` is the
          * #1409 follow-up to `Sbpp\View\Toast::emit`'s `duration_ms`
          * wire-format field — `undefined` falls through to
-         * `SHOWTOAST_DEFAULT_DURATION` (~4000ms), `0` is persistent
-         * (user must click the X button), `> 0` is an explicit
-         * override in milliseconds.
+         * `SHOWTOAST_DEFAULT_DURATION` (the chrome constant; see
+         * `theme.js` for the canonical value and rationale), `0`
+         * is persistent (user must click the X button), `> 0` is
+         * an explicit override in milliseconds.
          */
         showToast?: (opts: {
             kind?: 'info' | 'success' | 'warn' | 'error';
@@ -196,7 +197,20 @@ interface Window {
             body?: string;
             durationMs?: number;
         }) => void;
+        /**
+         * The chrome's default toast auto-dismiss duration in
+         * milliseconds. Exposed on the SBPP namespace so E2E
+         * specs can read it at runtime instead of hardcoding
+         * the literal value into wait thresholds — the lockstep
+         * relationship between this constant and the
+         * `toast-*` specs' timing windows is then
+         * machine-enforced rather than prose-documented. Defined
+         * in `web/themes/default/js/theme.js`.
+         */
+        SHOWTOAST_DEFAULT_DURATION?: number;
         openDrawer?: (bid: number | string) => void;
+        closeDrawer?: () => void;
+        setBusy?: (btn: HTMLElement | null, busy: boolean) => void;
         /**
          * Hydrate every `[data-testid="server-tile"]` inside a
          * container with the live A2S response. Defined in

--- a/web/tests/e2e/specs/flows/toast-hover-pause.spec.ts
+++ b/web/tests/e2e/specs/flows/toast-hover-pause.spec.ts
@@ -1,0 +1,404 @@
+/**
+ * Flow spec — issue #1444 (notification boxes disappear too quickly).
+ *
+ * The user-reported regression had two layers:
+ *
+ *   1. The default auto-dismiss window (4000ms in v2 RC chrome) was
+ *      below the read-time threshold for a corner-of-screen
+ *      notification — users perceived the toast as "flashed and
+ *      disappeared".
+ *   2. The screenshot use case (explicitly called out in the issue:
+ *      "I was expecting it…and couldn't get a screenshot of it") needs
+ *      an arbitrary-length hold, which a one-shot timer bump can't
+ *      provide — even 10s would be tight if the user has to find the
+ *      screenshot key first.
+ *
+ * The fix has two halves:
+ *   1. `SHOWTOAST_DEFAULT_DURATION` 4000ms → 6000ms — see the
+ *      `toast-persistent-duration.spec.ts` routine-toast arm for that
+ *      regression guard.
+ *   2. Pause-on-hover + pause-on-keyboard-focus on the auto-dismiss
+ *      timer — this spec. The contract: while the cursor is over the
+ *      painted toast OR keyboard focus is inside the toast (e.g. the
+ *      X button is tab-focused), the dismiss timer is paused. When
+ *      the user leaves the toast (mouseleave / focusout) AND no other
+ *      input modality is still active, the timer resumes from where
+ *      it was paused, NOT from the original full duration.
+ *
+ * # What's NOT covered here
+ *
+ * - The default-duration timer math (already covered by the routine-
+ *   toast arm in `toast-persistent-duration.spec.ts`).
+ * - The persistent-toast `duration_ms: 0` semantic (covered by the
+ *   persistent arm in `toast-persistent-duration.spec.ts`).
+ *
+ * This spec covers ONLY the pause/resume timer behaviour, end-to-end,
+ * to catch a regression that drops one of the four `addEventListener`
+ * calls in `showToast()` (`mouseenter` / `mouseleave` / `focusin` /
+ * `focusout`), breaks the `pauseIfActive()` / `resumeIfIdle()`
+ * closure math, or collapses the independent `hovered` / `focused`
+ * state booleans into a single signal (review M-1).
+ *
+ * # Timer semantics + lockstep with SHOWTOAST_DEFAULT_DURATION
+ *
+ * Every `waitForTimeout` here is derived at RUNTIME from
+ * `window.SBPP.SHOWTOAST_DEFAULT_DURATION` (#1444 review M-2). The
+ * lockstep between this spec and the chrome's default duration is
+ * machine-enforced rather than prose-documented: bump the constant
+ * and the spec's hover windows widen automatically. Hardcoded
+ * literals like `7500` derived from 6000 + 1500 would silently
+ * pass for the wrong reason if a future PR bumped the constant
+ * (the spec's "still visible" assertion would fire BEFORE the new
+ * unpaused timer would have, so pause-on-hover could be entirely
+ * commented out without the test failing).
+ *
+ * Two timing constants relative to the chrome's default:
+ *
+ *   - `HOVER_MARGIN_MS` (1500ms): how long past the chrome default
+ *     to keep hovering before asserting "still visible". An
+ *     unpaused timer would have fired at T=defaultMs (relative
+ *     to paint); we wait defaultMs + 1500 to leave enough slack
+ *     that a slow CI runner's setTimeout jitter can't close the
+ *     window prematurely. Margin sized to comfortably exceed
+ *     macrotask-queue delay (~100ms) + Playwright frame jitter
+ *     (~50-200ms) + any browser-process scheduling slack.
+ *
+ *   - `RESUME_MARGIN_MS` (500ms): how long past `defaultMs` to
+ *     wait after unhovering before asserting "gone". The
+ *     resumed timer restarts with `remainingMs` ~= defaultMs
+ *     minus the ~100ms between paint and hover-start, so
+ *     defaultMs + 500 leaves a ~600ms net margin for jitter.
+ *
+ * # Auth + DB scope
+ *
+ * Default storage state (admin/admin) so the home page renders. No DB
+ * mutations (we drive `window.SBPP.showToast(...)` directly).
+ * `truncateE2eDb` is NOT called — single-DB / `workers: 1` per
+ * AGENTS.md.
+ */
+
+import { expect, test } from '../../fixtures/auth.ts';
+import type { Page } from '@playwright/test';
+
+/**
+ * Read the chrome's default toast duration from
+ * `window.SBPP.SHOWTOAST_DEFAULT_DURATION` (the runtime-exposed
+ * constant — #1444 review M-2). Asserts a reasonable value so a
+ * regression that drops the exposure (`undefined`) or sets it to
+ * something nonsensical fails LOUDLY rather than producing
+ * mystery-meat wait timings.
+ */
+async function readDefaultDuration(page: Page): Promise<number> {
+    const ms = await page.evaluate(() => {
+        const sbpp = (window as unknown as { SBPP?: { SHOWTOAST_DEFAULT_DURATION?: unknown } }).SBPP;
+        return sbpp ? sbpp.SHOWTOAST_DEFAULT_DURATION : undefined;
+    });
+    expect(
+        typeof ms,
+        'window.SBPP.SHOWTOAST_DEFAULT_DURATION must be exposed as a number — chrome JS did not boot or'
+        + ' the SBPP namespace assignment in theme.js is broken (#1444 review M-2)',
+    ).toBe('number');
+    const ok = typeof ms === 'number' && ms >= 1000 && ms <= 60000;
+    expect(
+        ok,
+        `SHOWTOAST_DEFAULT_DURATION must be a sane positive duration (1000-60000ms); got ${String(ms)}`,
+    ).toBe(true);
+    return ms as number;
+}
+
+const HOVER_MARGIN_MS = 1500;
+const RESUME_MARGIN_MS = 500;
+
+test.describe('flow: pause-on-hover / pause-on-focus (#1444 part 2)', () => {
+    test('Hovering a routine toast pauses the auto-dismiss timer; un-hovering resumes it', async ({ page }) => {
+        const consoleErrors: string[] = [];
+        page.on('pageerror', (err) => consoleErrors.push(err.message));
+
+        await page.goto('/index.php?p=home');
+
+        const defaultMs = await readDefaultDuration(page);
+
+        // Pre-check: no leftover toasts on the home page.
+        await expect(
+            page.locator('[data-testid="toast"]'),
+            'precondition: home dashboard should have no pending toasts before the manual `showToast` call',
+        ).toHaveCount(0);
+
+        // Fire a routine toast (no `durationMs` → falls through to
+        // SHOWTOAST_DEFAULT_DURATION).
+        await page.evaluate(() => {
+            const sbpp = (window as unknown as { SBPP?: { showToast?: (opts: unknown) => void } }).SBPP;
+            if (!sbpp || !sbpp.showToast) {
+                throw new Error('window.SBPP.showToast is not exposed — chrome JS did not boot');
+            }
+            sbpp.showToast({
+                kind: 'info',
+                title: '1444 hover-pause probe',
+                body: 'Hovering this toast should pause the auto-dismiss timer.',
+            });
+        });
+
+        const toast = page
+            .locator('[data-testid="toast"]')
+            .filter({ hasText: '1444 hover-pause probe' });
+        await expect(toast).toBeVisible({ timeout: 1500 });
+
+        // Hover the toast immediately after paint — `hover()`
+        // dispatches `mouseenter` which the chrome's
+        // `addEventListener('mouseenter', onMouseEnter)` picks up.
+        // The timer should be cancelled.
+        await toast.hover();
+
+        // Wait LONGER than SHOWTOAST_DEFAULT_DURATION. An unpaused
+        // timer would have fired around T=defaultMs (relative to
+        // paint, NOT hover-start), so by T=defaultMs + HOVER_MARGIN_MS
+        // the toast would be gone if pause-on-hover regressed. We're
+        // still hovering at that point.
+        // eslint-disable-next-line playwright/no-wait-for-timeout
+        await page.waitForTimeout(defaultMs + HOVER_MARGIN_MS);
+
+        // The toast MUST still be visible. Catches a regression that
+        // drops the `mouseenter` listener, breaks the `pauseIfActive()`
+        // closure (e.g. forgets to `clearTimeout(timerId)`), or
+        // races with a `setTimeout(..., 0)` shape.
+        await expect(
+            toast,
+            'toast must remain visible while hovered, regardless of SHOWTOAST_DEFAULT_DURATION'
+            + ' — pause-on-hover regression: mouseenter handler is missing, timerId not cleared,'
+            + ' or pauseIfActive()/resumeIfIdle() closure is broken',
+        ).toBeVisible();
+
+        // Move the cursor off the toast. Playwright's `mouse.move()`
+        // dispatches `mousemove` events, and the move to a coord
+        // outside the toast's bounding box triggers a `mouseleave`
+        // on the toast — which the chrome's
+        // `addEventListener('mouseleave', onMouseLeave)` picks up.
+        // The timer resumes from where it was paused.
+        //
+        // The `(0, 0)` corner is outside the toast (toast lives at
+        // top-right of the viewport with `position: fixed`); a
+        // `body.click()` would ALSO leave the toast but would
+        // accidentally click whatever's at (0, 0).
+        await page.mouse.move(0, 0);
+
+        // Wait long enough for the resumed timer to fire. The toast
+        // was hovered at T=~100ms (so remainingMs ≈ defaultMs - 100
+        // after unhover). defaultMs + RESUME_MARGIN_MS is comfortably
+        // past that — leaves ~600ms net margin for jitter.
+        // eslint-disable-next-line playwright/no-wait-for-timeout
+        await page.waitForTimeout(defaultMs + RESUME_MARGIN_MS);
+
+        // The toast MUST be gone now. Catches a regression that
+        // drops the `mouseleave` listener (timer never restarts;
+        // toast lives forever) OR breaks the `resumeIfIdle()`
+        // closure (e.g. forgets to `setTimeout(..., remainingMs)`).
+        await expect(
+            toast,
+            'toast must auto-dismiss after the resume timer fires post-unhover'
+            + ' — pause-on-hover regression: mouseleave handler is missing, resumeIfIdle() closure is broken,'
+            + ' or remainingMs math is off',
+        ).toHaveCount(0);
+
+        expect(
+            consoleErrors,
+            `unexpected console errors:\n${consoleErrors.join('\n')}`,
+        ).toEqual([]);
+    });
+
+    test('Focusing a toast (keyboard navigation) pauses the auto-dismiss timer', async ({ page }) => {
+        // Sister contract: keyboard / screen-reader users should get
+        // the same "let me read this without scrambling" affordance
+        // as mouse users get via hover. The chrome wires both
+        // `mouseenter`/`mouseleave` AND `focusin`/`focusout` to the
+        // pause/resume helpers; this test probes the focus arm.
+        //
+        // Why `focusin` / `focusout` and not `focus` / `blur`:
+        // `focus`/`blur` don't bubble, so a tab landing on the
+        // inner X button wouldn't trigger them on the outer toast
+        // element. `focusin`/`focusout` DO bubble — the canonical
+        // shape for "the toast has focus, including via descendants".
+        // A regression that swapped back to non-bubbling events
+        // would silently break this test.
+        const consoleErrors: string[] = [];
+        page.on('pageerror', (err) => consoleErrors.push(err.message));
+
+        await page.goto('/index.php?p=home');
+
+        const defaultMs = await readDefaultDuration(page);
+
+        await expect(
+            page.locator('[data-testid="toast"]'),
+        ).toHaveCount(0);
+
+        await page.evaluate(() => {
+            const sbpp = (window as unknown as { SBPP?: { showToast?: (opts: unknown) => void } }).SBPP;
+            if (!sbpp || !sbpp.showToast) {
+                throw new Error('window.SBPP.showToast is not exposed — chrome JS did not boot');
+            }
+            sbpp.showToast({
+                kind: 'info',
+                title: '1444 focus-pause probe',
+                body: 'Tabbing into this toast should pause the auto-dismiss timer.',
+            });
+        });
+
+        const toast = page
+            .locator('[data-testid="toast"]')
+            .filter({ hasText: '1444 focus-pause probe' });
+        await expect(toast).toBeVisible({ timeout: 1500 });
+
+        // Focus the X button programmatically. We could also drive
+        // Tab from a focused element to walk to the X, but that
+        // depends on the DOM tab order which is fragile across
+        // chrome additions. Direct `.focus()` on the X button
+        // produces the same focusin event the keyboard path
+        // would.
+        await toast.locator('[data-toast-close]').focus();
+
+        // Wait past the default. An unpaused timer would have fired
+        // around T=defaultMs; we're still focused at that point + the
+        // safety margin.
+        // eslint-disable-next-line playwright/no-wait-for-timeout
+        await page.waitForTimeout(defaultMs + HOVER_MARGIN_MS);
+
+        await expect(
+            toast,
+            'toast must remain visible while keyboard-focused'
+            + ' — focus-pause regression: focusin/focusout listeners are missing or non-bubbling focus/blur substituted',
+        ).toBeVisible();
+
+        // Blur the X button by moving focus to `document.body`. The
+        // `.blur()` call on the focused element fires `focusout` on
+        // the toast which the chrome picks up via the bubbling
+        // listener. Using `evaluate` here rather than reaching for a
+        // chrome anchor outside the toast — the toast's own X
+        // button is the only guaranteed focusable element on every
+        // page, so blurring it directly is the simplest and most
+        // robust shape.
+        await page.evaluate(() => {
+            const closeBtn = document.querySelector(
+                '[data-testid="toast"] [data-toast-close]',
+            ) as HTMLElement | null;
+            if (closeBtn && typeof closeBtn.blur === 'function') closeBtn.blur();
+        });
+
+        // Wait for the resumed timer to fire.
+        // eslint-disable-next-line playwright/no-wait-for-timeout
+        await page.waitForTimeout(defaultMs + RESUME_MARGIN_MS);
+
+        await expect(
+            toast,
+            'toast must auto-dismiss after the resume timer fires post-blur'
+            + ' — focus-pause regression: focusout listener is missing or resumeIfIdle() is broken',
+        ).toHaveCount(0);
+
+        expect(
+            consoleErrors,
+            `unexpected console errors:\n${consoleErrors.join('\n')}`,
+        ).toEqual([]);
+    });
+
+    test('Multi-modal (hover + focus): unhovering while still focused must NOT resume the timer', async ({ page }) => {
+        // Review M-1 regression guard. Pre-fix `showToast` collapsed
+        // hover and focus into a single "is the timer paused?" signal,
+        // so leaving ONE modality while still actively engaged via
+        // the OTHER would call `resume()` and the timer would fire
+        // out from under a user who's clearly still on the toast.
+        //
+        // The trace pre-fix:
+        //   T=0      paint              → timer scheduled with full defaultMs
+        //   T=100    focus the X        → pause() runs, remainingMs ≈ defaultMs - 100
+        //   T=200    hover the toast    → mouseenter fires pause(); inner guard
+        //                                  (timerId === null) → no-op
+        //   T=300    unhover            → mouseleave fires resume(); guard checks
+        //                                  ONLY timerId (was null), so reschedules
+        //                                  a fresh setTimeout for remainingMs even
+        //                                  though X is still focused
+        //   T=300 + remainingMs ≈ defaultMs + 200
+        //                              → el.remove(), X-button focus lost
+        //                                  silently, toast disappears.
+        //
+        // Post-fix `hovered` and `focused` are independent state;
+        // `resumeIfIdle()` reschedules only when BOTH are false.
+        // Multi-input users (mouse + keyboard, AT user + mouse,
+        // anyone using two input devices at once) get the
+        // "stay-visible until I leave entirely" semantic the
+        // single-modality cases already had.
+        const consoleErrors: string[] = [];
+        page.on('pageerror', (err) => consoleErrors.push(err.message));
+
+        await page.goto('/index.php?p=home');
+
+        const defaultMs = await readDefaultDuration(page);
+
+        await expect(
+            page.locator('[data-testid="toast"]'),
+        ).toHaveCount(0);
+
+        await page.evaluate(() => {
+            const sbpp = (window as unknown as { SBPP?: { showToast?: (opts: unknown) => void } }).SBPP;
+            if (!sbpp || !sbpp.showToast) {
+                throw new Error('window.SBPP.showToast is not exposed — chrome JS did not boot');
+            }
+            sbpp.showToast({
+                kind: 'info',
+                title: '1444 hover-plus-focus probe',
+                body: 'Hover AND focus this toast, then leave hover only — timer must stay paused.',
+            });
+        });
+
+        const toast = page
+            .locator('[data-testid="toast"]')
+            .filter({ hasText: '1444 hover-plus-focus probe' });
+        await expect(toast).toBeVisible({ timeout: 1500 });
+
+        // Engage BOTH input modalities. Focus the X button (keyboard
+        // path) then hover the toast (mouse path). Order doesn't
+        // matter functionally — the post-fix code records both
+        // booleans independently.
+        await toast.locator('[data-toast-close]').focus();
+        await toast.hover();
+
+        // Now leave the MOUSE modality only — keep keyboard focus on
+        // the X button. Pre-fix `resume()` would have rescheduled
+        // the timer here; post-fix `resumeIfIdle()` returns early
+        // because `focused === true`.
+        await page.mouse.move(0, 0);
+
+        // Wait past the default. With the pre-fix bug the toast
+        // would dismiss around T=defaultMs + 200ms; with the fix
+        // the X button is still focused so the timer stays paused
+        // indefinitely.
+        // eslint-disable-next-line playwright/no-wait-for-timeout
+        await page.waitForTimeout(defaultMs + HOVER_MARGIN_MS);
+
+        await expect(
+            toast,
+            'toast must remain visible while X-button is still focused, even after mouse leaves'
+            + ' — M-1 regression: hover and focus collapsed into a single state; resume() runs when'
+            + ' only ONE modality is still active. Independent `hovered` / `focused` booleans are the contract',
+        ).toBeVisible();
+
+        // Now blur the X button. With both modalities idle the
+        // resumed timer fires within ~defaultMs.
+        await page.evaluate(() => {
+            const closeBtn = document.querySelector(
+                '[data-testid="toast"] [data-toast-close]',
+            ) as HTMLElement | null;
+            if (closeBtn && typeof closeBtn.blur === 'function') closeBtn.blur();
+        });
+
+        // eslint-disable-next-line playwright/no-wait-for-timeout
+        await page.waitForTimeout(defaultMs + RESUME_MARGIN_MS);
+
+        await expect(
+            toast,
+            'toast must auto-dismiss after BOTH modalities go idle',
+        ).toHaveCount(0);
+
+        expect(
+            consoleErrors,
+            `unexpected console errors:\n${consoleErrors.join('\n')}`,
+        ).toEqual([]);
+    });
+});

--- a/web/tests/e2e/specs/flows/toast-persistent-duration.spec.ts
+++ b/web/tests/e2e/specs/flows/toast-persistent-duration.spec.ts
@@ -25,9 +25,10 @@
  *   1. The wire-format JSON blob the PHP-side emits for a NOT-* branch
  *      carries `duration_ms: 0` (round-trip check at the wire layer).
  *   2. The `[data-testid="toast"]` paints AND outlasts the default
- *      `SHOWTOAST_DEFAULT_DURATION` (~4000ms) — the regression the
- *      issue describes (toast disappearing before the operator
- *      finishes reading the severe-error confirmation).
+ *      `SHOWTOAST_DEFAULT_DURATION` (~6000ms after #1444 — was
+ *      ~4000ms pre-fix) — the regression the issue describes
+ *      (toast disappearing before the operator finishes reading
+ *      the severe-error confirmation).
  *   3. Clicking the `[data-toast-close]` button dismisses the toast
  *      (the X-button is the only escape hatch on a persistent toast).
  *
@@ -73,13 +74,21 @@
  * One `waitForTimeout` is intentional and load-bearing here — AGENTS.md
  * "Playwright E2E specifics" notes the persistent-toast-after-N-ms
  * assertion is the canonical case where a timer wait is legitimate.
- * Specifically: we wait 4500ms (past the default 4000ms auto-dismiss
- * window) THEN assert the toast is STILL visible. A `toBeVisible`
- * assertion alone wouldn't catch the "auto-dismisses after the
- * default" regression because the toast paints immediately on
- * `DOMContentLoaded` and the assertion would pass before the timer
- * fires. The 4500ms gives a ~500ms safety margin over the
+ * Specifically: we wait 6500ms (past the default 6000ms auto-dismiss
+ * window, post-#1444) THEN assert the toast is STILL visible. A
+ * `toBeVisible` assertion alone wouldn't catch the "auto-dismisses
+ * after the default" regression because the toast paints immediately
+ * on `DOMContentLoaded` and the assertion would pass before the timer
+ * fires. The 6500ms gives a ~500ms safety margin over the
  * `SHOWTOAST_DEFAULT_DURATION` constant in `theme.js`.
+ *
+ * #1444 raised the default from 4000ms to 6000ms. The waits in this
+ * file were bumped in lockstep — without the paired bump the
+ * "outlasts the default" assertion would land BEFORE the auto-dismiss
+ * timer and pass for the wrong reason (the toast would still be
+ * visible because the timer hadn't fired yet, NOT because
+ * `duration_ms: 0` disabled the timer). Future tweaks to
+ * `SHOWTOAST_DEFAULT_DURATION` must update both halves.
  */
 
 import { expect, test } from '../../fixtures/auth.ts';
@@ -208,15 +217,34 @@ test.describe('flow: persistent toast on NOT-* branch (#1409 `duration_ms: 0`)',
         await expect(toast).toContainText(/There was an error unbanning/);
         await expect(toast).toHaveAttribute('data-kind', 'error');
 
-        // 6. Wait past `SHOWTOAST_DEFAULT_DURATION` (4000ms; we add
-        //    500ms safety margin). The single load-bearing timer wait
-        //    in the spec — AGENTS.md "Playwright E2E specifics" notes
-        //    the persistent-toast-after-N-ms assertion is the
-        //    canonical legitimate use of `waitForTimeout`. A `toBeVisible`
-        //    by itself wouldn't catch the auto-dismiss regression
-        //    because the toast paints immediately.
+        // 6. Wait past `SHOWTOAST_DEFAULT_DURATION` + a 500ms safety
+        //    margin. The single load-bearing timer wait in the spec
+        //    — AGENTS.md "Playwright E2E specifics" notes the
+        //    persistent-toast-after-N-ms assertion is the canonical
+        //    legitimate use of `waitForTimeout`. A `toBeVisible` by
+        //    itself wouldn't catch the auto-dismiss regression
+        //    because the toast paints immediately. The chrome's
+        //    default duration is read at runtime from
+        //    `window.SBPP.SHOWTOAST_DEFAULT_DURATION` (#1444 review
+        //    M-2): the spec's wait window moves in lockstep with the
+        //    production constant automatically. Hardcoding `6500`
+        //    here would silently pass for the wrong reason if a
+        //    future PR bumped the default — the wait would land
+        //    INSIDE the new default window and "still visible"
+        //    would pass because the timer hadn't fired yet, NOT
+        //    because `duration_ms: 0` disabled it.
+        const defaultMs = await page.evaluate(() => {
+            const sbpp = (window as unknown as {
+                SBPP?: { SHOWTOAST_DEFAULT_DURATION?: unknown };
+            }).SBPP;
+            return sbpp ? sbpp.SHOWTOAST_DEFAULT_DURATION : undefined;
+        });
+        expect(
+            typeof defaultMs,
+            'window.SBPP.SHOWTOAST_DEFAULT_DURATION must be exposed for lockstep timing — chrome JS did not boot',
+        ).toBe('number');
         // eslint-disable-next-line playwright/no-wait-for-timeout
-        await page.waitForTimeout(4500);
+        await page.waitForTimeout((defaultMs as number) + 500);
 
         // 7. The toast is STILL visible — this is the #1409 contract.
         //    A regression that drops `duration_ms: 0` from the call
@@ -226,9 +254,9 @@ test.describe('flow: persistent toast on NOT-* branch (#1409 `duration_ms: 0`)',
         //    HERE.
         await expect(
             toast,
-            'toast should persist past SHOWTOAST_DEFAULT_DURATION (~4000ms) when emit'
-            + ' passes duration_ms: 0 — this is the #1409 contract restoring v1.x'
-            + ' ShowBox(..., sticky=true) semantics for severe-error confirmations',
+            'toast should persist past SHOWTOAST_DEFAULT_DURATION when emit passes duration_ms: 0'
+            + ' — this is the #1409 contract restoring v1.x ShowBox(..., sticky=true) semantics'
+            + ' for severe-error confirmations',
         ).toBeVisible();
 
         // 8. Click the X button — the only escape hatch on a
@@ -253,12 +281,12 @@ test.describe('flow: persistent toast on NOT-* branch (#1409 `duration_ms: 0`)',
     });
 
     test('Routine toast (no duration_ms override) STILL auto-dismisses — contract regression guard', async ({ page }) => {
-        // Belt-and-braces: the 4000ms default behaviour must NOT
-        // regress with the #1409 additions. A "we forgot to skip the
-        // setTimeout call when durationMs is undefined" regression
-        // would make EVERY toast persistent — the worst kind of
-        // regression because every routine info / success surface
-        // would suddenly require manual dismissal.
+        // Belt-and-braces: the default-duration behaviour must NOT
+        // regress with the #1409 additions or the #1444 bump. A "we
+        // forgot to skip the setTimeout call when durationMs is
+        // undefined" regression would make EVERY toast persistent —
+        // the worst kind of regression because every routine info /
+        // success surface would suddenly require manual dismissal.
         //
         // **Why we don't drive a page-flow route here**: the obvious
         // shape (hit a 404-shaped GET-fallback like
@@ -266,13 +294,13 @@ test.describe('flow: persistent toast on NOT-* branch (#1409 `duration_ms: 0`)',
         // branch) carries a non-null `$redirect`, so the chrome's
         // `flushPendingToasts` schedules a `window.location.href`
         // navigation ~1500ms after paint. The toast disappears
-        // because the PAGE TEARS DOWN, not because the 4000ms timer
+        // because the PAGE TEARS DOWN, not because the default timer
         // fired — a regression that bumped `SHOWTOAST_DEFAULT_DURATION`
-        // to 10000ms would still silently pass that test because
-        // the navigation happens well before the (broken) timer
-        // would have. Reviewer Suggested #2 (post-PR #1414) caught
-        // this: the test was nominally green but proved nothing
-        // about the timer contract.
+        // unreasonably high would still silently pass that test
+        // because the navigation happens well before the (broken)
+        // timer would have. Reviewer Suggested #2 (post-PR #1414)
+        // caught this: the test was nominally green but proved
+        // nothing about the timer contract.
         //
         // The replacement isolates the contract under test. We:
         //   1. Navigate to a panel page that has no pending toasts
@@ -287,25 +315,37 @@ test.describe('flow: persistent toast on NOT-* branch (#1409 `duration_ms: 0`)',
         //      `web/scripts/globals.d.ts`; it's the same code path
         //      `flushPendingToasts` uses internally.)
         //   3. Assert the toast paints immediately.
-        //   4. Wait ~3500ms — STILL inside the default ~4000ms
-        //      window — and assert the toast is still visible.
-        //      Catches a regression where `SHOWTOAST_DEFAULT_DURATION`
-        //      was accidentally LOWERED to ~3000ms.
-        //   5. Wait another ~1500ms (total 5000ms — well past the
-        //      default 4000ms + a generous margin for slow CI
-        //      runners) and assert the toast is GONE. Catches the
-        //      "every toast is now persistent" regression (the
-        //      worst case the contract guards against) AND the
-        //      "default duration was bumped past 5000ms" regression.
+        //   4. Wait until defaultMs - 500 (still INSIDE the default
+        //      window with a ~500ms safety margin) — and assert the
+        //      toast is still visible. Catches a regression where
+        //      `SHOWTOAST_DEFAULT_DURATION` was accidentally LOWERED
+        //      back below the read-time threshold.
+        //   5. Wait until defaultMs + 2000 (~2000ms past the default
+        //      — generous margin for slow CI runners but tight enough
+        //      to catch a regression bumping the default
+        //      unreasonably high) and assert the toast is GONE.
+        //      Catches the "every toast is now persistent"
+        //      regression (the worst case the contract guards
+        //      against).
         //
         // The test proves ONLY the timer contract: no page-flow
         // dependency, no redirect interference, no orphan-ban
-        // setup. The single load-bearing `waitForTimeout` is the
-        // 3500ms / 5000ms pair documented above; AGENTS.md
-        // "Playwright E2E specifics" notes the auto-dismiss
-        // timing assertion is the canonical case where a timer
-        // wait is legitimate (along with the persistent-toast
-        // sister assertion in the test above).
+        // setup. The two load-bearing `waitForTimeout` calls are
+        // derived at runtime from `SHOWTOAST_DEFAULT_DURATION`
+        // (#1444 review M-2); AGENTS.md "Playwright E2E specifics"
+        // notes the auto-dismiss timing assertion is the canonical
+        // case where a timer wait is legitimate (along with the
+        // persistent-toast sister assertion in the test above).
+        //
+        // **The thresholds and the production constant are now
+        // machine-locked.** The spec reads
+        // `window.SBPP.SHOWTOAST_DEFAULT_DURATION` and derives every
+        // wait window from it — bumping the constant
+        // automatically widens the windows. No paired edit needed,
+        // and a future PR can't silently make a "still visible"
+        // assertion pass for the wrong reason (the wait would no
+        // longer land inside the new default window because the
+        // window itself moved).
         const consoleErrors: string[] = [];
         page.on('pageerror', (err) => consoleErrors.push(err.message));
 
@@ -323,6 +363,22 @@ test.describe('flow: persistent toast on NOT-* branch (#1409 `duration_ms: 0`)',
             + ' assertion below is meaningless',
         ).toHaveCount(0);
 
+        // Read the chrome's default duration at runtime — the spec
+        // moves in lockstep with the production constant
+        // automatically. See the test's docblock for the lockstep
+        // contract (#1444 review M-2).
+        const defaultMs = await page.evaluate(() => {
+            const sbpp = (window as unknown as {
+                SBPP?: { SHOWTOAST_DEFAULT_DURATION?: unknown };
+            }).SBPP;
+            return sbpp ? sbpp.SHOWTOAST_DEFAULT_DURATION : undefined;
+        });
+        expect(
+            typeof defaultMs,
+            'window.SBPP.SHOWTOAST_DEFAULT_DURATION must be exposed for lockstep timing — chrome JS did not boot',
+        ).toBe('number');
+        const defaultMsNumber = defaultMs as number;
+
         // Fire a routine toast directly through the chrome's
         // exposed API. `window.SBPP.showToast` is the documented
         // entry point (see `web/scripts/globals.d.ts`); calling
@@ -339,7 +395,7 @@ test.describe('flow: persistent toast on NOT-* branch (#1409 `duration_ms: 0`)',
             sbpp.showToast({
                 kind: 'info',
                 title: '1409 routine timer probe',
-                body: 'This toast must auto-dismiss after the default 4000ms.',
+                body: 'This toast must auto-dismiss after the chrome default duration.',
             });
         });
 
@@ -348,32 +404,32 @@ test.describe('flow: persistent toast on NOT-* branch (#1409 `duration_ms: 0`)',
             .filter({ hasText: '1409 routine timer probe' });
         await expect(toast).toBeVisible({ timeout: 1500 });
 
-        // Wait ~3500ms — still well inside the default 4000ms
-        // window with a ~500ms safety margin. The toast MUST
+        // Wait until defaultMs - 500ms (still inside the default
+        // window with a ~500ms safety margin). The toast MUST
         // still be visible. Catches a regression that lowered
-        // `SHOWTOAST_DEFAULT_DURATION` (e.g. to 3000ms during a
-        // "make toasts disappear faster" tweak).
+        // `SHOWTOAST_DEFAULT_DURATION` back below the read-time
+        // threshold.
         // eslint-disable-next-line playwright/no-wait-for-timeout
-        await page.waitForTimeout(3500);
+        await page.waitForTimeout(defaultMsNumber - 500);
         await expect(
             toast,
-            'routine toast must still be visible at ~3500ms (well within the SHOWTOAST_DEFAULT_DURATION ~4000ms'
-            + ' window) — a regression that lowered the default below ~3500ms would fail HERE',
+            'routine toast must still be visible at (defaultMs - 500ms) — still well within the'
+            + ' SHOWTOAST_DEFAULT_DURATION window. A regression that lowered the default below'
+            + ' (defaultMs - 500) would fail HERE',
         ).toBeVisible();
 
-        // Wait another ~1500ms (total ~5000ms post-paint), then
-        // assert the toast has been removed by the auto-dismiss
-        // timer. Total wait is ~1000ms past the default 4000ms
-        // window — generous margin for slow CI runners but
-        // tight enough that a regression bumping the default to
-        // 6000ms+ fails here. A regression that disabled the
-        // auto-dismiss timer entirely (e.g. dropped the
-        // `if (durationMs > 0)` guard's `setTimeout` call when
-        // `durationMs` is `undefined`) would ALSO fail here:
-        // the toast would still be visible at 5000ms because
-        // nothing schedules its removal.
+        // Wait another 2500ms (total defaultMs + 2000ms post-paint),
+        // then assert the toast has been removed by the auto-dismiss
+        // timer. Total wait is ~2000ms past the default window —
+        // generous margin for slow CI runners but tight enough that
+        // a regression bumping the default unreasonably high fails
+        // here. A regression that disabled the auto-dismiss timer
+        // entirely (e.g. dropped the `if (durationMs > 0)` guard's
+        // `setTimeout` call when `durationMs` is `undefined`) would
+        // ALSO fail here: the toast would still be visible at
+        // (defaultMs + 2000) because nothing schedules its removal.
         // eslint-disable-next-line playwright/no-wait-for-timeout
-        await page.waitForTimeout(1500);
+        await page.waitForTimeout(2500);
         await expect(
             toast,
             'routine toast (no `durationMs` option) MUST auto-dismiss within'

--- a/web/tests/integration/ToastEmitRegressionTest.php
+++ b/web/tests/integration/ToastEmitRegressionTest.php
@@ -594,9 +594,10 @@ final class ToastEmitRegressionTest extends ApiTestCase
     //
     // The 5th parameter on `Sbpp\View\Toast::emit` is the persistent-
     // toast escape hatch — `null` (default) keeps the chrome's
-    // SHOWTOAST_DEFAULT_DURATION (~4000ms) timing, `0` disables auto-
-    // dismiss entirely (X-button only), `> 0` overrides the timer in
-    // milliseconds. The tests below pin every leg of the contract:
+    // SHOWTOAST_DEFAULT_DURATION (~6000ms post-#1444; was ~4000ms in
+    // the v2 RC chrome) timing, `0` disables auto-dismiss entirely
+    // (X-button only), `> 0` overrides the timer in milliseconds.
+    // The tests below pin every leg of the contract:
     //
     //   - omitted from the wire format when caller passed null
     //   - included on the wire when caller passed 0 or a positive int
@@ -642,7 +643,7 @@ final class ToastEmitRegressionTest extends ApiTestCase
         $this->assertArrayNotHasKey(
             'duration_ms',
             $data,
-            'Wire payload must omit `duration_ms` when the caller did not pass a 5th argument. The chrome consumer\'s `typeof data.duration_ms === \'number\'` gate keeps absence and the chrome\'s SHOWTOAST_DEFAULT_DURATION (~4000ms) as the single source of truth for the default timing.',
+            'Wire payload must omit `duration_ms` when the caller did not pass a 5th argument. The chrome consumer\'s `typeof data.duration_ms === \'number\'` gate keeps absence and the chrome\'s SHOWTOAST_DEFAULT_DURATION (~6000ms post-#1444) as the single source of truth for the default timing.',
         );
     }
 
@@ -1096,7 +1097,7 @@ final class ToastEmitRegressionTest extends ApiTestCase
                 . "        null,                           // \$redirect MUST be null (persistent+redirect mutex)\n"
                 . "        0,                              // \$duration_ms MUST be 0 (persistent)\n"
                 . "    );\n"
-                . "A drop to non-persistent (5th arg removed or non-zero) re-enables the chrome's ~4000ms auto-dismiss timer — the operator misses the severe-error confirmation and the v1.x `ShowBox(..., sticky=true)` semantic #1409 restored is gone again. "
+                . "A drop to non-persistent (5th arg removed or non-zero) re-enables the chrome's ~6000ms auto-dismiss timer (post-#1444; was ~4000ms in the v2 RC chrome) — the operator misses the severe-error confirmation and the v1.x `ShowBox(..., sticky=true)` semantic #1409 restored is gone again. "
                 . "A non-null \$redirect re-introduces the chrome's `flushPendingToasts` redirect setTimeout, which navigates ~1500ms after paint and tears down the persistent toast (the chrome's whole-drain inhibit is defence-in-depth but the call-site half is the primary contract). "
                 . "If you intentionally split or merged a NOT-* branch, update `notStarBranches()` above with the new expected count or remove the entry entirely.",
                 $rel,

--- a/web/themes/default/js/theme.js
+++ b/web/themes/default/js/theme.js
@@ -1418,13 +1418,61 @@
    * `Sbpp\View\Toast::emit` PHP-side contract: a `null` /
    * missing `duration_ms` field on the wire payload means
    * "use this default". The constant is named (not inlined as
-   * a `4000` literal) so a future tweak / theme override lands
-   * in one place. Don't reach for this from outside the toast
-   * pathway — `showToast({durationMs: SHOWTOAST_DEFAULT_DURATION})`
-   * is identical to the default and noisier than just omitting
+   * a literal) so a future tweak / theme override lands in one
+   * place. Don't reach for this from outside the toast pathway
+   * — `showToast({durationMs: SHOWTOAST_DEFAULT_DURATION})` is
+   * identical to the default and noisier than just omitting
    * the option.
+   *
+   * #1444 bumped this from 4000ms (v2 RC chrome) to 6000ms
+   * AND added pause-on-hover / pause-on-keyboard-focus to
+   * the timer below. The user-reported regression was
+   * "notification appear top right and disappears very
+   * quickly (I was expecting it... and couldn't get a
+   * screenshot of it)" — 4 seconds was below the read-time
+   * threshold for a corner notification that asks the user
+   * to shift gaze from the action site (centre / list) to
+   * the corner and parse the title + body. 6 seconds (50%
+   * longer) lands in the industry sweet spot: Bootstrap 5
+   * Toast defaults to 5000ms, Material Design Snackbar
+   * guidelines recommend 4000-10000ms with ~5500ms for
+   * medium-length messages, and modern React libs
+   * (react-toastify, Mantine, react-hot-toast, Sonner,
+   * Notistack) ship 4000-5000ms defaults. The bump alone
+   * isn't enough for the screenshot use case the reporter
+   * called out — even 6s is tight if the user has to find
+   * the keyboard shortcut for a screenshot tool. Pairing
+   * the bump with pause-on-hover (the showToast() body
+   * below) covers both halves of the contract: 6s is the
+   * baseline "I read it casually" window, hover/focus is
+   * the "I want to read it carefully or screenshot it"
+   * escape hatch. Every modern toast library (Sonner,
+   * react-hot-toast, Notistack, Mantine) ships both
+   * defaults; Material UI Snackbar deliberately omits
+   * pause-on-hover (with the rationale that snackbars are
+   * for non-actionable status; toasts can be actionable so
+   * the pause-on-hover ladder is the right shape here).
+   * The bump is conservative: doesn't disturb the
+   * persistent (`0`) semantic, doesn't disturb the
+   * explicit-override (`> 0`) semantic, doesn't require
+   * any call-site changes, and doesn't introduce a config
+   * knob (operators with stronger preferences can fork
+   * the theme — same escape hatch as every other
+   * chrome-token default). The matching E2E regression
+   * guard (`toast-persistent-duration.spec.ts`) keys its
+   * "persistent toast outlasts the default" assertion off
+   * a hardcoded wait > this value; bumping here without
+   * paired bumps there silently breaks the persistence
+   * proof (the wait would land BEFORE the default's
+   * auto-dismiss timer, so the assertion would pass for
+   * the wrong reason — see the spec for the full
+   * rationale). The pause-on-hover regression guard lives
+   * in `toast-hover-pause.spec.ts`; it probes the
+   * mouseenter/mouseleave + focusin/focusout pairs by
+   * stalling at hover for longer than the default
+   * duration and asserting the toast is still painted.
    */
-  const SHOWTOAST_DEFAULT_DURATION = 4000;
+  const SHOWTOAST_DEFAULT_DURATION = 6000;
 
   /**
    * @typedef {Object} ToastOpts
@@ -1432,7 +1480,7 @@
    * @property {string} title
    * @property {string} [body]
    * @property {number} [durationMs]  Auto-dismiss timer in ms. Three values are meaningful:
-   *   - `undefined` (default): the chrome uses `SHOWTOAST_DEFAULT_DURATION` (~4000ms).
+   *   - `undefined` (default): the chrome uses `SHOWTOAST_DEFAULT_DURATION` (~6000ms).
    *   - `0`: persistent — the toast does NOT auto-dismiss; user must click the X button.
    *   - `> 0`: explicit override in ms.
    *   Mirrors the `duration_ms` field on `Sbpp\View\Toast::emit`'s
@@ -1453,7 +1501,21 @@
     // for the default fall-through; `!opts.durationMs` would
     // collapse `0` into the default branch and silently disable
     // the persistent semantic.
-    const durationMs = opts.durationMs === undefined ? SHOWTOAST_DEFAULT_DURATION : opts.durationMs;
+    //
+    // #1444 review m-5: normalize ANY non-numeric / negative input
+    // back to the default (`null`, `NaN`, `'5000'`, `false` from
+    // hand-rolled `window.SBPP.showToast(...)` callers would
+    // otherwise compare `false` against `> 0` below and silently
+    // become persistent — exactly the wrong default for a caller
+    // who passed garbage by accident). The wire path's `int|null`
+    // PHP type and the `typeof === 'number'` consumer gate at
+    // L1668 keep the wire-format surface safe; this guard is for
+    // direct JS callers (third-party themes, inline page-tail
+    // scripts, console diagnostics).
+    const rawDuration = opts.durationMs;
+    const durationMs = rawDuration === undefined || typeof rawDuration !== 'number' || rawDuration < 0
+      ? SHOWTOAST_DEFAULT_DURATION
+      : rawDuration;
     let stack = document.getElementById('toast-stack');
     if (!stack) {
       stack = document.createElement('div');
@@ -1505,8 +1567,109 @@
     // shape (no timer; user must click the X button). A naive
     // `setTimeout(..., 0)` would auto-dismiss IMMEDIATELY on the
     // next tick — exactly the opposite of what `0` means here.
+    //
+    // #1444 review #2: pause-on-hover (and pause-on-keyboard-focus,
+    // the keyboard-equivalent affordance — screen-reader / tab
+    // navigation users get the same "let me read this without
+    // scrambling" semantic as the mouse user gets via hover). The
+    // industry-standard pattern: Sonner, react-hot-toast,
+    // Notistack, Mantine all ship pause-on-hover by default. The
+    // pause logic uses `setTimeout` / `clearTimeout` rather than
+    // CSS `animation-play-state` because the dismiss is JS-side
+    // (`el.remove()`); we can't pause an `el.remove()` setTimeout
+    // by toggling CSS state on the element. Timing math runs on
+    // `performance.now()` (monotonic — survives NTP / system-clock
+    // jumps and laptop suspend/resume that would clamp wall-clock
+    // math to a negative `remainingMs` and auto-dismiss-on-next-
+    // tick the user's still-active toast). Example: at T=0 with
+    // durationMs=6000, hovering at T=2000 records remainingMs=4000
+    // and the un-hover at T=5000 schedules a new 4000ms timer (so
+    // dismiss lands at T=9000, NOT at the original T=6000). The
+    // `data-toast-close` button click is wired here too (rather
+    // than relying on the document-level delegate below) so the
+    // click can cancel the in-flight timer AND tear down the
+    // pause/resume listeners — without that explicit teardown
+    // the click would trigger `focusout` on the (now-detached)
+    // element, which would call `resume()` and schedule a fresh
+    // setTimeout whose closure holds the detached subtree until
+    // the timer fires (~remainingMs of transient memory per
+    // X-click; a code smell more than a leak — the eventual
+    // `el.remove()` on a detached node is a no-op). Persistent
+    // toasts (`durationMs === 0`) skip the hover hooks entirely
+    // (no timer to pause).
+    //
+    // #1444 review M-1: the pause/resume state tracks `hovered`
+    // and `focused` INDEPENDENTLY rather than collapsing them
+    // into a single "is the timer paused?" signal. Multi-modal
+    // users (mouse + keyboard, AT user + mouse, anyone using
+    // two input devices simultaneously) hit the prior bug shape
+    // where leaving ONE input surface while still actively on
+    // the OTHER would resume the timer and auto-dismiss out
+    // from under them. Example trace pre-fix: tab to X (T=1000,
+    // focused=true, pause), cursor over (T=2000, mouseenter
+    // hits the `if (timerId === null) return` guard, no-op),
+    // cursor off (T=3000, mouseleave calls resume() → schedules
+    // a fresh setTimeout even though X is still focused) →
+    // toast auto-dismisses at T=8000 while X-button still has
+    // focus. Post-fix: `resumeIfIdle()` short-circuits when
+    // EITHER `hovered` or `focused` is still true.
     if (durationMs > 0) {
-      setTimeout(() => el.remove(), durationMs);
+      let remainingMs = durationMs;
+      let startedAt = performance.now();
+      let timerId = /** @type {ReturnType<typeof setTimeout> | null} */ (setTimeout(() => el.remove(), remainingMs));
+      let hovered = false;
+      let focused = false;
+      const pauseIfActive = () => {
+        if (timerId === null) return;
+        clearTimeout(timerId);
+        timerId = null;
+        remainingMs = Math.max(0, remainingMs - (performance.now() - startedAt));
+      };
+      const resumeIfIdle = () => {
+        if (timerId !== null) return;
+        if (hovered || focused) return;
+        startedAt = performance.now();
+        timerId = setTimeout(() => el.remove(), remainingMs);
+      };
+      const onMouseEnter = () => { hovered = true; pauseIfActive(); };
+      const onMouseLeave = () => { hovered = false; resumeIfIdle(); };
+      const onFocusIn = () => { focused = true; pauseIfActive(); };
+      const onFocusOut = () => { focused = false; resumeIfIdle(); };
+      // Mouse hover surfaces (pointer users) AND focus surfaces
+      // (keyboard / screen-reader users who Tab into the X
+      // button). Both pause the dismiss timer; the timer only
+      // resumes when BOTH surfaces are idle (see M-1 docblock
+      // above). Using the bubbling `focusin` / `focusout` events
+      // instead of `focus` / `blur` so a tab landing on the
+      // inner X button still counts as "the toast has focus"
+      // (focus/blur don't bubble, focusin/focusout do).
+      el.addEventListener('mouseenter', onMouseEnter);
+      el.addEventListener('mouseleave', onMouseLeave);
+      el.addEventListener('focusin', onFocusIn);
+      el.addEventListener('focusout', onFocusOut);
+      // Wire the X-button click here (in addition to the
+      // document-level delegate below) so we can cancel the
+      // in-flight timer and detach the focus/hover listeners
+      // BEFORE the click's focus-shift fires `focusout` on the
+      // detached element. Without this teardown the focusout
+      // listener (still attached on the detached node) calls
+      // `resumeIfIdle()` and schedules a fresh setTimeout whose
+      // closure pins the detached subtree until the timer
+      // fires. The document-level delegate at L1605 stays as
+      // defence-in-depth for third-party themes that strip
+      // this wiring or for any future toast factory that
+      // doesn't reach this code path.
+      const closeBtn = el.querySelector('[data-toast-close]');
+      if (closeBtn) {
+        closeBtn.addEventListener('click', () => {
+          if (timerId !== null) { clearTimeout(timerId); timerId = null; }
+          el.removeEventListener('mouseenter', onMouseEnter);
+          el.removeEventListener('mouseleave', onMouseLeave);
+          el.removeEventListener('focusin', onFocusIn);
+          el.removeEventListener('focusout', onFocusOut);
+          el.remove();
+        });
+      }
     }
   }
 
@@ -1708,7 +1871,22 @@
     }
   }
 
-  /** @type {any} */ (window).SBPP = { showToast: showToast, openDrawer: openDrawer, closeDrawer: closeDrawer, setBusy: setBusy };
+  // `SHOWTOAST_DEFAULT_DURATION` is exposed on the SBPP namespace
+  // so E2E specs can read it at runtime instead of hardcoding
+  // `6000` (or `6500` / `7500` derived literals) into per-spec
+  // wait thresholds. The lockstep contract between the constant
+  // and the specs is documented in AGENTS.md "Duration semantics"
+  // and the per-spec docblocks — exposing the value here is what
+  // makes the lockstep machine-enforceable. Bumping the constant
+  // automatically widens the specs' wait windows; no paired
+  // edit needed (#1444 review M-2).
+  /** @type {any} */ (window).SBPP = {
+    showToast: showToast,
+    openDrawer: openDrawer,
+    closeDrawer: closeDrawer,
+    setBusy: setBusy,
+    SHOWTOAST_DEFAULT_DURATION: SHOWTOAST_DEFAULT_DURATION,
+  };
 
   // ---- HELPERS ---------------------------------------------
   /**


### PR DESCRIPTION
Fixes #1444.

## Summary

- Bump `SHOWTOAST_DEFAULT_DURATION` from 4000ms → 6000ms so corner-of-screen toasts sit in the modern industry sweet spot (Bootstrap 5 default 5000ms, MD snackbar medium-message ~5500ms; react-toastify / Mantine / react-hot-toast / Sonner / Notistack all ship 4000-5000ms defaults). 4000ms was at the floor of that band and below the read-time threshold a user needs to shift gaze from the action site to the corner and parse a title + body.
- Add **pause-on-hover** + **pause-on-keyboard-focus** to the auto-dismiss timer. Hovering OR focusing the toast cancels the dismiss `setTimeout`; leaving (mouseleave / focusout) resumes from where it paused. Mouse arm + bubbling-focus arm cover the screenshot use case the reporter called out explicitly ("I was expecting it… and couldn't get a screenshot of it") — the user gets unlimited time as long as they're engaged with the toast.
- Expose `SHOWTOAST_DEFAULT_DURATION` on `window.SBPP` so the E2E specs derive every wait threshold from the runtime value (no hardcoded literals that silently desync on a future tweak).

## Issue context

> Although it's not very important, the notification appear top right and disappears very quickly (I was expecting it... and couldn't get a screenshot of it).

The fix attacks both halves of the regression: the duration bump addresses "I missed it entirely" and pause-on-hover addresses "I want to read or screenshot it carefully". Every modern toast library (Sonner, react-hot-toast, Notistack, Mantine, react-toastify) ships both defaults; this PR brings SourceBans++ into line with the standard pattern.

## What changed

| File | What |
|---|---|
| `web/themes/default/js/theme.js` | Bump default 4000ms → 6000ms; add pause/resume with independent `hovered` / `focused` state + `performance.now()` math; explicit X-button click handler tears down the timer + listeners before `el.remove()`; normalize non-numeric `durationMs` upstream of the timer dispatch; expose `SHOWTOAST_DEFAULT_DURATION` on `window.SBPP`. |
| `web/scripts/globals.d.ts` | Declare `SHOWTOAST_DEFAULT_DURATION` on the `SBPP` interface so the E2E specs can read it at runtime (lockstep with the production constant — review M-2). |
| `web/tests/e2e/specs/flows/toast-hover-pause.spec.ts` (NEW) | Three tests: mouse arm (hover pauses, unhover resumes), keyboard arm (focus pauses, blur resumes), multi-modal (hover + focus, leaving ONE while still on the OTHER must NOT resume — the M-1 regression guard). All wait windows derived from `window.SBPP.SHOWTOAST_DEFAULT_DURATION`. |
| `web/tests/e2e/specs/flows/toast-persistent-duration.spec.ts` | Bumped persistent-toast wait + routine-toast windows; both now derive from the runtime-exposed constant so future tweaks to the default automatically widen the windows. |
| `web/includes/View/Toast.php` | Docblock updates (`~4000ms` → `~6000ms post-#1444`; preserves the historical note for readers diffing PRs). |
| `web/tests/integration/ToastEmitRegressionTest.php` | Same docblock/error-message updates as Toast.php — the regression-guard contract itself is unchanged. |
| `AGENTS.md` | New "Pause-on-hover / pause-on-focus" Conventions block documenting the contract, the independent-state / monotonic-time / X-button-teardown rationales, and the persistent-toast carve-out. Updated "Duration semantics", "Server-side toast emission", and "Mirroring the literal" anti-pattern to reflect the new default + the lockstep-via-runtime-exposure pattern for JS tests. |

## Adversarial review

Spawned an adversarial reviewer subagent after the initial patch. The reviewer flagged 2 majors, 3 minors, and several nits — all addressed in this PR before opening:

- **M-1** (multi-modal hover+focus race): independent `hovered` and `focused` booleans; `resumeIfIdle()` only restarts when BOTH are false. New spec test guards.
- **M-2** (E2E lockstep not machine-enforced): exposed `SHOWTOAST_DEFAULT_DURATION` on `window.SBPP`; specs derive every wait window from it at runtime.
- **m-3** (X-button click leaks timer + fires focusout on detached node): explicit per-toast click handler clears the timer + detaches the four pause/resume listeners BEFORE `el.remove()`.
- **m-4** (`Date.now()` vs `performance.now()`): switched to monotonic time so NTP steps, laptop suspend/resume, DST transitions, virtualisation clock skew can't clamp `remainingMs` to 0.
- **m-5** (non-numeric `durationMs` becomes persistent): normalize `null` / `NaN` / `'5000'` / `false` to `SHOWTOAST_DEFAULT_DURATION` upstream of the `> 0` comparison.
- **N-6 / N-7 / N-8 / N-10**: dead-code selector replaced with direct `evaluate(closeBtn.blur())`, docblock cleaned, JSDoc made version-agnostic, persistent-toast focus-pause carve-out documented in AGENTS.md.

## Test plan

Local quality gates (all passing):

- [x] `./sbpp.sh phpstan` (level 5 + dba, 0 errors)
- [x] `./sbpp.sh ts-check`
- [x] `./sbpp.sh composer api-contract` (no diff — handler shape unchanged)
- [x] `./sbpp.sh test tests/integration/ToastEmitRegressionTest.php` (17 tests, 70 assertions, all passing)
- [x] `./sbpp.sh e2e tests/e2e/specs/flows/toast-hover-pause.spec.ts` (3 tests × 2 projects = 6 passing)
- [x] `./sbpp.sh e2e tests/e2e/specs/flows/toast-persistent-duration.spec.ts` (2 tests × 2 projects = 4 passing)
- [x] Sister toast specs (`lostpassword-toast.spec.ts`, `protest-toast.spec.ts`, `admin-edit-comms-toast.spec.ts`, `banlist-getfallback-toast.spec.ts`, `commslist-getfallback-toast.spec.ts`, `action-loading-indicator.spec.ts`) verified passing under `--workers=1` (the CI-equivalent isolation contract per AGENTS.md "Playwright E2E specifics").

Manual smoke (dev stack):

- [ ] Fire a routine toast via DevTools console (`window.SBPP.showToast({title:'foo'})`) → confirm it auto-dismisses ~6s after paint when left alone.
- [ ] Hover the toast → confirm it persists while hovered.
- [ ] Unhover → confirm it resumes the timer (dismisses after `remainingMs`).
- [ ] Tab to the X button → confirm focus-pause works.
- [ ] Trigger a NOT-* branch (e.g. POST `?p=banlist&a=unban&id=<nonexistent>&ureason=x`) → confirm the persistent error toast outlasts the default and only dismisses via X-click.