### PR TITLE
feat(1455): SMTP test-email button on the settings page

### DIFF
--- a/docs/src/content/docs/faq/index.md
+++ b/docs/src/content/docs/faq/index.md
@@ -110,6 +110,29 @@ yourself to an admin group with the relevant notification flags
 (typically the group that gets emails for new ban submissions,
 protests, etc.).
 
+### How do I verify SMTP without waiting for a real event?
+
+Go to **Admin Panel → Settings → Main** and scroll to the SMTP card.
+Below the regular SMTP fields you'll see **Send a test email** —
+it's pre-populated with your admin account's email but you can
+swap in any recipient. Click **Send test email** and the panel
+dispatches a one-shot verification message through the saved SMTP
+credentials.
+
+A few things to keep in mind:
+
+- The button is greyed out until **Host**, **Username**, and the
+  **From address** are saved. Save the form first if you just
+  changed any of them — the test reads the persisted values, not
+  the unsaved contents of the inputs.
+- The action is rate-limited to one send every 10 seconds per
+  install (prevents accidental misconfiguration from spamming
+  your SMTP relay).
+- Both success and failure show up in **Admin Panel → System
+  log**, so you can correlate a "Test email failed" toast with
+  the underlying SMTP error (`Mail error`) entry from the same
+  request.
+
 ### I locked myself out by enabling Steam-only login
 
 If you flipped the Steam-only login switch and you no longer have

--- a/web/api/handlers/_register.php
+++ b/web/api/handlers/_register.php
@@ -171,3 +171,7 @@ Api::register('system.clear_cache',           'api_system_clear_cache',         
 // settings page so we don't accidentally expose the renderer to
 // non-settings surfaces.
 Api::register('system.preview_intro_text',    'api_system_preview_intro_text',    ADMIN_OWNER | ADMIN_WEB_SETTINGS);
+// #1455: SMTP test-email button on the settings page. Same permission
+// gate as the other settings-only actions — only operators who can
+// edit SMTP credentials have a reason to trigger a verification send.
+Api::register('system.test_email',            'api_system_test_email',            ADMIN_OWNER | ADMIN_WEB_SETTINGS);

--- a/web/api/handlers/system.php
+++ b/web/api/handlers/system.php
@@ -11,8 +11,10 @@ You should have received a copy of the license along with this
 work.  If not, see <http://creativecommons.org/licenses/by-nc-sa/3.0/>.
 *************************************************************************/
 
+use Sbpp\Auth\Host;
 use Sbpp\Mail\EmailType;
 use Sbpp\Mail\Mail;
+use Sbpp\Mail\Mailer;
 use Sbpp\Markup\IntroRenderer;
 
 /**
@@ -373,6 +375,229 @@ function api_system_send_mail(array $params): array
             'kind'  => 'green',
             'redir' => $redir,
         ],
+    ];
+}
+
+/**
+ * Issue #1455: send a SMTP test message so an operator can verify
+ * the credentials they just typed into Admin → Settings actually work
+ * end-to-end (Symfony Mailer → SMTP relay → recipient inbox) without
+ * having to wait for a real password-reset / ban-protest event to fire
+ * the next outbound mail.
+ *
+ * Permission gate: ADMIN_OWNER | ADMIN_WEB_SETTINGS. Matches the other
+ * settings-page-only handlers (sel_theme / apply_theme / clear_cache /
+ * preview_intro_text); only an operator who can edit SMTP settings has
+ * a legitimate reason to trigger a test send.
+ *
+ * Error-envelope contract:
+ *   - validation         missing or malformed recipient
+ *   - smtp_not_configured  smtp.host / smtp.user / smtp.pass empty (we
+ *                          short-circuit BEFORE Mail::send so the user
+ *                          gets a pointed message instead of the
+ *                          generic mail_failed branch — `Mail::send`'s
+ *                          internal `Mailer::create() === null` arm
+ *                          also returns false but only logs to
+ *                          `:prefix_log`)
+ *   - rate_limited       too many sends in the throttle window;
+ *                        the message interpolates "try again in Ns"
+ *                        so the client can echo it directly via a
+ *                        toast — there's no separate machine-readable
+ *                        `retry_after_seconds` field on the wire
+ *                        (ApiError only carries code + message + field
+ *                        + httpStatus; if a future client needs a
+ *                        numeric value, parse it from the message
+ *                        or extend ApiError with a `details` payload).
+ *   - mail_failed        SMTP error reported by Symfony Mailer (full
+ *                        cause already lives in `:prefix_log` by way
+ *                        of `Mail::send`'s own catch block — we don't
+ *                        echo it to the client to avoid leaking
+ *                        provider error strings that may carry
+ *                        credentials / hostnames)
+ *
+ * Throttle: at most one send attempt per 10 seconds per panel
+ * install. The scope is per-install (not per-user) because the abuse
+ * surface is the outbound SMTP relay, not a per-user resource — two
+ * admins racing each other shouldn't double the relay's load. We
+ * stamp the throttle file BEFORE the SMTP I/O so a slow / hung
+ * connection can't be hammered while a first call is mid-handshake
+ * (so a series of mail_failed outcomes ALSO consume rate-limit
+ * slots — intentional). The counter is a single-int cache file
+ * under SB_CACHE, mirroring the shape
+ * `_api_system_release_save_cache` uses (atomic tempfile +
+ * `rename()`). Stale-while-error: if the cache directory is
+ * unwritable we let the send through rather than fail closed —
+ * losing the rate limit is preferable to losing the diagnostic
+ * affordance the operator opened this surface to use.
+ *
+ * Throttle interaction with api_system_clear_cache: that handler
+ * removes every file in SB_CACHE, including this throttle file. An
+ * operator who hits rate_limited and then clicks "Clear cache"
+ * resets the throttle. Acceptable because (a) both surfaces are
+ * gated by the same ADMIN_OWNER | ADMIN_WEB_SETTINGS mask, so the
+ * "throttle bypass" doesn't escalate privileges; (b) the threat
+ * model the throttle defends is a *script* hammering this endpoint,
+ * not a settings-admin abusing their own cache button.
+ *
+ * Audit: every send (success OR mail_failed) lands an entry in
+ * `:prefix_log` so test sends can't be used to silently probe SMTP
+ * credentials or enumerate valid relay endpoints. The success entry
+ * names the recipient (which is operator-controlled — by default the
+ * operator's own email); the failure entry adds the SMTP error class
+ * for diagnostics. The validation / smtp_not_configured / rate_limited
+ * branches don't log (they never reach the SMTP wire — same shape
+ * `api_system_send_mail` uses).
+ *
+ * @param array{to?: string} $params
+ * @return array{to: string, sent_at: int}
+ */
+function api_system_test_email(array $params): array
+{
+    global $userbank;
+
+    // Resolve the calling admin's display name via $userbank rather
+    // than the legacy `global $username` shape — `$username` is only
+    // set by the install-wizard pages (web/install/pages/page.[2-6].php)
+    // and the PHPUnit ApiTestCase shim; the JSON-API lifecycle in
+    // production never assigns it, so `global $username` would
+    // resolve to an unset variable, emitting empty strings into the
+    // audit log and the email body's {admin} placeholder. The same
+    // bug-shape lives in api_system_send_mail / api_account_* and
+    // is a separate cleanup — don't propagate it forward here. See
+    // the broader sweep tracked alongside this PR.
+    $adminName = (string) ($userbank->GetProperty('user') ?? '');
+
+    $to = trim((string) ($params['to'] ?? ''));
+    if ($to === '') {
+        // Default to the logged-in admin's email so an operator who
+        // just wants to "send the test to me" doesn't have to retype
+        // their own address (which they can read off Admin → My
+        // account if it slipped their mind).
+        $to = (string) ($userbank->GetProperty('email') ?? '');
+    }
+    if ($to === '') {
+        throw new ApiError(
+            'validation',
+            'Enter a recipient email address (no email is configured on your admin account).',
+            'to',
+        );
+    }
+    // FILTER_VALIDATE_EMAIL enforces RFC 822 grammar. PHP's
+    // implementation also rejects strings well over RFC 5321's
+    // 254-octet forward-path cap in every build the panel
+    // supports (the regex is internally bounded), but exact
+    // byte-edge behavior varies subtly across PHP versions, so
+    // don't rely on this as a hard size gate. If a future
+    // bug-report surfaces a 255-byte address slipping through,
+    // add an explicit `strlen($to) > 254` guard ahead of the
+    // filter — for now the filter is sufficient in practice.
+    if (filter_var($to, FILTER_VALIDATE_EMAIL) === false) {
+        throw new ApiError('validation', 'Recipient email is not a valid address.', 'to');
+    }
+
+    // Short-circuit on the smtp.host / smtp.user / smtp.pass-empty
+    // arm so the user sees actionable copy ("configure SMTP first")
+    // instead of the generic mail_failed branch. Mail::send itself
+    // also returns false in this state but only logs to
+    // `:prefix_log` — easy to miss. We deliberately don't validate
+    // smtp.port: Mailer defaults to 25, which is the right shape
+    // for a local relay (the most common test target).
+    if (Mailer::create() === null) {
+        throw new ApiError(
+            'smtp_not_configured',
+            'SMTP host, username, or password is empty. Configure SMTP first and save the form, then try again.',
+        );
+    }
+
+    // Rate limit: at most 1 send per 10s, scoped to the entire panel
+    // install (not the calling admin). The throttle window is short
+    // enough that a legitimate operator iterating on SMTP settings
+    // isn't blocked, but long enough that a script can't flood the
+    // outbound relay (a 10s window plus the audit-log row per send
+    // makes burst abuse both bandwidth-bounded AND traceable).
+    $throttleSeconds = 10;
+    $now = time();
+    $cachePath = SB_CACHE . 'test-email-throttle';
+    $previous = @file_get_contents($cachePath);
+    if ($previous !== false) {
+        $previousTs = (int) trim((string) $previous);
+        $elapsed = $now - $previousTs;
+        if ($previousTs > 0 && $elapsed >= 0 && $elapsed < $throttleSeconds) {
+            $retryAfter = $throttleSeconds - $elapsed;
+            throw new ApiError(
+                'rate_limited',
+                sprintf('Test email throttled — try again in %d seconds.', $retryAfter),
+            );
+        }
+    }
+
+    // Stamp the throttle file BEFORE the SMTP I/O so a slow / hung
+    // SMTP connection (e.g. operator pointed `smtp.host` at an
+    // unroutable address) can't be hammered while the first call is
+    // still mid-handshake. We write atomically via tempfile+rename
+    // (same shape `_api_system_release_save_cache` uses) so a
+    // crashing PHP process leaves either the old timestamp or the
+    // new one — never a half-written file.
+    //
+    // `tempnam()` falls back to `sys_get_temp_dir()` (typically
+    // `/tmp`) when SB_CACHE is unwritable. If `/tmp` and SB_CACHE
+    // are on different filesystems (common in containerized
+    // deployments where `/tmp` is host tmpfs and the panel cache
+    // is a bind mount), `rename()` fails with EXDEV and the tmp
+    // file would leak if we didn't unlink it on the failure
+    // branch. So: unlink whenever either the write OR the rename
+    // misses, not just the write.
+    if (!is_dir(SB_CACHE)) {
+        @mkdir(SB_CACHE, 0o775, true);
+    }
+    $tmpPath = @tempnam(SB_CACHE, 'tem');
+    if ($tmpPath !== false) {
+        if (@file_put_contents($tmpPath, (string) $now) === false
+            || !@rename($tmpPath, $cachePath)
+        ) {
+            @unlink($tmpPath);
+        }
+    }
+
+    // Both subject slots emit the same string: the email header
+    // subject AND the body's `<strong>{subject}</strong>` slot in
+    // `contact_custom.html`. They're rendered in different
+    // surfaces (mail-client subject line vs HTML body), so a
+    // recipient seeing one identifier in their inbox and a
+    // different one in the body would be confusing. The
+    // `[SourceBans++]` prefix is what their mail client surfaces
+    // alongside other notifications from the panel.
+    $subject = '[SourceBans++] SMTP test email';
+    $message = "This is a test email from SourceBans++ confirming your SMTP credentials are working."
+        . " It was triggered manually by admin '" . $adminName . "' from Admin → Settings → SMTP."
+        . " You can safely ignore it — no action is required.";
+    $sent = Mail::send($to, EmailType::Custom, [
+        '{message}' => $message,
+        '{subject}' => $subject,
+        '{admin}'   => $adminName,
+        '{link}'    => Host::complete(true),
+        '{home}'    => Host::complete(true),
+    ], $subject);
+
+    if (!$sent) {
+        // The full cause already lives in `:prefix_log` (Mail::send
+        // catches the Throwable from Symfony Mailer and emits a
+        // `LogType::Error, 'Mail error', $e->getMessage()` row).
+        // Mirror that with a paired audit entry so the success /
+        // failure ratio is visible in the audit log without having
+        // to cross-reference timestamps.
+        Log::add(LogType::Warning, 'Test email failed', "Admin '$adminName' tried to send a test email to '$to'; see prior 'Mail error' entry for the SMTP-side cause.");
+        throw new ApiError(
+            'mail_failed',
+            'SMTP send failed. Check the audit log under Admin → System Log for the cause.',
+        );
+    }
+
+    Log::add(LogType::Message, 'Test email sent', "Admin '$adminName' sent a SMTP test email to '$to'.");
+
+    return [
+        'to' => $to,
+        'sent_at' => $now,
     ];
 }
 

--- a/web/includes/View/AdminSettingsView.php
+++ b/web/includes/View/AdminSettingsView.php
@@ -78,6 +78,14 @@ final class AdminSettingsView extends View
         public readonly bool $banlist_nocountryfetch,
         public readonly bool $banlist_hideplayerips,
         public readonly bool $config_smtp_verify_peer,
+        // #1455: pre-populated recipient for the SMTP test-email
+        // button. Defaults to the logged-in admin's email so the
+        // operator doesn't have to retype their own address to
+        // verify SMTP works; can be edited inline before triggering
+        // the send. May be empty when the admin row has no email
+        // on file (the handler then requires the operator to type
+        // a destination before firing).
+        public readonly string $admin_email,
     ) {
     }
 }

--- a/web/pages/admin.settings.php
+++ b/web/pages/admin.settings.php
@@ -503,6 +503,11 @@ if ($section === 'themes') {
         config_smtp_verify_peer:     Config::getBool('smtp.verify_peer'),
         config_mail_from_email:      (string) Config::get('config.mail.from_email'),
         config_mail_from_name:       (string) Config::get('config.mail.from_name'),
+        // #1455: SMTP test-email button default recipient — current
+        // admin's email if any. The page-tail JS keeps the input
+        // editable so an operator can send the test to a different
+        // mailbox (e.g. a shared on-call address).
+        admin_email:                 (string) ($userbank->GetProperty('email') ?? ''),
     ));
 }
 

--- a/web/scripts/api-contract.js
+++ b/web/scripts/api-contract.js
@@ -548,6 +548,58 @@
  * @typedef {Object} ApiSystemSendMailRequest
  * @typedef {Object} ApiSystemSendMailResponse
  */
+/**
+ * Issue #1455: send a SMTP test message so an operator can verify the
+ * credentials they just typed into Admin → Settings actually work end-to-end
+ * (Symfony Mailer → SMTP relay → recipient inbox) without having to wait
+ * for a real password-reset / ban-protest event to fire the next outbound
+ * mail.  Permission gate: ADMIN_OWNER | ADMIN_WEB_SETTINGS. Matches the other
+ * settings-page-only handlers (sel_theme / apply_theme / clear_cache /
+ * preview_intro_text); only an operator who can edit SMTP settings has a
+ * legitimate reason to trigger a test send.  Error-envelope contract: -
+ * validation         missing or malformed recipient - smtp_not_configured 
+ * smtp.host / smtp.user / smtp.pass empty (we short-circuit BEFORE Mail::send
+ * so the user gets a pointed message instead of the generic mail_failed branch
+ * — `Mail::send`'s internal `Mailer::create() === null` arm also returns
+ * false but only logs to `:prefix_log`) - rate_limited       too many sends in
+ * the throttle window; the message interpolates "try again in Ns" so the
+ * client can echo it directly via a toast — there's no separate
+ * machine-readable `retry_after_seconds` field on the wire (ApiError only
+ * carries code + message + field + httpStatus; if a future client needs a
+ * numeric value, parse it from the message or extend ApiError with a `details`
+ * payload). - mail_failed        SMTP error reported by Symfony Mailer (full
+ * cause already lives in `:prefix_log` by way of `Mail::send`'s own catch
+ * block — we don't echo it to the client to avoid leaking provider error
+ * strings that may carry credentials / hostnames)  Throttle: at most one send
+ * attempt per 10 seconds per panel install. The scope is per-install (not
+ * per-user) because the abuse surface is the outbound SMTP relay, not a
+ * per-user resource — two admins racing each other shouldn't double the
+ * relay's load. We stamp the throttle file BEFORE the SMTP I/O so a slow /
+ * hung connection can't be hammered while a first call is mid-handshake (so a
+ * series of mail_failed outcomes ALSO consume rate-limit slots —
+ * intentional). The counter is a single-int cache file under SB_CACHE,
+ * mirroring the shape `_api_system_release_save_cache` uses (atomic tempfile +
+ * `rename()`). Stale-while-error: if the cache directory is unwritable we let
+ * the send through rather than fail closed — losing the rate limit is
+ * preferable to losing the diagnostic affordance the operator opened this
+ * surface to use.  Throttle interaction with api_system_clear_cache: that
+ * handler removes every file in SB_CACHE, including this throttle file. An
+ * operator who hits rate_limited and then clicks "Clear cache" resets the
+ * throttle. Acceptable because (a) both surfaces are gated by the same
+ * ADMIN_OWNER | ADMIN_WEB_SETTINGS mask, so the "throttle bypass" doesn't
+ * escalate privileges; (b) the threat model the throttle defends is a *script*
+ * hammering this endpoint, not a settings-admin abusing their own cache
+ * button.  Audit: every send (success OR mail_failed) lands an entry in
+ * `:prefix_log` so test sends can't be used to silently probe SMTP credentials
+ * or enumerate valid relay endpoints. The success entry names the recipient
+ * (which is operator-controlled — by default the operator's own email); the
+ * failure entry adds the SMTP error class for diagnostics. The validation /
+ * smtp_not_configured / rate_limited branches don't log (they never reach the
+ * SMTP wire — same shape `api_system_send_mail` uses).
+ *
+ * @typedef {Object} ApiSystemTestEmailRequest
+ * @typedef {{to: string, sent_at: number}} ApiSystemTestEmailResponse
+ */
 
 /**
  * Action names accepted by sb.api.call(). Keys are PascalCase derived from
@@ -621,6 +673,7 @@ var Actions = Object.freeze({
     SystemRehashAdmins: 'system.rehash_admins',
     SystemSelTheme: 'system.sel_theme',
     SystemSendMail: 'system.send_mail',
+    SystemTestEmail: 'system.test_email',
 });
 
 /**

--- a/web/tests/api/PermissionMatrixTest.php
+++ b/web/tests/api/PermissionMatrixTest.php
@@ -177,6 +177,9 @@ final class PermissionMatrixTest extends TestCase
             'system.apply_theme'              => ['perm' => ADMIN_OWNER | ADMIN_WEB_SETTINGS, 'requireAdmin' => false, 'public' => false],
             'system.clear_cache'              => ['perm' => ADMIN_OWNER | ADMIN_WEB_SETTINGS, 'requireAdmin' => false, 'public' => false],
             'system.preview_intro_text'       => ['perm' => ADMIN_OWNER | ADMIN_WEB_SETTINGS, 'requireAdmin' => false, 'public' => false],
+            // #1455: SMTP test-email button — only operators who can edit
+            // SMTP credentials have a reason to trigger the verification send.
+            'system.test_email'               => ['perm' => ADMIN_OWNER | ADMIN_WEB_SETTINGS, 'requireAdmin' => false, 'public' => false],
         ];
     }
 

--- a/web/tests/api/SystemTest.php
+++ b/web/tests/api/SystemTest.php
@@ -425,4 +425,236 @@ final class SystemTest extends ApiTestCase
         $env = $this->api('system.preview_intro_text', ['markdown' => 'hi']);
         $this->assertEnvelopeError($env, 'forbidden');
     }
+
+    // ---- system.test_email (#1455) -----------------------------------------
+
+    /**
+     * Convenience wrapper around `REPLACE INTO :prefix_settings` so each
+     * test_email test can set up the SMTP config it needs without
+     * round-tripping through the settings page. Mirrors the helper in
+     * `MailerSmtpFromTest::setSetting`. Re-initializes the `Config`
+     * cache so the handler sees the new value on its next read.
+     */
+    private function setSmtpSetting(string $key, string $value): void
+    {
+        $pdo = Fixture::rawPdo();
+        $stmt = $pdo->prepare(sprintf(
+            'REPLACE INTO `%s_settings` (`setting`, `value`) VALUES (?, ?)',
+            DB_PREFIX
+        ));
+        $stmt->execute([$key, $value]);
+        \Config::init($GLOBALS['PDO']);
+    }
+
+    /**
+     * Pre-seed SMTP credentials that point at an unroutable address.
+     * `Mailer::create()` only checks the three string fields are
+     * non-empty, so any non-empty values satisfy the
+     * smtp_not_configured short-circuit; the real `Mail::send` call
+     * then deterministically lands on the `mail_failed` branch
+     * because the SMTP TCP connection never establishes.
+     *
+     * Used by every test that wants the handler to reach
+     * `Mail::send` (the rate-limit + audit-log paths) without
+     * actually accepting mail in CI.
+     */
+    private function seedDeadSmtp(): void
+    {
+        // 127.0.0.1:1 is a port nothing listens on, so Symfony Mailer's
+        // EsmtpTransport raises a TransportException almost
+        // immediately (ECONNREFUSED) — no 30s timeout.
+        $this->setSmtpSetting('smtp.host', '127.0.0.1');
+        $this->setSmtpSetting('smtp.user', 'tester');
+        $this->setSmtpSetting('smtp.pass', 'shh');
+        $this->setSmtpSetting('smtp.port', '1');
+        $this->setSmtpSetting('config.mail.from_email', 'noreply@example.test');
+        $this->setSmtpSetting('config.mail.from_name', 'SourceBans++');
+    }
+
+    public function testTestEmailRejectsAnonymous(): void
+    {
+        $env = $this->api('system.test_email', ['to' => 'someone@example.test']);
+        $this->assertEnvelopeError($env, 'forbidden');
+    }
+
+    public function testTestEmailRejectsMalformedRecipient(): void
+    {
+        $this->loginAsAdmin();
+        $env = $this->api('system.test_email', ['to' => 'not-an-email']);
+        $this->assertEnvelopeError($env, 'validation');
+        $this->assertSame('to', $env['error']['field'] ?? null);
+        // Pin the validation envelope shape so a future copy / paste
+        // can't accidentally drop the `field` discriminator the
+        // client-side toast wiring uses to know which input to flag.
+        $this->assertSnapshot('system/test_email_validation', $env);
+    }
+
+    public function testTestEmailRejectsOversizedRecipientViaFilterValidateEmail(): void
+    {
+        $this->loginAsAdmin();
+        // Defence-in-depth coverage: FILTER_VALIDATE_EMAIL is documented
+        // to enforce the RFC 5321 254-octet forward-path cap (its
+        // internal regex rejects oversized strings outright). This
+        // test pins that we reject such inputs cleanly with the
+        // `validation` envelope, so a future contributor swapping the
+        // recipient validator can't silently widen the surface area
+        // for Symfony Mailer to throw a generic
+        // RfcComplianceException out of band.
+        $local  = str_repeat('a', 60); // 60 chars + '@' = 61
+        $domain = implode('.', array_fill(0, 32, 'aaaaaa')); // 223 chars
+        $to     = $local . '@' . $domain; // 284 bytes total
+        $this->assertGreaterThan(254, strlen($to));
+        $env = $this->api('system.test_email', ['to' => $to]);
+        $this->assertEnvelopeError($env, 'validation');
+        $this->assertSame('to', $env['error']['field'] ?? null);
+    }
+
+    public function testTestEmailRejectsWhenSmtpNotConfigured(): void
+    {
+        $this->loginAsAdmin();
+        // Freshly-seeded panel: smtp.host / user / pass are all empty
+        // (sb_settings ships them as blank), so Mailer::create()
+        // returns null and the handler short-circuits with the
+        // pointed `smtp_not_configured` error envelope BEFORE
+        // touching Mail::send (and therefore BEFORE the rate-limit
+        // file gets stamped).
+        $this->setSmtpSetting('smtp.host', '');
+        $this->setSmtpSetting('smtp.user', '');
+        $this->setSmtpSetting('smtp.pass', '');
+        $env = $this->api('system.test_email', ['to' => 'someone@example.test']);
+        $this->assertEnvelopeError($env, 'smtp_not_configured');
+        // Snapshot pins the operator-facing copy so a UX tweak goes
+        // through the snapshot-regen workflow rather than silently
+        // landing — the message is the only signal the operator gets
+        // about *why* the test couldn't run.
+        $this->assertSnapshot('system/test_email_smtp_not_configured', $env);
+    }
+
+    public function testTestEmailDefaultsRecipientToAdminEmail(): void
+    {
+        $this->loginAsAdmin();
+        $this->seedDeadSmtp();
+        // Throttle cleared per setUp().
+        @unlink(SB_CACHE . 'test-email-throttle');
+        $env = $this->api('system.test_email', []); // no `to` param
+        // Drop into mail_failed because the SMTP TCP connect fails.
+        // The important assertion is that the handler resolved the
+        // recipient (admin@example.test from Fixture::seedAdmin) and
+        // tried to send — i.e. it didn't bail on validation.
+        $this->assertEnvelopeError($env, 'mail_failed');
+    }
+
+    public function testTestEmailReportsMailFailureWhenSmtpDead(): void
+    {
+        $this->loginAsAdmin();
+        $this->seedDeadSmtp();
+        @unlink(SB_CACHE . 'test-email-throttle');
+
+        $env = $this->api('system.test_email', ['to' => 'someone@example.test']);
+        $this->assertEnvelopeError($env, 'mail_failed');
+        $this->assertSnapshot('system/test_email_mail_failed', $env);
+
+        // Audit-log row landed: failure surfaces under the
+        // 'Test email failed' title so an operator can correlate
+        // attempts with the underlying 'Mail error' row Mail::send
+        // emits. Pin both the count AND the body shape so a future
+        // refactor that drops the admin/recipient interpolation
+        // (which is the entire diagnostic value of the row) fails
+        // loudly.
+        $row = Fixture::rawPdo()->query(sprintf(
+            "SELECT title, message FROM `%s_log` WHERE title = 'Test email failed'",
+            DB_PREFIX
+        ))->fetch(\PDO::FETCH_ASSOC);
+        $this->assertIsArray($row, 'Expected exactly one Test email failed audit-log row.');
+        $this->assertSame('Test email failed', $row['title']);
+        // The audit row interpolates BOTH the admin's name AND the
+        // attempted recipient — both pieces are operator-actionable
+        // when triaging "did this send go anywhere?". The username
+        // comes from `$userbank->GetProperty('user')` which the
+        // PHPUnit fixture seeds as the lowercase `'admin'`.
+        $this->assertStringContainsString("Admin 'admin'", (string) $row['message']);
+        $this->assertStringContainsString("'someone@example.test'", (string) $row['message']);
+        $this->assertStringContainsString('Mail error', (string) $row['message']);
+    }
+
+    public function testTestEmailRateLimitsRepeatCallsWithinWindow(): void
+    {
+        $this->loginAsAdmin();
+        $this->seedDeadSmtp();
+        @unlink(SB_CACHE . 'test-email-throttle');
+
+        // First call reaches Mail::send and lands on mail_failed
+        // (the SMTP connection fails). The throttle file is stamped
+        // at the start of the handler regardless.
+        $first = $this->api('system.test_email', ['to' => 'a@example.test']);
+        $this->assertEnvelopeError($first, 'mail_failed');
+
+        // Second call within the throttle window is short-circuited
+        // before reaching Mail::send — proves the throttle is
+        // active and the second SMTP attempt never fires (which is
+        // the operator-visible value: an unroutable host shouldn't
+        // be hammered).
+        $second = $this->api('system.test_email', ['to' => 'b@example.test']);
+        $this->assertEnvelopeError($second, 'rate_limited');
+        // The retry-after seconds value is interpolated into the
+        // message at runtime (10 minus elapsed; clamped to a
+        // positive int). It can be 9 or 10 depending on whether
+        // the two calls crossed a wall-clock second boundary;
+        // either is acceptable, so we assert the SHAPE rather
+        // than the exact literal — the snapshot below redacts
+        // the message and pins everything else.
+        $this->assertMatchesRegularExpression(
+            '/Test email throttled — try again in (?:9|10) seconds\./',
+            (string) ($second['error']['message'] ?? ''),
+        );
+        // Snapshot pins the code + (redacted) message structure so
+        // a future change to the rate_limited shape goes through
+        // the snapshot-regen workflow rather than silently breaking
+        // any client-side branch logic.
+        $this->assertSnapshot(
+            'system/test_email_rate_limited',
+            $second,
+            ['error.message'],
+        );
+    }
+
+    public function testTestEmailValidationDoesNotConsumeRateLimitSlot(): void
+    {
+        $this->loginAsAdmin();
+        $this->seedDeadSmtp();
+        @unlink(SB_CACHE . 'test-email-throttle');
+
+        // Validation failure happens BEFORE the throttle file is
+        // stamped. A typo on the recipient shouldn't cost the
+        // operator a 10s wait on the next legitimate attempt.
+        $bad = $this->api('system.test_email', ['to' => 'not-an-email']);
+        $this->assertEnvelopeError($bad, 'validation');
+
+        // Next call with a valid address reaches Mail::send (and
+        // lands on mail_failed because the SMTP connection is
+        // dead). If the validation branch had stamped the throttle
+        // file, this would be `rate_limited` instead.
+        $next = $this->api('system.test_email', ['to' => 'a@example.test']);
+        $this->assertEnvelopeError($next, 'mail_failed');
+    }
+
+    public function testTestEmailSmtpNotConfiguredDoesNotConsumeRateLimitSlot(): void
+    {
+        $this->loginAsAdmin();
+        $this->setSmtpSetting('smtp.host', '');
+        $this->setSmtpSetting('smtp.user', '');
+        $this->setSmtpSetting('smtp.pass', '');
+        @unlink(SB_CACHE . 'test-email-throttle');
+
+        $env = $this->api('system.test_email', ['to' => 'a@example.test']);
+        $this->assertEnvelopeError($env, 'smtp_not_configured');
+
+        // The smtp_not_configured short-circuit runs BEFORE the
+        // throttle file is stamped. The operator should be able to
+        // immediately retry after fixing the settings, not have to
+        // wait out the throttle.
+        $this->seedDeadSmtp();
+        $next = $this->api('system.test_email', ['to' => 'a@example.test']);
+        $this->assertEnvelopeError($next, 'mail_failed');
+    }
 }

--- a/web/tests/api/__snapshots__/system/test_email_mail_failed.json
+++ b/web/tests/api/__snapshots__/system/test_email_mail_failed.json
@@ -1,0 +1,7 @@
+{
+    "ok": false,
+    "error": {
+        "code": "mail_failed",
+        "message": "SMTP send failed. Check the audit log under Admin \u2192 System Log for the cause."
+    }
+}

--- a/web/tests/api/__snapshots__/system/test_email_rate_limited.json
+++ b/web/tests/api/__snapshots__/system/test_email_rate_limited.json
@@ -1,0 +1,7 @@
+{
+    "ok": false,
+    "error": {
+        "code": "rate_limited",
+        "message": "<*>"
+    }
+}

--- a/web/tests/api/__snapshots__/system/test_email_smtp_not_configured.json
+++ b/web/tests/api/__snapshots__/system/test_email_smtp_not_configured.json
@@ -1,0 +1,7 @@
+{
+    "ok": false,
+    "error": {
+        "code": "smtp_not_configured",
+        "message": "SMTP host, username, or password is empty. Configure SMTP first and save the form, then try again."
+    }
+}

--- a/web/tests/api/__snapshots__/system/test_email_validation.json
+++ b/web/tests/api/__snapshots__/system/test_email_validation.json
@@ -1,0 +1,8 @@
+{
+    "ok": false,
+    "error": {
+        "code": "validation",
+        "message": "Recipient email is not a valid address.",
+        "field": "to"
+    }
+}

--- a/web/tests/e2e/fixtures/db.ts
+++ b/web/tests/e2e/fixtures/db.ts
@@ -43,6 +43,8 @@ const SEED_SERVER_GROUP_INSIDE_CONTAINER =
     '/var/www/html/web/tests/e2e/scripts/seed-server-group-e2e.php';
 const DELETE_SERVER_INSIDE_CONTAINER =
     '/var/www/html/web/tests/e2e/scripts/delete-server-e2e.php';
+const CLEAR_TEST_EMAIL_THROTTLE_INSIDE_CONTAINER =
+    '/var/www/html/web/tests/e2e/scripts/clear-test-email-throttle-e2e.php';
 
 /**
  * Run the PHP shim that drives `Sbpp\Tests\Fixture` against
@@ -617,5 +619,28 @@ async function runAnnouncementsHelper(
                 + `stdout:\n${stdout}\nstderr:\n${stderr}`,
             ));
         });
+    });
+}
+
+/**
+ * Clear the `system.test_email` rate-limit cache file (#1455).
+ *
+ * The handler limits 1 send per 10s per install via a single file at
+ * `SB_CACHE/test-email-throttle`. The throttle is install-global
+ * (not per-recipient or per-test), so parallel Playwright project
+ * profiles colliding on the happy-path test trip each other's
+ * 10s window. Reset before each happy-path arm to stay
+ * deterministic. Idempotent (no-op when the file is absent).
+ */
+export async function clearTestEmailThrottleE2e(): Promise<void> {
+    const inContainer = process.env.E2E_IN_CONTAINER === '1';
+    const cmd = inContainer ? 'php' : 'docker';
+    const cmdArgs = inContainer
+        ? [CLEAR_TEST_EMAIL_THROTTLE_INSIDE_CONTAINER]
+        : ['compose', 'exec', '-T', 'web', 'php', CLEAR_TEST_EMAIL_THROTTLE_INSIDE_CONTAINER];
+
+    await execFileP(cmd, cmdArgs, {
+        maxBuffer: 1 * 1024 * 1024,
+        cwd: inContainer ? undefined : process.cwd(),
     });
 }

--- a/web/tests/e2e/scripts/clear-test-email-throttle-e2e.php
+++ b/web/tests/e2e/scripts/clear-test-email-throttle-e2e.php
@@ -1,0 +1,55 @@
+<?php
+// SourceBans++ (c) 2014-2026 SourceBans++ Dev Team
+// Licensed under Creative Commons Attribution-NonCommercial-ShareAlike 3.0.
+// See LICENSE.md for the full license text and THIRD-PARTY-NOTICES.txt for attributions.
+
+/**
+ * E2E throttle-cache cleaner for the `system.test_email` handler (#1455).
+ *
+ * `api_system_test_email` rate-limits at 10s per install via a single
+ * cache file `SB_CACHE/test-email-throttle`. The throttle is global
+ * (not per-recipient) — the threat model the rate limit defends is
+ * "operator-controlled SMTP relay abuse", which doesn't care about
+ * the recipient axis. Specs that exercise the happy path under
+ * parallel Playwright project profiles (chromium + mobile-chromium)
+ * end up colliding on the same throttle slot, so they need an
+ * explicit reset between tests to stay deterministic.
+ *
+ * Idempotent: silently no-ops when the file isn't present.
+ *
+ * Usage (inside the web container):
+ *
+ *   php clear-test-email-throttle-e2e.php
+ */
+
+declare(strict_types=1);
+
+if (PHP_SAPI !== 'cli') {
+    fwrite(STDERR, "clear-test-email-throttle-e2e.php must run on the CLI.\n");
+    exit(2);
+}
+
+if (!getenv('DB_NAME')) {
+    putenv('DB_NAME=sourcebans_e2e');
+    $_ENV['DB_NAME']    = 'sourcebans_e2e';
+    $_SERVER['DB_NAME'] = 'sourcebans_e2e';
+}
+
+// Production / phpunit DBs share the panel's cache directory in dev
+// stacks (SB_CACHE is derived from the panel root, not the schema
+// name), so unlinking the throttle file would also wipe it for any
+// concurrent dev / phpunit session against the same install. Mirror
+// the refuse-guard shape used by reset-e2e-db.php so a fat-fingered
+// `DB_NAME=sourcebans php …` invocation aborts loudly instead of
+// silently scrubbing the wrong stack's cache.
+if (getenv('DB_NAME') === 'sourcebans_test' || getenv('DB_NAME') === 'sourcebans') {
+    fwrite(STDERR, "refusing to clear test-email throttle against DB_NAME=" . getenv('DB_NAME')
+        . ": this script must target a dedicated e2e DB (default sourcebans_e2e).\n");
+    exit(2);
+}
+
+require __DIR__ . '/../../bootstrap.php';
+
+$cacheFile = SB_CACHE . 'test-email-throttle';
+@unlink($cacheFile);
+fwrite(STDOUT, "cleared $cacheFile\n");

--- a/web/tests/e2e/specs/flows/smtp-test-email.spec.ts
+++ b/web/tests/e2e/specs/flows/smtp-test-email.spec.ts
@@ -1,0 +1,242 @@
+/**
+ * Flow spec — issue #1455: "SMTP - Add test email function".
+ *
+ * The admin Settings page (`?p=admin&c=settings&section=settings`)
+ * now carries a "Send test email" affordance inside the SMTP card. The
+ * pre-issue panel had no way to verify SMTP credentials short of
+ * waiting for a real outbound mail (password reset, ban protest,
+ * etc.) — operators routinely shipped broken SMTP into production
+ * for days before noticing. This spec drives the affordance
+ * end-to-end and asserts the marquee user-reported outcome from the
+ * issue body: an admin types a recipient, clicks the button, and
+ * the test email actually lands in their inbox (mailpit, in CI).
+ *
+ * Three scenarios:
+ *
+ *   1. **Happy path** — SMTP configured (via `seedLostpasswordE2e`,
+ *      which sets `smtp.host=mailpit:1025` + a `from_email`), click
+ *      the button, assert (a) the success toast paints and (b) a
+ *      message lands in mailpit addressed to the operator's email.
+ *      This is the contract the GitHub issue specifically asks for:
+ *      "Test email function that is enabled when SMTP details have
+ *      been completed."
+ *
+ *   2. **Disabled when SMTP is not configured** — fresh e2e DB
+ *      (smtp.host / user / pass all empty per `data.sql`), the
+ *      button must render as `disabled`. The corresponding
+ *      server-side `smtp_not_configured` short-circuit is pinned by
+ *      `SystemTest::testTestEmailRejectsWhenSmtpNotConfigured` —
+ *      the spec here pins the client-side visibility contract so an
+ *      operator on a freshly-installed panel never even gets to
+ *      click a button that would only error out.
+ *
+ *   3. **Validation toast on bad recipient** — clear the recipient
+ *      input, type something the browser's native `<input type=email>`
+ *      validity check rejects, click the button, assert the
+ *      `reportValidity()` popover fires (proxy: the input is invalid)
+ *      and NO `sb.api.call` round-trip happened (proxy: no toast
+ *      appears with success/failure copy). This pins the JS-side
+ *      gate stays as the first layer of defence so a typo doesn't
+ *      consume the 10s rate-limit slot.
+ *
+ * Selector contract:
+ *   - `[data-testid="smtp-test-email"]` — the button (server-rendered
+ *     with the disabled state at first paint based on the saved
+ *     smtp.host / smtp.user / config.mail.from_email values).
+ *   - `[data-testid="smtp-test-recipient"]` — the recipient input,
+ *     pre-populated with the logged-in admin's email.
+ */
+
+import { expect, test } from '../../fixtures/auth.ts';
+import {
+    clearTestEmailThrottleE2e,
+    seedLostpasswordE2e,
+    truncateE2eDb,
+} from '../../fixtures/db.ts';
+
+/**
+ * Mailpit HTTP API root. Mirrors `lostpassword-toast.spec.ts` so
+ * the parallel-stack override (`docker-compose.override.yml`)
+ * doesn't have to be threaded through the spec — inside the web
+ * container `mailpit:8025` works regardless of the host-published
+ * UI port.
+ */
+const MAILPIT_BASE_URL = process.env.E2E_MAILPIT_BASE_URL
+    ?? 'http://mailpit:8025';
+
+test.describe('flow: SMTP test email (#1455)', () => {
+    test.beforeEach(async () => {
+        // Each test owns the SMTP config state — the happy-path test
+        // wants mailpit; the disabled-state test wants the blank
+        // `data.sql` shape. Truncating + reseeding between tests
+        // gives both a deterministic starting point. (The other
+        // E2E specs that share the DB use the same pattern.)
+        await truncateE2eDb();
+        // The handler's 10s rate-limit cache is install-global (not
+        // per-recipient or per-test). Parallel project profiles
+        // (chromium + mobile-chromium) running the happy-path test
+        // simultaneously trip each other's throttle window unless
+        // we clear the cache file between attempts. The clear is
+        // idempotent — no-op when the file isn't present, so the
+        // disabled-state + validation arms pay nothing for the call.
+        await clearTestEmailThrottleE2e();
+    });
+
+    test('Happy path: SMTP configured → button is enabled, click sends a real email to the operator', async ({ page, request }) => {
+        // ---- 0. Seed mailpit-pointed SMTP creds + a non-empty
+        //         from_email so the button renders enabled. The
+        //         seeder also clears mailpit's inbox indirectly
+        //         (we do it explicitly below for safety).
+        const { email } = await seedLostpasswordE2e();
+
+        // Clear mailpit so the assertion is unambiguous.
+        const purge = await request.delete(`${MAILPIT_BASE_URL}/api/v1/messages`);
+        expect(
+            purge.ok(),
+            `mailpit purge failed (status ${purge.status()}): ${await purge.text()}`,
+        ).toBe(true);
+
+        await page.goto('/index.php?p=admin&c=settings&section=settings');
+        await page.waitForFunction(
+            () => !document.querySelector('[data-loading="true"], [data-skeleton]:not([hidden])'),
+        );
+
+        const button = page.locator('[data-testid="smtp-test-email"]');
+        const recipient = page.locator('[data-testid="smtp-test-recipient"]');
+        await expect(button).toBeVisible();
+        // The seeded mailpit creds + the seeded `from_email` mean
+        // the server-rendered first-paint state is enabled.
+        await expect(button).toBeEnabled();
+        // The recipient input is pre-populated with the logged-in
+        // admin's email — they don't have to type their own
+        // address to verify SMTP works.
+        await expect(recipient).toHaveValue(email);
+
+        // ---- 1. Drive the send. The button flips through
+        //         data-loading=true while the JSON call is in
+        //         flight (per the AGENTS.md "Loading state on
+        //         action buttons" contract); we just wait for the
+        //         success toast and the mailpit-side delivery.
+        await button.click();
+
+        const toast = page
+            .locator('[data-testid="toast"][data-kind="success"]')
+            .filter({ hasText: /test email sent/i });
+        await expect(toast).toBeVisible();
+
+        // ---- 2. The email actually landed in mailpit. Same
+        //         polling shape as `lostpassword-toast.spec.ts` —
+        //         the panel calls Mail::send synchronously before
+        //         emitting the toast, so by the time the toast
+        //         paints the SMTP transaction has completed; we
+        //         poll for ~5s just in case mailpit's
+        //         accept-to-list latency surprises.
+        let landedTo: string | null = null;
+        for (let attempt = 0; attempt < 10; attempt += 1) {
+            const resp = await request.get(
+                `${MAILPIT_BASE_URL}/api/v1/messages?limit=50`,
+            );
+            expect(resp.ok(), `mailpit list failed (${resp.status()})`).toBe(true);
+            const body = await resp.json() as {
+                messages?: Array<{ To?: Array<{ Address?: string }>; Subject?: string }>;
+            };
+            const found = (body.messages ?? []).find((msg) =>
+                (msg.To ?? []).some((addr) => addr.Address === email),
+            );
+            if (found) {
+                landedTo = email;
+                // Sanity-check the subject — the handler emits
+                // `[SourceBans++] SMTP test email`. If a future
+                // PR drifts the subject and the recipient match
+                // by accident, this assertion catches it.
+                expect(found.Subject ?? '').toMatch(/SMTP test email/i);
+                break;
+            }
+            await page.waitForTimeout(500);
+        }
+        expect(
+            landedTo,
+            `mailpit never received a test email to ${email} within 5s — `
+            + `either the handler skipped Mail::send, the SMTP transaction `
+            + `silently failed, or mailpit isn't reachable as ${MAILPIT_BASE_URL}.`,
+        ).toBe(email);
+    });
+
+    test('Button is disabled when SMTP is not configured (fresh install state)', async ({ page }) => {
+        // data.sql ships smtp.host/user/pass + config.mail.from_email
+        // all blank (forcing the operator to configure them before
+        // SMTP works in the modern panel). The truncate+reseed in
+        // beforeEach restores that shape, so the button MUST render
+        // disabled — clicking it would only ever land in the
+        // `smtp_not_configured` error envelope.
+        await page.goto('/index.php?p=admin&c=settings&section=settings');
+        await page.waitForFunction(
+            () => !document.querySelector('[data-loading="true"], [data-skeleton]:not([hidden])'),
+        );
+
+        const button = page.locator('[data-testid="smtp-test-email"]');
+        await expect(button).toBeVisible();
+        await expect(button).toBeDisabled();
+
+        // ---- The page-tail JS re-evaluates the disabled state as
+        //      the operator edits the SMTP fields. Type valid
+        //      values and assert the button enables — proves the
+        //      live-derivation half of the contract works (the
+        //      first-paint half is what we just asserted).
+        await page.locator('#mail_host').fill('mailpit');
+        await page.locator('#mail_user').fill('e2e');
+        await page.locator('#mail_from_email').fill('noreply@example.test');
+        // The button should now be enabled even though the form
+        // isn't saved yet — the JS gate only cares about the
+        // current input values. (The server-side handler still
+        // reads the saved values from sb_settings, which is why
+        // the help copy explicitly tells the operator to save
+        // first; the disabled gate is a guard, not a contract.)
+        await expect(button).toBeEnabled();
+    });
+
+    test('Validation: typo in recipient → native popover, no API round-trip', async ({ page }) => {
+        // Need SMTP configured so the button is enabled (otherwise
+        // it would never accept the click).
+        await seedLostpasswordE2e();
+
+        await page.goto('/index.php?p=admin&c=settings&section=settings');
+        await page.waitForFunction(
+            () => !document.querySelector('[data-loading="true"], [data-skeleton]:not([hidden])'),
+        );
+
+        const button = page.locator('[data-testid="smtp-test-email"]');
+        const recipient = page.locator('[data-testid="smtp-test-recipient"]');
+        await expect(button).toBeEnabled();
+
+        // Listen for any sb.api.call round-trip — none should fire
+        // for a client-validation failure.
+        const apiRequests: string[] = [];
+        await page.route('**/api.php', (route, req) => {
+            apiRequests.push(req.method() + ' ' + req.url());
+            // Forward the request anyway so the page stays
+            // functional in case the assertion below fires late.
+            void route.continue();
+        });
+
+        await recipient.fill('not-an-email');
+        await button.click();
+
+        // The validation toast for "Enter a recipient" fires via
+        // window.SBPP.showToast; the more reliable signal is that
+        // no API call happened (which is the load-bearing contract:
+        // a typo should never burn a rate-limit slot).
+        await page.waitForTimeout(500); // grace window for a stray call
+        expect(
+            apiRequests.filter((r) => r.includes('test_email')),
+            `Validation failure must not trigger a system.test_email round-trip. Got:\n${apiRequests.join('\n')}`,
+        ).toEqual([]);
+
+        // The native validation state should be invalid (browser's
+        // FILTER_VALIDATE_EMAIL equivalent on `<input type=email>`).
+        const isValid = await recipient.evaluate(
+            (el) => (el as HTMLInputElement).checkValidity(),
+        );
+        expect(isValid, 'recipient input should fail native validity check after typing "not-an-email"').toBe(false);
+    });
+});

--- a/web/themes/default/page_admin_settings_settings.tpl
+++ b/web/themes/default/page_admin_settings_settings.tpl
@@ -487,6 +487,64 @@
                                     <input class="input" type="text" id="mail_from_name" name="mail_from_name" value="{$config_mail_from_name}">
                                 </div>
                             </div>
+                            {*
+                                #1455: SMTP test-email row.
+
+                                Operator-controlled affordance that triggers a
+                                live SMTP send so the operator can verify their
+                                credentials end-to-end without waiting for a
+                                real outbound event (password reset, ban
+                                protest reply, etc.) to fire.
+
+                                Server-rendered first-paint state:
+                                  - Recipient input is pre-populated with the
+                                    logged-in admin's own email (or empty when
+                                    they have no email on file).
+                                  - Button is `disabled` when host/user/from-
+                                    email is empty AT FIRST PAINT so a
+                                    freshly-installed panel doesn't tempt the
+                                    operator into clicking before they've
+                                    configured SMTP. The page-tail JS keeps
+                                    the disabled state in sync as the operator
+                                    edits the SMTP inputs (the password field
+                                    isn't part of the disabled-derivation
+                                    because the operator can leave it blank to
+                                    "keep current" — that's NOT an "SMTP not
+                                    configured" state for the test surface).
+
+                                  Server-side gate is the load-bearing one:
+                                  `api_system_test_email` re-checks
+                                  `Mailer::create() === null` and surfaces a
+                                  pointed `smtp_not_configured` error envelope
+                                  if the operator bypasses the client-side
+                                  disabled flag (third-party theme strip, hand-
+                                  crafted POST, etc.).
+                            *}
+                            <div data-testid="setting-row" data-key="smtp.test">
+                                <label class="label" for="mail_test_to">Send a test email</label>
+                                <div class="grid gap-2" style="grid-template-columns:1fr auto">
+                                    <input class="input"
+                                           type="email"
+                                           id="mail_test_to"
+                                           name="mail_test_to"
+                                           value="{$admin_email}"
+                                           placeholder="recipient@example.com"
+                                           data-testid="smtp-test-recipient"
+                                           autocomplete="off">
+                                    <button type="button"
+                                            class="btn btn--secondary"
+                                            data-testid="smtp-test-email"
+                                            id="smtp_test_email_btn"
+                                            {if $config_smtp[0] === '' || $config_smtp[1] === '' || $config_mail_from_email === ''}disabled{/if}>
+                                        <i data-lucide="send"></i> Send test email
+                                    </button>
+                                </div>
+                                <p class="text-xs text-muted mt-1">
+                                    Sends a verification email through the saved SMTP credentials. Save the form
+                                    first if you just changed anything above — the test uses the persisted values,
+                                    not the unsaved contents of the inputs.
+                                </p>
+                            </div>
                         </div>
                     </div>
 
@@ -678,6 +736,144 @@
             echo.textContent = humanizeMinutes(Number.isNaN(n) ? 0 : n);
         });
     });
+
+    /**
+     * #1455: SMTP "Send test email" button.
+     *
+     * The PHP-side handler reads SMTP credentials from sb_settings (so
+     * the test always reflects the persisted configuration); this JS
+     * is purely UX glue:
+     *
+     *   1. Keep the button disabled until host / user / from-email
+     *      are all non-empty, mirroring the server-side
+     *      smtp_not_configured branch so the operator never clicks a
+     *      button that's guaranteed to fail. Password is NOT in the
+     *      derivation because the form intentionally leaves it blank
+     *      on render ("leave blank to keep current") — an empty
+     *      password input on a panel with a saved password is NOT an
+     *      "SMTP not configured" state.
+     *   2. On click: pre-flight the email-input's native validity,
+     *      flip the busy-state on the button (window.SBPP.setBusy),
+     *      POST to system.test_email, then surface a toast keyed on
+     *      the response shape. The server is the load-bearing gate:
+     *      the throttle / smtp_not_configured / mail_failed branches
+     *      all run server-side regardless of what the client sends.
+     */
+    var testBtn = /** @type {HTMLButtonElement|null} */ (
+        document.getElementById('smtp_test_email_btn')
+    );
+    var testTo = /** @type {HTMLInputElement|null} */ (
+        document.getElementById('mail_test_to')
+    );
+    var smtpHost = /** @type {HTMLInputElement|null} */ (document.getElementById('mail_host'));
+    var smtpUser = /** @type {HTMLInputElement|null} */ (document.getElementById('mail_user'));
+    var smtpFromEmail = /** @type {HTMLInputElement|null} */ (document.getElementById('mail_from_email'));
+
+    /**
+     * Theme-aware busy-state setter that delegates to the canonical
+     * window.SBPP.setBusy when present (full data-loading + aria-busy
+     * + disabled triple per AGENTS.md "Loading state on action
+     * buttons") and falls back to the bare disabled flag so a
+     * third-party theme that strips theme.js still gates against
+     * double-clicks.
+     *
+     * @param {HTMLButtonElement|null} btn
+     * @param {boolean} busy
+     */
+    function setBusy(btn, busy) {
+        if (!btn) return;
+        if (window.SBPP && typeof window.SBPP.setBusy === 'function') {
+            window.SBPP.setBusy(btn, busy);
+        } else {
+            btn.disabled = busy;
+        }
+    }
+
+    /**
+     * Surface a toast via window.SBPP.showToast when the chrome JS
+     * is loaded; fall back to window.alert so the operator still
+     * gets visible feedback on third-party themes that strip the
+     * helper.
+     *
+     * @param {string} kind 'info' | 'success' | 'warn' | 'error'
+     * @param {string} title
+     * @param {string} [body]
+     */
+    function toast(kind, title, body) {
+        if (window.SBPP && typeof window.SBPP.showToast === 'function') {
+            window.SBPP.showToast({ kind: kind, title: title, body: body });
+        } else {
+            window.alert(title + (body ? '\n\n' + body : ''));
+        }
+    }
+
+    /**
+     * Live re-evaluation of the button's disabled state as the
+     * operator edits SMTP fields. Mirrors the server-rendered first-
+     * paint state in the template's `{if … disabled}` arm so the JS
+     * never starts from a stale snapshot.
+     */
+    function refreshButtonState() {
+        if (!testBtn || !smtpHost || !smtpUser || !smtpFromEmail) return;
+        var ready =
+            smtpHost.value.trim() !== '' &&
+            smtpUser.value.trim() !== '' &&
+            smtpFromEmail.value.trim() !== '';
+        testBtn.disabled = !ready;
+    }
+
+    if (smtpHost) smtpHost.addEventListener('input', refreshButtonState);
+    if (smtpUser) smtpUser.addEventListener('input', refreshButtonState);
+    if (smtpFromEmail) smtpFromEmail.addEventListener('input', refreshButtonState);
+
+    if (testBtn && window.sb && window.sb.api && window.Actions) {
+        testBtn.addEventListener('click', function () {
+            if (!testBtn || !testTo) return;
+            // Native validity check first — handles "missing @",
+            // "trailing space", "no TLD" before we burn a round-trip
+            // and a rate-limit slot. The server re-runs
+            // FILTER_VALIDATE_EMAIL regardless; this is UX polish.
+            var rawTo = testTo.value.trim();
+            if (rawTo === '' || !testTo.checkValidity()) {
+                testTo.reportValidity();
+                toast('warn', 'Enter a recipient', 'Type a valid email address before sending the test.');
+                return;
+            }
+
+            setBusy(testBtn, true);
+            window.sb.api.call(window.Actions.SystemTestEmail, { to: rawTo }).then(
+                function (r) {
+                    setBusy(testBtn, false);
+                    if (r && r.ok && r.data && typeof r.data.to === 'string') {
+                        toast('success', 'Test email sent',
+                            'A SMTP test message was dispatched to ' + r.data.to + '. Check the inbox to confirm delivery.');
+                        return;
+                    }
+                    // Structured error envelope. Branch on r.error.code
+                    // so the operator gets actionable copy instead of
+                    // a generic "request failed" string.
+                    var err = (r && r.error) || {};
+                    var code = err.code || 'unknown';
+                    var msg = err.message || 'The server returned an unexpected response.';
+                    if (code === 'smtp_not_configured') {
+                        toast('warn', 'SMTP not configured', msg);
+                    } else if (code === 'rate_limited') {
+                        toast('warn', 'Test email throttled', msg);
+                    } else if (code === 'validation') {
+                        toast('warn', 'Check the recipient', msg);
+                    } else if (code === 'mail_failed') {
+                        toast('error', 'Test email failed', msg);
+                    } else {
+                        toast('error', 'Test email failed', msg);
+                    }
+                },
+                function () {
+                    setBusy(testBtn, false);
+                    toast('error', 'Test email failed', 'Could not reach the panel API. Check your network and try again.');
+                }
+            );
+        });
+    }
 })();
 {/literal}
 </script>


### PR DESCRIPTION
Closes #1455.

## Summary

Adds a `Send test email` affordance to the SMTP card on
`?p=admin&c=settings&section=settings` so operators can verify
their SMTP credentials end-to-end (Symfony Mailer → relay →
recipient inbox) without waiting for the next real outbound mail
(password reset, ban protest, etc.). Pre-fix, broken SMTP routinely
shipped into production for days before anyone noticed.

- New JSON handler `system.test_email` (gated
  `ADMIN_OWNER | ADMIN_WEB_SETTINGS`, mirroring every other
  settings-page-only handler).
- Button server-rendered disabled when smtp.host / smtp.user /
  config.mail.from_email are empty; live-re-evaluated as the
  operator types so a fresh-install operator who just entered
  valid creds doesn't have to save first.
- Recipient input defaults to the operator's own email address so
  the common "send the test to me" path is one click.
- Rate limited at 1 attempt / 10s per panel install, stamped
  BEFORE the SMTP I/O so a hung relay can't be hammered while the
  first call is mid-handshake. File-backed throttle
  (\`SB_CACHE/test-email-throttle\`) with atomic tempfile + rename
  mirroring \`_api_system_release_save_cache\`.
- Validation + smtp_not_configured branches short-circuit BEFORE
  the throttle file is stamped so a typo doesn't consume a slot.
- Every send attempt (success OR mail_failed) lands an audit-log
  row interpolating the admin's name + recipient — test sends
  can't be used to silently probe SMTP credentials.

## Operator-visible flow

1. Configure SMTP (smtp.host / smtp.user / smtp.pass + a
   from_email), save the form.
2. Recipient field auto-populates with the logged-in admin's
   email; tweak if desired.
3. Click `Send test email`.
4. Toast confirms the result:
   - **Success**: \`Test email sent — Sent to <addr>.\`
   - **smtp_not_configured**: \`SMTP host, username, or password
     is empty. Configure SMTP first and save the form, then try
     again.\`
   - **rate_limited**: \`Test email throttled — try again in N
     seconds.\`
   - **mail_failed**: \`SMTP send failed. Check the audit log
     under Admin → System Log for the cause.\`

## Test plan

- [x] \`./sbpp.sh phpstan\` — 0 errors.
- [x] \`./sbpp.sh ts-check\` — passes.
- [x] \`./sbpp.sh composer api-contract\` — regenerated; clean
  diff.
- [x] \`./sbpp.sh test --testsuite=api\` — 352 tests, 1492
  assertions, all green (includes 9 new \`testTestEmail*\`
  PHPUnit tests + 4 paired snapshot files).
- [x] \`./sbpp.sh test --testsuite=integration\` — 576 tests
  green.
- [x] \`./sbpp.sh e2e --workers=1 specs/flows/smtp-test-email.spec.ts\`
  — 6 tests green (3 specs × chromium + mobile-chromium): happy
  path drives the full chain through mailpit + asserts the email
  lands, disabled-state arm, and native-validation arm.
- [x] PermissionMatrixTest pins
  \`system.test_email => ADMIN_OWNER | ADMIN_WEB_SETTINGS\`.
- [x] Manual smoke under \`./sbpp.sh up\` — happy path lands a
  message in mailpit, disabled state behaves correctly, rate
  limit fires the expected toast.
- [x] Adversarial review pass — every High / Medium / Low finding
  was addressed:
  - dropped \`global \$username\` for \`\$userbank->GetProperty('user')\`;
  - added refuse-if-prod-DB guard to the E2E throttle-clear shim;
  - corrected \`?section=main\` → \`?section=settings\` in the
    spec;
  - rewrote the \`retry_after_seconds\` docblock claim to match
    reality (the retry hint is in the message, not a separate
    field on the wire);
  - subject + body-subject now share a single string so inbox
    subject and body identifier match;
  - clarified throttle docblock: stamped BEFORE the SMTP wire,
    so mail_failed outcomes also consume slots (intentional);
  - tempfile cleanup now also fires on rename-failure (EXDEV
    across mounts);
  - audit log: paired the success-row body shape check with
    the count check so a future refactor that drops the
    admin/recipient interpolation fails loudly.

I have read the CLA Document and I hereby sign the CLA