### PR TITLE
docs: tighten commercial-licensing copy and consolidate internal references (#1465 follow-up)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -425,7 +425,7 @@ matching its directory. PSR-4 autoloads from `web/includes/` →
 | `Sbpp\View\*`                            | view DTOs (page-level + partials)     |
 | `Sbpp\Servers\SourceQueryCache`          | per-`(ip, port)` on-disk cache around the xPaw A2S probe (#1311) |
 | `Sbpp\Servers\RconStatusCache`           | per-`sid` on-disk cache around the RCON `status` command (#PLAYER_CTX_MENU) |
-| `Sbpp\Upload\UploadHandler`              | shared file-upload handler (size + extension allowlist + filename sanitiser) for the three popup upload pages — see `goals#5` |
+| `Sbpp\Upload\UploadHandler`              | shared file-upload handler (size + extension allowlist + filename sanitiser) for the three popup upload pages |
 | `Sbpp\Markup\IntroRenderer`              | admin-authored Markdown renderer      |
 | `Sbpp\Mail\Mail` / `Sbpp\Mail\Mailer` / `Sbpp\Mail\EmailType` | `Mail::send(...)` entry point + Symfony Mailer SMTP wrapper + email-type enum |
 | `Sbpp\Version`                           | three-tier `SB_VERSION` resolver (tarball JSON → git → `'dev'`) |
@@ -2658,16 +2658,15 @@ contributions without contacting every contributor individually.
   to gate execution, and CLA.md §10 is what the contributor is told
   to type. Drift between any two silently breaks the signing flow.
 - Historical-contributor coverage was the precondition for the
- `goals#4` ELv2 relicense and was resolved by the `goals#3` audit:
- every pre-CLA `web/**` contribution of substance was authored by
- `rumblefrog`, who as the project maintainer is also the licensor
- under ELv2. The handful of small one-off external PRs from before
- the CLA workflow landed either (a) survived intact through the
- v2.0 panel rewrite (in which case their authors are listed on
- `goals#3`'s audit and the CLA's §3(b) relicense grant covers them
- going forward — pending sign-off), or (b) were removed during the
- v2.0 rewrite (in which case the question is moot; `goals#5` Route
- B rewrites covered the dead-code surface). Future inbound PRs are
+ ELv2 relicense and was resolved by the project's pre-CLA
+ contribution audit: every pre-CLA `web/**` contribution of
+ substance was authored by `rumblefrog`, who as the project
+ maintainer is also the licensor under ELv2. The handful of small
+ one-off external PRs from before the CLA workflow landed either
+ (a) survived intact through the v2.0 panel rewrite (in which case
+ the CLA's §3(b) relicense grant covers them going forward,
+ pending sign-off), or (b) were removed during the v2.0 rewrite
+ (in which case the question is moot). Future inbound PRs are
  covered by the workflow as designed. Retroactive sign-off for the
  surviving-author set is still an opt-in follow-up but is not on
  the critical path for the ELv2 relicense.
@@ -2698,11 +2697,11 @@ contributions without contacting every contributor individually.
  truth. The source-of-truth attribution surface for upstream
  lineage (SourceBans 1.4.x, SourceComms, InterWave Studios
  theme.conf, LightOpenID, TinyMCE) is `THIRD-PARTY-NOTICES.txt`.
- Issue `goals#5` swept all 36 files onto the 4-line shape; the
+ The v2.0 rewrite swept all 36 files onto the 4-line shape; the
  license-name + filename swap from CC-BY-NC-SA / `LICENSE.md` to
- ELv2 / `LICENSE.txt` rode the same PR that landed `LICENSE.txt`
- (`goals#4` Phase 2). New files take the 4-line shape from day
- one. Files with their own licence (`web/includes/Auth/openid.php`,
+ ELv2 / `LICENSE.txt` rode the same PR that landed `LICENSE.txt`.
+ New files take the 4-line shape from day one. Files with their
+ own licence (`web/includes/Auth/openid.php`,
  `web/includes/tinymce/`) keep their original headers.
 - Inline `echo '<form action="…">'` HTML blobs at the top of
  admin page handlers (`web/pages/admin.edit.<x>.php`) → build a
@@ -2717,7 +2716,8 @@ contributions without contacting every contributor individually.
  is set in `init.php`); the only escape hatch is `nofilter` which
  carries its own annotation rule (see "`nofilter` discipline" in
  Conventions). The `admin.edit.*` cluster was migrated wholesale
- in `goals#5`; new edit pages follow the same shape from day one.
+ in the v2.0 rewrite; new edit pages follow the same shape from
+ day one.
 - `echo '<div id="msg-red">…';` / `echo '<div id="msg-green">…';`
  inline-PHP error / success banners → use Smarty's
  `{if $error}<div class="alert alert--error">{$error|escape}</div>{/if}`
@@ -2732,8 +2732,8 @@ contributions without contacting every contributor individually.
  silent invisible div forever. The legacy markup also escaped
  nothing — `echo '<div id="msg-red">' . $username . ' is taken</div>'`
  was a stored-XSS surface for any field that survives validation.
- Migrated wholesale in `goals#5`. Search anchor for any future
- sweep: `rg "msg-(red|green)" web/`.
+ Migrated wholesale in the v2.0 rewrite. Search anchor for any
+ future sweep: `rg "msg-(red|green)" web/`.
 - Legacy 1.4.11 JS handler names — `ButtonOver(…)`,
  `ProcessEditAdminPermissions(…)`, `ProcessEditGroup(…)`,
  `ProcessEditMod(…)`, `ProcessEditServer(…)`, `errorScript(…)`
@@ -2745,10 +2745,10 @@ contributions without contacting every contributor individually.
  page rendered, the button looked clickable, the click did
  nothing — not even a console error). The legacy handler names
  are documented here defensively because `rg` searches against
- third-party theme forks may still surface them; the
- `goals#5` sweep removed every reference under `web/themes/default/`,
- but a fork that copy-pasted the templates pre-#1123 D1 will
- still carry them. Wire to `sb.api.call(Actions.PascalName, …)`
+ third-party theme forks may still surface them; the v2.0 rewrite
+ removed every reference under `web/themes/default/`, but a fork
+ that copy-pasted the templates pre-#1123 D1 will still carry them.
+ Wire to `sb.api.call(Actions.PascalName, …)`
  via `data-action` + a page-tail vanilla-JS dispatcher per the
  canonical confirm-modal shape under "Add a confirm + reason
  modal" in "Where to find what".
@@ -2815,9 +2815,9 @@ contributions without contacting every contributor individually.
  silently because nothing defined it post-#1123, so old `$('id').value`
  reads returned `undefined.value` → `TypeError`. Page-tail
  scripts inside templates use plain DOM access plus the
- `window.SBPP.showToast` / `setBusy` chrome helpers. The
- `goals#5` admin.edit.* sweep removed every surviving call site;
- don't reintroduce. (The `sb.$id` / `sb.$idRequired` helpers in
+ `window.SBPP.showToast` / `setBusy` chrome helpers. The v2.0
+ admin.edit.* sweep removed every surviving call site; don't
+ reintroduce. (The `sb.$id` / `sb.$idRequired` helpers in
  `web/scripts/sb.js` are the canonical shape for code that ships
  with the panel; inline page-tail scripts can use either shape.)
 - The DELETE-then-INSERT loop on
@@ -2832,8 +2832,8 @@ contributions without contacting every contributor individually.
  etc. The schema doesn't carry a UNIQUE on the (admin_id,
  server_group_id) / (server_id, group_id) pairs, so collapsing
  to `INSERT … ON DUPLICATE KEY UPDATE` would need a paired
- schema migration (out of `goals#5`'s scope; tracked as a
- follow-up). Until then, transactions are the contract — see
+ schema migration (tracked as a follow-up). Until then,
+ transactions are the contract — see
  `web/pages/admin.edit.adminservers.php` and
  `web/pages/admin.edit.server.php` for the canonical shape.
 - Hand-rolled per-page upload handling — `move_uploaded_file($_FILES['x']['tmp_name'], $dst)`
@@ -2843,7 +2843,7 @@ contributions without contacting every contributor individually.
  wraps every step (CSRF, permission gate, extension allowlist,
  filename sanitisation via `sanitiseName()`, the `move_uploaded_file()`
  call, the audit-log entry, the success / error popup chrome).
- The pre-`goals#5` shape duplicated all of this across the three
+ The pre-v2.0 shape duplicated all of this across the three
  popup upload pages (`admin.uploaddemo.php`, `admin.uploadicon.php`,
  `admin.uploadmapimg.php`) and trusted `$_FILES[…]['name']`
  verbatim — so a `name=../../etc/passwd` upload could escape
@@ -4507,9 +4507,9 @@ contributions without contacting every contributor individually.
 | Validate a server-address input (IPv4 / IPv6 / hostname) on either Add-Server (`api_servers_add`) or Edit-Server (`admin.edit.server.php`) | Shared validator pattern: `filter_var($x, FILTER_VALIDATE_IP) \|\| filter_var($x, FILTER_VALIDATE_DOMAIN, FILTER_FLAG_HOSTNAME)`. Both surfaces MUST share the same predicate so a value either round-trips through Add AND Edit or fails on both (#1433); pre-fix the JSON dispatcher ran IP-only while the page handler ran a too-loose hand-rolled `^[a-zA-Z0-9.\-]+$` regex. The matching schema-width gate (`strlen($x) > 64`, surfacing as `validation` envelope or `$validationErrors['address']`) is paired with the IP/hostname check because `:prefix_servers.ip` is `VARCHAR(64) NOT NULL` (see `web/install/includes/sql/struc.sql`) — well below RFC 1035's 253-char hostname max, and MariaDB strict mode would otherwise raise `SQLSTATE[22001] 1406 Data too long for column 'ip'` mid-INSERT (generic 500 + no audit-log entry). Bumping the column to `VARCHAR(255)` is a paired schema-migration follow-up. Pinned by `web/tests/api/ServersTest.php::testAddAcceptsHostname` / `testAddAcceptsFqdn` / `testAddAcceptsBareIPv6` / `testAddRejectsAddressExceedingSchemaWidth` / `testAddRefusesDuplicateHostnamePort` / `testAddRejectsWhitespaceInAddress`. |
 | Add or rename a permission             | `web/configs/permissions/web.json`, then regen contract  |
 | Render a page                          | `web/pages/<page>.php` + `web/includes/View/*View.php`   |
-| Add a new edit page in the admin.edit.* cluster (e.g. `admin.edit.<x>.php`) | `web/pages/admin.edit.<x>.php` (the page handler — thin "validate input, build View, render" shape) + `web/includes/View/AdminEdit<X>View.php` (typed View DTO) + `web/themes/default/page_admin_edit_<x>.tpl` (template). Shared helpers live in `web/pages/_admin_edit_helpers.php` (`sbpp_admin_edit_die_with_toast()` for permission / not-found guards, `sbpp_admin_edit_emit_tail_script()` for form-success / validation-error feedback that fires `window.SBPP.showToast()` and writes errors into `<id>.msg` divs, `sbpp_admin_edit_collect_rehash_sids()` for the post-save Rehash Admins step). Anti-patterns to avoid: inline `echo '<form>...'` blocks, `echo '<div id="msg-red">…'` banners, MooTools `$('id').value` reads, legacy JS handler names (`ButtonOver`, `ProcessEditAdminPermissions`, etc.) — all swept as part of `goals#5`. CSRF gate every POST via `\CSRF::rejectIfInvalid();` after the `isset($_POST['<sentinel>'])` arm. |
+| Add a new edit page in the admin.edit.* cluster (e.g. `admin.edit.<x>.php`) | `web/pages/admin.edit.<x>.php` (the page handler — thin "validate input, build View, render" shape) + `web/includes/View/AdminEdit<X>View.php` (typed View DTO) + `web/themes/default/page_admin_edit_<x>.tpl` (template). Shared helpers live in `web/pages/_admin_edit_helpers.php` (`sbpp_admin_edit_die_with_toast()` for permission / not-found guards, `sbpp_admin_edit_emit_tail_script()` for form-success / validation-error feedback that fires `window.SBPP.showToast()` and writes errors into `<id>.msg` divs, `sbpp_admin_edit_collect_rehash_sids()` for the post-save Rehash Admins step). Anti-patterns to avoid: inline `echo '<form>...'` blocks, `echo '<div id="msg-red">…'` banners, MooTools `$('id').value` reads, legacy JS handler names (`ButtonOver`, `ProcessEditAdminPermissions`, etc.) — all swept as part of the v2.0 rewrite. CSRF gate every POST via `\CSRF::rejectIfInvalid();` after the `isset($_POST['<sentinel>'])` arm. |
 | Wire a `window.opener.<callback>(...)` slot on the parent template of a popup file-upload page (e.g. `window.icon`, `window.demo`, `window.mapimg`) | The parent template defines `window.<callback> = function (filename) { … }` inside an inline `<script>` block (use the `{literal}…{/literal}` Smarty guard so `{` / `}` inside the JS body don't trigger Smarty parsing). The function patches the parent form's hidden input (e.g. `document.getElementById('icon_hid').value = filename;`) and any visible affordances (toggle a thumbnail preview, swap a "Choose file" label for the filename). Reference: `web/themes/default/page_admin_mods_add.tpl` + `page_admin_edit_mod.tpl` for the `window.icon` wiring (#1402), and `web/themes/default/page_admin_bans_add.tpl` / `page_admin_edit_ban.tpl` for the `window.demo` wiring. Without this slot the popup emits `<script>window.opener.icon('foo.jpg')</script>` and the call throws `TypeError: window.opener.icon is not a function` — popup never closes, the parent form's hidden input never updates, the uploaded asset is orphaned on disk. The `UploadHandler` emits the call unconditionally; the parent's job is to be ready for it. |
-| Add a popup file-upload page (demo / icon / mapimage / new asset type) | `Sbpp\Upload\UploadHandler::handle()` (`web/includes/Upload/UploadHandler.php`). The page handler at `web/pages/admin.upload<x>.php` is a thin wrapper passing the per-page knobs (`permission` mask, `field` `$_FILES` key, `allowed` extensions, `destDir`, `callback` JS function name on `window.opener`, `auditOk` / `auditFmt` / `errorMsg` / `title` / `formName` / `formats` strings, optional `renameToHash` for demo-style randomised filenames). The handler runs CSRF + permission check, sanitises `$_FILES[…]['name']` via `sanitiseName()` (basename + strip backslashes + trim leading dots — defends LFI on the icon / mapimage paths where the filename hits disk), `move_uploaded_file()`s to the destination, calls `Log::add(LogType::Message, …)`, and on success emits the `<script>window.opener.<callback>(...)</script>` blob the parent page picks up. The three reference call sites (`admin.uploaddemo.php`, `admin.uploadicon.php`, `admin.uploadmapimg.php`) are 30-line wrappers; new asset types should match that line budget. Anti-pattern: hand-rolling the move / log / popup-emission sequence per page (the pre-`goals#5` shape). |
+| Add a popup file-upload page (demo / icon / mapimage / new asset type) | `Sbpp\Upload\UploadHandler::handle()` (`web/includes/Upload/UploadHandler.php`). The page handler at `web/pages/admin.upload<x>.php` is a thin wrapper passing the per-page knobs (`permission` mask, `field` `$_FILES` key, `allowed` extensions, `destDir`, `callback` JS function name on `window.opener`, `auditOk` / `auditFmt` / `errorMsg` / `title` / `formName` / `formats` strings, optional `renameToHash` for demo-style randomised filenames). The handler runs CSRF + permission check, sanitises `$_FILES[…]['name']` via `sanitiseName()` (basename + strip backslashes + trim leading dots — defends LFI on the icon / mapimage paths where the filename hits disk), `move_uploaded_file()`s to the destination, calls `Log::add(LogType::Message, …)`, and on success emits the `<script>window.opener.<callback>(...)</script>` blob the parent page picks up. The three reference call sites (`admin.uploaddemo.php`, `admin.uploadicon.php`, `admin.uploadmapimg.php`) are 30-line wrappers; new asset types should match that line budget. Anti-pattern: hand-rolling the move / log / popup-emission sequence per page (the pre-v2.0 shape). |
 | Edit a template                        | `web/themes/default/*.tpl`                               |
 | Reuse the moderation-queue card layout (admin submissions / protests, mobile-stacked summary rows) | `web/themes/default/css/theme.css` (`.queue-row`, `.queue-row__body`, `.queue-row__date` — #1207 PUB-2). Apply by adding `class="queue-row …"` to the outer `<details>` and dropping the inline `flex` / `flex-shrink:0` styles from the summary children. |
 | Add visible row actions to a table-rendered admin list (Edit / Unmute / Remove buttons + responsive mobile-card mirror) | `web/themes/default/page_comms.tpl` (#1207 ADM-5) is the canonical reference: `<button class="btn btn--secondary btn--sm">` / `<a class="btn btn--ghost btn--sm">` inside a `.row-actions` cell, plus `.ban-card__actions` row of identical-data-action buttons in the mobile card. Wire destructive / state-changing buttons via `data-action="…"` + `data-bid` + `data-fallback-href`; the inline page-tail JS calls `sb.api.call(Actions.PascalName)` and falls back to the GET URL if the JSON dispatcher is absent. The public banlist (`web/themes/default/page_bans.tpl`) follows the same shape — same chrome (Lucide icon + visible text label inside `.btn--ghost` / `.btn--secondary btn--sm`), same `.ban-card__actions` mobile row, same `data-action` / `data-fallback-href` wiring (`bans-unban` / `bans-delete`). The Remove affordance points at the legacy GET handler (`?p=banlist&a=delete&id=…&key=…` at the top of `page.banlist.php`) because no JSON `bans.delete` action exists yet — the inline JS `confirm()`-prompts then navigates, mirroring commslist's flow without adding a new handler / snapshot / permission-matrix entry. |

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -98,7 +98,7 @@ web/
 │   ├── View/Install/         Sbpp\View\Install\* — install-wizard step DTOs (#1332)
 │   ├── Markup/               Sbpp\Markup\IntroRenderer — admin Markdown -> safe HTML
 │   ├── Servers/              Sbpp\Servers\{SourceQueryCache, RconStatusCache} — per-(ip, port) cache around the xPaw A2S probe (#1311) + per-sid cache around the RCON `status` command (#PLAYER_CTX_MENU)
-│   ├── Upload/               Sbpp\Upload\UploadHandler — shared file-upload handler (perm + CSRF + extension allowlist + filename sanitiser + popup chrome) for the demo / icon / mapimage popup pages (goals#5)
+│   ├── Upload/               Sbpp\Upload\UploadHandler — shared file-upload handler (perm + CSRF + extension allowlist + filename sanitiser + popup chrome) for the demo / icon / mapimage popup pages
 │   ├── Mail/                 Sbpp\Mail\{Mail,Mailer,EmailType} — Symfony Mailer wrapper + enum
 │   ├── Telemetry/            Sbpp\Telemetry\{Telemetry,Schema1} — anonymous opt-out daily ping (#1126); schema-1.lock.json is the vendored cross-repo contract
 │   ├── Announce/             Sbpp\Announce\{AnnouncementFetcher,Announcement} — anonymous opt-out daily fetch of project news / security advisories from https://sbpp.github.io/announcements.json (source of truth: docs/public/announcements.json); admin-only banner on the home dashboard

--- a/CLA.md
+++ b/CLA.md
@@ -152,18 +152,14 @@ the date the bot records it.
 ### Pre-CLA contribution history
 
 Contributions made to the Project before this CLA workflow landed
-(initial workflow rollout in `sbpp/goals#4` Phase 2) are addressed by
-the audit recorded at
-[`sbpp/goals#3`](https://github.com/sbpp/goals/issues/3). That audit
-confirmed that the surviving substantive `web/**` contributions
-prior to the CLA workflow are attributable to the project
-maintainer ([@rumblefrog](https://github.com/rumblefrog)), whose
-authorship clears the path for the
-[`sbpp/goals#4`](https://github.com/sbpp/goals/issues/4) relicense
-from CC BY-NC-SA 3.0 to the Elastic License 2.0 without contacting
-third-party contributors individually. The handful of small one-off
-external pre-CLA `web/**` PRs identified by the audit are listed in
-that issue; their authors are welcome to retroactively sign this
+are addressed by the project's pre-CLA contribution audit. The
+audit confirmed that the surviving substantive `web/**`
+contributions prior to the CLA workflow are attributable to the
+project maintainer ([@rumblefrog](https://github.com/rumblefrog)),
+whose authorship covers the relicense from CC BY-NC-SA 3.0 to the
+Elastic License 2.0 without contacting third-party contributors
+individually. Authors of the handful of small one-off external
+pre-CLA `web/**` PRs are welcome to retroactively sign this
 Agreement against any subsequent PR so the §3(b) relicense grant
 applies to their historical contributions too, but the project's
 ELv2 standing does not depend on those retroactive signatures.

--- a/README.md
+++ b/README.md
@@ -63,10 +63,10 @@ modernization work landing across v2.x.
 
 [![Sponsor on GitHub](https://img.shields.io/github/sponsors/sbpp?style=flat-square&logo=github&label=Sponsor%20on%20GitHub)](https://github.com/sponsors/sbpp)
 
-**Game-server hosts and SourceBans++-as-a-feature providers offering
-the panel as a hosted or managed service to third parties:** that
-use case is reserved by the Elastic License 2.0 and covered by a
-separate commercial license; see **License** below.
+**Game-server hosts offering the panel as a hosted or managed
+service to third parties:** that use case is reserved by the
+Elastic License 2.0 and covered by a separate commercial license;
+see **License** below.
 
 <!-- sponsors:start -->
 <!-- Corporate sponsor logos land here once the corporate tier ships. -->
@@ -76,23 +76,16 @@ separate commercial license; see **License** below.
 
 - **Web panel** (everything under `web/`): [Elastic License 2.0](LICENSE.txt).
   You may use, copy, modify, create derivative works of, and
-  redistribute the panel — for hobby use, community use, running it
+  redistribute the panel for hobby use, community use, running it
   for your own clan / network, bundling it into a Docker image,
-  publishing a Pterodactyl egg, packaging it for a distro, all of
-  that stays free. What ELv2 reserves is the right to **provide the
-  panel as a hosted or managed service to third parties** (the
-  classic "SourceBans++-as-a-feature" upsell from a game-server
-  hosting business); for that, a separate commercial license is
-  available. Open a thread in the
-  [Commercial licensing discussion category](https://github.com/sbpp/sourcebans-pp/discussions/categories/commercial-licensing)
-  or DM [@rumblefrog](https://github.com/rumblefrog) on the
-  SourceBans++ [Discord](https://discord.gg/tzqYqmAtF5) (a dedicated
-  inbox is on the roadmap once volume warrants it).
+  publishing a Pterodactyl egg, or packaging it for a distro. What
+  ELv2 reserves is the right to **provide the panel as a hosted
+  or managed service to third parties**; for that, a separate
+  commercial license is available. For commercial licensing
+  inquiries, reach out on the
+  [Discord](https://discord.gg/tzqYqmAtF5).
 - **SourceMod plugins** (everything under `game/addons/sourcemod/`):
-  [GPLv3](LICENSE-plugins.txt). Copyleft is the right tool there —
-  the managed-service loophole the Elastic License closes for the
-  panel doesn't exist for SourcePawn plugins that run in-process on
-  the customer's game server.
+  [GPLv3](LICENSE-plugins.txt).
 - **Vendored third-party code** (LightOpenID, TinyMCE, the
   SourceBans 1.4.x lineage, etc.) keeps its own license terms; see
   [`THIRD-PARTY-NOTICES.txt`](THIRD-PARTY-NOTICES.txt).

--- a/THIRD-PARTY-NOTICES.txt
+++ b/THIRD-PARTY-NOTICES.txt
@@ -11,13 +11,14 @@ are present in this distribution and the attributions owed to their
 authors per their respective licences.
 
 Pre-Elastic-License-2.0 (CC-BY-NC-SA 3.0) history note: prior to
-`goals#4`, the web panel rode CC BY-NC-SA 3.0. The relicense to ELv2
-was made under the authority of the contributor licence agreement
-(`CLA.md` §3(b)) and the audit recorded at `goals#3`. The InterWave
-Studios + SourceBans Team / GameConnect attributions below ride that
-historical CC-BY-NC-SA 3.0 lineage; they are preserved here as a
-matter of courtesy and to honour the spirit of CC BY-NC-SA 3.0 §4(c)
-as it applied to the panel at the time those upstreams were merged.
+v2.0.0, the web panel was distributed under CC BY-NC-SA 3.0. The
+relicense to ELv2 was made under the authority of the Contributor
+Licence Agreement (`CLA.md` §3(b)) and the project's pre-CLA
+contribution audit. The InterWave Studios + SourceBans Team /
+GameConnect attributions below ride that historical CC-BY-NC-SA 3.0
+lineage; they are preserved here as a matter of courtesy and to
+honour the spirit of CC BY-NC-SA 3.0 §4(c) as it applied to the
+panel at the time those upstreams were merged.
 
 If you are a downstream consumer (theme fork, distribution
 maintainer, vendor) and notice an attribution missing here, please
@@ -35,11 +36,11 @@ treat attribution drift as a bug.
                   (https://creativecommons.org/licenses/by-nc-sa/3.0/)
 
 SourceBans++ originated as a community fork of SourceBans 1.4.11 in
-2014 and has since been substantially rewritten — see issue #3 in
-https://github.com/sbpp/goals for a per-file audit confirming that
-the surviving v2.0 panel carries no substantive 1.4.11 source
-expression. However, the project's continuous-through-line traces
-back to that codebase in a number of structural ways:
+2014 and has since been substantially rewritten; the project's
+pre-CLA contribution audit confirmed that the surviving v2.0 panel
+carries no substantive 1.4.11 source expression. However, the
+project's continuous-through-line traces back to that codebase in a
+number of structural ways:
 
   - The MariaDB schema layout (`web/install/includes/sql/struc.sql`)
     inherits its table names, column names, and column types from
@@ -81,16 +82,15 @@ derivative work and remains under GPLv3 in lockstep — see
 `LICENSE-plugins.txt`. That continuity is explicit and load-
 bearing.
 
-The web panel's communications surfaces — the public
+The web panel's communications surfaces (the public
 `?p=commslist` page, the admin `?p=admin&c=comms` moderation
 queue, the `?p=admin&c=comms&section=search` advanced filter, and
-the `:prefix_comms` schema — were inspired by and historically
+the `:prefix_comms` schema) were inspired by and historically
 forked from the SourceComms panel add-on. The v2.0 panel
-rewrite (`goals#3` per-file audit + `goals#5` Route B rewrites)
-re-implemented every surface against the new typed View DTO +
-JSON API + vanilla JS chrome stack so that no SourceComms-panel
-source expression survives in the rendered v2.0 chrome. The
-remaining continuities are:
+rewrite re-implemented every surface against the new typed View
+DTO + JSON API + vanilla JS chrome stack so that no
+SourceComms-panel source expression survives in the rendered v2.0
+chrome. The remaining continuities are:
 
   - Table name (`:prefix_comms`) and column-name conventions
     (schema layout is factual, not expressive, but the lineage

--- a/docs/src/content/docs/faq/index.md
+++ b/docs/src/content/docs/faq/index.md
@@ -22,7 +22,7 @@ The [Overview](/getting-started/overview/) has the longer answer.
 
 ### Is it free?
 
-Yes — for everyone except game-server hosting companies who want to
+Yes, for everyone except game-server hosting companies who want to
 offer the panel to their customers as a hosted, managed service.
 
 The web panel is distributed under the
@@ -30,14 +30,13 @@ The web panel is distributed under the
 the SourceMod plugins are under
 [GPLv3](https://www.gnu.org/licenses/gpl-3.0.html). Hobby use,
 community use, running it for your own clan / network, bundling it
-into a Docker image, publishing a Pterodactyl egg, packaging it for
-a distro — all of that stays free under ELv2's terms. What ELv2
+into a Docker image, publishing a Pterodactyl egg, and packaging
+it for a distro all stay free under ELv2's terms. What ELv2
 reserves is the right to provide the panel as a hosted or managed
 service to third parties; if that's your business model, the
-project offers a separate commercial license. Open a thread in the
-[Commercial licensing discussion category](https://github.com/sbpp/sourcebans-pp/discussions/categories/commercial-licensing)
-or DM [@rumblefrog](https://github.com/rumblefrog) on the
-[Discord](https://discord.gg/tzqYqmAtF5) — see the
+project offers a separate commercial license. For commercial
+licensing inquiries, reach out on the
+[Discord](https://discord.gg/tzqYqmAtF5). See the
 [sponsor page](/sponsor/) for the longer breakdown.
 
 We don't sell hosting, support, or plugins ourselves.

--- a/docs/src/content/docs/sponsor.mdx
+++ b/docs/src/content/docs/sponsor.mdx
@@ -56,21 +56,12 @@ Money is one way; there are others. The project always welcomes:
   there is.
 
 :::note
-**Game-server hosts and SourceBans++-as-a-feature providers**: the
-web panel is distributed under the
+**Game-server hosts offering the panel as a hosted or managed
+service to third parties**: the web panel is distributed under the
 [Elastic License 2.0](https://www.elastic.co/licensing/elastic-license),
-which reserves the right to offer the panel as a hosted or managed
-service to third parties. If that's your business model — for
-example, surfacing SourceBans++ to your customers as a one-click
-add-on, white-labelling it inside a control panel, or running it
-on their behalf as part of a managed-game-server product — a
+which reserves that use case. If that's your business model, a
 separate commercial license is available.
 
-Open a thread in the
-[Commercial licensing discussion category](https://github.com/sbpp/sourcebans-pp/discussions/categories/commercial-licensing)
-to start the conversation publicly, or DM
-[@rumblefrog](https://github.com/rumblefrog) on the SourceBans++
-[Discord](https://discord.gg/tzqYqmAtF5) for a private
-introduction. A dedicated inbox is on the roadmap once commercial
-inquiry volume warrants the dedicated address.
+For commercial licensing inquiries, reach out on the
+[Discord](https://discord.gg/tzqYqmAtF5).
 :::

--- a/docs/src/content/docs/updating/1-8-to-2-0.mdx
+++ b/docs/src/content/docs/updating/1-8-to-2-0.mdx
@@ -23,8 +23,7 @@ The five things to know about the v2.0 upgrade:
    for logged-in admins. Opt-out is a one-line `config.php` define.
 5. The **web panel licence has changed** from CC BY-NC-SA 3.0 to the
    Elastic License 2.0. Hobby and community use stays free; offering
-   the panel as a hosted or managed service to third parties (the
-   classic game-server hosting "panel-as-a-feature" upsell) now
+   the panel as a hosted or managed service to third parties now
    requires a separate commercial licence. SourceMod plugins remain
    GPLv3. See [Licence change](#licence-change) below.
 
@@ -279,10 +278,8 @@ Most installs see no operational change. The matrix:
   managed service. Internal use isn't a third-party-managed-service
   use case.
 - **Game-server hosting providers offering SourceBans++ to your
-  customers as a hosted panel** (the "we install and manage it for
-  you, you click a button in your control panel and a SourceBans++
-  instance appears" upsell): this is the use case ELv2 reserves.
-  You need a commercial licence to keep doing this under v2.0.x —
+  customers as a hosted panel**: this is the use case ELv2 reserves.
+  You need a commercial licence to keep doing this under v2.0.x;
   see [Sponsor / commercial licensing](/sponsor/) for how to start
   the conversation. The project doesn't pursue retroactive
   enforcement against operators upgrading in good faith; reach out
@@ -290,7 +287,7 @@ Most installs see no operational change. The matrix:
   you.
 - **Forking and redistributing** the panel (publishing your own
   variant on GitHub, shipping a custom theme as part of a tarball):
-  still allowed. ELv2 requires you preserve the licence text +
+  still allowed. ELv2 requires you preserve the licence text and
   attribution notices (which the release artefacts already ship);
   the panel makes no other demands on your fork.
 
@@ -316,25 +313,23 @@ The maintainers' standing under ELv2 to relicense future
 contributions comes from the
 [Contributor License Agreement](https://github.com/sbpp/sourcebans-pp/blob/main/CLA.md)
 contributors sign on PRs touching `web/**`. The pre-CLA
-contribution history is covered by `sbpp/goals#3`'s audit (which
-confirmed [@rumblefrog](https://github.com/rumblefrog) as the sole
-significant pre-CLA contributor to the panel) and the relicense
-itself landed via `sbpp/goals#4`.
+contribution history is covered by the project's pre-CLA
+contribution audit, which confirmed the project maintainer as the
+sole significant pre-CLA contributor to the panel.
 
 ### Files that moved
 
-- `LICENSE.md` (CC BY-NC-SA 3.0 text) → deleted. ELv2 text now lives
-  at `LICENSE.txt`.
-- `LICENSE-plugins.txt` (new) — GPLv3 text for the SourceMod
+- `LICENSE.md` (CC BY-NC-SA 3.0 text) was deleted. ELv2 text now
+  lives at `LICENSE.txt`.
+- `LICENSE-plugins.txt` (new): GPLv3 text for the SourceMod
   plugins, broken out so the two licences are unambiguous.
-- `THIRD-PARTY-NOTICES.txt` (new) — bundled-third-party attributions
+- `THIRD-PARTY-NOTICES.txt` (new): bundled-third-party attributions
   (LightOpenID MIT, SourceBans 1.4.x + SourceComms + InterWave
   Studios theme.conf historical CC BY-NC-SA 3.0).
 - Every `.php` / `.js` / `.tpl` source-file header was updated from
-  the 17-line / 4-line legacy banner to the new 4-line ELv2 banner
-  (104 files swept; same operation that landed in `goals#5`).
+  the legacy banner to the new 4-line ELv2 banner.
 
-No operator action required for any of the file moves — the panel
+No operator action required for any of the file moves; the panel
 keeps running through the upgrade. The
 [Sponsor / commercial licensing](/sponsor/) page is the right place
 to read if you're affected by the managed-service reservation; the

--- a/web/includes/Upload/UploadHandler.php
+++ b/web/includes/Upload/UploadHandler.php
@@ -15,7 +15,7 @@ use LogType;
 /**
  * Shared file-upload chrome for the three pop-up upload handlers
  * (`admin.uploaddemo.php`, `admin.uploadicon.php`,
- * `admin.uploadmapimg.php` — issue sbpp/goals#5, Phase 2.5i).
+ * `admin.uploadmapimg.php`).
  *
  * The pre-rewrite path duplicated the same six-step flow across the
  * three pages (CSRF check → extension allowlist → `move_uploaded_file`

--- a/web/includes/View/AdminHomeView.php
+++ b/web/includes/View/AdminHomeView.php
@@ -30,10 +30,10 @@ namespace Sbpp\View;
  * Comms intentionally folds into the sidebar nav (`admin/comms`) and
  * does not surface a separate Comms card on the landing.
  *
- * Pre-#5 this DTO also carried a `access_*` / `demosize` / `total_*` /
+ * This DTO previously carried a `access_*` / `demosize` / `total_*` /
  * `archived_*` legacy compatibility surface for theme forks of the
- * pre-v2.0.0 default. `goals#5` deletes those properties along with
- * the COUNT compute that backed them; theme forks still rendering
+ * pre-v2.0.0 default. The v2.0 rewrite deletes those properties along
+ * with the COUNT compute that backed them; theme forks still rendering
  * the legacy stat-counts row must migrate to the 8-card grid or
  * compute the values themselves.
  */

--- a/web/includes/View/EditAdminPermsView.php
+++ b/web/includes/View/EditAdminPermsView.php
@@ -8,7 +8,7 @@ declare(strict_types=1);
 namespace Sbpp\View;
 
 /**
- * "Edit admin permissions" page (issue sbpp/goals#5, Phase 2.5c).
+ * "Edit admin permissions" page.
  *
  * Pre-rewrite the page handler `echo`'d a 1.4.11-shaped HTML form
  * built around `groups.web.perm.php` / `groups.server.perm.php`

--- a/web/includes/View/EditGroupView.php
+++ b/web/includes/View/EditGroupView.php
@@ -8,7 +8,7 @@ declare(strict_types=1);
 namespace Sbpp\View;
 
 /**
- * "Edit group" page (issue sbpp/goals#5, Phase 2.5f).
+ * "Edit group" page.
  *
  * Single template covers both `?type=web` and `?type=srv` (also the
  * legacy `?type=server` alias used by the admin-groups list links).

--- a/web/install/pages/page.1.php
+++ b/web/install/pages/page.1.php
@@ -19,44 +19,39 @@ require_once PANEL_INCLUDES_PATH . '/View/Install/InstallLicenseView.php';
 require_once PANEL_INCLUDES_PATH . '/View/Renderer.php';
 
 // Short-form license summary. The full legal text lives at
-// LICENSE.txt in the repo root — a textarea-with-12-pages-of-text
+// LICENSE.txt in the repo root; a textarea-with-12-pages-of-text
 // reads as legalese-noise that nobody reads, so we surface a
-// human-readable summary + the canonical reference link.
+// human-readable summary plus the canonical reference link.
 //
 // Issue #1335 m2: pre-fix this step used British "Licence"
 // throughout (page title, step title, step label, body copy, the
 // checkbox label). Everywhere else in the repo uses American
-// "License" — README, file paths (`page_license.tpl`), test IDs
-// (`install-license-*`), the project's own `LICENSE.txt`. Standardise
+// "License" (README, file paths (`page_license.tpl`), test IDs
+// (`install-license-*`), the project's own `LICENSE.txt`). Standardise
 // here too.
 //
-// `goals#4`: the license itself flipped from CC-BY-NC-SA 3.0 to
-// the Elastic License 2.0 — a software-purpose, source-available
-// license whose "no managed service to third parties" restriction
-// is the precise legal vehicle for the dual-licensing arrangement
-// the README + commercial-license track described all along.
-// `THIRD-PARTY-NOTICES.txt` carries the upstream-lineage attributions
-// (SourceBans 1.4.x, SourceComms, InterWave Studios theme.conf,
-// LightOpenID, TinyMCE).
+// v2.0.0 flipped the panel license from CC-BY-NC-SA 3.0 to the
+// Elastic License 2.0, a software-purpose, source-available
+// license. `THIRD-PARTY-NOTICES.txt` carries the upstream-lineage
+// attributions (SourceBans 1.4.x, SourceComms, InterWave Studios
+// theme.conf, LightOpenID, TinyMCE).
 $licenseText = <<<'TEXT'
 This installation of SourceBans++ is governed by the project's
 license:
 
   - The web panel is distributed under the Elastic License 2.0
     (ELv2). You may use, copy, modify, create derivative works of,
-    and redistribute the panel — for hobby use, community use,
+    and redistribute the panel for hobby use, community use,
     bundling it into a Docker image, packaging it for a distro,
-    publishing a Pterodactyl egg, all of that stays free.
+    or publishing a Pterodactyl egg. All of that stays free.
 
     What ELv2 reserves is the right to provide the panel as a
-    hosted or managed service to third parties. Concretely, if you
-    plan to (a) sell SourceBans++ to your customers as a one-click
-    hosted add-on inside a game-server control panel, (b) run the
-    panel on your customers' behalf as part of a managed-server
-    product, or (c) white-label the panel and resell it, a
-    separate commercial license is needed for those use cases.
-    Self-hosting for your own community, clan, or network is not
-    a "managed service to third parties" and is free under ELv2.
+    hosted or managed service to third parties. If your business
+    model involves offering SourceBans++ to your customers as a
+    hosted, managed product, a separate commercial license is
+    required. Self-hosting for your own community, clan, or
+    network is not a "managed service to third parties" and is
+    free under ELv2.
 
   - The bundled SourceMod plugins are distributed under the GNU
     General Public License version 3 (GPL-3.0).
@@ -69,8 +64,8 @@ license:
 By installing SourceBans++ you agree to comply with the terms of
 the licenses above. Full text:
 
-  - LICENSE.txt           (Elastic License 2.0 — shipped at the root of this install)
-  - LICENSE-plugins.txt   (GPLv3 — shipped at the root of this install)
+  - LICENSE.txt           (Elastic License 2.0, shipped at the root of this install)
+  - LICENSE-plugins.txt   (GPLv3, shipped at the root of this install)
   - https://www.elastic.co/licensing/elastic-license
   - https://www.gnu.org/licenses/gpl-3.0.html
 

--- a/web/pages/_admin_edit_helpers.php
+++ b/web/pages/_admin_edit_helpers.php
@@ -6,8 +6,7 @@
 declare(strict_types=1);
 
 /**
- * Shared helpers for the `admin.edit.*` cluster (issue sbpp/goals#5,
- * Phase 2.5).
+ * Shared helpers for the `admin.edit.*` cluster.
  *
  * Pre-fix every page handler in the cluster carried its own ad-hoc
  * `<script>ShowBox(…)</script>` emitter, its own `errorScript .= "$('id.msg')…"`

--- a/web/pages/page.admin.php
+++ b/web/pages/page.admin.php
@@ -31,7 +31,7 @@ global $userbank, $theme;
  * for the legacy v1.x stat-counts row. The v2.0 8-card grid never
  * displayed those values, and the compute was gated behind a
  * `Sbpp\Theme::wantsLegacyAdminCounts()` opt-in for theme forks that
- * still rendered them. `goals#5` deletes both halves: the gate, the
+ * still rendered them. The v2.0 rewrite deletes both halves: the gate, the
  * `access_*` / `total_*` / `archived_*` / `demosize` properties on
  * `AdminHomeView`, and the matching `{if false}` parity block in
  * `page_admin.tpl` that kept SmartyTemplateRule green. Theme forks

--- a/web/themes/default/page_admin_edit_admins_perms.tpl
+++ b/web/themes/default/page_admin_edit_admins_perms.tpl
@@ -3,8 +3,8 @@
     Licensed under the Elastic License 2.0.
     See LICENSE.txt for the full license text and THIRD-PARTY-NOTICES.txt for attributions.
 
-    "Edit admin permissions" — pair: web/pages/admin.edit.adminperms.php +
-    web/includes/View/EditAdminPermsView.php (issue sbpp/goals#5, Phase 2.5c).
+    "Edit admin permissions" pair: web/pages/admin.edit.adminperms.php +
+    web/includes/View/EditAdminPermsView.php.
 
     Replaces the v1.x-era inline `echo` of `groups.web.perm.php` and
     `groups.server.perm.php` partials and their `ProcessEditAdminPermissions()`

--- a/web/themes/default/page_admin_edit_group.tpl
+++ b/web/themes/default/page_admin_edit_group.tpl
@@ -3,8 +3,8 @@
     Licensed under the Elastic License 2.0.
     See LICENSE.txt for the full license text and THIRD-PARTY-NOTICES.txt for attributions.
 
-    "Edit group" — pair: web/pages/admin.edit.group.php +
-    web/includes/View/EditGroupView.php (issue sbpp/goals#5, Phase 2.5f).
+    "Edit group" pair: web/pages/admin.edit.group.php +
+    web/includes/View/EditGroupView.php.
 
     Replaces the v1.x-era inline `echo` of `groups.web.perm.php` /
     `groups.server.perm.php` partials and the `ProcessEditGroup()` /

--- a/web/themes/default/page_admin_edit_mod.tpl
+++ b/web/themes/default/page_admin_edit_mod.tpl
@@ -3,9 +3,8 @@
     Licensed under the Elastic License 2.0.
     See LICENSE.txt for the full license text and THIRD-PARTY-NOTICES.txt for attributions.
 
-    "Edit mod" — pair: web/pages/admin.edit.mod.php +
-    web/includes/View/AdminEditModView.php (issue sbpp/goals#5,
-    Phase 2.5g).
+    "Edit mod" pair: web/pages/admin.edit.mod.php +
+    web/includes/View/AdminEditModView.php.
 
     Submission stays form-POST (admin.edit.mod.php still owns the
     UPDATE round-trip) but error display is now server-side: empty


### PR DESCRIPTION
## Summary

Follow-up to #1465. Tightens user-facing copy around the new
Elastic License 2.0 licensing model and consolidates internal
references throughout the docs and source-code comments.

User-facing surfaces:

- \`README.md\`: simplifies the GPLv3 bullet and the "what ELv2
  reserves" paragraph; replaces the dead GitHub Discussions link
  and personal DM routing with a generic "reach out on the Discord"
  line.
- \`docs/src/content/docs/sponsor.mdx\`: simplifies the commercial
  licensing aside; same routing change.
- \`docs/src/content/docs/faq/index.md\`: trims the "Is it free?"
  answer to the same shape.
- \`docs/src/content/docs/updating/1-8-to-2-0.mdx\`: replaces
  internal-issue references with neutral phrasing.
- \`web/install/pages/page.1.php\`: cleans up the on-install license
  blurb and the internal comment block.

Project / contributor docs:

- \`CLA.md\`: replaces direct issue links with "the project's
  pre-CLA contribution audit".
- \`THIRD-PARTY-NOTICES.txt\`: same treatment for the
  upstream-lineage attributions block.
- \`AGENTS.md\`: consolidates internal issue references in the
  Namespacing table, CLA gate block, anti-pattern entries, and the
  "Where to find what" rows.
- \`ARCHITECTURE.md\`: drops the trailing internal reference from
  the directory layout entry.

Internal source-code comments:

- \`web/includes/Upload/UploadHandler.php\`,
  \`web/includes/View/AdminHomeView.php\`,
  \`web/includes/View/EditAdminPermsView.php\`,
  \`web/includes/View/EditGroupView.php\`,
  \`web/pages/_admin_edit_helpers.php\`,
  \`web/pages/page.admin.php\`, and the three
  \`web/themes/default/page_admin_edit_*.tpl\` files: trim internal
  issue references from file-header / docblock comments.

No code paths or behaviour change; docs / comments only.

## Test plan

- [ ] CI passes (PHPStan, PHPUnit, ts-check, API contract, Playwright, plugin-build, CLA)
- [ ] Visual diff on the install wizard's step 1 (license-accept page) still reads correctly
- [ ] Visual diff on the docs site (\`/sponsor/\`, \`/faq/\`, \`/updating/1-8-to-2-0/\`)