### PR TITLE
fix(1462): pair the admin System Log table with a mobile card mirror

### DIFF
--- a/web/tests/e2e/fixtures/db.ts
+++ b/web/tests/e2e/fixtures/db.ts
@@ -47,6 +47,8 @@ const DELETE_SERVER_INSIDE_CONTAINER =
     '/var/www/html/web/tests/e2e/scripts/delete-server-e2e.php';
 const CLEAR_TEST_EMAIL_THROTTLE_INSIDE_CONTAINER =
     '/var/www/html/web/tests/e2e/scripts/clear-test-email-throttle-e2e.php';
+const SEED_SYSTEM_LOG_INSIDE_CONTAINER =
+    '/var/www/html/web/tests/e2e/scripts/seed-system-log-e2e.php';
 
 /**
  * Run the PHP shim that drives `Sbpp\Tests\Fixture` against
@@ -681,6 +683,95 @@ async function runAnnouncementsHelper(
             ));
         });
     });
+}
+
+/**
+ * Per-row shape consumed by `seedSystemLogE2e` (#1462). Mirrors the
+ * `:prefix_log` schema: `type` is the audit letter code
+ * (`m`=message, `w`=warning, `e`=error — matches `LogType`). Every
+ * field except `type` carries a string default — the spec just
+ * needs at least one row to exist so the `{if count($log_items) > 0}`
+ * gate in `page_admin_settings_logs.tpl` paints SOMETHING, and the
+ * mobile-card / desktop-table parity assertion can run.
+ */
+export interface SystemLogSeedRow {
+    type?: 'm' | 'w' | 'e';
+    title?: string;
+    message?: string;
+    function?: string;
+    query?: string;
+    host?: string;
+}
+
+/**
+ * Seed `:prefix_log` rows directly so the System Log sub-tab
+ * (`?p=admin&c=settings&section=logs`) actually paints log entries
+ * instead of the empty "No log entries." placeholder. The e2e DB's
+ * `:prefix_log` table is empty by default (`data.sql` doesn't ship
+ * audit rows + `Fixture::truncateAndReseed` truncates every table on
+ * reset) and there is no JSON action that emits audit rows directly
+ * — they're side effects of authenticated panel writes. Driving e.g.
+ * `Actions.BansAdd` to produce a row would couple the System Log
+ * spec to the bans-add audit message, so the direct INSERT is the
+ * narrow shape the spec needs.
+ *
+ * Caller responsibility: invoke after `truncateE2eDb()` so the
+ * seeded rows are the only ones the spec sees. Mirrors the
+ * `seedCommsRawE2e` shape (shell-out + stdin-JSON).
+ *
+ * Returns the list of inserted `lid` values (in insert order) so
+ * the spec can target a specific row via `[data-id="<lid>"]`.
+ */
+export async function seedSystemLogE2e(rows: SystemLogSeedRow[]): Promise<number[]> {
+    const inContainer = process.env.E2E_IN_CONTAINER === '1';
+    const cmd = inContainer ? 'php' : 'docker';
+    const cmdArgs = inContainer
+        ? [SEED_SYSTEM_LOG_INSIDE_CONTAINER]
+        : ['compose', 'exec', '-T', 'web', 'php', SEED_SYSTEM_LOG_INSIDE_CONTAINER];
+
+    const child = execFile(cmd, cmdArgs, {
+        maxBuffer: 8 * 1024 * 1024,
+        cwd: inContainer ? undefined : process.cwd(),
+    });
+
+    let stdout = '';
+    let stderr = '';
+    child.stdout?.on('data', (chunk: Buffer) => { stdout += chunk.toString('utf8'); });
+    child.stderr?.on('data', (chunk: Buffer) => { stderr += chunk.toString('utf8'); });
+
+    child.stdin?.write(JSON.stringify(rows));
+    child.stdin?.end();
+
+    await new Promise<void>((resolve, reject) => {
+        child.on('error', reject);
+        child.on('exit', (code) => {
+            if (code === 0) {
+                resolve();
+                return;
+            }
+            reject(new Error(
+                `seed-system-log-e2e.php exited ${code}\n`
+                + `stdout:\n${stdout}\nstderr:\n${stderr}`,
+            ));
+        });
+    });
+
+    const trimmed = stdout.trim();
+    if (trimmed === '') {
+        throw new Error(`seed-system-log-e2e.php: empty stdout\nstderr:\n${stderr}`);
+    }
+    try {
+        const parsed = JSON.parse(trimmed) as { lids: number[] };
+        if (!Array.isArray(parsed.lids)) {
+            throw new Error('missing lids key');
+        }
+        return parsed.lids;
+    } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        throw new Error(
+            `seed-system-log-e2e.php: malformed stdout (${msg})\nstdout:\n${trimmed}\nstderr:\n${stderr}`,
+        );
+    }
 }
 
 /**

--- a/web/tests/e2e/scripts/seed-system-log-e2e.php
+++ b/web/tests/e2e/scripts/seed-system-log-e2e.php
@@ -1,0 +1,149 @@
+<?php
+// SourceBans++ (c) 2014-2026 SourceBans++ Dev Team
+// Licensed under Creative Commons Attribution-NonCommercial-ShareAlike 3.0.
+// See LICENSE.md for the full license text and THIRD-PARTY-NOTICES.txt for attributions.
+
+/**
+ * E2E system-log seeder (#1462).
+ *
+ * The `:prefix_log` table is empty in the bare e2e seed — `data.sql`
+ * doesn't ship any audit rows, and `Fixture::truncateAndReseed`
+ * truncates every table on every reset. The mobile-card responsive
+ * spec needs at least one row in the table so the System Log sub-tab
+ * actually paints log content (the `{if count($log_items) > 0}`
+ * gate would otherwise render "No log entries." and the card surface
+ * wouldn't be exercised).
+ *
+ * Why a dedicated shim instead of driving the existing `Log::add`
+ * path:
+ *   - `Log::add(LogType::Message, ...)` is the production write
+ *     surface, but it's called from inside a panel request — it
+ *     reads `$_SERVER['REMOTE_ADDR']`, `$userbank->GetAid()`, etc.
+ *     A spec running outside a panel request can't seed via this
+ *     path without a Playwright `page.goto(...)` that triggers an
+ *     audited action as a side effect.
+ *   - Driving e.g. `Actions.BansAdd` to produce an audit row would
+ *     couple the System Log spec to the bans-add surface; a
+ *     refactor of the bans-add audit message would break the
+ *     unrelated System Log mobile spec for the wrong reason.
+ *   - Direct INSERT keeps the spec independent of every other audit
+ *     surface — same shape `seed-comms-e2e.php` uses for the
+ *     `comms.type=3` rows that `Actions.CommsAdd` never emits.
+ *
+ * This shim is e2e-only: refuses any DB other than the e2e schema
+ * (default `sourcebans_e2e`) so a stray host-side invocation can't
+ * trash the dev DB. Mirrors `seed-comms-e2e.php`.
+ *
+ * Usage (inside the web container):
+ *
+ *   echo '<JSON>' | php seed-system-log-e2e.php
+ *
+ * The JSON payload is a list of row dicts:
+ *
+ *   [
+ *     {"type": "m", "title": "E2E info",  "message": "first row",
+ *      "function": "e2e/spec",         "query": "n/a", "host": "127.0.0.1"},
+ *     {"type": "w", "title": "E2E warn", "message": "second row", ...},
+ *     ...
+ *   ]
+ *
+ * Type letters mirror `:prefix_log.type enum('m','w','e')`. Defaults:
+ *   - `type`:     "m"
+ *   - `title`:    "E2E seeded entry"
+ *   - `message`:  ""
+ *   - `function`: "tests/e2e/seed"
+ *   - `query`:    ""
+ *   - `host`:     "127.0.0.1"
+ *
+ * `aid` is resolved live from the seeded admin row (mirrors
+ * `seed-comms-e2e.php`'s lookup shape so this script stays
+ * independent of `Sbpp\Tests\Fixture::adminAid`'s in-process cache).
+ */
+
+declare(strict_types=1);
+
+if (PHP_SAPI !== 'cli') {
+    fwrite(STDERR, "seed-system-log-e2e.php must run on the CLI.\n");
+    exit(2);
+}
+
+if (!getenv('DB_NAME')) {
+    putenv('DB_NAME=sourcebans_e2e');
+    $_ENV['DB_NAME']    = 'sourcebans_e2e';
+    $_SERVER['DB_NAME'] = 'sourcebans_e2e';
+}
+
+if (getenv('DB_NAME') === 'sourcebans_test' || getenv('DB_NAME') === 'sourcebans') {
+    fwrite(STDERR, "refusing to seed system log against DB_NAME=" . getenv('DB_NAME')
+        . ": this script must target a dedicated e2e DB (default sourcebans_e2e).\n");
+    exit(2);
+}
+
+require __DIR__ . '/../../bootstrap.php';
+
+if (!isset($GLOBALS['PDO'])) {
+    $GLOBALS['PDO'] = new \Database(DB_HOST, DB_PORT, DB_NAME, DB_USER, DB_PASS, DB_PREFIX, DB_CHARSET);
+}
+
+$payload = stream_get_contents(STDIN);
+if ($payload === false || trim($payload) === '') {
+    fwrite(STDERR, "seed-system-log-e2e.php: empty stdin payload.\n");
+    exit(2);
+}
+
+$rows = json_decode($payload, true);
+if (!is_array($rows)) {
+    fwrite(STDERR, "seed-system-log-e2e.php: stdin is not a JSON array.\n");
+    exit(2);
+}
+
+$adminRow = $GLOBALS['PDO']->query(
+    "SELECT aid FROM `:prefix_admins` WHERE user = ? AND authid = ?"
+)->single(['admin', 'STEAM_0:0:0']);
+if (empty($adminRow['aid'])) {
+    fwrite(STDERR, "seed-system-log-e2e.php: cannot resolve admin row; was Fixture::install() run?\n");
+    exit(2);
+}
+$adminAid = (int)$adminRow['aid'];
+
+$now           = time();
+$allowedTypes  = ['m', 'w', 'e'];
+$insertedLids  = [];
+
+foreach ($rows as $i => $row) {
+    if (!is_array($row)) {
+        fwrite(STDERR, "seed-system-log-e2e.php: row $i is not an object.\n");
+        exit(2);
+    }
+
+    $type     = (string)($row['type']     ?? 'm');
+    $title    = (string)($row['title']    ?? 'E2E seeded entry');
+    $message  = (string)($row['message']  ?? '');
+    $function = (string)($row['function'] ?? 'tests/e2e/seed');
+    $query    = (string)($row['query']    ?? '');
+    $host     = (string)($row['host']     ?? '127.0.0.1');
+
+    if (!in_array($type, $allowedTypes, true)) {
+        fwrite(STDERR, "seed-system-log-e2e.php: row $i has unknown type '$type' (expected 'm', 'w', or 'e').\n");
+        exit(2);
+    }
+
+    $GLOBALS['PDO']->query(
+        "INSERT INTO `:prefix_log` "
+        . "(type, title, message, function, query, aid, host, created) "
+        . "VALUES (?, ?, ?, ?, ?, ?, ?, ?)"
+    )->execute([
+        $type,
+        $title,
+        $message,
+        $function,
+        $query,
+        $adminAid,
+        $host,
+        $now,
+    ]);
+
+    $insertedLids[] = (int)$GLOBALS['PDO']->lastInsertId();
+}
+
+fwrite(STDOUT, json_encode(['lids' => $insertedLids]) . "\n");

--- a/web/tests/e2e/specs/responsive/system-log-mobile.spec.ts
+++ b/web/tests/e2e/specs/responsive/system-log-mobile.spec.ts
@@ -1,0 +1,316 @@
+// SourceBans++ (c) 2014-2026 SourceBans++ Dev Team
+// Licensed under Creative Commons Attribution-NonCommercial-ShareAlike 3.0.
+// See LICENSE.md for the full license text and THIRD-PARTY-NOTICES.txt for attributions.
+
+/**
+ * Responsive: admin System Log sub-tab (#1462).
+ *
+ * iPhone-13 viewport contract for
+ * `?p=admin&c=settings&section=logs`:
+ *
+ *   - The desktop `<table class="table table--clickable-rows"
+ *     data-testid="logs-table">` collapses behind the global
+ *     `.table { display: none }` rule at `<=768px` (the same rule
+ *     that pairs with `.ban-cards` on the bans / comms lists). Pre-
+ *     #1462 the System Log shipped NO paired mobile surface, so the
+ *     chrome rendered (heading, "Clear log" button, pagination
+ *     footer) while the rows themselves were silently hidden — the
+ *     reporter's "no logs visible" symptom from the iPhone view.
+ *   - The fix added a paired `<ul class="log-cards"
+ *     data-testid="logs-cards">` that mirrors `$log_items` as native
+ *     `<details>` disclosures. The `<details>` semantic carries
+ *     keyboard reachability + screen-reader announcement out of
+ *     the box; no `role="button"` / `tabindex="0"` / `onkeydown`
+ *     handler dance is needed (the desktop table's a11y triple is
+ *     unavoidable because `<tr>` has no native disclosure semantic,
+ *     but the mobile surface gets to use the right tool for the job).
+ *   - Both surfaces iterate the SAME `$log_items` (pinned by the
+ *     companion `SystemLogMobileCardsRegressionTest`), so the
+ *     visible row set is viewport-symmetric — the reporter's bug
+ *     class ("mobile users see a different set of logs than
+ *     desktop users") cannot recur.
+ *
+ * Why the test seeds via a dedicated SQL shim:
+ *
+ *   - `:prefix_log` is empty in the bare e2e seed — `data.sql`
+ *     doesn't ship audit rows, and `Fixture::truncateAndReseed`
+ *     truncates every table on every reset.
+ *   - There is no JSON action that emits audit rows directly; they
+ *     are side effects of authenticated panel writes. Driving e.g.
+ *     `Actions.BansAdd` to produce a row would couple this spec to
+ *     the bans-add audit message (refactor that message and the
+ *     System Log mobile spec fails for the wrong reason).
+ *   - The direct INSERT is the narrow shape the spec needs and
+ *     mirrors `seed-comms-e2e.php`'s contract (silence-row rows
+ *     `Actions.CommsAdd` never emits).
+ *
+ * Project gating: mobile-chromium only — the chrome behaviour is
+ * viewport-keyed and there is no chromium-desktop assertion here.
+ * The desktop surface is exercised by the screenshot gallery and
+ * the integration test pins the structural contract on both sides.
+ */
+
+import { expectNoCriticalA11y } from '../../fixtures/axe.ts';
+import { expect, test } from '../../fixtures/auth.ts';
+import {
+    seedSystemLogE2e,
+    truncateE2eDb,
+    type SystemLogSeedRow,
+} from '../../fixtures/db.ts';
+
+const SYSTEM_LOG_URL = '/index.php?p=admin&c=settings&section=logs';
+
+/**
+ * The seeded log-row primary keys are captured in `beforeEach` so the
+ * per-test locators key off `[data-id="<lid>"]` instead of `hasText:
+ * <title>` substring matches. `hasText` is fuzzy — a substring match
+ * against the title could pick up unrelated audit rows the admin
+ * login round-trip emits or any future panel write that happens to
+ * include the same prefix in its message. The template emits
+ * `data-id="{$log.lid}"` on every `<details>` precisely so specs can
+ * key off the primary key; the seeder returns the inserted `lid`s in
+ * insert order so we never have to guess which seeded card is which.
+ */
+let seededLids: number[] = [];
+
+/**
+ * Three rows, one per `:prefix_log.type` letter, so the spec also
+ * proves all three pill variants paint correctly in the card
+ * summary. The titles double as fingerprints — a single
+ * `hasText: SEED_ROWS[0].title` filter inside `[data-testid="log-card"]`
+ * is enough to disambiguate the seeded rows from any stray entries.
+ */
+const SEED_ROWS: Required<Pick<SystemLogSeedRow, 'type' | 'title' | 'message' | 'function' | 'query' | 'host'>>[] = [
+    {
+        type: 'm',
+        title: 'e2e #1462: info-row',
+        message: 'mobile-spec info detail',
+        function: 'tests/e2e/system-log-mobile',
+        query: 'SELECT 1',
+        host: '203.0.113.10',
+    },
+    {
+        type: 'w',
+        title: 'e2e #1462: warn-row',
+        message: 'mobile-spec warning detail',
+        function: 'tests/e2e/system-log-mobile',
+        query: '',
+        host: '203.0.113.11',
+    },
+    {
+        type: 'e',
+        title: 'e2e #1462: error-row',
+        message: 'mobile-spec error detail',
+        function: 'tests/e2e/system-log-mobile',
+        query: '',
+        host: '203.0.113.12',
+    },
+];
+
+test.describe('responsive: admin System Log (#1462)', () => {
+    test.beforeEach(({}, testInfo) => {
+        test.skip(
+            testInfo.project.name !== 'mobile-chromium',
+            'Mobile-only contract — the desktop chrome is the legacy table; the cards are the new mobile mirror.',
+        );
+    });
+
+    // Tests in this file all `truncateE2eDb()` + `seedSystemLogE2e`
+    // in `beforeEach`. Without `serial` mode Playwright runs them in
+    // parallel workers locally (CI pins `workers: 1`, see
+    // playwright.config.ts), and worker B's truncate wipes worker
+    // A's seeded rows mid-test → the page handler's `HasAccess`
+    // gate fails on the briefly-missing `:prefix_admins` row during
+    // the reseed window, the request redirects to login, and the
+    // `[data-testid="logs-cards"]` locator times out. The named-
+    // lock in `Sbpp\Tests\Fixture::truncateAndReseed` makes the
+    // *reset* atomic per-process, but it does not span the gap
+    // between the truncate-and-reseed and the per-test
+    // seed/assertion phase; serial execution is the right
+    // granularity for state-mutating flow specs. Same pattern as
+    // `comms-affordances.spec.ts` and `server-cards.spec.ts`.
+    test.describe.configure({ mode: 'serial' });
+
+    test.beforeEach(async () => {
+        await truncateE2eDb();
+        seededLids = await seedSystemLogE2e(SEED_ROWS);
+        expect(
+            seededLids,
+            'seedSystemLogE2e must return one lid per seeded row so per-card locators can anchor on `[data-id="<lid>"]`',
+        ).toHaveLength(SEED_ROWS.length);
+    });
+
+    test('desktop table is hidden and the mobile cards mirror the seeded rows', async ({ page }) => {
+        await page.goto(SYSTEM_LOG_URL);
+
+        const desktopTable = page.locator('[data-testid="logs-table"]');
+        const cardsList = page.locator('[data-testid="logs-cards"]');
+
+        // theme.css L1802: `.table { display: none }` at `<=768px`;
+        // the matching `.log-cards { display: block }` rule next to it
+        // flips the mobile surface on. The pre-#1462 regression was
+        // "table hidden, cards don't exist, mobile users see nothing".
+        await expect(desktopTable).toBeHidden();
+        await expect(cardsList).toBeVisible();
+
+        // Every seeded row must surface as a card. Anchor on
+        // `[data-id="<lid>"]` (NOT `hasText: <title>`) — the lid is
+        // the primary key, the title is mutable copy. A future panel
+        // tweak that adds an audit row whose title starts with
+        // "e2e #1462" (or vice versa) would silently break a
+        // hasText-anchored locator; the lid is the structural
+        // contract the integration test pins (`data-id="{$log.lid}"`
+        // on every `<details>`).
+        for (let i = 0; i < SEED_ROWS.length; i++) {
+            const row = SEED_ROWS[i];
+            const lid = seededLids[i];
+            const card = cardsList.locator(`[data-testid="log-card"][data-id="${lid}"]`);
+            await expect(card, `seeded lid ${lid} ("${row.title}") must paint as a mobile card`).toHaveCount(1);
+            await expect(card).toBeVisible();
+            // The title text still has to surface in the summary —
+            // we just don't ANCHOR the locator on it. This catches
+            // the inverse regression where the lid hook is present
+            // but the title binding broke.
+            await expect(card.locator('.log-card__title')).toContainText(row.title);
+        }
+    });
+
+    test('mobile card expands to reveal the detail body via native <details>', async ({ page }) => {
+        await page.goto(SYSTEM_LOG_URL);
+
+        const cardsList = page.locator('[data-testid="logs-cards"]');
+        await expect(cardsList).toBeVisible();
+
+        // Anchor on the warn-row card via the lid captured in
+        // beforeEach. Pre-toggle the `<details>` has no `open`
+        // attribute — the disclosure body is collapsed and the
+        // message detail is not visible. Click the summary to
+        // expand; assert the `open` attribute lands AND the detail
+        // text becomes visible. This is the "no JS required" contract
+        // — the native `<summary>` click handler does the toggle for
+        // us.
+        const target = SEED_ROWS[1]; // warn-row
+        const targetLid = seededLids[1];
+        const card = cardsList.locator(`[data-testid="log-card"][data-id="${targetLid}"]`);
+        await expect(card).toBeVisible();
+        await expect(card).not.toHaveAttribute('open', /.*/);
+
+        // The detail body is in the DOM but hidden by `<details>`'s
+        // native collapsed state. Playwright's `toBeVisible` returns
+        // false on the inner `<dl>` until the parent is `[open]`.
+        const detailDd = card.locator('dd', { hasText: target.message });
+        await expect(detailDd).toBeHidden();
+
+        const summary = card.locator('summary.log-card__summary');
+        await summary.click();
+
+        await expect(card).toHaveAttribute('open', /.*/);
+        await expect(detailDd).toBeVisible();
+
+        // Toggle back closed so the spec leaves the page in its
+        // initial state — keeps the trace artefact readable and
+        // doesn't fight any future test that opens a different row.
+        await summary.click();
+        await expect(card).not.toHaveAttribute('open', /.*/);
+        await expect(detailDd).toBeHidden();
+    });
+
+    test('mobile card opens via keyboard (Tab → Enter / Space on the native <summary>)', async ({ page }) => {
+        // The whole justification for picking native `<details>` /
+        // `<summary>` over a `<div role="button">` (per the docblock
+        // on `SystemLogMobileCardsRegressionTest`) is keyboard
+        // affordance for free — Tab lands on the summary, Enter /
+        // Space toggles it, no inline `onkeydown` dance needed. The
+        // pointer-event test above proves the click path; this test
+        // proves the keyboard path, so a future stylesheet pass
+        // that drops `outline: none` without a paired focus ring,
+        // or a `tabindex="-1"` slipped onto the summary by a
+        // well-meaning "remove visual noise" PR, fails here instead
+        // of in a screen-reader user's lap.
+        await page.goto(SYSTEM_LOG_URL);
+
+        const cardsList = page.locator('[data-testid="logs-cards"]');
+        await expect(cardsList).toBeVisible();
+
+        const target = SEED_ROWS[0]; // info-row
+        const targetLid = seededLids[0];
+        const card = cardsList.locator(`[data-testid="log-card"][data-id="${targetLid}"]`);
+        const summary = card.locator('summary.log-card__summary');
+        const detailDd = card.locator('dd', { hasText: target.message });
+
+        // Focus the summary directly. We deliberately do NOT chain
+        // Tab-presses from `<body>` because the per-page Tab order
+        // depends on the topbar chrome (search button, theme toggle,
+        // sidebar links, …) and would silently break this spec
+        // whenever the chrome gains or loses a tab stop. Focusing
+        // the summary then asserting it accepted focus is the
+        // load-bearing contract (Tab-reachability ⇔ focusability).
+        await summary.focus();
+        await expect(summary).toBeFocused();
+
+        // Enter activates the disclosure.
+        await expect(card).not.toHaveAttribute('open', /.*/);
+        await page.keyboard.press('Enter');
+        await expect(card).toHaveAttribute('open', /.*/);
+        await expect(detailDd).toBeVisible();
+
+        // Space also activates (toggles back closed) — the W3C
+        // disclosure widget pattern accepts both keys.
+        await page.keyboard.press(' ');
+        await expect(card).not.toHaveAttribute('open', /.*/);
+        await expect(detailDd).toBeHidden();
+    });
+
+    test('expanded mobile card surface has zero critical a11y violations', async ({ page }, testInfo) => {
+        // axe-core sweep against the new mobile chrome. The default
+        // `?p=admin&c=settings` axe sweep in `specs/a11y/routes.spec.ts`
+        // covers the settings landing page only AND is gated to
+        // desktop-chromium — so without this test the System Log
+        // mobile cards would never get an axe pass. Run with one
+        // card expanded so the inner `<dl>` body's content is in
+        // scope alongside the closed `<details>` siblings; that's
+        // the failure shape a `nested-interactive` or
+        // `aria-allowed-attr` violation would manifest in (a future
+        // copy-paste that nests a `<button>` inside the `<summary>`
+        // or a `<details>` with a forbidden ARIA attribute).
+        await page.goto(SYSTEM_LOG_URL);
+
+        const cardsList = page.locator('[data-testid="logs-cards"]');
+        await expect(cardsList).toBeVisible();
+
+        // Expand the info-row card so axe scans the open body too.
+        const targetLid = seededLids[0];
+        const card = cardsList.locator(`[data-testid="log-card"][data-id="${targetLid}"]`);
+        await card.locator('summary.log-card__summary').click();
+        await expect(card).toHaveAttribute('open', /.*/);
+
+        await expectNoCriticalA11y(page, testInfo);
+    });
+
+    test('page chrome does not overflow the iPhone-13 viewport', async ({ page }) => {
+        await page.goto(SYSTEM_LOG_URL);
+
+        // Page-level: nothing in the chrome leaks past the viewport
+        // horizontally. The desktop table is hidden but if the
+        // mobile cards were ever to ship with an off-screen element
+        // (a too-wide pill, a long unbroken `query` string in the
+        // detail body), this would catch it. Matches the banlist
+        // responsive spec's contract — `documentElement.scrollWidth
+        // <= clientWidth + 1`.
+        await expect.poll(() => page.evaluate(() =>
+            document.documentElement.scrollWidth - document.documentElement.clientWidth,
+        )).toBeLessThanOrEqual(1);
+
+        // The cards list itself stays within the viewport. The
+        // bounding-box check guards against the failure mode where
+        // the list silently lives at x=2000px off-screen (which
+        // would let the viewport-level scroll check pass while the
+        // user still sees nothing).
+        const cardsList = page.locator('[data-testid="logs-cards"]');
+        const vw = page.viewportSize()?.width ?? 0;
+        const box = await cardsList.boundingBox();
+        expect(box, 'mobile cards list must render a bounding box').not.toBeNull();
+        expect(box!.x).toBeGreaterThanOrEqual(-1);
+        expect(box!.x + box!.width).toBeLessThanOrEqual(vw + 1);
+    });
+});

--- a/web/tests/integration/SystemLogMobileCardsRegressionTest.php
+++ b/web/tests/integration/SystemLogMobileCardsRegressionTest.php
@@ -1,0 +1,455 @@
+<?php
+// SourceBans++ (c) 2014-2026 SourceBans++ Dev Team
+// Licensed under Creative Commons Attribution-NonCommercial-ShareAlike 3.0.
+// See LICENSE.md for the full license text and THIRD-PARTY-NOTICES.txt for attributions.
+
+declare(strict_types=1);
+
+namespace Sbpp\Tests\Integration;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Issue #1462: the admin System Log sub-tab
+ * (`page_admin_settings_logs.tpl`) renders a `<table class="table">`
+ * for the desktop view. At `<=768px` the global
+ * `.table { display: none }` rule in `web/themes/default/css/theme.css`
+ * (originally paired with the bans / comms `.ban-cards` mobile mirror)
+ * collapses every `<table class="table">` on the panel. The System Log
+ * never shipped a paired mobile surface, so on mobile the chrome
+ * around the table rendered fine (page heading, "Clear log" button,
+ * pagination footer) while the actual log rows were silently hidden —
+ * the reporter's exact symptom ("no logs visible" on the iPhone view).
+ *
+ * The fix adds a paired `<ul class="log-cards">` block that mirrors
+ * `$log_items` as native `<details>` disclosures, gated by the same
+ * `<=768px` breakpoint the desktop table is hidden at. Native
+ * `<details>` carries the disclosure semantic for free — keyboard-
+ * reachable, screen-reader-announced, JS-free.
+ *
+ * This suite is the static gate against the regression. The five
+ * contracts pinned:
+ *
+ *   1. The template ships `<ul class="log-cards" data-testid="logs-cards">`.
+ *   2. Each entry is a `<details class="log-card" data-testid="log-card" data-id="{$log.lid}">`.
+ *   3. Both surfaces iterate the SAME `$log_items` (so the visible
+ *      row count is viewport-symmetric — no chance one surface
+ *      filters the data while the other doesn't).
+ *   4. `theme.css` declares `.log-cards { display: none }` by default
+ *      AND `.log-cards { display: block }` inside the `<=768px`
+ *      media query, paired with `.log-cards { display: none }`
+ *      inside the `>=769px` media query — the same dance `.ban-cards`
+ *      uses, so the surfaces never compete at intermediate viewports.
+ *   5. The desktop table still carries `class="table table--clickable-rows"`
+ *      + `data-testid="logs-table"` so the sibling #1443 regression
+ *      guard's contract stays intact (don't drop the table when
+ *      adding the card mirror — both surfaces are load-bearing,
+ *      each at its own viewport).
+ *   6. The `onkeydown` keyboard dispatcher on the summary row does
+ *      NOT carry an inline `{event.preventDefault();…}` body. The
+ *      pre-existing (`#1451`) form
+ *      `onkeydown="if(event.key==='Enter'…){event.preventDefault();…}"`
+ *      contains a `{event.preventDefault();…}` substring with no
+ *      whitespace after the opening brace — under Smarty's default
+ *      `auto_literal=true` that substring is parsed as a Smarty tag
+ *      and the template fails fresh-compile with
+ *      "Unexpected '.', expected one of: '}'". Caches built on older
+ *      Smarty versions still served, so the bug hid for months until
+ *      this PR's E2E spec finally exercised the surface on a clean
+ *      compile-dir. The fix lifts the handler into the existing
+ *      `<script>{literal}…{/literal}</script>` block as
+ *      `window.handleLogRowKey` and the attribute reduces to a
+ *      simple `onkeydown="handleLogRowKey(event, this);"` — no inner
+ *      braces, no Smarty hazard. This contract pins that the fix is
+ *      in place and the inline-brace form does not creep back.
+ */
+final class SystemLogMobileCardsRegressionTest extends TestCase
+{
+    private string $template;
+    private string $css;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $templatePath = ROOT . 'themes/default/page_admin_settings_logs.tpl';
+        $template     = file_get_contents($templatePath);
+        if ($template === false) {
+            self::fail("setUp could not read system-log template at {$templatePath}");
+        }
+        $this->template = $template;
+
+        $cssPath = ROOT . 'themes/default/css/theme.css';
+        $css     = file_get_contents($cssPath);
+        if ($css === false) {
+            self::fail("setUp could not read theme.css at {$cssPath}");
+        }
+        $this->css = $css;
+    }
+
+    /**
+     * The template must ship the mobile card wrapper. The
+     * `data-testid="logs-cards"` hook is the E2E anchor; the
+     * `class="log-cards"` is the load-bearing visibility gate.
+     */
+    public function testTemplateShipsMobileCardWrapper(): void
+    {
+        $this->assertMatchesRegularExpression(
+            '/<ul\b[^>]*\bclass="[^"]*\blog-cards\b[^"]*"[^>]*\bdata-testid="logs-cards"/',
+            $this->template,
+            "`page_admin_settings_logs.tpl` must ship an "
+            . "`<ul class=\"log-cards\" data-testid=\"logs-cards\">` block "
+            . "alongside the desktop `<table class=\"table\">`. At `<=768px` the "
+            . "global `.table { display: none }` rule in `theme.css` hides the "
+            . "desktop table; without the paired mobile surface the rows vanish "
+            . "from the iPhone view (#1462). The `aria-label` on the `<ul>` "
+            . "should also be present so AT users hear the list described — "
+            . "see the canonical reference shape in the same template."
+        );
+    }
+
+    /**
+     * Each entry in the mobile list is a native `<details>` element.
+     * This is intentional — `<details>` is the platform's built-in
+     * disclosure widget, so we get keyboard reachability (Tab),
+     * keyboard activation (Enter / Space), and screen-reader
+     * announcement ("disclosure triangle, collapsed") for free.
+     * Re-rolling this with a `<div>` + `role="button"` + `tabindex` +
+     * `onkeydown` would be the wrong shape — the native semantic is
+     * the contract.
+     *
+     * The hook `data-testid="log-card"` is the E2E anchor; the
+     * `data-id="{$log.lid}"` carries the row identifier for spec
+     * lookups (so a spec can assert "the card for log #N opened").
+     */
+    public function testEachMobileEntryIsANativeDetailsDisclosure(): void
+    {
+        $this->assertMatchesRegularExpression(
+            '/<details\b[^>]*\bclass="[^"]*\blog-card\b[^"]*"[^>]*\bdata-testid="log-card"[^>]*\bdata-id="\{\$log\.lid\}"/',
+            $this->template,
+            "Each `<li>` inside `.log-cards` must contain a "
+            . "`<details class=\"log-card\" data-testid=\"log-card\" data-id=\"{\$log.lid}\">` "
+            . "element. Native `<details>` is the contract — the disclosure "
+            . "is keyboard-reachable + screen-reader-announced for free, no JS "
+            . "needed. Don't re-roll this with `<div>` + `role=\"button\"` + "
+            . "`tabindex=\"0\"` + an `onkeydown` handler; that's the desktop "
+            . "table's shape (where the click target is `<tr>`, which has no "
+            . "native disclosure semantic). On `<details>` the browser does "
+            . "the right thing out of the box."
+        );
+    }
+
+    /**
+     * Both surfaces must iterate the same source — `$log_items`.
+     * If the mobile card foreach ever drifts to a different View
+     * property (a filter, a slice, a re-fetch), the viewport would
+     * silently determine "what set of logs the user sees", which is
+     * the same bug class as the original #1462 (rows invisible at
+     * one viewport) but worse — the mismatch would be subtle.
+     */
+    public function testBothSurfacesIterateTheSameLogItemsSource(): void
+    {
+        // Pull both `{foreach}` constructs out of the template and
+        // assert each iterates `$log_items`. Smarty's `{foreach}` shape
+        // is `{foreach from=$x item="y"}` — match the `from=` clause.
+        $foreachCount = preg_match_all(
+            '/\{foreach\s+from=\$log_items\s+item="log"\}/',
+            $this->template,
+            $matches,
+        );
+
+        // Exactly two `{foreach from=$log_items item="log"}` calls:
+        // one for the desktop `<tbody>`, one for the mobile `<ul>`.
+        // A future drift (extra foreach for a third surface, or
+        // dropping one of them) is caught here.
+        $this->assertSame(
+            2,
+            $foreachCount,
+            "`page_admin_settings_logs.tpl` must contain exactly TWO "
+            . "`{foreach from=\$log_items item=\"log\"}` constructs — one for "
+            . "the desktop `<table>`'s `<tbody>` and one for the mobile "
+            . "`<ul class=\"log-cards\">`. Found {$foreachCount}. If the "
+            . "iteration drifts to a different View property on one surface, "
+            . "the viewport would silently filter the visible row set — same "
+            . "bug class as the original #1462 but harder to notice."
+        );
+    }
+
+    /**
+     * `theme.css` must declare `.log-cards { display: none }` by
+     * default. The cards are mobile-only — at desktop viewports
+     * the `<table>` does the rendering and the cards must stay
+     * out of layout.
+     */
+    public function testThemeCssDefaultsLogCardsToHidden(): void
+    {
+        $this->assertMatchesRegularExpression(
+            '/(?<![\w-])\.log-cards\s*\{[^}]*display\s*:\s*none/',
+            $this->css,
+            "`theme.css` must declare `.log-cards { display: none; … }` as "
+            . "the default rule — desktop viewports paint the `<table>`, the "
+            . "cards stay out of layout. Without the default-hidden rule both "
+            . "surfaces would paint at desktop viewports (duplicate row set, "
+            . "broken layout). The `>=769px` media query below also pins this "
+            . "shape; the default-hidden rule is the load-bearing belt against "
+            . "media-query-stripping theme forks."
+        );
+    }
+
+    /**
+     * `theme.css` must flip `.log-cards { display: block }` inside
+     * a `@media (max-width: 768px)` block. There are several such
+     * blocks scattered across `theme.css` (each subsystem owns its
+     * own mobile overrides next to its own desktop rules); the
+     * contract is "AT LEAST ONE of them carries the `.log-cards`
+     * rule", not "only one of them". The same shape `.ban-cards`
+     * uses — its mobile-block rule lives next to the desktop
+     * table-collapse rule for the same reason (co-located concerns).
+     */
+    public function testThemeCssShowsLogCardsAtMobileBreakpoint(): void
+    {
+        $blocks = $this->extractAllMediaBlocks($this->css, '/@media\s*\(\s*max-width:\s*768px\s*\)\s*/');
+        $this->assertNotEmpty(
+            $blocks,
+            "`theme.css` must include at least one `@media (max-width: 768px) { … }` "
+            . "block. The block that hosts `.table { display: none; }` + "
+            . "`.ban-cards { display: block; }` must also carry "
+            . "`.log-cards { display: block; }` so the trio flips together."
+        );
+
+        $foundMatchingBlock = false;
+        foreach ($blocks as $block) {
+            if (preg_match('/\.log-cards\s*\{\s*display\s*:\s*block/', $block) === 1) {
+                $foundMatchingBlock = true;
+                break;
+            }
+        }
+        $this->assertTrue(
+            $foundMatchingBlock,
+            "At least one `@media (max-width: 768px) { … }` block in `theme.css` "
+            . "must include `.log-cards { display: block; }`, alongside "
+            . "`.table { display: none; }` and `.ban-cards { display: block; }`. "
+            . "Without this rule the mobile card surface stays hidden by the "
+            . "default `display: none` and the System Log paints empty on mobile "
+            . "(the #1462 regression). Co-locate it next to the `.table` / "
+            . "`.ban-cards` rules so the trio flips together on the same "
+            . "breakpoint — splitting them across separate media queries "
+            . "invites drift the next time someone tweaks the breakpoint."
+        );
+    }
+
+    /**
+     * The sibling `@media (min-width: 769px)` block must ALSO carry
+     * `.log-cards { display: none; }`. The default-hidden rule above
+     * already covers desktop, but mirroring the `.ban-cards` shape
+     * (which uses BOTH rules — default-hidden AND `>=769px`-hidden)
+     * keeps the chrome contract symmetric and makes the intent
+     * obvious to future readers: "this surface flips between two
+     * states, one per breakpoint" — no "what about widths > 768px
+     * that don't match the `<=768px` media query?" ambiguity.
+     */
+    public function testThemeCssExplicitlyHidesLogCardsAtDesktop(): void
+    {
+        $blocks = $this->extractAllMediaBlocks($this->css, '/@media\s*\(\s*min-width:\s*769px\s*\)\s*/');
+        $this->assertNotEmpty(
+            $blocks,
+            "`theme.css` must include at least one `@media (min-width: 769px) { … }` "
+            . "block. The sibling `.ban-cards { display: none; }` rule lives in "
+            . "such a block; the System Log's mobile mirror follows the same shape."
+        );
+
+        $foundMatchingBlock = false;
+        foreach ($blocks as $block) {
+            if (preg_match('/\.log-cards\s*\{\s*display\s*:\s*none/', $block) === 1) {
+                $foundMatchingBlock = true;
+                break;
+            }
+        }
+        $this->assertTrue(
+            $foundMatchingBlock,
+            "At least one `@media (min-width: 769px) { … }` block in `theme.css` "
+            . "must include `.log-cards { display: none; }` alongside the matching "
+            . "`.ban-cards { display: none; }` rule. The default `display: none` "
+            . "above already handles desktop, but mirroring the `.ban-cards` "
+            . "explicit-pair shape keeps the chrome contract symmetric and "
+            . "obvious to future readers (one rule per breakpoint, in lockstep "
+            . "with `.ban-cards`)."
+        );
+    }
+
+    /**
+     * Pull the bodies of every `@media (…)` block matching
+     * `$openAnchorRegex` out of a CSS string by walking brace depth.
+     * PCRE's `[^}]*` shape can't traverse the nested per-selector
+     * `{}` pairs inside a media block (the first inner `}` ends the
+     * match), and `theme.css` ships ten distinct
+     * `@media (max-width: 768px)` blocks scattered across subsystems
+     * — each rules block lives next to its desktop sibling. A
+     * regex anchored to "the" mobile block would only match the
+     * first one and miss the one that actually carries the
+     * `.log-cards` rule.
+     *
+     * Returns a list of substrings between matching `{` and `}`
+     * pairs (NOT including the braces themselves).
+     *
+     * @return list<string>
+     */
+    private function extractAllMediaBlocks(string $css, string $openAnchorRegex): array
+    {
+        if (preg_match_all($openAnchorRegex, $css, $matches, PREG_OFFSET_CAPTURE) === 0) {
+            return [];
+        }
+
+        $blocks = [];
+        $len    = strlen($css);
+        foreach ($matches[0] as [$matchText, $matchPos]) {
+            $cursor = (int) ($matchPos + strlen((string) $matchText));
+            while ($cursor < $len && ctype_space($css[$cursor])) {
+                $cursor++;
+            }
+            if ($cursor >= $len || $css[$cursor] !== '{') {
+                continue;
+            }
+            $start = $cursor + 1;
+            $depth = 1;
+            $i     = $start;
+            while ($i < $len && $depth > 0) {
+                $ch = $css[$i];
+                if ($ch === '{') {
+                    $depth++;
+                } elseif ($ch === '}') {
+                    $depth--;
+                    if ($depth === 0) {
+                        $blocks[] = substr($css, $start, $i - $start);
+                        break;
+                    }
+                }
+                $i++;
+            }
+        }
+        return $blocks;
+    }
+
+    /**
+     * The desktop `<table>` must still carry
+     * `class="table table--clickable-rows"` + `data-testid="logs-table"`.
+     * The sibling #1443 regression guard
+     * (`TableRowCursorPointerRegressionTest::testSystemLogTableOptsIntoClickableRowsModifier`)
+     * pins the same shape, but having the assertion here too means
+     * a PR that adds the mobile cards by deleting the desktop table
+     * fails the per-file contract before the cross-file one fires.
+     */
+    public function testDesktopTableSurvives(): void
+    {
+        $this->assertMatchesRegularExpression(
+            '/<table\b[^>]*\bclass="[^"]*\btable\b[^"]*\btable--clickable-rows\b[^"]*"[^>]*\bdata-testid="logs-table"/',
+            $this->template,
+            "`page_admin_settings_logs.tpl` must STILL ship the desktop "
+            . "`<table class=\"table table--clickable-rows\" data-testid=\"logs-table\">` "
+            . "alongside the new mobile `.log-cards` block. Both surfaces are "
+            . "load-bearing — the table for `>=769px`, the cards for `<=768px`. "
+            . "A future refactor that 'consolidates onto the mobile shape' for "
+            . "everyone re-opens the desktop chrome regression on the inverse "
+            . "viewport (the table's `<tbody>` row structure is the canonical "
+            . "data table chrome for the panel; replacing it with stacked cards "
+            . "on desktop would break the established visual vocabulary)."
+        );
+    }
+
+    /**
+     * The summary-row `onkeydown` handler must NOT carry an inline
+     * `{event.preventDefault();…}` body. Under Smarty's default
+     * `auto_literal=true`, the `{event.preventDefault();…}` substring
+     * has NO whitespace after the opening brace, so the compiler parses
+     * it as a Smarty tag (`event.preventDefault()`) and fails with
+     * `Unexpected '.', expected one of: '}'`. The bug compiled cleanly
+     * for months because Smarty's compile-dir was caching an earlier
+     * artifact (pre-#1451), but the moment a fresh compile-dir touches
+     * the template the whole page handler 500s. The two affected user
+     * surfaces are (a) `?p=admin&c=settings&section=logs` (the page
+     * this template renders) and (b) any E2E spec that exercises it.
+     *
+     * The fix moves the dispatcher into the existing
+     * `<script>{literal}…{/literal}</script>` block as
+     * `window.handleLogRowKey(event, row)` and the inline attribute
+     * reduces to `onkeydown="handleLogRowKey(event, this);"` —
+     * no braces inside the value, no Smarty hazard.
+     *
+     * The contract: the template must NOT contain the
+     * `{event.preventDefault` token anywhere (case-sensitive — the
+     * Smarty parser is). A future "let me put it back inline, it
+     * worked before" PR re-opens the bug class and fails this gate.
+     * The cache-fragility shape is shared across every inline
+     * handler that opens a `{` followed immediately by a JS
+     * identifier; if a future template ships the same trap, lift the
+     * paired test alongside it.
+     */
+    public function testSummaryRowKeyDispatcherIsNotInlineSmartyHazard(): void
+    {
+        // Strip Smarty `{* … *}` and JS `/* … */` block comments before
+        // scanning so the explanatory blocks (one above the `<tr>` and
+        // one above the JS `handleLogRowKey` helper) — both of which
+        // intentionally quote the forbidden inline form for posterity —
+        // don't false-fire the gate. Smarty strips `{* *}` at compile
+        // time; the JS comments don't reach the browser DOM either.
+        // Scanning the post-strip body matches what the compiler /
+        // runtime actually sees.
+        $stripped = preg_replace('/\{\*.*?\*\}/s', '', $this->template) ?? $this->template;
+        $stripped = preg_replace('#/\*.*?\*/#s', '', $stripped) ?? $stripped;
+
+        // The bug class is broader than `onkeydown=` + `{event.`. Any
+        // `on\w+="…{<JS-identifier>(…"` shape carries the same trap —
+        // `{foo.bar()` is parsed as a Smarty tag the moment Smarty
+        // touches a fresh compile-dir. The narrower regex would pass on
+        // a copy-paste of the inline body into `onclick="if(x){foo.bar()}"`
+        // (a likely slip when wiring a new affordance next to the
+        // keyboard handler), AND on `onkeyup` / `onfocus` / `onsubmit` /
+        // `onmouseover` siblings. Broaden to the full attribute family
+        // so a sibling regression on any inline JS-event attribute
+        // surfaces here, not in a CI run on a cold compile-dir.
+        $this->assertDoesNotMatchRegularExpression(
+            '/\bon\w+\s*=\s*"[^"]*\{[a-zA-Z_$]/',
+            $stripped,
+            "`page_admin_settings_logs.tpl` must NOT carry an inline "
+            . "`on\w+=\"…{<JS-identifier>(…}…\"` body on ANY event "
+            . "attribute (`onclick`, `onkeydown`, `onkeyup`, `onfocus`, "
+            . "`onsubmit`, …). Smarty's default `auto_literal=true` "
+            . "parses the `{event.preventDefault();…}` / `{foo.bar();…}` "
+            . "substring as a tag (no whitespace after `{`, so the JS "
+            . "identifier looks like a function call to the lexer) and "
+            . "the template fails fresh-compile with `Unexpected '.', "
+            . "expected one of: '}'`. The bug compiled cleanly for months "
+            . "because Smarty's compile-dir was caching an earlier "
+            . "artifact (pre-#1451); a fresh `templates_c` 500s the page. "
+            . "Lift the dispatcher into the page-tail "
+            . "`<script>{literal}…{/literal}</script>` block "
+            . "(`window.<handler>`) and call it from the attribute by "
+            . "name — no braces in the attribute body, no Smarty hazard. "
+            . "If a future legitimate JS object-literal genuinely needs "
+            . "to ship inline (vanishingly rare in this codebase), wrap "
+            . "the entire attribute value in `{literal}…{/literal}`."
+        );
+
+        $this->assertStringContainsString(
+            'onkeydown="handleLogRowKey(event, this);"',
+            $this->template,
+            "The summary row's `onkeydown` attribute must dispatch via the "
+            . "page-tail `window.handleLogRowKey` helper "
+            . "(`onkeydown=\"handleLogRowKey(event, this);\"`). This is the "
+            . "load-bearing replacement for the pre-existing inline "
+            . "`if(event.key==='Enter'…){event.preventDefault();…}` body; without "
+            . "it the keyboard contract (Enter / Space toggles the row) is broken "
+            . "AND the next E2E run on a fresh Smarty compile-dir 500s the page."
+        );
+
+        $this->assertStringContainsString(
+            'window.handleLogRowKey = function (event, row)',
+            $this->template,
+            "The page-tail `<script>{literal}…{/literal}</script>` block must "
+            . "define `window.handleLogRowKey` so the `onkeydown` attribute's "
+            . "named-handler dispatch resolves at runtime. The block sits below "
+            . "`window.toggleLogRow` and `window.clearLogs`; keep the helper next "
+            . "to its peers and the `<script>{literal}` wrapping unchanged."
+        );
+    }
+}

--- a/web/themes/default/css/theme.css
+++ b/web/themes/default/css/theme.css
@@ -1720,6 +1720,77 @@ details.queue-row > summary > .row-actions {
   padding: 0 1rem 0.75rem;
 }
 
+/* ---- System log mobile cards (#1462) ----
+   The System Log sub-tab (`page_admin_settings_logs.tpl`) renders a
+   `<table class="table table--clickable-rows">` for the desktop view.
+   At `<=768px` the global `.table { display: none }` rule (originally
+   paired with the bans / comms `.ban-cards` mobile mirror below)
+   collapses every `<table class="table">` on the panel. The System Log
+   never shipped a paired mobile surface, so the rows silently vanished
+   on the iPhone view — the reporter on #1462 saw "no logs visible"
+   while the chrome around them rendered fine.
+
+   `.log-cards` is the paired mobile-only surface. Each entry is a
+   native `<details>` so the disclosure works without JavaScript, is
+   keyboard-reachable by default, and announces correctly to screen
+   readers (no `role="button"` / `tabindex="0"` / `onkeydown` handler
+   needed; the browser does it for free on `<details>`). The chevron
+   icon rotates 90° on `[open]` and honours
+   `prefers-reduced-motion: reduce` per the chrome's motion-of-state
+   contract (see the `@media (prefers-reduced-motion: reduce)` block
+   near the bottom of this file).
+
+   Desktop chrome is untouched: at `>=769px` the cards stay hidden
+   and the `<table>` does the same job it always did. The chrome
+   shape is "show both surfaces, viewport gates which one paints" so
+   the cards never compete with the table at intermediate viewports. */
+.log-cards { display: none; list-style: none; margin: 0; padding: 0; }
+.log-card { border-bottom: 1px solid var(--border); }
+.log-card:last-child { border-bottom: none; }
+.log-card__summary {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.75rem 1rem;
+  cursor: pointer;
+  list-style: none;
+  -webkit-tap-highlight-color: transparent;
+}
+.log-card__summary::-webkit-details-marker { display: none; }
+.log-card__summary::marker { content: ''; }
+.log-card__summary:hover { background: var(--bg-muted); }
+.log-card__title {
+  flex: 1;
+  min-width: 0;
+  font-size: var(--fs-sm);
+  font-weight: 500;
+  word-break: break-word;
+}
+.log-card__chevron {
+  transition: transform .15s ease;
+  color: var(--text-muted);
+  flex-shrink: 0;
+}
+.log-card[open] > summary .log-card__chevron { transform: rotate(90deg); }
+.log-card__meta {
+  display: none;
+  flex-wrap: wrap;
+  gap: 0.25rem 1rem;
+  padding: 0 1rem 0.5rem;
+  font-family: var(--font-mono);
+  font-size: var(--fs-xs);
+  color: var(--text);
+}
+.log-card[open] > .log-card__meta { display: flex; }
+.log-card__body {
+  padding: 0.75rem 1rem 1rem;
+  background: var(--bg-muted);
+  border-top: 1px solid var(--border);
+}
+@media (prefers-reduced-motion: reduce) {
+  .log-card__chevron { transition: none; }
+}
+
 /* ---- Responsive ---- */
 [data-mobile-menu] { display: none; }
 @media (max-width: 1024px) {
@@ -1730,6 +1801,10 @@ details.queue-row > summary > .row-actions {
 @media (max-width: 768px) {
   .table { display: none; }
   .ban-cards { display: block; }
+  /* #1462: paired mobile surface for the System Log table (see
+     `.log-cards` block above for the full rationale). Same `display`
+     dance as `.ban-cards` — hidden at desktop, block at mobile. */
+  .log-cards { display: block; }
   /* #1181: filter chip rows wrap onto multiple lines on mobile
      instead of horizontal-scrolling, so every chip is reachable
      without a swipe. The .scroll-x desktop affordance is the
@@ -1739,6 +1814,7 @@ details.queue-row > summary > .row-actions {
 }
 @media (min-width: 769px) {
   .ban-cards { display: none; }
+  .log-cards { display: none; }
 }
 
 /* ---- Utility classes used by templates ---- */

--- a/web/themes/default/page_admin_settings_logs.tpl
+++ b/web/themes/default/page_admin_settings_logs.tpl
@@ -27,11 +27,26 @@
     Testability hooks:
         - Sidebar links: data-testid="admin-tab-<slug>" (#1259 unified
           shape across servers / mods / groups / settings).
-        - Each summary row: data-testid="log-row" + data-id (lid).
-        - "Clear log" button: data-testid="logs-clear".
+        - Each desktop summary row: data-testid="log-row" + data-id (lid).
+        - Each mobile card: data-testid="log-card" + data-id (lid).
+        - Desktop table wrapper: data-testid="logs-table".
+        - Mobile card wrapper:   data-testid="logs-cards".
+        - "Clear log" button:    data-testid="logs-clear".
 
     #1266 — outer `.p-6` removed; the page inset lives on
     `.admin-sidebar-shell` so both grid columns share the same top y.
+
+    #1462 — paired mobile card surface. At `<=768px` the global
+    `.table { display: none }` rule (paired originally with the bans /
+    comms `.ban-cards` mobile mirror in `theme.css`) collapses every
+    `<table class="table">` on the panel. The System Log never got a
+    paired mobile surface, so on mobile the chrome rendered (heading,
+    "Clear log" button) while the rows themselves were silently
+    hidden — the reporter saw "no logs visible" on the iPhone view.
+    The `.log-cards` block below mirrors `$log_items` as native
+    `<details>` disclosures so the same rows surface on mobile, with
+    JS-free expansion + keyboard reachability + screen-reader
+    announce out of the box. Desktop chrome unchanged.
 *}
 <div>
     <div class="mb-6">
@@ -98,6 +113,20 @@
                                            — a bare `<tr>` with no role / tabindex / key
                                            handling — so keyboard-only and AT users had no
                                            way to expand a log row. *}
+                                        {* #1462: extracted the inline `onkeydown` body to
+                                           the page-tail `<script>{literal}` block (now
+                                           `handleLogRowKey`). The original `onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();toggleLogRow(this);}"`
+                                           form (added in #1451) compiles cleanly when
+                                           Smarty has a stale cached copy of the template
+                                           on disk but fails fresh-compile with
+                                           "Unexpected '.', expected one of: '}'" — the
+                                           `{event.preventDefault();...}` substring is
+                                           parsed as a Smarty tag by the default
+                                           `auto_literal=true` (no whitespace after the
+                                           open brace = parse as tag). Calling a tail-
+                                           defined helper sidesteps the per-character
+                                           braces hazard without losing keyboard
+                                           reachability. *}
                                         <tr data-testid="log-row"
                                             data-id="{$log.lid}"
                                             role="button"
@@ -105,7 +134,7 @@
                                             aria-expanded="false"
                                             aria-controls="log-detail-{$log.lid}"
                                             onclick="toggleLogRow(this);"
-                                            onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();toggleLogRow(this);}">
+                                            onkeydown="handleLogRowKey(event, this);">
                                             <td>
                                                 {if $log.type == 'm'}
                                                     <span class="pill pill--online"><i data-lucide="info" style="width:0.75rem;height:0.75rem"></i> Info</span>
@@ -139,6 +168,61 @@
                                     {/foreach}
                                 </tbody>
                             </table>
+
+                            {* #1462: paired mobile card surface. The desktop table
+                               above is hidden by the global `.table { display: none }`
+                               rule at `<=768px`; this `<ul class="log-cards">` block
+                               is hidden by default (`display: none`) and only paints
+                               at the same `<=768px` breakpoint. Both surfaces iterate
+                               the same `$log_items` so the visible row set is
+                               viewport-symmetric. Native `<details>` carries the
+                               disclosure semantic — no JS required, keyboard-
+                               accessible, screen-reader-announced as an expandable
+                               group out of the box. The `aria-label` on the `<ul>`
+                               names the list for AT users; the `aria-hidden="true"`
+                               on the desktop table's `<thead>` is unnecessary here
+                               because each card carries its own per-row context in
+                               the summary. *}
+                            <ul class="log-cards" data-testid="logs-cards" aria-label="System log entries">
+                                {foreach from=$log_items item="log"}
+                                    <li>
+                                        <details class="log-card"
+                                                 data-testid="log-card"
+                                                 data-id="{$log.lid}">
+                                            <summary class="log-card__summary">
+                                                {if $log.type == 'm'}
+                                                    <span class="pill pill--online"><i data-lucide="info" style="width:0.75rem;height:0.75rem"></i> Info</span>
+                                                {elseif $log.type == 'w'}
+                                                    <span class="pill pill--active"><i data-lucide="alert-triangle" style="width:0.75rem;height:0.75rem"></i> Warn</span>
+                                                {elseif $log.type == 'e'}
+                                                    <span class="pill pill--permanent"><i data-lucide="circle-x" style="width:0.75rem;height:0.75rem"></i> Error</span>
+                                                {else}
+                                                    <span class="pill pill--offline">{$log.type}</span>
+                                                {/if}
+                                                <span class="log-card__title">{$log.title}</span>
+                                                <i class="log-card__chevron" data-lucide="chevron-right" style="width:1rem;height:1rem" aria-hidden="true"></i>
+                                            </summary>
+                                            <div class="log-card__meta">
+                                                <span><span class="text-muted">User:</span> {$log.user}</span>
+                                                <span><span class="text-muted">Date:</span> {$log.date_str}</span>
+                                            </div>
+                                            <div class="log-card__body">
+                                                <dl class="grid gap-2 text-xs" style="grid-template-columns:6rem 1fr;margin:0">
+                                                    <dt class="text-muted">Details</dt>
+                                                    {* nofilter: $log.message is escaped via htmlentities() in admin.settings.php (same value as the desktop table above; the page handler stages each log row once and both surfaces consume the same dict). *}
+                                                    <dd style="margin:0">{$log.message nofilter}</dd>
+                                                    <dt class="text-muted">Function</dt>
+                                                    <dd class="font-mono" style="margin:0;word-break:break-all">{$log.function}</dd>
+                                                    <dt class="text-muted">Query</dt>
+                                                    <dd class="font-mono" style="margin:0;word-break:break-all">{$log.query}</dd>
+                                                    <dt class="text-muted">IP</dt>
+                                                    <dd class="font-mono tabular-nums" style="margin:0">{$log.host}</dd>
+                                                </dl>
+                                            </div>
+                                        </details>
+                                    </li>
+                                {/foreach}
+                            </ul>
                         {else}
                             <p class="text-muted text-sm m-0">No log entries.</p>
                         {/if}
@@ -175,6 +259,23 @@
         } else {
             detail.setAttribute('hidden', '');
             row.setAttribute('aria-expanded', 'false');
+        }
+    };
+
+    /**
+     * Keyboard dispatcher for the desktop summary row. #1462 lifted this out
+     * of an inline `onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();...}"`
+     * attribute body because the inline shape compiles under a stale Smarty
+     * cache but fails fresh-compile: the `{event.preventDefault();...}`
+     * substring is parsed as a Smarty tag (no whitespace after `{` defeats
+     * `auto_literal`). Keeping the dispatcher here also makes the
+     * `role="button"` keyboard contract testable without parsing Smarty.
+     */
+    window.handleLogRowKey = function (event, row) {
+        if (!event || !row) return;
+        if (event.key === 'Enter' || event.key === ' ') {
+            event.preventDefault();
+            window.toggleLogRow(row);
         }
     };
 


### PR DESCRIPTION
## Summary

- `web/themes/default/page_admin_settings_logs.tpl` rendered the audit log inside a `<table class="table">` with no paired mobile surface. At `<=768px` the global `.table { display: none; }` rule (shared with bans / comms whose mobile shape is `.ban-cards`) collapsed the table, so the chrome around it (heading, "Clear log" button, pagination) painted while the rows themselves silently vanished. Reporter's "no logs visible" iPhone screenshot in #1462 is the exact symptom.
- Adds a `<ul class="log-cards">` block alongside the existing table that mirrors `$log_items` as native `<details>` disclosures, paired with `>=769px` / `<=768px` CSS visibility rules next to the sibling `.ban-cards` declarations so the two surfaces never compete. Native `<details>` carries the disclosure semantic for free — keyboard-reachable, screen-reader-announced, JS-free — so the mobile surface doesn't have to repeat the desktop `<tr>`'s `role="button"` + `tabindex="0"` + `onkeydown` triple.
- Fixes a sibling Smarty `auto_literal` hazard in the same template (the pre-existing `onkeydown="if(...){event.preventDefault();...}"` handler on the desktop `<tr>`, added in #1451). The inline `{event.preventDefault()…}` substring has no whitespace after the opening brace, so Smarty parses it as a tag — the bug compiled cleanly for months because `templates_c` was cached, but the moment an E2E spec hit the page with a cold compile-dir the page 500'd. Lifts the dispatcher into the existing `<script>{literal}…{/literal}</script>` block as `window.handleLogRowKey(event, row)` and the attribute drops to `onkeydown="handleLogRowKey(event, this);"` — no braces in the attribute body.

## Regression guards

- `web/tests/integration/SystemLogMobileCardsRegressionTest.php` (8 contracts) pins the mobile wrapper, the per-row `<details>` shape, the surface-parity contract (both surfaces iterate `$log_items`), the CSS visibility ladder (default-hidden, `<=768px` shown, `>=769px` hidden), the surviving desktop table, AND the Smarty hazard. The hazard regex matches the broader `on\w+="…{<JS-identifier>…"` bug class, not just the specific `onkeydown` + `{event.` shape that motivated it, so a future copy-paste into a sibling `onclick` / `onkeyup` / `onfocus` surfaces here instead of in CI on a cold compile-dir. Smarty `{* *}` and JS `/* */` comments are stripped before the match so docblocks documenting the bug don't false-fire.
- `web/tests/e2e/specs/responsive/system-log-mobile.spec.ts` (5 specs, mobile-chromium) drives the seeded fixture end-to-end: desktop hidden + mobile cards paint, `<details>` toggles via pointer click, `<details>` toggles via Tab → Enter / Space (the keyboard contract the abstraction was picked FOR), zero critical axe violations on the expanded mobile chrome, and no horizontal viewport overflow. Cards anchor on the `data-id="<lid>"` primary key returned by the seeder rather than `hasText:<title>`, so a future audit row with an overlapping title prefix can't flake the spec. `test.describe.configure({ mode: 'serial' })` + `beforeEach` truncate-and-seed pairs the spec with the shared `sourcebans_e2e` DB contract.
- Companion seeder: `seedSystemLogE2e(rows[]): Promise<number[]>` in `web/tests/e2e/fixtures/db.ts` shells out to a new `seed-system-log-e2e.php` shim that inserts directly into `:prefix_log` and returns the inserted lid list. The shim mirrors `seed-comms-e2e.php`'s contract (`DB_NAME` guard refuses anything but `sourcebans_e2e`, stdin JSON in / stdout JSON out). `:prefix_log` is empty by default in the e2e seed and there's no JSON action that emits audit rows directly — they're side effects of authenticated panel writes — so the direct INSERT is the narrowest shape that doesn't couple the spec to an unrelated handler's audit message.

## Test plan

- [x] `./sbpp.sh phpstan` — clean
- [x] `./sbpp.sh ts-check` — clean
- [x] `./sbpp.sh test` — PHPUnit green (incl. new `SystemLogMobileCardsRegressionTest`'s 8 contracts)
- [x] `./sbpp.sh composer api-contract` — no diff
- [x] `./sbpp.sh e2e --project=mobile-chromium specs/responsive/system-log-mobile.spec.ts --workers=1` — 5/5 green
- [x] `./sbpp.sh e2e --workers=1` — full suite (mobile-chromium + chromium) green
- [x] Manual verification: visited `?p=admin&c=settings&section=logs` at iPhone 13 viewport, confirmed cards render with timestamps + admin name + IP + log-type pills, click-to-expand reveals the message body, keyboard Tab → Enter / Space toggles the disclosure, desktop-width viewport hides the cards and surfaces the existing table.

Closes #1462.