### PR TITLE
feat(export): full data export — ZIP download + S3 presigned upload

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,6 +64,7 @@ code change — never as a follow-up. CI doesn't gate this; it's on you.
 | Publish or amend a project announcement (the admin-only home-dashboard banner) | `docs/public/announcements.json` (Astro publishes it as a static asset at `https://sbpp.github.io/announcements.json`). One-file source of truth — don't reach for an admin endpoint, an in-panel composer, or a separate git repo. Schema + sort + expiry rules are in `docs/src/content/docs/configuring/announcements.mdx` (operator-facing) and the "Project announcements feed" Conventions block in `AGENTS.md` (agent-facing). The starter file is `[]` (empty array); the deploy chain (`docs-deploy-trigger.yml`) ships the updated file within minutes of merge to `main`. |
 | Add or edit a project sponsor / funding platform / sponsor tier | `docs/src/data/sponsors.json` is the single source of truth. Three top-level keys: `platforms` (`{id, name, url, description?, icon?}` — funding channels), `tiers` (`{id, name, monthlyMinUsd?, description?}` — ordered display tiers), `sponsors` (`{name, url?, logo?, tier?, since?}` — `tier` matches a tier `id`, missing/empty places the sponsor in the "Individual supporters" bucket). The docs `/sponsor/` landing page (`docs/src/content/docs/sponsor.mdx`) renders the file via `docs/src/components/Sponsors.astro`; the topbar heart icon, the per-page footer link, the panel-side footer link (`web/themes/default/core/footer.tpl` — #1417 added a `data-testid="app-footer-sponsor"` anchor pointing at the same `/sponsor/` landing page), and `.github/FUNDING.yml`'s `custom:` URL all point at `/sponsor/`. A future README-injector script will read the same file. Adding a new platform (Open Collective, Patreon, …) is a one-line append to `platforms`; no component / config / template edit required, and no panel release needed (the panel link points at the docs anchor, not at any single platform URL). The docs page is intentionally absent from `astro.config.mjs`'s `sidebar` (reached only via the heart icon + footer + FUNDING.yml). Issues #1416 / #1417. |
 | Touch any UI under `web/install/` or the panel chrome that's screenshotted in docs | Run `npm run capture` in `docs/` locally and commit the PNG diff. Maintainers can alternatively apply the `safe-to-screenshot` label after reviewing the PR diff so `docs-screenshots-capture.yml` regenerates the captures (see `docs/README.md` for the security model + label-strip-on-push contract) |
+| Touch `web/includes/Export/**`, `web/export.php`, `web/pages/admin.export.php`, `web/includes/View/AdminExportView.php`, or `web/themes/default/page_admin_export.tpl` (the "Full data export" feature) | `AGENTS.md` (the "Full data export" Conventions block + the "Build / extend the owner-only full data export feature" row in "Where to find what" + the "Generate a presigned S3 PUT URL for the panel's Full data export S3 mode" row when the operator workflow changes) + `ARCHITECTURE.md` (the "Data export" subsystem section + the `web/includes/Export/` line in the Directory layout + the `web/export.php` line in the panel-root scripts list) + `docs/src/content/docs/configuring/data-export.mdx` (operator-facing — what's in the bundle, delivery modes, presigned-URL workflows per provider, the security model summary, troubleshooting). The wire-format contract (`null`-for-absent, Steam64-as-decimal-string, unix-seconds, manifest-first) is the load-bearing piece downstream consumers rely on — any change to the JSONL shape or manifest schema bumps `Manifest::FORMAT_VERSION` AND lands a paired downstream-migration note in the operator-facing docs. The forbidden-columns list (`admins.password` / `validate` / `attempts` / `lockout_until` / `servers.rcon` / `settings.smtp.pass` / `settings.telemetry.instance_id`) is hard-coded in `EntityExporter` — relaxing it silently invalidates the manifest's `pii_policy.password_hashes: "never"` attestation; never reach for "let me read the schema and deny dynamically" because a future column addition would slip through that gate. |
 | Change panel theme tokens — palette, geometry, semantic colors — in `web/themes/default/css/theme.css` (the `:root` block or `html.dark` overrides) | Mirror the change in `docs/src/styles/sbpp.css` so the docs site stays visually consistent with the panel. Same PR. (Fonts intentionally not mirrored — see #2.) |
 
 Quick rules:
@@ -2311,6 +2312,272 @@ any real content goes out — same shape `Sbpp\Telemetry\Schema1`'s
 lock file uses (file shape pinned by tests, content can change
 freely).
 
+### Full data export (`Sbpp\Export\*`)
+
+Owner-only, synchronous, one-shot streamed ZIP bundle of every row
+in the database plus every uploaded demo. Reachable at
+`?p=admin&c=export`; the actual streaming work lives at panel-root
+in `web/export.php` because the wire format is binary
+(`Content-Type: application/zip`) and doesn't fit the JSON API
+dispatcher's `Content-Type: application/json` contract — same shape
+as the long-standing `web/exportbans.php` (public ban-list export)
+and `web/getdemo.php` (single demo download).
+
+Subsystem shape: five classes under `Sbpp\Export\*`
+(`ManifestBuilder` / `EntityExporter` / `BundleWriter` /
+`S3PresignedUploader` / `ExportError`) plus the `Manifest` DTO, the
+`web/export.php` entry point, the `web/pages/admin.export.php` page
+handler, the `Sbpp\View\AdminExportView` DTO, and the
+`web/themes/default/page_admin_export.tpl` form template.
+
+The contract:
+
+- **Synchronous, in-request execution.** No queue, no background
+  worker, no FPM-only `fastcgi_finish_request()` trickery — the
+  request stays open for the full duration of the export. The
+  panel is shared-host-friendly first; reaching for a worker
+  daemon would close that door for the majority of self-hosters.
+  Shared-host hardening on the entry point is the three-pronged
+  triplet: `@set_time_limit(0)` (no max-execution-time abort),
+  `@ini_set('memory_limit', '256M')` (the writer streams, so the
+  resident set stays bounded; the bump is for the SELECT cursors
+  + the ZIP-mode in-flight encryption buffers), and
+  `ignore_user_abort(true)` (a client disconnect mid-stream must
+  NOT tear down the script — the audit-log entry needs to land
+  even on the abort path). The `@` guards a host with
+  `disable_functions = set_time_limit,ini_set` from injecting
+  warning text into the streamed response body.
+- **Two delivery modes (deliberately asymmetric).** The asymmetry
+  is structural — `zip` mode streams straight to `php://output`
+  with `flushAfterEntries=true` so the browser's download progress
+  bar moves in real time, while `s3` mode builds to a tempfile
+  under `SB_CACHE/exports/<bundle_id>.zip` and then PUTs the
+  finished file in a second cURL call. The reason for the
+  asymmetry: presigned S3 PUT signatures bind a specific
+  `Content-Length` value (and the spec rejects chunked-transfer-
+  encoded PUTs), so the bundle has to fully materialise before the
+  upload knows its size. The shutdown function registered BEFORE
+  the build wipes the tempfile even when a mid-build fatal
+  escapes — `if (is_file($tmp)) @unlink($tmp);` covers the
+  normal-exit + uncaught-Throwable + client-abort cases uniformly.
+- **Manifest-first contract.** `BundleWriter::write()` emits
+  `manifest.json` as the FIRST ZIP entry via `addFile()` BEFORE
+  any entity stream or demo file lands. A downstream consumer
+  can short-circuit the bundle to read just the PII policy / row
+  counts by parsing one central-directory entry. The contract is
+  pinned by `ExportBundleWriterTest`'s `statIndex(0)['name'] ===
+  'manifest.json'` assertion; the writer's structure is what makes
+  the assertion stable, NOT alphabetical ordering of the entity
+  list (which would land `admins.jsonl` first if you trusted
+  ordering alone).
+- **No ZIP64.** The `ZipStream` is constructed with `$enableZip64
+  = false`. ZIP64 support across consumer tools is patchy (Windows
+  Explorer's built-in unzipper, macOS Archive Utility, cloud
+  console previewers all handle ZIP 2.0 reliably; ZIP64 is the
+  hit-or-miss arm). The 4 GiB ceiling is the cap consequence; the
+  manifest's `MAX_BUNDLE_BYTES = 4 * 1024**3` constant carries
+  the spec ceiling, `SAFETY_MARGIN_BYTES = 64 * 1024**2` is the
+  cushion against the central directory / per-entry overhead /
+  JSONL byte-estimate undershoot. Pre-flight in `ManifestBuilder`
+  subtracts the margin before comparing the estimate against
+  the ceiling AND the writer re-checks the running compressed-byte
+  total per-entity (defence-in-depth against pre-flight
+  undershooting).
+- **JSONL wire contracts (uniform across every entity).** The
+  contracts are: `null` for absent values (never `""`, never an
+  omitted field — consumers can iterate `Object.keys()` confident
+  the set is stable per entity); timestamps as unix-seconds
+  integers (every `int(11) created` column gets `(int)`-cast,
+  every `datetime` column routes through `strtotime`); Steam64 IDs
+  as decimal STRINGS, not JSON numbers (Steam64 exceeds
+  `Number.MAX_SAFE_INTEGER` and silently round-trips wrong through
+  any consumer using double-precision floats; `authid_steam2`
+  preserves the legacy `STEAM_X:Y:Z` shape alongside); source PKs
+  renamed to `id` (`admins.aid` → `id`, `bans.bid` → `id`, etc.);
+  JSON encoder flags ALWAYS include `JSON_INVALID_UTF8_SUBSTITUTE`
+  (player names on `:prefix_bans.name` / `:prefix_comms.name` can
+  carry malformed UTF-8 from the pre-#1108 / #765 Latin-1-on-utf8
+  truncation shape — without the flag the export 500s mid-stream
+  on a hostile-historical row, same load-bearing reason `Toast::emit`
+  carries the flag). The contracts are wholesale documented in
+  `EntityExporter`'s class docblock; new entity additions inherit
+  the entire set.
+- **Forbidden columns are hard-coded.** `EntityExporter`'s class
+  constants `FORBIDDEN_ADMIN_COLUMNS`, `FORBIDDEN_SERVER_COLUMNS`,
+  and `FORBIDDEN_SETTING_KEYS` enumerate every value the bundle
+  MUST NEVER carry: `admins.password` (bcrypt hash),
+  `admins.validate` / `admins.attempts` / `admins.lockout_until`
+  (live session credentials), `servers.rcon` (RCON password), and
+  the `settings` rows with key `smtp.pass` (SMTP credential) or
+  `telemetry.instance_id` (deliberately panel-local). The filter
+  applies at the SQL `SELECT` / `WHERE` layer so the values never
+  reach PHP memory; the unit tests assert by grep that the values
+  literally don't appear in the JSONL output. The list is
+  intentionally pre-encoded — NEVER reach for "let me read the
+  schema and deny dynamically", because a future column addition
+  would silently slip through that gate. The manifest's
+  `password_hashes: "never"` PII attestation is operator-facing
+  and load-bearing on this contract.
+- **Owner-only.** Every PII category the panel knows about is in
+  scope (admin emails, IP addresses, every Steam ID, every unban
+  reason, every admin-authored comment, every note). A partial-
+  permission admin who could export everything is functionally an
+  owner, so granular delegation isn't meaningful. Deliberately
+  deferred to a future version when downstream consumers have
+  asked for a use case the current shape doesn't cover. The
+  gate's defence-in-depth shape is THREE layers: (1) page-builder
+  routes `?p=admin&c=export` to `admin.export.php` ONLY for
+  callers holding `ADMIN_OWNER`; (2) `admin.export.php` re-checks
+  via `CheckAdminAccess(ADMIN_OWNER)`; (3) `web/export.php`'s
+  entry-point checks `$userbank->HasAccess(WebPermission::Owner)`
+  BEFORE the CSRF gate even runs and lands a `LogType::Warning`
+  row in the audit log on the deny branch so a triage flow can
+  find the attempt. The chrome-side filtering on navbar +
+  PaletteActions hides the entry from non-owners but is UX gating
+  only — the load-bearing security gate is the entry point.
+- **No new permission flag.** `ADMIN_OWNER` only.
+  `web/configs/permissions/web.json` is UNTOUCHED; no new
+  `Perms.*` member, no `api-contract.js` regen, no new
+  `WebPermission` enum case. The reasoning matches "Owner-only"
+  above — the feature's PII surface is the full panel dataset,
+  and a granular flag whose holder can export everything is
+  indistinguishable from `ADMIN_OWNER` itself.
+- **No schema change.** V1 is one-shot — every export starts from
+  a fresh pre-flight pass. No `:prefix_exports` table, no
+  scheduled-job state, no persistent in-DB tracking. The audit
+  log (`Log::add(LogType::Message, 'Data Export', ...)` on
+  success, `LogType::Error` on failure) carries the durable
+  record per attempt: acting admin's `aid`, the mode (`zip` vs
+  `s3`), the bundle's UUIDv4, the estimated + actual byte counts,
+  and the `ExportError::code()` on the failure branch. No paired
+  updater migration ships with this subsystem.
+- **No JSON API handler.** The entry point at `web/export.php` is
+  a top-level streaming script with a binary wire format (`Content-Type:
+  application/zip`); the JSON API dispatcher's contract is JSON
+  envelopes, with no extension point for streaming binary. Reaching
+  for a JSON handler that returns a download URL was considered
+  and rejected because the download URL would itself need to land
+  on a panel-root streaming script (the same problem one indirection
+  removed). The pattern is symmetric to `exportbans.php` and
+  `getdemo.php`; future binary-wire features land at panel-root
+  too.
+- **Error handling.** The entry point catches ONLY `ExportError`
+  — anything else (a real DB outage, a memory exhaustion, a
+  regression in the writer) propagates to the dispatcher's generic
+  500 so the stack trace lands in the audit log via the project's
+  error handler. Catching `\Throwable` blanket would mask real
+  bugs behind a generic "export failed" toast. The supported
+  `ExportError` codes are class constants (`CAP_EXCEEDED`,
+  `S3_PUT_FAILED`, `PRESIGN_INVALID_SCHEME`,
+  `PRESIGN_INVALID_URL`, `DISK_WRITE_FAILED`, `DISK_FULL`) so
+  call sites can't typo a string literal; `web/pages/admin.export.php`'s
+  `sbpp_admin_export_describe_error()` `match` table maps each
+  code to an operator-readable toast body.
+- **Persistent error toast on the redirect-back branch.** The
+  page handler's `?result=error&code=<code>` arm emits via
+  `\Sbpp\View\Toast::emit('error', 'Export failed', ..., null, 0)`
+  — `duration_ms: 0` (persistent) with `$redirect: null` per the
+  Toast contract. Destructive operations that failed mid-flight
+  carry potential cleanup work for the operator (a stale tempfile,
+  an upstream charge), and the operator MUST acknowledge before
+  moving on. The success arm emits a non-persistent confirmation
+  via the default chrome timing — routine success doesn't need
+  the X-click acknowledgement. See "Server-side toast emission"
+  earlier in this file for the full contract.
+- **S3 scheme guard is unconditional.** `S3PresignedUploader`
+  refuses `http://` URLs server-side regardless of caller — the
+  bundle carries the full panel PII dataset; cleartext transit
+  for that workload is unsupported. The form template's
+  `pattern="^https://[^\s]+$"` HTML5 attribute is the UX-first
+  gate; the server-side `parse_url` + scheme check is the
+  load-bearing security gate. URL parse failures raise
+  `PRESIGN_INVALID_URL` BEFORE any network call fires.
+- **No `try/catch (\Throwable)` around the entry point body.**
+  Per the "Error handling" entry above. The only legitimate
+  catches in the entry point are the two specific `ExportError`
+  catches (pre-flight, mid-build) — both surface the error code
+  to the redirect URL and the audit log. Anything else
+  intentionally falls through to the dispatcher's 500.
+
+Test override: `S3PresignedUploader::_setHttpTransportForTests(?callable
+$transport)` swaps the cURL call with a closure that receives
+`(string $url, string $localPath, int $size): array{http_code: int,
+body: string}` and returns the shape the production path produces.
+Mirrors `Sbpp\Announce\AnnouncementFetcher::_setHttpFetcherForTests`
++ `Sbpp\Servers\SourceQueryCache::setProbeOverrideForTesting`.
+Production code never sets it; integration tests use it to pin the
+wire-layer contract without spinning up a real S3 endpoint.
+
+Regression guards:
+
+- `web/tests/unit/EntityExporterTest.php` — per-entity contract:
+  `FORBIDDEN_*` columns never appear in the JSONL, SteamID
+  conversion produces decimal strings, `comms.mute_kind` enum,
+  partial-removal `state` derivation across the
+  `BanType × BanRemoval` matrix, empty-entity yields no lines,
+  the `null`-for-absent contract, the `log.level` derivation,
+  the unix-seconds timestamp contract.
+- `web/tests/unit/ManifestBuilderTest.php` — cap math constants
+  (`MAX_BUNDLE_BYTES`, `SAFETY_MARGIN_BYTES`), UUIDv4 shape
+  (regex + version + variant nibbles), bundle ID uniqueness
+  across builds, `created_at` is integer unix seconds,
+  `pii_policy` block presence + every required field,
+  `format_version = 1`, `toJson()` output shape.
+- `web/tests/integration/ExportBundleWriterTest.php` — full
+  export against the test fixture. Asserts the manifest-first
+  contract (`statIndex(0)['name'] === 'manifest.json'`),
+  manifest's `row_counts.<entity>` equals the literal
+  newline-separated line count in `entities/<entity>.jsonl`,
+  every demo entry's compression method is `ZipArchive::CM_STORE`,
+  every JSONL line parses as a JSON object with an `id` field,
+  no SteamID appears as a JSON number (grep for
+  `"authid":\s*\d+`), every timestamp field is integer,
+  forbidden column values never appear in the bundle (grep for
+  bcrypt hash patterns / `rcon` password values / `smtp.pass`
+  values / `telemetry.instance_id` values).
+- `web/tests/integration/AdminExportPermissionTest.php` — the
+  static-shape permission gate: the navbar entry, the
+  PaletteActions entry, the page-builder route, the page
+  handler's `CheckAdminAccess` call, and the entry-point's
+  `HasAccess(WebPermission::Owner)` check all key on
+  `ADMIN_OWNER`. Catches a future "let me sneak this through
+  on a partial flag" refactor at PR time.
+- `web/tests/integration/AdminExportRuntimePermissionTest.php`
+  — the runtime-primitive gate: `CSRF::validate()` returns the
+  expected verdict on the canonical valid + invalid + empty
+  token cases; `CUserManager::HasAccess(WebPermission::Owner)`
+  returns the expected verdict for an owner / non-owner / no-
+  session caller; the `SourceMod root char alone` case doesn't
+  grant `WebPermission::Owner` (defence against a future SM-char
+  delegation that would otherwise sneak through). Page-handler
+  `require` tests were tried and dropped because PHP's `exit`
+  (called by `CheckAdminAccess`) is uncatchable and terminates
+  the child process before PHPUnit can serialize results; the
+  Playwright spec covers the end-to-end runtime contract
+  instead.
+- `web/tests/integration/S3PresignedUploaderTest.php` — the
+  wire-layer contract via `_setHttpTransportForTests`. Asserts:
+  `http://` URL rejected with `PRESIGN_INVALID_SCHEME` (no
+  transport call fires), non-URL string rejected with
+  `PRESIGN_INVALID_URL`, happy path passes the correct
+  `(url, localPath, size)` triple to the transport, success
+  codes 200/201/204 don't throw, 403 throws `S3_PUT_FAILED`
+  with the response body truncated to 2 KiB in the exception
+  message, the byte-stable error code constants stay byte-stable.
+- `web/tests/e2e/specs/flows/data-export.spec.ts` — end-to-end:
+  log in as the seeded `admin/admin` (owner storage state),
+  navigate to `?p=admin&c=export`, click the "Export as ZIP"
+  submit button (anchored on `[data-testid="admin-export-zip-submit"]`),
+  capture the streamed download via `page.waitForEvent('download')`,
+  parse the resulting ZIP with `jszip`, assert: zip parses,
+  first entry is `manifest.json`, manifest carries
+  `format_version: 1` + valid UUIDv4 `bundle_id` + integer
+  `created_at` + `row_counts` dict (with `admins >= 1`) + the
+  `pii_policy.password_hashes: "never"` attestation. Also
+  asserts `GET /export.php` returns HTTP 405 (POST-only
+  enforcement). The spec covers the marquee end-to-end shape
+  the static + primitive tests can't reach.
+
 ### Admin-authored display text (`Sbpp\Markup\IntroRenderer`)
 
 - Anything an admin types in the panel that we render to other users
@@ -4547,6 +4814,8 @@ contributions without contacting every contributor individually.
 | Embed the sponsor roll on a docs page other than `/sponsor/` (e.g. a future docs index hero) | Import `docs/src/components/Sponsors.astro` and render `<Sponsors showPlatforms={false} />` — the component reads `docs/src/data/sponsors.json` and renders just the tier-grouped roll (with the "Individual supporters" bucket) when `showPlatforms` is false. `showEmptyHint={false}` additionally suppresses the "be the first" line when the roll is empty. The component renders its own `<h2>` headings; the embedding page should not add a parallel `## Our sponsors` heading or the chrome doubles. Issue #1416. |
 | Build / extend the daily project-announcements feed (banner-side wiring; mirror of telemetry) | `web/includes/Announce/AnnouncementFetcher.php` (`Sbpp\Announce\AnnouncementFetcher` — `latest()`, `tickIfDue()`, `_setHttpFetcherForTests()`) + `web/includes/Announce/Announcement.php` (the readonly DTO). Tick is registered at the tail of `init.php` via `register_shutdown_function`, gated on a non-empty `SB_ANNOUNCEMENTS_URL` constant (with the `if (!defined(...))` shape so `config.php` can override — empty string is the documented air-gap escape hatch; non-`http(s)://` schemes are also treated as air-gap by `resolveUpstreamUrl`'s scheme guard so a `file://` / `php://` / `phar://` / `data://` typo can't pull arbitrary local files into the cache). Cache shape mirrors `system.check_version`'s `_api_system_release_save_cache` (atomic tempfile + rename under `SB_CACHE/announcements.json`, persisted as the upstream body verbatim; the cache load path also caps the read at 256 KiB so a hostile / hand-edited cache file can't OOM the worker before the post-read size check fires). Wire layer mirrors `system.check_version`'s fetch helper: 5s combined connect+read timeout (PHP's stream wrapper exposes a single knob — split into connect + total only if a future cURL reshape lands), `User-Agent: SourceBans++/<ver> (announcements)`, 256 KiB body cap. The page handler in `web/pages/page.home.php` short-circuits to `null` for anonymous + non-admin viewers; the View DTO `HomeDashboardView` carries `?array $announcement`; the template (`page_dashboard.tpl`) gates the entire `<aside>` block on truthy. Markdown rendering goes through `Sbpp\Markup\IntroRenderer::renderIntroText()` and lands as `body_html` on the DTO — the template emits it with `{nofilter}` per the documented contract. Test override: `_setHttpFetcherForTests(?callable)` mirrors `Sbpp\Servers\SourceQueryCache::setProbeOverrideForTesting`. Regression guards: `web/tests/integration/AnnouncementFetcherTest.php` (cache shape, atomic write, stale-while-error, body-cap, expired-entry filter, malformed JSON, IntroRenderer integration, URL-scheme rejection, dedup, sort), `web/tests/integration/HomeDashboardAnnouncementTest.php` (admin sees / anonymous doesn't / cold cache yields null — process-isolated render with stub Smarty), `web/tests/e2e/specs/flows/dashboard-announcement.spec.ts` (end-to-end mount + disclosure expand + `rel="noopener noreferrer"` + axe-clean + anonymous-storage-state arm). E2E cache seeding shim: `web/tests/e2e/scripts/seed-announcements-e2e.php` + `seedAnnouncementsE2e` / `clearAnnouncementsCacheE2e` in `fixtures/db.ts`. See "Project announcements feed" under Conventions. |
 | Flip a `:prefix_settings` row (feature toggle) from an E2E spec so the surface under test renders | `setSettingE2e(setting, value)` from `web/tests/e2e/fixtures/db.ts` (#1402). Shells out to `web/tests/e2e/scripts/set-setting-e2e.php` which `REPLACE INTO`s the row — mirror of the `REPLACE INTO sb_settings` shape `BansTest.php` uses to enable `config.enablegroupbanning` for the same reason. Pair with `afterAll(async () => { await setSettingE2e(key, defaultValue); })` because the e2e DB is shared between specs (`Fixture::truncateAndReseed` does NOT reset `sb_settings`). Reference: the group-ban dispatcher spec (`web/tests/e2e/specs/flows/groupban-dispatcher.spec.ts`) flips `config.enablegroupbanning` on in `beforeAll` and reverts in `afterAll`. Don't drive the change through `Actions.SettingsSave` from the spec — that requires CSRF + an Owner-permission + would fan out through `Config::init()` + audit-log writes on every flip, way more moving pieces than the spec needs. |
+| Build / extend the owner-only full data export feature (the panel-wide JSONL+demos ZIP bundle download / S3 upload) | Five classes under `web/includes/Export/` + entry point + admin page. `Sbpp\Export\ManifestBuilder` (`web/includes/Export/ManifestBuilder.php`) — pre-flight pass. `build()` produces a `Manifest` DTO carrying row counts + demo byte totals + UUIDv4 `bundle_id` + the `pii_policy` block; `buildOrThrow()` raises `ExportError::CAP_EXCEEDED` upfront if the estimated bundle would exceed `Manifest::MAX_BUNDLE_BYTES - Manifest::SAFETY_MARGIN_BYTES` (4 GiB minus 64 MiB). `Sbpp\Export\EntityExporter` (`web/includes/Export/EntityExporter.php`) — per-entity SELECT + JSONL emission via `Database::iterate()` (no entity in PHP memory). One public method per entity (`admins`, `bans`, `comms`, `log`, `notes`, …). Hard-coded `FORBIDDEN_ADMIN_COLUMNS` / `FORBIDDEN_SERVER_COLUMNS` / `FORBIDDEN_SETTING_KEYS` filter at the SQL `SELECT`/`WHERE` layer — `admins.password` / `validate` / `attempts` / `lockout_until`, `servers.rcon`, `settings` rows keyed `smtp.pass` / `telemetry.instance_id` never reach JSONL regardless of caller. Per-row contracts (uniform across every entity): `null` for absent values (never `""`), timestamps as unix-seconds integers, Steam64 as decimal STRINGS (Steam64 exceeds `Number.MAX_SAFE_INTEGER` and silently round-trips wrong through any consumer using double-precision floats — `authid_steam2` preserves the legacy `STEAM_X:Y:Z` shape alongside), source PKs renamed to `id` where the source's PK is a single column. Per-entity derivations: `comms.mute_kind` (`mute|gag|silence|unknown` from `:prefix_comms.type`), `bans.state` (mirrors `page.banlist.php`'s `BanType×BanRemoval` classifier), `bans.demo_filename` + `bans.demo_size_bytes` (LEFT JOIN against `:prefix_demos`; both `null` when no demo file exists), `log.level` (`message|warning|error` from `LogType`). JSON encoder flags ALWAYS include `JSON_INVALID_UTF8_SUBSTITUTE` — player names on `:prefix_bans.name` / `:prefix_comms.name` can carry malformed UTF-8 from the pre-#1108 / #765 Latin-1-on-utf8 truncation shape; without the flag the export 500s mid-stream on a hostile-historical row (same load-bearing reason `Toast::emit` carries the flag). `Sbpp\Export\BundleWriter` (`web/includes/Export/BundleWriter.php`) — orchestrates. Takes `ZipStream\ZipStream` + `Manifest` + `EntityExporter`. Emits `manifest.json` FIRST via `addFile()` (the manifest-first contract — downstream consumers can read the manifest by parsing one central-directory entry; pinned by `ExportBundleWriterTest::statIndex(0)['name'] === 'manifest.json'`), then iterates entity exporters via `addFileFromCallback()` in deterministic name order, then iterates demos via `addFileFromPath(..., compressionMethod: CompressionMethod::STORE)` (demos are already DEFLATE'd by the Source engine; re-compressing is a CPU tax for no gain). Tracks running compressed-byte total and aborts with `ExportError::CAP_EXCEEDED` if it exceeds the margin (defence-in-depth against `ManifestBuilder`'s pre-flight estimate undershooting). zip-mode runs with `flushAfterEntries=true` (each `flush() + @ob_flush()` after every entry keeps the browser progress bar moving); s3-mode runs with `flushAfterEntries=false` (output is a tempfile, no socket to flush to). `Sbpp\Export\S3PresignedUploader` (`web/includes/Export/S3PresignedUploader.php`) — cURL `PUT` against the operator-supplied presigned URL. Scheme guard is unconditional: `https://` only, `http://` raises `ExportError::PRESIGN_INVALID_SCHEME` before any network call (panel-full PII dataset in flight, cleartext transit unsupported). URL parse failures raise `PRESIGN_INVALID_URL`. cURL uses `CURLOPT_CUSTOMREQUEST='PUT'` + `CURLOPT_INFILE` + `CURLOPT_INFILESIZE` + explicit `Content-Length` header (presigned PUT signatures bind the Content-Length value); `CURLOPT_CONNECTTIMEOUT=60`, `CURLOPT_TIMEOUT=0` (no overall ceiling — uploads can be slow). HTTP 200/201/204 success; anything else raises `S3_PUT_FAILED` with the response body truncated to 2 KiB for diagnostics. Test override: `_setHttpTransportForTests(?callable)` mirrors `Sbpp\Announce\AnnouncementFetcher::_setHttpFetcherForTests`. `Sbpp\Export\ExportError` (`web/includes/Export/ExportError.php`) — `final class extends \RuntimeException` with `public readonly string $code`. Error codes as class constants (`CAP_EXCEEDED`, `S3_PUT_FAILED`, `PRESIGN_INVALID_SCHEME`, `PRESIGN_INVALID_URL`, `DISK_WRITE_FAILED`, `DISK_FULL`) so call sites can't typo a string literal. Entry point: `web/export.php` (panel-root because binary wire format doesn't fit the JSON API dispatcher's contract — same shape as `web/exportbans.php` / `web/getdemo.php`). POST-only (GET returns HTTP 405 with `Allow: POST`), CSRF-gated, owner-only via `WebPermission::Owner` (deny branch lands `LogType::Warning` in audit log), shared-host hardening (`@set_time_limit(0)` + `@ini_set('memory_limit', '256M')` + `ignore_user_abort(true)`), output-buffer drain + `X-Accel-Buffering: no` + `apache_setenv('no-gzip', '1')`. Mode dispatch via `$_POST['mode']` (`'zip'` streams to `php://output`; `'s3'` builds to `SB_CACHE/exports/<bundle_id>.zip` tempfile + `register_shutdown_function` cleanup hook + `S3PresignedUploader::upload()` + 302 to `?p=admin&c=export&result={success\|error}&...`). Catches ONLY `ExportError` — anything else propagates to the dispatcher's generic 500 so real bugs surface in the audit log via the project's error handler. Page handler: `web/pages/admin.export.php` re-checks `CheckAdminAccess(ADMIN_OWNER)` (defence-in-depth — page-builder route also gates), runs `ManifestBuilder::build()` for counts-only, mounts `new AdminTabs([], $userbank, $theme)` (back-link-only partial, same shape as `admin.email.php`), reads `?result=…&code=…` and emits `\Sbpp\View\Toast::emit` accordingly (success uses default chrome timing; failure uses persistent `duration_ms: 0` + `$redirect: null` so the operator MUST acknowledge before moving on), renders via `Sbpp\View\AdminExportView` + `web/themes/default/page_admin_export.tpl`. Owner-only by design: every PII category in scope (admin emails, IPs, every Steam ID, every unban reason, every comment) means a partial-permission admin who could export everything is functionally an owner; granular delegation deliberately deferred. No new permission flag (`ADMIN_OWNER` only); no schema change (V1 is one-shot per request; the audit log carries the durable record); no JSON API handler (the entry point's binary wire format doesn't fit). Routing wired into `web/includes/page-builder.php` (`'export' => [..., 'permission' => ADMIN_OWNER]`), `web/pages/core/navbar.php` (`'permission' => ADMIN_OWNER`), and `web/includes/View/PaletteActions.php` (`'permission' => \WebPermission::Owner->value`). See "Full data export" under Conventions for the full contract (the per-entity wire-format contracts subsection covers the `null`-for-absent + Steam64-as-string + unix-seconds rules; the lifecycle subsection covers the entry-point + page-handler + toast emission chain). Operator-facing docs at `docs/src/content/docs/configuring/data-export.mdx`. Regression guards: `web/tests/unit/EntityExporterTest.php` (per-entity contracts), `web/tests/unit/ManifestBuilderTest.php` (cap math + UUIDv4 + PII policy + format version), `web/tests/integration/ExportBundleWriterTest.php` (end-to-end bundle against the test fixture — manifest-first, row-count parity, demo entries are STORE-compressed, Steam64 is string not number, forbidden values absent), `web/tests/integration/AdminExportPermissionTest.php` (static-shape permission gate across navbar / palette / page-builder / page-handler / entry-point), `web/tests/integration/AdminExportRuntimePermissionTest.php` (runtime-primitive gate for CSRF + `HasAccess(WebPermission::Owner)` — SourceMod root char alone does NOT grant `WebPermission::Owner`), `web/tests/integration/S3PresignedUploaderTest.php` (wire-layer via `_setHttpTransportForTests` — scheme rejection / URL parse rejection / happy path / 403 → `S3_PUT_FAILED`), `web/tests/e2e/specs/flows/data-export.spec.ts` (Playwright end-to-end — admin clicks "Export as ZIP", downloads stream, `jszip` parses, manifest carries `format_version: 1` + valid UUIDv4 + `pii_policy.password_hashes: "never"`; `GET /export.php` returns HTTP 405). |
+| Generate a presigned S3 PUT URL for the panel's "Full data export" S3 mode | Operator-side workflow — the panel never generates the URL itself, only consumes it. AWS: `aws s3 presign s3://bucket/key --http-method PUT --expires-in 3600` (the `--http-method PUT` flag is load-bearing — defaults to GET). Cloudflare R2: same `aws` CLI configured against an R2 token + `--endpoint-url https://<account-id>.r2.cloudflarestorage.com`; or `wrangler r2 object put` with `--presign`; or the R2 dashboard's "Generate URL" tool. MinIO: `mc share upload --expire 1h myminio/bucket/key` (note `share upload`, NOT `share download` — distinct presign flavours). The presigned URL is a single-use write credential; use a short expiry (≤1 hour) and never paste the URL into chat / public logs / issue trackers (anyone who sees it can PUT arbitrary content to your bucket until it expires). Operator-facing docs at `docs/src/content/docs/configuring/data-export.mdx` carry the worked examples per provider. |
 | Add a cross-repo JSON contract (vendored schema lock + reader + extractor parity test) | `web/includes/Telemetry/Schema1.php` is the reference shape (`payloadFieldNames(): list<string>` over a Draft-7 JSON Schema lock file). Pair with one PHPUnit extractor parity test (collect() vs. lock file in both directions). The schema lock file is the single source of truth — don't mirror the field list into a markdown doc paired with a separate parity test, that pattern was tried for telemetry and removed because the duplication paid for the drift risk it created. Sync via a manual `make sync-<subsystem>-schema` target — no scheduled auto-PR. See "Cross-repo JSON contracts" under Conventions. |
 | Display a user's own permission flags grouped by category | `Sbpp\View\PermissionCatalog::groupedDisplayFromMask($mask)` (`web/includes/View/PermissionCatalog.php`). Adding a new flag to `web/configs/permissions/web.json` requires a paired entry in `WEB_CATEGORIES`; `PermissionCatalogTest` enforces it. |
 | Live-preview Markdown in a settings textarea | `system.preview_intro_text` JSON action + `web/themes/default/page_admin_settings_settings.tpl` (`.dash-intro-editor` / `.dash-intro-preview`) |

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -74,6 +74,7 @@ web/
 ├── config.php            DB credentials etc. (generated; ignored by git)
 ├── config.php.template   Template the installer + dev entrypoint render
 ├── exportbans.php        Public ban-list export (CSV/XML)
+├── export.php            Full data export (owner-only ZIP bundle; see includes/Export/)
 ├── getdemo.php           Demo file download
 │
 ├── api/handlers/         JSON API: one file per topic, _register.php wires them
@@ -103,6 +104,7 @@ web/
 │   ├── Mail/                 Sbpp\Mail\{Mail,Mailer,EmailType} — Symfony Mailer wrapper + enum
 │   ├── Telemetry/            Sbpp\Telemetry\{Telemetry,Schema1} — anonymous opt-out daily ping (#1126); schema-1.lock.json is the vendored cross-repo contract
 │   ├── Announce/             Sbpp\Announce\{AnnouncementFetcher,Announcement} — anonymous opt-out daily fetch of project news / security advisories from https://sbpp.github.io/announcements.json (source of truth: docs/public/announcements.json); admin-only banner on the home dashboard
+│   ├── Export/               Sbpp\Export\{ManifestBuilder,EntityExporter,BundleWriter,S3PresignedUploader,ExportError,Manifest} — owner-only full data export feature; streamed one-shot ZIP bundle of every row + every uploaded demo; entry point web/export.php (binary wire format, sits at panel-root next to exportbans.php / getdemo.php)
 │   ├── SteamID/              SteamID parsing / vanity-URL resolution
 │   ├── PHPStan/              Sbpp\PHPStan\* — custom PHPStan rules (Smarty + SQL prefix)
 │   ├── page-builder.php      route() + build() (the page router; procedural)
@@ -772,6 +774,171 @@ lock file from
 and overwrites the vendored copy. No scheduled auto-PR workflow in
 v1 — the parity tests gate the result and the maintainer invokes
 the make target when picking up cf-analytics changes.
+
+### Data export (`includes/Export/`)
+
+`Sbpp\Export\*` packages the panel's "full data export" feature — a
+synchronous, one-shot streamed ZIP bundle of every row in the
+database plus every uploaded demo. Reachable to logged-in owners at
+`?p=admin&c=export`; the actual streaming work lives at panel-root
+in `web/export.php` because the wire format is binary
+(`Content-Type: application/zip`) and doesn't fit the JSON API
+dispatcher's `Content-Type: application/json` contract. Same shape
+as the long-standing `web/exportbans.php` (public ban-list export)
+and `web/getdemo.php` (single demo download).
+
+The subsystem is five classes plus an entry point plus an admin
+page:
+
+- `Sbpp\Export\ManifestBuilder` — pre-flight pass. `build()` returns
+  a `Manifest` DTO with `row_counts` per entity, `demo_total_bytes`
+  (sum of on-disk demos referenced by `:prefix_demos`),
+  `estimated_bundle_bytes`, the UUIDv4 `bundle_id`, the cap
+  thresholds, and the `pii_policy` block (operator attestation —
+  `password_hashes: "never"` is load-bearing and never reachable
+  for relaxation; `includes_chat_messages: false` because the panel
+  schema doesn't carry chat messages anywhere). `buildOrThrow()`
+  raises `ExportError(CAP_EXCEEDED)` upfront if the estimated bundle
+  would exceed `MAX_BUNDLE_BYTES - SAFETY_MARGIN_BYTES` (4 GiB minus
+  64 MiB).
+- `Sbpp\Export\EntityExporter` — per-entity SELECT + JSONL emission.
+  One public method per entity (`admins`, `bans`, `comms`, `log`,
+  `notes`, …). Uses `Database::iterate()` so no entity is held in
+  memory. Hard-coded `FORBIDDEN_COLUMNS` filter at the SQL `SELECT`
+  / `WHERE` layer: `admins.password`, `admins.validate`,
+  `admins.attempts`, `admins.lockout_until`, `servers.rcon`, and
+  `settings` rows with key `smtp.pass` / `telemetry.instance_id`
+  never reach the JSONL regardless of caller. Per-row contracts:
+  `null` for absent (never `""`), timestamps as unix-seconds ints,
+  Steam64 as decimal strings (NOT JSON numbers — Steam64 exceeds
+  `Number.MAX_SAFE_INTEGER`), source PKs renamed to `id`. Per-entity
+  derivations: `comms.mute_kind` (`mute|gag|silence|unknown` from
+  `:prefix_comms.type`), `bans.state` (mirrors `BanListView`'s
+  classifier), `bans.demo_filename` + `demo_size_bytes` via LEFT
+  JOIN against `:prefix_demos`, `log.level` from `LogType`. JSON
+  encoder flags MUST include `JSON_INVALID_UTF8_SUBSTITUTE` — player
+  names on `:prefix_bans.name` / `:prefix_comms.name` can carry
+  malformed UTF-8 from the pre-#1108 / #765 Latin-1-on-utf8
+  truncation shape; without the flag the export 500s mid-stream on
+  a hostile-historical row.
+- `Sbpp\Export\BundleWriter` — orchestrates. Takes
+  `ZipStream\ZipStream` + the `Manifest` + the `EntityExporter`.
+  Emits `manifest.json` FIRST via `addFile()` (the manifest-first
+  contract — downstream consumers can read just the manifest by
+  parsing the first central-directory entry), then iterates entity
+  exporters in deterministic name order via `addFileFromCallback()`,
+  then iterates demos via `addFileFromPath(..., compressionMethod:
+  CompressionMethod::STORE)` (demo files are already compressed by
+  the Source engine; re-deflating is a CPU tax for no gain). Tracks
+  running compressed-byte count; aborts with
+  `ExportError(CAP_EXCEEDED)` when the running total exceeds the
+  margin. After each entity / demo in zip-mode (`$flushAfterEntries
+  = true`), calls `flush() + @ob_flush()` to push bytes downstream
+  so the browser's download progress bar moves in real time. S3
+  mode (`$flushAfterEntries = false`) skips the flush because the
+  output is a tempfile, not a socket.
+- `Sbpp\Export\S3PresignedUploader` — cURL `PUT` against the
+  operator-supplied presigned URL. Scheme guard is unconditional:
+  `https://` only, `http://` raises `ExportError(PRESIGN_INVALID_SCHEME)`
+  before any network call — a panel-full dataset is in flight and
+  cleartext transit is unsupported. URL parse failures raise
+  `PRESIGN_INVALID_URL`. The cURL call uses `CURLOPT_CUSTOMREQUEST
+  = 'PUT'` + `CURLOPT_INFILE` + `CURLOPT_INFILESIZE` + explicit
+  `Content-Length` header (presigned PUT signatures bind the
+  Content-Length value); `CURLOPT_CONNECTTIMEOUT = 60`,
+  `CURLOPT_TIMEOUT = 0` (no overall ceiling — uploads can be slow).
+  HTTP 200/201/204 are success; anything else raises
+  `ExportError(S3_PUT_FAILED)` with the response body truncated to
+  2 KiB for diagnostics. Test override:
+  `_setHttpTransportForTests(?callable $transport)` mirroring
+  `Sbpp\Announce\AnnouncementFetcher::_setHttpFetcherForTests` so
+  the integration tests can pin the wire-layer contract without
+  spinning up a real S3 endpoint.
+- `Sbpp\Export\ExportError` — `final class extends \RuntimeException`
+  with a `public readonly string $code`. The supported error codes
+  are class constants (`CAP_EXCEEDED`, `S3_PUT_FAILED`,
+  `PRESIGN_INVALID_SCHEME`, `PRESIGN_INVALID_URL`,
+  `DISK_WRITE_FAILED`, `DISK_FULL`) so call sites can't typo a
+  string literal. The entry point's redirect-failure helper maps
+  each code to an operator-readable toast body via a `match`
+  table in `web/pages/admin.export.php`.
+
+`web/export.php` is the top-level streaming entry point. Lifecycle:
+
+1. `REQUEST_METHOD === 'POST'` gate — GET / HEAD return HTTP 405
+   with a plain-text `Allow: POST` body. The form posts; a direct
+   GET is either a hostile probe or operator URL typing.
+2. `init.php` bootstraps `$userbank` / `CSRF` / `$GLOBALS['PDO']` /
+   `SB_VERSION` / `SB_DEMOS` / `SB_CACHE`.
+3. `CSRF::rejectIfInvalid()` — state-changing PII-class surface; a
+   stale tab MUST NOT trigger an export.
+4. `$userbank->HasAccess(WebPermission::Owner)` re-check (the
+   navbar / palette filter is UX gating; this is the load-bearing
+   security gate that catches direct-curl POSTs by partial-permission
+   admins). Failures land a `LogType::Warning` row in the audit log
+   so a triage flow can find them.
+5. Shared-host hardening: `@set_time_limit(0)`, `@ini_set('memory_limit',
+   '256M')`, `ignore_user_abort(true)`. The `@` guards a host with
+   `disable_functions = set_time_limit,ini_set` from injecting warning
+   text into the streamed response body.
+6. Output buffer drain: walk every `ob_get_level()` and end each so
+   `BundleWriter::write()`'s `flush() + @ob_flush()` calls actually
+   reach the wire.
+7. `X-Accel-Buffering: no` + Apache's `apache_setenv('no-gzip', '1')`
+   so reverse proxies and Apache don't re-buffer the stream.
+8. Mode dispatch:
+   - `zip` → `Content-Type: application/zip` +
+     `Content-Disposition: attachment; filename="sbpp-export-<uuid>.zip"`
+     + cache-defeat headers; ZipStream writes to `php://output`;
+     `BundleWriter::write()` runs with `flushAfterEntries=true`.
+   - `s3` → build to `SB_CACHE/exports/<uuid>.zip` (tempfile);
+     `register_shutdown_function` registers an `@unlink()` cleanup
+     BEFORE the build so a mid-build fatal still wipes the
+     staging file; `BundleWriter::write()` runs with
+     `flushAfterEntries=false`; then `S3PresignedUploader::upload()`
+     PUTs to the operator's URL; on success 302 to
+     `?p=admin&c=export&result=success&bid=<uuid>`; on
+     `ExportError` 302 to `?result=error&code=<code>` (the
+     page handler reads the arm and emits a persistent error toast
+     via `\Sbpp\View\Toast::emit` so the operator MUST acknowledge
+     the destructive-operation failure before moving on).
+9. Every reachable terminal branch lands an audit-log entry —
+   `LogType::Message` for success (carries `aid`, `bundle_id`,
+   estimated + actual byte counts); `LogType::Error` for failure
+   (carries `aid`, `bundle_id`, `ExportError::code()` value plus
+   the underlying message). The operator's "what happened to my
+   export attempt" question is answerable from a single audit-log
+   query.
+
+The entry point catches only `ExportError` — anything else (a real
+DB outage, a memory exhaustion, a regression in the writer)
+propagates to the dispatcher's generic 500 so the stack trace lands
+in the audit log via the project's error handler. Catching
+`\Throwable` blanket would mask real bugs behind a generic "export
+failed" toast.
+
+The admin page handler is `web/pages/admin.export.php` →
+`Sbpp\View\AdminExportView` →
+`web/themes/default/page_admin_export.tpl`. The page handler runs
+the pre-flight pass (counts only) and renders the form chrome with
+two cards (ZIP download / S3 upload) plus a stats grid (admin / ban
+/ comm / demo counts + estimated bundle size). When the pre-flight
+detects `exceeds_cap`, both submit buttons are server-rendered as
+`disabled` and an `.empty-state` block explains what to prune
+before retrying — the cap is re-enforced at the entry point's
+pre-flight pass too (a stale-tab POST hits the gate), but the form
+disabled state is the UX-first contract.
+
+No schema change ships with this subsystem: there's no `:prefix_exports`
+table, no scheduled jobs, no persistent state. V1 is deliberately
+one-shot — every export starts from a fresh pre-flight pass. The
+audit log carries the durable record per operator request.
+
+Owner-only by design: every PII category in scope (admin emails, IP
+addresses, every Steam ID, every unban reason, every comment) means
+a partial-permission admin who can export everything is functionally
+an owner regardless. Granular delegation is deliberately deferred
+to a future version where downstream consumers have asked for it.
 
 ## Database schema
 

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -138,6 +138,7 @@ export default defineConfig({
           label: 'Configuring',
           items: [
             { label: 'Project announcements', slug: 'configuring/announcements' },
+            { label: 'Full data export', slug: 'configuring/data-export' },
           ],
         },
         {

--- a/docs/src/content/docs/configuring/data-export.mdx
+++ b/docs/src/content/docs/configuring/data-export.mdx
@@ -1,0 +1,383 @@
+---
+title: Full data export
+description: How to stream a one-shot ZIP bundle of every panel row plus uploaded demos, either as a browser download or via a presigned S3 PUT URL.
+sidebar:
+  order: 2
+  label: Full data export
+---
+
+import { Aside, Code, Tabs, TabItem } from '@astrojs/starlight/components';
+
+The panel ships a built-in "Full data export" surface that streams a
+one-shot ZIP bundle of every row in the database plus every uploaded
+demo. The bundle is suitable for:
+
+- Backups — the bundle is self-contained; restore by feeding the
+  JSONL streams into a downstream importer.
+- Migration to a different host — same shape as backup, but typically
+  paired with a fresh install on the target.
+- Downstream analytics — the JSONL is JSON-line per row with stable
+  schema, easy to feed into BigQuery / DuckDB / pandas / etc.
+
+<Aside type="caution">
+The bundle contains the **full panel dataset**, including admin
+email addresses, IP addresses, every Steam ID the panel knows about,
+admin-authored unban reasons, comments, and notes. **Password
+hashes are NEVER exported** (panel rule), but the bundle is still
+high-sensitivity PII. Treat it accordingly: encrypted storage,
+short-lived presigned URLs, no posting the URL in chat or public
+logs.
+</Aside>
+
+## Permission
+
+Access is gated on the `OWNER` permission flag — the same flag that
+gates Settings, the in-panel admin/group/server editors, and every
+other "this changes how the panel works" surface. There is **no
+delegated "data export" flag** by design: every row in the panel is
+in scope (admin emails, ban authids, comment text), so a partial-
+permission admin who can export everything is functionally an owner
+anyway. If you need to share read-only data with a non-owner (e.g.
+an audit pipeline), generate the bundle yourself and hand the
+recipient just the rows they need.
+
+You reach the surface from:
+
+- The sidebar's **Admin → Export** entry (owner-only — non-owners
+  don't see it).
+- The command palette (Ctrl/Cmd+K → "Data export").
+- Direct URL: `?p=admin&c=export`.
+
+## What's in the bundle
+
+Every bundle is a ZIP 2.0 file with the same overall shape:
+
+```
+sbpp-export-<uuid>.zip
+├── manifest.json
+├── entities/
+│   ├── admins.jsonl
+│   ├── admins_servers_groups.jsonl
+│   ├── banlog.jsonl
+│   ├── bans.jsonl
+│   ├── comms.jsonl
+│   ├── comments.jsonl
+│   ├── demos.jsonl
+│   ├── groups.jsonl
+│   ├── log.jsonl
+│   ├── mods.jsonl
+│   ├── notes.jsonl
+│   ├── overrides.jsonl
+│   ├── protests.jsonl
+│   ├── server_groups.jsonl
+│   ├── servers.jsonl
+│   ├── servers_groups.jsonl
+│   ├── settings.jsonl
+│   ├── srvgroups.jsonl
+│   ├── srvgroups_overrides.jsonl
+│   └── submissions.jsonl
+└── demos/
+    ├── <filename>.dem
+    └── …
+```
+
+**`manifest.json` is always the first entry in the central
+directory.** Downstream consumers can read just the manifest by
+parsing the first central-directory entry without slurping the
+whole bundle into memory. The manifest carries:
+
+- `format_version`: integer (currently `1`). Bump triggers a
+  documented migration on the consumer side.
+- `bundle_id`: UUIDv4 string. Unique per export attempt; persisted
+  in the panel's audit log so an operator can correlate a downstream
+  bundle with the source export.
+- `created_at`: integer unix seconds (UTC).
+- `panel_version`: string (matches the `data-version` footer hook in
+  the panel chrome).
+- `row_counts`: dict of `<entity>: <int>`. The byte-for-byte count
+  of JSONL lines in each `entities/<entity>.jsonl`. Lets a consumer
+  size-check the import before parsing.
+- `demo_total_bytes`: integer. Sum of every demo file on disk that
+  the bundle includes.
+- `estimated_bundle_bytes`: integer. The pre-flight estimate the
+  cap check ran against (sum of demos + JSONL byte estimate).
+- `pii_policy`: dict documenting what's in scope:
+  - `includes_admin_emails: true`
+  - `includes_ip_addresses: true`
+  - `includes_chat_messages: false` — the panel doesn't store chat
+    messages anywhere in its schema; this field declares the
+    category as out-of-scope so a downstream consumer doesn't have
+    to guess.
+  - `includes_steam_ids: true`
+  - `includes_unban_reasons: true`
+  - `password_hashes: "never"` — load-bearing operator
+    attestation. Always literally `"never"`; the panel will never
+    emit `admins.password` regardless of caller permission.
+
+### JSONL wire format
+
+Each `entities/<entity>.jsonl` file is one JSON object per line,
+trailing newline:
+
+```jsonl
+{"id":42,"user":"alice","authid":"76561197960265728","authid_steam2":"STEAM_0:0:1","created":1717000000,"email":null,"immunity":99}
+{"id":43,"user":"bob","authid":"76561197960265729","authid_steam2":"STEAM_0:1:1","created":1717000100,"email":"bob@example.test","immunity":50}
+```
+
+Wire-format contracts:
+
+- **`null` for absent values** — never an empty string, never an
+  omitted field. A consumer iterates `Object.keys()` confident the
+  set is stable per entity.
+- **Timestamps are unix-seconds integers (UTC)** — `created`,
+  `ends`, `RemovedOn`, etc. all share this shape regardless of
+  whether the source column was `int` or `datetime`.
+- **Steam64 IDs are decimal strings** (`"76561197960265728"`), not
+  JSON numbers — Steam64 values exceed the JavaScript `Number.MAX_SAFE_INTEGER`
+  and would silently round-trip wrong through JSON parsers that
+  use double-precision floats. The `authid_steam2` sister field
+  preserves the legacy `STEAM_X:Y:Z` shape for consumers that
+  prefer it.
+- **Source primary keys are renamed to `id`** — `admins.aid` →
+  `id`, `bans.bid` → `id`, etc. Cross-entity foreign keys keep
+  their original names (`bans.aid`, `comments.bid`, …) so the
+  graph is recoverable.
+
+### Per-entity derivations
+
+A few entities carry derived fields the underlying DB columns
+don't:
+
+- `comms.mute_kind`: one of `"mute"`, `"gag"`, `"silence"`, or
+  `"unknown"`. Maps from `:prefix_comms.type` (1/2/3 respectively);
+  `type_raw` is the source int for consumers that prefer the raw
+  shape.
+- `bans.state`: one of `"active"`, `"expired"`, `"unbanned"`,
+  `"deleted"`, `"permanent"`. Derived from `length` + `ends` +
+  `RemoveType` + `RemovedBy` using the same classifier the panel's
+  banlist page uses. `RemoveType` / `removed_by` / `removed_on` /
+  `ureason` are preserved verbatim too.
+- `bans.demo_filename` / `bans.demo_size_bytes` (and the matching
+  pair on `submissions`): present (`"demos/<basename>.dem"` +
+  size in bytes) when a `:prefix_demos` row references the ban;
+  `null` otherwise. Lets a consumer cross-reference the `demos/`
+  directory without re-running the JOIN.
+- `log.level`: one of `"message"`, `"warning"`, `"error"`. Maps
+  from `:prefix_log.type` (`m`/`w`/`e`). `actor_user` and
+  `actor_steam` are joined from `:prefix_admins` when `aid` is
+  non-null.
+
+### What's NEVER in the bundle
+
+The following fields are stripped at the SQL layer (`SELECT`
+omits them or `WHERE` filters them out) so they never reach the
+JSONL even when the requesting admin is an owner. Operator
+attestation matches what the manifest's `pii_policy` block
+declares:
+
+- `admins.password` — bcrypt hash. Stripped.
+- `admins.validate` / `admins.attempts` / `admins.lockout_until` —
+  password-reset token + lockout state. Stripped.
+- `servers.rcon` — RCON password. Stripped.
+- `settings` rows whose key is `smtp.pass` (SMTP credential) or
+  `telemetry.instance_id` (random identifier; deliberately
+  panel-local).
+
+The forbidden list is hard-coded in
+`web/includes/Export/EntityExporter.php`. Reaching into the code
+to relax the filter (e.g. for a "full backup including bcrypt
+hashes" workflow) is unsupported and will silently invalidate the
+manifest's `password_hashes: "never"` attestation that downstream
+consumers rely on.
+
+## Two delivery modes
+
+The form ships two submit buttons. They differ in how the bundle
+reaches its destination:
+
+<Tabs>
+<TabItem label="ZIP download">
+
+The browser downloads the bundle directly. Apache streams from
+`php://output` through the writer's `flush()` calls so the
+browser's progress bar moves in real time as each entity / demo
+lands. No on-disk staging file — close the tab mid-download and
+the panel cleans up immediately (no orphaned state).
+
+**When to use**: ad-hoc backups, one-off audits, debugging a
+particular row's wire shape, anything where a human is sitting in
+front of the panel waiting.
+
+**When not to use**: when the bundle is multi-GiB and your laptop
+is on a flaky hotel wifi (the connection has to stay open for the
+full transfer; abort and you start over). Switch to S3 mode for
+unattended uploads.
+
+</TabItem>
+<TabItem label="S3 presigned PUT">
+
+The panel builds the bundle to a temp file under
+`cache/exports/`, then HTTPS-PUTs it to your operator-supplied
+presigned URL. The PUT travels server-to-server (no operator
+browser in the loop); you get a redirect-back toast when the upload
+finishes (success or failure). The staging file is unlinked
+immediately after the upload acknowledges.
+
+**When to use**: scheduled backups, multi-GiB bundles where the
+browser-to-panel hop is the bottleneck, hand-off to cloud
+analytics pipelines.
+
+**When not to use**: when you don't have an S3-compatible
+destination — AWS S3, Cloudflare R2, MinIO, Wasabi, Backblaze
+B2 (with `--check-eligible-for-batch-api` style auth), etc. all
+work; raw FTP / SCP / Dropbox do not.
+
+<Aside type="caution">
+The presigned URL is a **single-use write credential**. Anyone
+who sees it can PUT arbitrary content to your bucket until the
+URL expires. Use a short expiry (≤1 hour), generate the URL
+fresh per export, and never paste it into chat / public logs /
+issue trackers.
+</Aside>
+
+</TabItem>
+</Tabs>
+
+## Generating a presigned PUT URL
+
+Pick the workflow that matches your S3-compatible destination:
+
+<Tabs>
+<TabItem label="AWS S3">
+
+```bash
+aws s3 presign \
+    s3://your-bucket/path/sbpp-export.zip \
+    --http-method PUT \
+    --expires-in 3600
+```
+
+Output is the presigned URL — paste it directly into the panel
+form. The URL is valid for one hour (3600 seconds) from generation.
+
+</TabItem>
+<TabItem label="Cloudflare R2">
+
+R2 uses the same SigV4 signing scheme as AWS S3. With the `aws`
+CLI configured against an R2 token:
+
+```bash
+aws s3 presign \
+    s3://your-r2-bucket/path/sbpp-export.zip \
+    --http-method PUT \
+    --expires-in 3600 \
+    --endpoint-url https://<account-id>.r2.cloudflarestorage.com
+```
+
+Alternatively use the R2 dashboard's "Generate URL" tool or
+`wrangler r2 object put` with the `--presign` flag.
+
+</TabItem>
+<TabItem label="MinIO">
+
+MinIO ships its own `mc` client:
+
+```bash
+mc alias set myminio https://minio.example.com ACCESS_KEY SECRET_KEY
+mc share upload --expire 1h myminio/your-bucket/path/sbpp-export.zip
+```
+
+The `share upload` output prints both a `curl` command and the
+raw presigned URL. Copy just the URL into the panel form.
+
+</TabItem>
+</Tabs>
+
+## Cap: 4 GiB minus 64 MiB safety margin
+
+The panel enforces a hard cap of **4 GiB minus 64 MiB** on the
+estimated bundle size. The cap comes from the ZIP 2.0 spec ceiling
+(4 GiB per archive / per-entry) — we deliberately don't enable
+ZIP64 because not every downstream tool supports it cleanly, and
+the safety margin gives the in-stream writer headroom to land
+without tripping the cap mid-stream.
+
+When the cap is exceeded:
+
+- The admin export page renders the form with **both submit
+  buttons disabled**.
+- An `.empty-state` block appears explaining the situation and
+  pointing at the typical remediation: prune old demos via the
+  bans list, or trim unrelated rows (banlog, audit log).
+- The cap is re-enforced at the entry point's pre-flight pass, so
+  a hand-edited stale-tab POST also bounces.
+
+If you genuinely need to export a >4 GiB dataset, the right move
+is to split: prune the demos directory of anything not currently
+under active appeal, run the export, then restore the demos
+afterward. Future versions may add a chunked / multipart S3
+upload mode for very large bundles; the current architecture
+explicitly chooses one-shot simplicity.
+
+## Audit log
+
+Every export attempt — success or failure — lands an entry in the
+panel's audit log (`?p=admin&c=audit`). The entry carries:
+
+- The acting admin's `aid` and Steam ID.
+- The mode (`zip` or `s3`).
+- The bundle's UUIDv4 (so a downstream "where did this file come
+  from?" question is answerable from the audit row).
+- On success: the estimated and actual bundle byte count.
+- On failure: the `ExportError` code (e.g. `cap_exceeded`,
+  `s3_put_failed`, `presign_invalid_url`) and a truncated copy of
+  the underlying error message for diagnostics.
+
+If your panel sits behind a SIEM or audit-forwarder, the bundle
+export is a load-bearing event to monitor — every successful
+export is a PII-class data flow off the panel.
+
+## Security model summary
+
+| Aspect | Contract |
+| ------ | -------- |
+| Permission | `OWNER` only. No delegated flag; not configurable. |
+| CSRF | Every POST is gated through `Sbpp\Security\CSRF`. A stale tab cannot trigger an export. |
+| Transport (ZIP) | TLS where the panel is reachable via TLS (operator concern). |
+| Transport (S3) | `https://` only. The panel refuses `http://` URLs server-side regardless of caller. |
+| Password hashes | Never emitted. Hard-coded SQL filter. |
+| Audit | Every attempt logged with acting admin + bundle ID + outcome. |
+| Staging file | Removed immediately on upload completion or process exit (shutdown hook). |
+| Presigned URL | Single-use. Operator generates, panel uses once. The panel does not store the URL anywhere persistent. |
+
+## Troubleshooting
+
+**"Export failed — The bundle would exceed the 4 GiB ZIP 2.0 cap"**
+:   See the cap section above. Prune demos or split the export.
+
+**"Export failed — Presigned URL must use HTTPS"**
+:   You pasted an `http://` URL. Re-generate with HTTPS.
+    The panel refuses cleartext transit for a PII-class dataset
+    server-side; flipping it to permit `http://` is unsupported.
+
+**"Export failed — The S3 endpoint rejected the upload"**
+:   The audit log carries the HTTP status + response body. Common
+    causes: presigned URL expired (regenerate with a longer expiry),
+    SigV4 signature mismatch (clock skew between the panel and
+    your S3 client — sync via NTP), bucket policy denies PUT
+    (check the bucket's IAM policy).
+
+**ZIP download stops partway through**
+:   Either the operator closed the tab (audit log shows a
+    truncated bundle for that aid) or the panel hit the
+    `cap_exceeded` gate mid-stream. The latter shouldn't happen
+    in production because the pre-flight pass gates first, but a
+    pathological "the on-disk demo file grew between pre-flight
+    and stream" race is possible. Re-run; the second pass picks
+    up the larger size.
+
+**Want a partial export (just bans, not demos)**
+:   Not currently supported by the chrome — V1 is one-shot
+    full-dataset. The wire format makes a manual partial-extract
+    trivial (`unzip sbpp-export-*.zip entities/bans.jsonl`) so a
+    consumer-side filter is the supported workflow.

--- a/web/composer.json
+++ b/web/composer.json
@@ -26,7 +26,8 @@
         "symfony/mailer": "^8.0",
         "ext-pdo": "*",
         "ext-openssl": "*",
-        "php": ">=8.5"
+        "php": ">=8.5",
+        "maennchen/zipstream-php": "^3.2"
     },
 
     "autoload": {

--- a/web/composer.lock
+++ b/web/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "db00044a03bc515fd98b5e7ed82fafba",
+    "content-hash": "dab8fab477460725e85d46ec584d5a81",
     "packages": [
         {
             "name": "dflydev/dot-access-data",
@@ -486,6 +486,84 @@
                 }
             ],
             "time": "2022-12-11T20:36:23+00:00"
+        },
+        {
+            "name": "maennchen/zipstream-php",
+            "version": "3.2.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/maennchen/ZipStream-PHP.git",
+                "reference": "77bebeb4c6c340bb3c11c843b2cffd8bbfde4d5e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/maennchen/ZipStream-PHP/zipball/77bebeb4c6c340bb3c11c843b2cffd8bbfde4d5e",
+                "reference": "77bebeb4c6c340bb3c11c843b2cffd8bbfde4d5e",
+                "shasum": ""
+            },
+            "require": {
+                "ext-mbstring": "*",
+                "ext-zlib": "*",
+                "php-64bit": "^8.3"
+            },
+            "require-dev": {
+                "brianium/paratest": "^7.7",
+                "ext-zip": "*",
+                "friendsofphp/php-cs-fixer": "^3.86",
+                "guzzlehttp/guzzle": "^7.5",
+                "mikey179/vfsstream": "^1.6",
+                "php-coveralls/php-coveralls": "^2.5",
+                "phpunit/phpunit": "^12.0",
+                "vimeo/psalm": "^6.0"
+            },
+            "suggest": {
+                "guzzlehttp/psr7": "^2.4",
+                "psr/http-message": "^2.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "ZipStream\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Paul Duncan",
+                    "email": "pabs@pablotron.org"
+                },
+                {
+                    "name": "Jonatan Männchen",
+                    "email": "jonatan@maennchen.ch"
+                },
+                {
+                    "name": "Jesse Donat",
+                    "email": "donatj@gmail.com"
+                },
+                {
+                    "name": "András Kolesár",
+                    "email": "kolesar@kolesar.hu"
+                }
+            ],
+            "description": "ZipStream is a library for dynamically streaming dynamic zip files from PHP without writing to the disk at all on the server.",
+            "keywords": [
+                "stream",
+                "zip"
+            ],
+            "support": {
+                "issues": "https://github.com/maennchen/ZipStream-PHP/issues",
+                "source": "https://github.com/maennchen/ZipStream-PHP/tree/3.2.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/maennchen",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-04-11T18:38:28+00:00"
         },
         {
             "name": "maxmind-db/reader",

--- a/web/export.php
+++ b/web/export.php
@@ -1,0 +1,420 @@
+<?php
+// SourceBans++ (c) 2014-2026 SourceBans++ Dev Team
+// Licensed under the Elastic License 2.0.
+// See LICENSE.txt for the full license text and THIRD-PARTY-NOTICES.txt for attributions.
+
+/*
+ * Top-level streaming entry point for the data export feature.
+ *
+ * Lives at panel-root because the bundle's wire format is binary
+ * (`Content-Type: application/zip`) and doesn't fit the JSON API
+ * dispatcher's contract — the JSON dispatcher always emits a
+ * `Content-Type: application/json` envelope, and there's no clean
+ * extension point for a streaming binary handler. Same shape as
+ * `web/exportbans.php` (which has lived at panel-root since the v1.x
+ * line for the same reason) and `web/getdemo.php`.
+ *
+ * Lifecycle (mirrors the plan's "Request flow" diagram):
+ *
+ *   1. POST-only. GET / HEAD / etc. return HTTP 405 with a plain
+ *      text body. The form posts; a direct GET is either a hostile
+ *      probe or operator typing the URL into the address bar.
+ *   2. `init.php` bootstraps `$userbank`, `CSRF`, `$GLOBALS['PDO']`,
+ *      `SB_VERSION`, `SB_DEMOS`, `SB_CACHE`. Per the panel-wide
+ *      convention this comes BEFORE anything else.
+ *   3. CSRF validation via `CSRF::rejectIfInvalid()`. The form
+ *      template emits `{csrf_field}`; the helper checks the form
+ *      field AND the `X-CSRF-Token` header. Rejects via toast+redirect
+ *      on failure.
+ *   4. Owner-only permission check via `HasAccess(WebPermission::Owner)`.
+ *      Non-owner attempts log a warning row to the audit log and
+ *      return HTTP 403 with a plain-text body — there's no chrome
+ *      to render at this layer of the stack.
+ *   5. Shared-host hardening: `@set_time_limit(0)`,
+ *      `@ini_set('memory_limit', '256M')`, `ignore_user_abort(true)`.
+ *      Wrapped with `@` so a `disable_functions = set_time_limit,ini_set`
+ *      host doesn't inject warning text into the response body.
+ *   6. Output buffer drain: walk every `ob_get_level()` and end them.
+ *      Apache + the SAPI may have stacked buffers; we want bytes to
+ *      flow directly from the writer's `flush()` calls to the wire.
+ *   7. `X-Accel-Buffering: no` + Apache's `no-gzip` so reverse
+ *      proxies and Apache don't re-buffer our streamed bytes.
+ *   8. Mode dispatch: `zip` streams to `php://output`; `s3` builds
+ *      to a tempfile under `SB_CACHE/exports/` and PUTs the result
+ *      to the operator's presigned URL.
+ *   9. Every reachable terminal branch emits an audit-log entry —
+ *      successes via `LogType::Message`, failures via `LogType::Error`
+ *      with the `ExportError::code()` value pinned in the body so
+ *      the operator can correlate the toast they saw with the audit
+ *      row.
+ *
+ * Error handling: this entry point deliberately catches ONLY
+ * `ExportError` — anything else (a real DB outage, a memory
+ * exhaustion, a regression in the writer) propagates to the
+ * dispatcher's generic 500 so the stack trace lands in the audit
+ * log via the project's error handler. Catching `Throwable` blanket
+ * would mask real bugs behind a generic "export failed" toast.
+ */
+
+use Sbpp\Export\BundleWriter;
+use Sbpp\Export\EntityExporter;
+use Sbpp\Export\ExportError;
+use Sbpp\Export\Manifest;
+use Sbpp\Export\ManifestBuilder;
+use Sbpp\Export\S3PresignedUploader;
+use Sbpp\Security\CSRF;
+use ZipStream\CompressionMethod;
+use ZipStream\ZipStream;
+
+require_once __DIR__ . '/init.php';
+
+// ---------------------------------------------------------------------
+// 1. Method gate
+// ---------------------------------------------------------------------
+if (($_SERVER['REQUEST_METHOD'] ?? 'GET') !== 'POST') {
+    header('HTTP/1.1 405 Method Not Allowed');
+    header('Allow: POST');
+    header('Content-Type: text/plain; charset=utf-8');
+    echo "POST required.\n";
+    exit;
+}
+
+// ---------------------------------------------------------------------
+// 3. CSRF (load-bearing — this is a state-changing surface that
+//    emits PII; a stale tab MUST NOT be able to trigger an export).
+//    `rejectIfInvalid` 403s with a plain-text body on failure.
+// ---------------------------------------------------------------------
+CSRF::rejectIfInvalid();
+
+// ---------------------------------------------------------------------
+// 4. Owner-only permission gate. The navbar + palette filter hides
+//    the entry from non-owners (UX), but the load-bearing security
+//    check is right here at the entry point. A direct curl post by
+//    a partial-permission admin hits THIS gate, not the navbar.
+// ---------------------------------------------------------------------
+if (!$userbank->HasAccess(WebPermission::Owner)) {
+    Log::add(
+        LogType::Warning,
+        'Data Export',
+        sprintf(
+            'Non-owner aid=%d attempted to POST /export.php — blocked at permission gate.',
+            $userbank->GetAid(),
+        ),
+    );
+    header('HTTP/1.1 403 Forbidden');
+    header('Content-Type: text/plain; charset=utf-8');
+    echo "Forbidden.\n";
+    exit;
+}
+
+// ---------------------------------------------------------------------
+// 5-7. Shared-host hardening + response buffer drain.
+// ---------------------------------------------------------------------
+@set_time_limit(0);
+@ini_set('memory_limit', '256M');
+ignore_user_abort(true);
+
+while (ob_get_level() > 0) {
+    ob_end_clean();
+}
+
+header('X-Accel-Buffering: no');
+if (function_exists('apache_setenv')) {
+    @apache_setenv('no-gzip', '1');
+}
+
+// ---------------------------------------------------------------------
+// 8. Mode dispatch.
+// ---------------------------------------------------------------------
+$mode = isset($_POST['mode']) ? (string) $_POST['mode'] : '';
+if (!in_array($mode, ['zip', 's3'], true)) {
+    sbpp_export_redirect_failure('mode_invalid', $mode);
+}
+
+// Build the manifest pre-flight. `buildOrThrow` raises CAP_EXCEEDED
+// upfront so a too-big bundle bails BEFORE any bytes hit the wire —
+// the operator's page handler also surfaces this state as a disabled
+// submit button, but the POST gate is the load-bearing one (a stale
+// page that's open from yesterday hits this guard).
+try {
+    $manifest = (new ManifestBuilder(
+        dbs:          $GLOBALS['PDO'],
+        demosDir:     SB_DEMOS,
+        panelVersion: SB_VERSION,
+    ))->buildOrThrow();
+} catch (ExportError $e) {
+    Log::add(
+        LogType::Error,
+        'Data Export',
+        sprintf(
+            'Pre-flight failed: aid=%d code=%s — %s',
+            $userbank->GetAid(),
+            $e->code(),
+            $e->getMessage(),
+        ),
+    );
+    sbpp_export_redirect_failure($e->code(), $e->getMessage());
+}
+
+$entities = new EntityExporter(
+    dbs:      $GLOBALS['PDO'],
+    demosDir: SB_DEMOS,
+);
+
+if ($mode === 'zip') {
+    sbpp_export_run_zip_mode($manifest, $entities, $userbank->GetAid());
+} else {
+    sbpp_export_run_s3_mode($manifest, $entities, $userbank->GetAid());
+}
+
+// ---------------------------------------------------------------------
+// Helpers below this line — locals to the entry point so they can't
+// be reached from another scope.
+// ---------------------------------------------------------------------
+
+/**
+ * Stream the bundle straight to the client's TCP socket as
+ * `Content-Type: application/zip`. The writer's `flush()` after each
+ * entry keeps the browser's download progress bar moving.
+ *
+ * On success: the response naturally ends when `ZipStream::finish()`
+ * emits the central directory and the script exits. The audit-log
+ * row lands AFTER the bytes are gone — that's deliberate; logging
+ * before would race the client-abort path.
+ *
+ * On `ExportError` mid-stream (the running-byte cap trip): we can't
+ * redirect — the response headers are already on the wire as
+ * `application/zip` — so we log the error, push whatever bytes have
+ * already been written downstream (the consumer will see a
+ * truncated ZIP), and exit. The browser surfaces the truncation
+ * as a "download failed" message; the audit log carries the why.
+ */
+function sbpp_export_run_zip_mode(Manifest $manifest, EntityExporter $entities, int $aid): never
+{
+    header('Content-Type: application/zip');
+    header('Content-Disposition: attachment; filename="sbpp-export-' . $manifest->bundle_id . '.zip"');
+    // Defeat caching at every reasonable hop — the bundle is a one-shot
+    // dynamic response and any caching would leak across operators.
+    header('Cache-Control: no-store, no-cache, must-revalidate, max-age=0');
+    header('Pragma: no-cache');
+
+    $output = fopen('php://output', 'wb');
+    if ($output === false) {
+        // Falls through to the generic 500 (the dispatcher's
+        // Throwable handler) — `fopen('php://output')` failing is
+        // a real bug, not an operator-actionable error.
+        throw new RuntimeException('Failed to open php://output for writing.');
+    }
+
+    $zip = new ZipStream(
+        outputStream:             $output,
+        sendHttpHeaders:          false,
+        enableZip64:              false,
+        defaultCompressionMethod: CompressionMethod::DEFLATE,
+    );
+
+    $writer = new BundleWriter(
+        zip:                $zip,
+        manifest:           $manifest,
+        entities:           $entities,
+        demosDir:           SB_DEMOS,
+        flushAfterEntries:  true,
+    );
+
+    try {
+        $writer->write();
+        Log::add(
+            LogType::Message,
+            'Data Export',
+            sprintf(
+                'ZIP mode bundle delivered: aid=%d bundle_id=%s estimated=%d bytes=%d',
+                $aid,
+                $manifest->bundle_id,
+                $manifest->estimated_bundle_bytes,
+                $writer->bytesWritten(),
+            ),
+        );
+    } catch (ExportError $e) {
+        Log::add(
+            LogType::Error,
+            'Data Export',
+            sprintf(
+                'ZIP mode failed mid-stream: aid=%d bundle_id=%s code=%s — %s',
+                $aid,
+                $manifest->bundle_id,
+                $e->code(),
+                $e->getMessage(),
+            ),
+        );
+    }
+    exit;
+}
+
+/**
+ * Build the bundle to a tempfile under `SB_CACHE/exports/`, then
+ * PUT it to the operator's presigned URL. On success → 302 redirect
+ * back to the admin page with a `?result=success` arm; on
+ * `ExportError` → 302 with `?result=error&code=...`. The shutdown
+ * function guarantees the tempfile is cleaned up even if a mid-build
+ * fatal escapes.
+ */
+function sbpp_export_run_s3_mode(Manifest $manifest, EntityExporter $entities, int $aid): never
+{
+    // ----- presigned URL validation (server-side; the form template's
+    //       `pattern="^https://...$"` is the UX-first gate) -------
+    $presignUrl = isset($_POST['presign_url']) ? trim((string) $_POST['presign_url']) : '';
+    if ($presignUrl === '' || strlen($presignUrl) > 2048) {
+        sbpp_export_redirect_failure(
+            ExportError::PRESIGN_INVALID_URL,
+            'Presigned URL must be 1-2048 characters.',
+        );
+    }
+
+    // ----- staging file under SB_CACHE/exports/ -----------------
+    $stagingDir = SB_CACHE . 'exports' . DIRECTORY_SEPARATOR;
+    if (!is_dir($stagingDir) && !@mkdir($stagingDir, 0755, true) && !is_dir($stagingDir)) {
+        Log::add(
+            LogType::Error,
+            'Data Export',
+            sprintf('S3 mode failed: aid=%d — cache dir not writable: %s', $aid, $stagingDir),
+        );
+        sbpp_export_redirect_failure(
+            ExportError::DISK_WRITE_FAILED,
+            'Bundle staging directory is not writable.',
+        );
+    }
+
+    $tmpFile = $stagingDir . $manifest->bundle_id . '.zip';
+
+    // Register the cleanup BEFORE the build so a mid-build fatal
+    // still wipes the staging file. The shutdown function fires
+    // after `exit`/`die`/the natural script end, regardless of
+    // whether an uncaught Throwable bubbled up.
+    register_shutdown_function(static function () use ($tmpFile): void {
+        if (is_file($tmpFile)) {
+            @unlink($tmpFile);
+        }
+    });
+
+    $output = @fopen($tmpFile, 'wb');
+    if ($output === false) {
+        Log::add(
+            LogType::Error,
+            'Data Export',
+            sprintf('S3 mode failed: aid=%d — could not open staging file: %s', $aid, $tmpFile),
+        );
+        sbpp_export_redirect_failure(
+            ExportError::DISK_WRITE_FAILED,
+            'Failed to open bundle staging file for write.',
+        );
+    }
+
+    $zip = new ZipStream(
+        outputStream:             $output,
+        sendHttpHeaders:          false,
+        enableZip64:              false,
+        defaultCompressionMethod: CompressionMethod::DEFLATE,
+    );
+
+    $writer = new BundleWriter(
+        zip:                $zip,
+        manifest:           $manifest,
+        entities:           $entities,
+        demosDir:           SB_DEMOS,
+        flushAfterEntries:  false,
+    );
+
+    try {
+        $writer->write();
+    } catch (ExportError $e) {
+        @fclose($output);
+        Log::add(
+            LogType::Error,
+            'Data Export',
+            sprintf(
+                'S3 mode build failed: aid=%d bundle_id=%s code=%s — %s',
+                $aid,
+                $manifest->bundle_id,
+                $e->code(),
+                $e->getMessage(),
+            ),
+        );
+        sbpp_export_redirect_failure($e->code(), $e->getMessage());
+    }
+
+    // ZipStream::finish closes the underlying handle on most builds,
+    // but we re-call fclose defensively in case a future ZipStream
+    // change changes that behaviour. The double-close is a no-op
+    // when the handle is already gone.
+    if (is_resource($output)) {
+        @fclose($output);
+    }
+
+    // ----- upload -----------------------------------------------
+    try {
+        (new S3PresignedUploader())->upload($presignUrl, $tmpFile);
+    } catch (ExportError $e) {
+        Log::add(
+            LogType::Error,
+            'Data Export',
+            sprintf(
+                'S3 mode upload failed: aid=%d bundle_id=%s code=%s — %s',
+                $aid,
+                $manifest->bundle_id,
+                $e->code(),
+                $e->getMessage(),
+            ),
+        );
+        sbpp_export_redirect_failure($e->code(), $e->getMessage());
+    }
+
+    // Success: the shutdown function will clean up the tempfile;
+    // we also explicitly unlink here so the file is gone the
+    // instant the upload acknowledges, not whenever PHP gets
+    // around to shutdown handlers.
+    if (is_file($tmpFile)) {
+        @unlink($tmpFile);
+    }
+
+    Log::add(
+        LogType::Message,
+        'Data Export',
+        sprintf(
+            'S3 mode upload OK: aid=%d bundle_id=%s estimated=%d bytes=%d',
+            $aid,
+            $manifest->bundle_id,
+            $manifest->estimated_bundle_bytes,
+            $writer->bytesWritten(),
+        ),
+    );
+
+    sbpp_export_redirect_success($manifest->bundle_id);
+}
+
+/**
+ * 302 back to the admin export page with a `result=success` arm.
+ * The page handler reads the query, drops a success toast via
+ * {@see \Sbpp\View\Toast::emit}, and renders the form.
+ */
+function sbpp_export_redirect_success(string $bundleId): never
+{
+    header('Location: ?p=admin&c=export&result=success&bid=' . rawurlencode($bundleId));
+    exit;
+}
+
+/**
+ * 302 back to the admin export page with a `result=error&code=...`
+ * arm. The page handler maps the code back to an operator-readable
+ * message and surfaces it via a persistent error toast (so the
+ * operator can't miss it — the destructive operation FAILED and
+ * cleanup may be needed).
+ *
+ * `$context` is logged but NOT propagated to the redirect URL — we
+ * trust the toast's operator-facing message to be self-explanatory,
+ * and the audit log already carries the full diagnostic body.
+ */
+function sbpp_export_redirect_failure(string $code, string $context = ''): never
+{
+    header('Location: ?p=admin&c=export&result=error&code=' . rawurlencode($code));
+    exit;
+}

--- a/web/export.php
+++ b/web/export.php
@@ -128,6 +128,21 @@ if (function_exists('apache_setenv')) {
 // ---------------------------------------------------------------------
 $mode = isset($_POST['mode']) ? (string) $_POST['mode'] : '';
 if (!in_array($mode, ['zip', 's3'], true)) {
+    // L1: log the attempt so an operator triaging "the form posted
+    // but I got an error toast" can correlate the rejected mode
+    // value with the painted toast. The mode value is operator-
+    // typed indirectly (the form template hardcodes `zip` / `s3`),
+    // so anything else is either a stale tab or a curl-driven
+    // probe; either way the audit log is the source of truth.
+    Log::add(
+        LogType::Warning,
+        'Data Export',
+        sprintf(
+            'Rejected POST: aid=%d invalid mode=%s',
+            $userbank->GetAid(),
+            substr($mode, 0, 32),
+        ),
+    );
     sbpp_export_redirect_failure('mode_invalid', $mode);
 }
 
@@ -264,6 +279,22 @@ function sbpp_export_run_s3_mode(Manifest $manifest, EntityExporter $entities, i
     //       `pattern="^https://...$"` is the UX-first gate) -------
     $presignUrl = isset($_POST['presign_url']) ? trim((string) $_POST['presign_url']) : '';
     if ($presignUrl === '' || strlen($presignUrl) > 2048) {
+        // L1: log the malformed-URL rejection so audit-trail
+        // visibility matches the painted toast. Do NOT log the
+        // raw URL (operator-typed; could carry sensitive presign
+        // signature parameters even on the failure branch) —
+        // log a length signature instead. The audit log is for
+        // operator triage, not credential capture.
+        Log::add(
+            LogType::Warning,
+            'Data Export',
+            sprintf(
+                'Rejected POST: aid=%d bundle_id=%s S3 presign URL length=%d (must be 1-2048).',
+                $aid,
+                $manifest->bundle_id,
+                strlen($presignUrl),
+            ),
+        );
         sbpp_export_redirect_failure(
             ExportError::PRESIGN_INVALID_URL,
             'Presigned URL must be 1-2048 characters.',
@@ -273,10 +304,17 @@ function sbpp_export_run_s3_mode(Manifest $manifest, EntityExporter $entities, i
     // ----- staging file under SB_CACHE/exports/ -----------------
     $stagingDir = SB_CACHE . 'exports' . DIRECTORY_SEPARATOR;
     if (!is_dir($stagingDir) && !@mkdir($stagingDir, 0755, true) && !is_dir($stagingDir)) {
+        // L2: include bundle_id so the audit row can be correlated
+        // with the manifest-build event upstream of this branch.
         Log::add(
             LogType::Error,
             'Data Export',
-            sprintf('S3 mode failed: aid=%d — cache dir not writable: %s', $aid, $stagingDir),
+            sprintf(
+                'S3 mode failed: aid=%d bundle_id=%s — cache dir not writable: %s',
+                $aid,
+                $manifest->bundle_id,
+                $stagingDir,
+            ),
         );
         sbpp_export_redirect_failure(
             ExportError::DISK_WRITE_FAILED,
@@ -298,10 +336,18 @@ function sbpp_export_run_s3_mode(Manifest $manifest, EntityExporter $entities, i
 
     $output = @fopen($tmpFile, 'wb');
     if ($output === false) {
+        // L2: include bundle_id for cross-reference with the
+        // manifest-build event upstream + the cleanup register
+        // call below.
         Log::add(
             LogType::Error,
             'Data Export',
-            sprintf('S3 mode failed: aid=%d — could not open staging file: %s', $aid, $tmpFile),
+            sprintf(
+                'S3 mode failed: aid=%d bundle_id=%s — could not open staging file: %s',
+                $aid,
+                $manifest->bundle_id,
+                $tmpFile,
+            ),
         );
         sbpp_export_redirect_failure(
             ExportError::DISK_WRITE_FAILED,
@@ -322,6 +368,13 @@ function sbpp_export_run_s3_mode(Manifest $manifest, EntityExporter $entities, i
         entities:           $entities,
         demosDir:           SB_DEMOS,
         flushAfterEntries:  false,
+        // M1: hand the writer the staging-file handle so its
+        // running cap counter snaps to the on-disk `fstat` size
+        // after each entry — exact compressed-byte tracking
+        // instead of the conservative uncompressed-byte estimate
+        // the zip-mode path is stuck with. Documented on
+        // BundleWriter::bytesWritten + BundleWriter::currentCompressedSize.
+        outputHandle:       $output,
     );
 
     try {

--- a/web/includes/Export/BundleWriter.php
+++ b/web/includes/Export/BundleWriter.php
@@ -1,0 +1,248 @@
+<?php
+// SourceBans++ (c) 2014-2026 SourceBans++ Dev Team
+// Licensed under the Elastic License 2.0.
+// See LICENSE.txt for the full license text and THIRD-PARTY-NOTICES.txt for attributions.
+
+declare(strict_types=1);
+
+namespace Sbpp\Export;
+
+use ZipStream\CompressionMethod;
+use ZipStream\ZipStream;
+
+/**
+ * Orchestrates the streaming ZIP bundle for the data export feature.
+ *
+ * The writer is the single seam between (a) the in-memory manifest
+ * payload + the {@see EntityExporter}-yielded JSONL streams + the
+ * on-disk demo files and (b) the ZIP output sink. The two consumers
+ * are:
+ *
+ *   - **`zip` mode** ({@see \Sbpp\Export\BundleWriter}'s caller in
+ *     `web/export.php` constructs a {@see ZipStream::class} pointing
+ *     at `php://output` with `$flushAfterEntries = true`). The
+ *     entry point hands the writer a {@see ZipStream} instance
+ *     pre-wired to flush headers + write bytes straight to the
+ *     client TCP socket; the writer's job is to feed the entries
+ *     in deterministic order AND `flush()` after each one so a
+ *     slow client doesn't sit with a `Content-Type: application/zip`
+ *     header for 30 seconds before the first byte arrives.
+ *   - **`s3` mode** (the caller constructs a {@see ZipStream}
+ *     pointing at a `fopen($tempfile, 'wb')` handle with
+ *     `$flushAfterEntries = false`). No client to flush to —
+ *     the bundle builds to disk first and the {@see S3PresignedUploader}
+ *     PUTs the finished file in a second step. Suppressing the flush
+ *     keeps per-entry kernel overhead off the critical path.
+ *
+ * Contract:
+ *
+ *   - **`manifest.json` is the FIRST entry.** The integration test
+ *     anchors on `ZipArchive::statIndex(0)['name'] === 'manifest.json'`;
+ *     a consumer that wants to short-circuit the bundle to read the
+ *     PII policy or row counts can stop after one entry.
+ *   - **Entity JSONL files land under `entities/<name>.jsonl`** in
+ *     deterministic key order.
+ *   - **Demo files land under `demos/<basename>.dem`** in
+ *     deterministic name order, compressed with {@see CompressionMethod::STORE}.
+ *     Demos are already DEFLATE'd at the source-engine level, and
+ *     re-compressing them costs CPU without saving bytes — STORE
+ *     means "wrap the raw bytes in a ZIP entry without compression"
+ *     which is the right shape for a binary payload that's
+ *     already entropy-maximal.
+ *   - **Running compressed-byte budget.** After each entity / demo
+ *     the writer checks the cumulative byte total against
+ *     {@see Manifest::MAX_BUNDLE_BYTES} minus
+ *     {@see Manifest::SAFETY_MARGIN_BYTES}; if exceeded, throws
+ *     {@see ExportError::CAP_EXCEEDED}. Pre-flight in
+ *     {@see ManifestBuilder} should catch this earlier in 99% of
+ *     cases — this is the safety net for the JSONL byte-estimate
+ *     undershoot case.
+ *   - **No ZIP64.** The {@see ZipStream} is constructed with
+ *     `$enableZip64 = false` by the caller; the 4 GiB ceiling is
+ *     the load-bearing reason — every mainstream unzipper handles
+ *     ZIP 2.0 natively, ZIP64 support is patchy.
+ */
+final class BundleWriter
+{
+    /**
+     * Cumulative compressed-byte count, including ZIP headers /
+     * central directory bytes the {@see ZipStream} tracks.
+     */
+    private int $bytesWritten = 0;
+
+    public function __construct(
+        private readonly ZipStream $zip,
+        private readonly Manifest $manifest,
+        private readonly EntityExporter $entities,
+        private readonly string $demosDir,
+        private readonly bool $flushAfterEntries,
+    ) {
+    }
+
+    /**
+     * Drive the full bundle: manifest first, entity JSONL streams
+     * next, demo files last, then finalise the ZIP central
+     * directory.
+     *
+     * Caller is responsible for the outer try/catch — see
+     * `web/export.php` for the canonical shape. {@see ExportError}
+     * surfaces a structured error code; anything else is a real
+     * bug and propagates to the dispatcher's generic 500.
+     */
+    public function write(): void
+    {
+        $this->writeManifest();
+
+        foreach ($this->entities->entityStreams() as $name => $factory) {
+            $this->writeEntity($name, $factory);
+        }
+
+        foreach ($this->manifest->demo_files as $demo) {
+            $this->writeDemo($demo);
+        }
+
+        // Finalize the ZIP — emits the central directory. ZipStream
+        // tracks an estimated cumulative size internally; the
+        // returned value is authoritative for the cap-check sanity
+        // assertion in tests.
+        $this->bytesWritten = (int) $this->zip->finish();
+    }
+
+    /**
+     * Total bytes the underlying ZipStream reports written. Only
+     * meaningful AFTER {@see write} returns; intermediate values
+     * during the run track the running budget, not the final
+     * compressed size (the central directory bytes land in
+     * {@see ZipStream::finish}).
+     */
+    public function bytesWritten(): int
+    {
+        return $this->bytesWritten;
+    }
+
+    /**
+     * Manifest goes in first by contract. `addFile` is the simplest
+     * shape since we already have the encoded body in memory.
+     */
+    private function writeManifest(): void
+    {
+        $body = $this->manifest->toJson();
+        $this->zip->addFile(
+            fileName:          'manifest.json',
+            data:              $body,
+            compressionMethod: CompressionMethod::DEFLATE,
+        );
+        $this->bytesWritten += strlen($body);
+        $this->checkCap('manifest.json');
+        $this->maybeFlush();
+    }
+
+    /**
+     * Stream one entity's JSONL output through `addFileFromCallback`
+     * so the bytes flow straight from the SELECT iterator into the
+     * ZIP without buffering the whole entity in PHP memory.
+     *
+     * @param callable(): iterable<string> $factory
+     */
+    private function writeEntity(string $name, callable $factory): void
+    {
+        $estimatedBytes = 0;
+        $this->zip->addFileFromCallback(
+            fileName:          'entities/' . $name . '.jsonl',
+            exactSize:         null,
+            compressionMethod: CompressionMethod::DEFLATE,
+            callback:          function () use ($factory, &$estimatedBytes): string {
+                $out = '';
+                foreach ($factory() as $line) {
+                    $out .= $line;
+                }
+                $estimatedBytes = strlen($out);
+                return $out;
+            },
+        );
+        $this->bytesWritten += $estimatedBytes;
+        $this->checkCap('entities/' . $name . '.jsonl');
+        $this->maybeFlush();
+    }
+
+    /**
+     * Demo files land under `demos/<basename>.dem` with
+     * {@see CompressionMethod::STORE} — they're already
+     * entropy-maximal binary streams (the source engine emits a
+     * DEFLATE-friendly demo only when explicitly told to), and
+     * re-compressing trades CPU for no byte savings.
+     *
+     * @param array{name: string, size_bytes: int} $demo
+     */
+    private function writeDemo(array $demo): void
+    {
+        $path = $this->demosDir . DIRECTORY_SEPARATOR . $demo['name'];
+        // Defence-in-depth: ManifestBuilder already stat'd the file
+        // when minting the demo list, but a race window between
+        // pre-flight and write (operator manually deletes a demo,
+        // a sweep cron runs) shouldn't 500 the export — skip and
+        // continue. The manifest still claims the demo exists, so
+        // a strict consumer would notice the bookkeeping drift;
+        // the alternative is silent corruption of an inflight
+        // bundle, which is worse.
+        if (!is_file($path)) {
+            return;
+        }
+        $this->zip->addFileFromPath(
+            fileName:          'demos/' . $demo['name'],
+            path:              $path,
+            compressionMethod: CompressionMethod::STORE,
+        );
+        $this->bytesWritten += $demo['size_bytes'];
+        $this->checkCap('demos/' . $demo['name']);
+        $this->maybeFlush();
+    }
+
+    /**
+     * Compare the running cumulative byte total against the cap
+     * (minus safety margin). Throws {@see ExportError::CAP_EXCEEDED}
+     * with the offending entry's name so an operator can identify
+     * which slice tipped the budget over.
+     */
+    private function checkCap(string $lastEntry): void
+    {
+        $cap = Manifest::MAX_BUNDLE_BYTES - Manifest::SAFETY_MARGIN_BYTES;
+        if ($this->bytesWritten > $cap) {
+            throw new ExportError(
+                ExportError::CAP_EXCEEDED,
+                sprintf(
+                    'Bundle exceeded the %d-byte cap (4 GiB minus the %d-byte safety margin) '
+                    . 'after writing %s (cumulative %d bytes). Clean up stale demos and rerun.',
+                    $cap,
+                    Manifest::SAFETY_MARGIN_BYTES,
+                    $lastEntry,
+                    $this->bytesWritten,
+                ),
+            );
+        }
+    }
+
+    /**
+     * Push bytes downstream after each entry in zip-mode so the
+     * client TCP socket sees progress instead of a long opaque
+     * pause. In s3-mode the writer's output is a file handle — no
+     * client to flush to, and the per-call kernel overhead is dead
+     * weight.
+     */
+    private function maybeFlush(): void
+    {
+        if (!$this->flushAfterEntries) {
+            return;
+        }
+        // PHP's flush() pushes the output buffer chain; the wrapping
+        // entry point in `web/export.php` has already cleared every
+        // ob_* layer, so this hits the SAPI directly. ob_flush() is
+        // a defensive no-op when there's no buffer to flush, but the
+        // `@` suppresses the notice that PHP emits when called
+        // outside an ob_start context.
+        flush();
+        if (function_exists('ob_flush')) {
+            @ob_flush();
+        }
+    }
+}

--- a/web/includes/Export/BundleWriter.php
+++ b/web/includes/Export/BundleWriter.php
@@ -65,18 +65,80 @@ use ZipStream\ZipStream;
 final class BundleWriter
 {
     /**
-     * Cumulative compressed-byte count, including ZIP headers /
-     * central directory bytes the {@see ZipStream} tracks.
+     * Threshold (bytes) above which entity / manifest bodies spill
+     * from the in-memory `php://temp` buffer onto disk. Below this,
+     * the stream stays in PHP's heap — the typical settings /
+     * groups / mods bundle entity is a few KiB and never touches
+     * the filesystem; the spill is the safety net for the long
+     * tail (large `:prefix_log` audit-log streams on long-lived
+     * installs, banlog history, large banlists with thousands of
+     * appeals).
+     *
+     * 8 MiB matches the OOM ceiling the runtime hardening in
+     * `web/export.php` sets via `@ini_set('memory_limit', '256M')`
+     * minus the headroom needed for PDO row buffers + Smarty +
+     * Composer autoload — pushing the spill threshold higher would
+     * eat into that headroom and risk OOM on shared hosting where
+     * 128 MiB is the realistic floor.
+     */
+    private const SPILL_THRESHOLD_BYTES = 8 * 1024 * 1024;
+
+    /**
+     * Cumulative byte count tracking the bundle's progress against
+     * {@see Manifest::MAX_BUNDLE_BYTES}.
+     *
+     * The accuracy of this counter depends on which output sink the
+     * caller wired the {@see ZipStream} to. See
+     * {@see currentCompressedSize} for the per-mode details:
+     *
+     *   - **`s3` mode** — the writer holds a non-null
+     *     {@see outputHandle} pointing at the build-to-disk
+     *     tempfile; after each entry the writer `fstat`s the
+     *     handle and gets the EXACT compressed-byte count. The
+     *     cap check is precise.
+     *   - **`zip` mode** — the writer's output sink is
+     *     `php://output` (unseekable, unstattable), so the writer
+     *     falls back to a conservative uncompressed-byte estimate.
+     *     This OVER-counts (DEFLATE typically compresses JSONL
+     *     3-8x) but the over-count direction is the safe one — a
+     *     premature `CAP_EXCEEDED` surfaces a clear error message
+     *     pre-overflow, whereas an under-count would let the
+     *     bundle exceed ZIP 2.0's 4 GiB ceiling and corrupt
+     *     silently. The conservative estimate stays in place for
+     *     `zip` mode because there is no exact counter the
+     *     unseekable sink can offer.
      */
     private int $bytesWritten = 0;
 
+    /**
+     * Optional file resource the {@see ZipStream} is writing to.
+     * Non-null in `s3` mode (build-to-disk path); null in `zip`
+     * mode (output is `php://output`). When non-null, post-entry
+     * `fstat`s give the exact compressed-byte count and the cap
+     * check is precise; when null, the writer falls back to the
+     * uncompressed estimate documented on {@see bytesWritten}.
+     *
+     * @var resource|null
+     */
+    private $outputHandle;
+
+    /**
+     * @param resource|null $outputHandle  Pass the same file
+     *   resource the caller handed to {@see ZipStream} when
+     *   building the s3-mode build-to-disk tempfile. Pass `null`
+     *   for the zip-mode `php://output` path (the writer falls
+     *   back to a conservative uncompressed-byte cap estimate per
+     *   the {@see bytesWritten} contract).
+     */
     public function __construct(
         private readonly ZipStream $zip,
         private readonly Manifest $manifest,
         private readonly EntityExporter $entities,
         private readonly string $demosDir,
         private readonly bool $flushAfterEntries,
+        $outputHandle = null,
     ) {
+        $this->outputHandle = $outputHandle;
     }
 
     /**
@@ -101,11 +163,17 @@ final class BundleWriter
             $this->writeDemo($demo);
         }
 
-        // Finalize the ZIP — emits the central directory. ZipStream
-        // tracks an estimated cumulative size internally; the
-        // returned value is authoritative for the cap-check sanity
-        // assertion in tests.
-        $this->bytesWritten = (int) $this->zip->finish();
+        // Finalize the ZIP — emits the central directory. ZipStream's
+        // return value tracks the bytes IT pushed to the output
+        // sink (independent of any compression layer the sink might
+        // apply). For s3 mode we re-snap from the on-disk tempfile
+        // post-finish so the reported count includes the central
+        // directory bytes and matches what the S3 PUT will see. For
+        // zip mode the ZipStream-reported count is authoritative
+        // since we have no on-disk file to stat.
+        $reported = (int) $this->zip->finish();
+        $exact    = $this->currentCompressedSize();
+        $this->bytesWritten = $exact ?? $reported;
     }
 
     /**
@@ -121,8 +189,12 @@ final class BundleWriter
     }
 
     /**
-     * Manifest goes in first by contract. `addFile` is the simplest
-     * shape since we already have the encoded body in memory.
+     * Manifest goes in first by contract. The body is bounded
+     * (per-entity row counts + the demo manifest entries — a few
+     * KiB to a few hundred KiB on a busy install), so addFile
+     * with the in-memory body is the right shape; spilling to a
+     * tempfile here would only add filesystem overhead with no
+     * memory benefit.
      */
     private function writeManifest(): void
     {
@@ -132,36 +204,78 @@ final class BundleWriter
             data:              $body,
             compressionMethod: CompressionMethod::DEFLATE,
         );
-        $this->bytesWritten += strlen($body);
-        $this->checkCap('manifest.json');
+        $this->advanceCounter(strlen($body), 'manifest.json');
         $this->maybeFlush();
     }
 
     /**
-     * Stream one entity's JSONL output through `addFileFromCallback`
-     * so the bytes flow straight from the SELECT iterator into the
-     * ZIP without buffering the whole entity in PHP memory.
+     * Stream one entity's JSONL output through a `php://temp`
+     * spill stream so each row flows from the SELECT iterator into
+     * the spill stream and only the bounded
+     * {@see SPILL_THRESHOLD_BYTES} working set ever lives in PHP's
+     * heap. Larger entities (audit log on long-lived installs,
+     * banlog history, banlists with thousands of rows) spill to a
+     * tempfile that the OS cleans up automatically when the
+     * resource handle is closed at the end of the call.
+     *
+     * The pre-#H1 shape concatenated the entire entity into a
+     * single PHP string inside an `addFileFromCallback`, which
+     * defeated the streaming contract documented on the writer
+     * AND risked OOM on installs with multi-hundred-MB audit
+     * logs.
      *
      * @param callable(): iterable<string> $factory
      */
     private function writeEntity(string $name, callable $factory): void
     {
-        $estimatedBytes = 0;
-        $this->zip->addFileFromCallback(
-            fileName:          'entities/' . $name . '.jsonl',
-            exactSize:         null,
-            compressionMethod: CompressionMethod::DEFLATE,
-            callback:          function () use ($factory, &$estimatedBytes): string {
-                $out = '';
-                foreach ($factory() as $line) {
-                    $out .= $line;
+        $spill = fopen('php://temp/maxmemory:' . self::SPILL_THRESHOLD_BYTES, 'w+b');
+        if ($spill === false) {
+            // SECURITY-REVIEW: fopen of php://temp should never
+            // fail on a healthy install — the only realistic
+            // cause is a pathological tmpfs / open_basedir
+            // configuration. Surface as a structured DISK_WRITE
+            // failure rather than silently dropping the entity.
+            throw new ExportError(
+                ExportError::DISK_WRITE_FAILED,
+                sprintf(
+                    'fopen(php://temp/maxmemory:%d) failed while preparing entity %s.',
+                    self::SPILL_THRESHOLD_BYTES,
+                    $name,
+                ),
+            );
+        }
+        try {
+            $uncompressed = 0;
+            foreach ($factory() as $line) {
+                $written = fwrite($spill, $line);
+                if ($written === false || $written !== strlen($line)) {
+                    throw new ExportError(
+                        ExportError::DISK_WRITE_FAILED,
+                        sprintf(
+                            'Short write to php://temp spill while staging entity %s.',
+                            $name,
+                        ),
+                    );
                 }
-                $estimatedBytes = strlen($out);
-                return $out;
-            },
-        );
-        $this->bytesWritten += $estimatedBytes;
-        $this->checkCap('entities/' . $name . '.jsonl');
+                $uncompressed += $written;
+            }
+            rewind($spill);
+            $this->zip->addFileFromStream(
+                fileName:          'entities/' . $name . '.jsonl',
+                stream:            $spill,
+                compressionMethod: CompressionMethod::DEFLATE,
+            );
+            // Counter advance comes AFTER addFileFromStream
+            // returns — at that point the zip has finished
+            // writing the entry to the underlying output handle.
+            // For s3 mode the post-write fstat sees the exact
+            // compressed size; for zip mode the fallback uses the
+            // uncompressed total (conservative — see the
+            // bytesWritten docblock).
+            $this->advanceCounter($uncompressed, 'entities/' . $name . '.jsonl');
+        } finally {
+            fclose($spill);
+        }
         $this->maybeFlush();
     }
 
@@ -193,9 +307,57 @@ final class BundleWriter
             path:              $path,
             compressionMethod: CompressionMethod::STORE,
         );
-        $this->bytesWritten += $demo['size_bytes'];
-        $this->checkCap('demos/' . $demo['name']);
+        // STORE-mode demos: compressed size ≈ uncompressed size
+        // (the ZIP entry adds ~46 bytes of local header overhead,
+        // negligible against multi-MB demo payloads). Track the
+        // file's on-disk size as the increment.
+        $this->advanceCounter($demo['size_bytes'], 'demos/' . $demo['name']);
         $this->maybeFlush();
+    }
+
+    /**
+     * Advance the running cap-check counter by `$uncompressedDelta`
+     * — the uncompressed-byte size of the entry just handed off to
+     * {@see ZipStream}. When the writer has access to the output
+     * handle (s3 mode), the counter snaps to the handle's `fstat`
+     * size INSTEAD, giving the exact compressed-byte total. When
+     * the output handle isn't seekable (zip mode), the counter
+     * adds the uncompressed delta as the conservative fallback
+     * documented on {@see bytesWritten}.
+     */
+    private function advanceCounter(int $uncompressedDelta, string $lastEntry): void
+    {
+        $exact = $this->currentCompressedSize();
+        if ($exact !== null) {
+            $this->bytesWritten = $exact;
+        } else {
+            $this->bytesWritten += $uncompressedDelta;
+        }
+        $this->checkCap($lastEntry);
+    }
+
+    /**
+     * Return the EXACT compressed-byte count when the writer's
+     * output handle is seekable (s3 mode's build-to-disk
+     * tempfile), or `null` when it isn't (zip mode's
+     * `php://output`). The exact count includes ZipStream's
+     * per-entry local-file-header bytes the in-flight central
+     * directory tracker can't see, so it's the authoritative
+     * value for cap-check purposes.
+     */
+    private function currentCompressedSize(): ?int
+    {
+        if ($this->outputHandle === null) {
+            return null;
+        }
+        if (!is_resource($this->outputHandle)) {
+            return null;
+        }
+        $stat = @fstat($this->outputHandle);
+        if ($stat === false) {
+            return null;
+        }
+        return (int) $stat['size'];
     }
 
     /**

--- a/web/includes/Export/EntityExporter.php
+++ b/web/includes/Export/EntityExporter.php
@@ -1,0 +1,919 @@
+<?php
+// SourceBans++ (c) 2014-2026 SourceBans++ Dev Team
+// Licensed under the Elastic License 2.0.
+// See LICENSE.txt for the full license text and THIRD-PARTY-NOTICES.txt for attributions.
+
+declare(strict_types=1);
+
+namespace Sbpp\Export;
+
+use BanRemoval;
+use BanType;
+use Exception;
+use LogType;
+use Sbpp\Db\Database;
+use SteamID\SteamID;
+
+/**
+ * Per-entity SELECT + JSONL emission for the data export bundle.
+ *
+ * One public method per entity, each returning `iterable<string>`
+ * of JSONL lines (one JSON object per line, trailing `\n`). The
+ * caller ({@see BundleWriter}) wires each iterable into a
+ * `ZipStream::addFileFromCallback` so the SELECT streams straight
+ * out the wire without materialising the full result set in PHP
+ * memory. Every read goes through {@see Database::iterate} for the
+ * same reason.
+ *
+ * Wire contracts (uniform across every entity unless noted):
+ *
+ *   - **`null` for absent, never `""` and never omitted.** Every
+ *     column the exporter touches gets {@see asString} treatment
+ *     so an empty-string default at the schema level surfaces as
+ *     JSON `null` in the export. Consumers can write to a schema
+ *     with `NOT NULL` defaults more comfortably when "no value"
+ *     and "empty string" can't be confused.
+ *   - **Timestamps as unix-seconds `int`.** Every `int(11) created`
+ *     column is `(int)`-cast verbatim; every `datetime` column
+ *     (only `:prefix_admins.lockout_until` today, which we never
+ *     export anyway) routes through `strtotime`. The plan's
+ *     "epoch-only" contract is structural — a downstream consumer
+ *     never has to choose between two date formats.
+ *   - **Steam IDs as decimal-string Steam64.** Every column that
+ *     stores a Steam ID (`authid` on bans / comms / admins,
+ *     `SteamId` on submissions, `steam_id` on notes) routes
+ *     through {@see steamPair} which returns
+ *     `[authid: <decimal string>, authid_steam2: <STEAM_X:Y:Z>]`.
+ *     Legacy malformed `authid` rows (pre-#1108 / #765 truncation,
+ *     unset rows, "BOT", "STEAM_ID_LAN") yield `null` for both
+ *     fields — the exporter never throws on a bad row, because the
+ *     export is a recovery / migration surface and the operator
+ *     shouldn't have to clean up legacy garbage before they can
+ *     run it.
+ *   - **Forbidden columns are hard-coded.** {@see FORBIDDEN_ADMIN_COLUMNS},
+ *     {@see FORBIDDEN_SERVER_COLUMNS}, and {@see FORBIDDEN_SETTING_KEYS}
+ *     enumerate every value the bundle MUST NEVER carry. The
+ *     unit tests assert by grep that the values literally don't
+ *     appear in the entity output. This list is intentionally
+ *     pre-encoded — never reach for "let me read the schema and
+ *     deny dynamically", because a future column addition would
+ *     silently slip through that gate.
+ *   - **Source PK preserved as `id` where possible.** Single-PK
+ *     tables emit `id: <int>` matching the source's PK column
+ *     (`:prefix_admins.aid` → `id`, `:prefix_bans.bid` → `id`,
+ *     etc.). Composite-PK tables (`:prefix_banlog`,
+ *     `:prefix_admins_servers_groups`, `:prefix_servers_groups`)
+ *     skip `id` and preserve the join keys verbatim; the consumer
+ *     reconstructs identity from the composite shape.
+ *
+ * Per-entity special derivations live next to their `*()` method,
+ * documented inline. The headline ones:
+ *
+ *   - {@see comms} emits `mute_kind` ∈ {`mute`, `gag`, `silence`,
+ *     `unknown`} alongside the raw `type` int.
+ *   - {@see bans} emits `state` ∈ {`active`, `expired`, `unbanned`,
+ *     `permanent`} derived from the same `RemoveType` + `length` +
+ *     `ends` classifier `page.banlist.php` uses for the UI pill.
+ *   - {@see bans} and {@see submissions} both LEFT JOIN
+ *     `:prefix_demos` so a row's `demo_filename` / `demo_size_bytes`
+ *     surface when the file exists on disk (and both fields are
+ *     `null` otherwise — the row still ships, the demo just
+ *     doesn't).
+ *   - {@see log} JOINs `:prefix_admins` to surface the actor's
+ *     display name + Steam64; emits `level` ∈ {`message`, `warning`,
+ *     `error`} derived from `LogType`.
+ */
+final class EntityExporter
+{
+    /**
+     * Columns we MUST NEVER include in the `admins` JSONL stream.
+     *
+     *   - `password`       Salted hash. Including it would defeat
+     *                      the entire "data export is safe to
+     *                      hand off" property.
+     *   - `validate`       Single-use password-reset token. Live
+     *                      session credential.
+     *   - `attempts`       Failed-login counter — implementation
+     *                      detail of the lockout flow, not panel
+     *                      data the operator cares about exporting.
+     *   - `lockout_until`  Same — lockout deadline driven by
+     *                      `attempts`.
+     *
+     * The actual enforcement is the per-column SELECT projection in
+     * {@see admins} (the forbidden columns are NOT projected, so
+     * they can never leak even through a code-path that bypasses
+     * the row builder). This constant is the test-visible
+     * declaration of the contract — the unit tests pull from
+     * {@see forbiddenColumns} to assert by grep that none of the
+     * listed names appear in the actual export.
+     */
+    public const FORBIDDEN_ADMIN_COLUMNS = ['password', 'validate', 'attempts', 'lockout_until'];
+
+    /**
+     * Columns we MUST NEVER include in the `servers` JSONL stream.
+     *
+     *   - `rcon`  Server's RCON password. Recipients of an export
+     *             bundle have no business holding the keys to the
+     *             game servers themselves.
+     *
+     * See {@see FORBIDDEN_ADMIN_COLUMNS} for the enforcement
+     * structure (SQL projection at the call site is the
+     * load-bearing gate; this constant is the test-visible
+     * declaration).
+     */
+    public const FORBIDDEN_SERVER_COLUMNS = ['rcon'];
+
+    /**
+     * `sb_settings.setting` keys we MUST NEVER export.
+     *
+     *   - `smtp.pass`             SMTP relay password.
+     *   - `telemetry.instance_id` Anonymous-by-default telemetry
+     *                             identifier — keeping it on the
+     *                             panel of origin is the whole
+     *                             point of anonymity.
+     */
+    public const FORBIDDEN_SETTING_KEYS = ['smtp.pass', 'telemetry.instance_id'];
+
+    /**
+     * Test-visible accessor for the forbidden-column allowlist.
+     * The integration test uses this to greps the produced JSONL
+     * by value rather than by hard-coded literal — a future
+     * forbidden-column addition gets picked up automatically.
+     *
+     * @return array{admins: list<string>, servers: list<string>, settings: list<string>}
+     */
+    public static function forbiddenColumns(): array
+    {
+        return [
+            'admins'   => self::FORBIDDEN_ADMIN_COLUMNS,
+            'servers'  => self::FORBIDDEN_SERVER_COLUMNS,
+            'settings' => self::FORBIDDEN_SETTING_KEYS,
+        ];
+    }
+
+    /**
+     * JSON encoder flags every entity row uses.
+     *
+     * `JSON_THROW_ON_ERROR` surfaces malformed payloads loudly
+     * instead of silently emitting `false`. `JSON_INVALID_UTF8_SUBSTITUTE`
+     * is the load-bearing flag for fault tolerance — player names on
+     * `:prefix_bans.name` / `:prefix_comms.name` can carry malformed
+     * UTF-8 from the pre-#1108 (#765) Latin-1-on-utf8 truncation
+     * shape, and without this flag the export 500s mid-stream on a
+     * hostile-historical row. Same precedent as
+     * {@see \Sbpp\View\Toast::emit}; non-negotiable per the plan.
+     * `JSON_UNESCAPED_*` keeps the on-disk JSONL human-readable.
+     */
+    private const JSON_FLAGS = JSON_THROW_ON_ERROR
+        | JSON_INVALID_UTF8_SUBSTITUTE
+        | JSON_UNESCAPED_SLASHES
+        | JSON_UNESCAPED_UNICODE;
+
+    public function __construct(
+        private readonly Database $dbs,
+        private readonly string $demosDir,
+    ) {
+    }
+
+    /**
+     * Deterministic-by-name map of entity name → factory closure.
+     *
+     * {@see BundleWriter} iterates in `ksort` order so the bundle's
+     * central-directory ordering is stable across reruns. Keep in
+     * lockstep with {@see ManifestBuilder::ENTITIES}.
+     *
+     * @return array<string, callable(): iterable<string>>
+     */
+    public function entityStreams(): array
+    {
+        return [
+            'admins'                => fn(): iterable => $this->admins(),
+            'admins_servers_groups' => fn(): iterable => $this->adminsServersGroups(),
+            'banlog'                => fn(): iterable => $this->banlog(),
+            'bans'                  => fn(): iterable => $this->bans(),
+            'comments'              => fn(): iterable => $this->comments(),
+            'comms'                 => fn(): iterable => $this->comms(),
+            'groups'                => fn(): iterable => $this->groups(),
+            'log'                   => fn(): iterable => $this->log(),
+            'mods'                  => fn(): iterable => $this->mods(),
+            'notes'                 => fn(): iterable => $this->notes(),
+            'overrides'             => fn(): iterable => $this->overrides(),
+            'protests'              => fn(): iterable => $this->protests(),
+            'servers'               => fn(): iterable => $this->servers(),
+            'servers_groups'        => fn(): iterable => $this->serversGroups(),
+            'settings'              => fn(): iterable => $this->settings(),
+            'srvgroups'             => fn(): iterable => $this->srvgroups(),
+            'srvgroups_overrides'   => fn(): iterable => $this->srvgroupsOverrides(),
+            'submissions'           => fn(): iterable => $this->submissions(),
+        ];
+    }
+
+    /**
+     * `:prefix_admins`. Forbidden columns ({@see FORBIDDEN_ADMIN_COLUMNS})
+     * are NOT projected in the SELECT, so they can never leak even
+     * through a future code-path that bypasses the projection helper.
+     *
+     * @return iterable<string>
+     */
+    public function admins(): iterable
+    {
+        $this->dbs->query(
+            "SELECT `aid`, `user`, `authid`, `gid`, `email`, `extraflags`, `immunity`,
+                    `srv_group`, `srv_flags`, `srv_password`, `lastvisit`
+             FROM `:prefix_admins`
+             ORDER BY `aid`"
+        );
+        foreach ($this->dbs->iterate() as $row) {
+            $steam = $this->steamPair($row['authid'] ?? null);
+            yield $this->encode([
+                'id'             => (int) $row['aid'],
+                'user'           => $this->asString($row['user'] ?? null),
+                'authid'         => $steam['authid'],
+                'authid_steam2'  => $steam['authid_steam2'],
+                'gid'            => (int) ($row['gid'] ?? 0),
+                'email'          => $this->asString($row['email'] ?? null),
+                'extraflags'     => (int) ($row['extraflags'] ?? 0),
+                'immunity'       => (int) ($row['immunity'] ?? 0),
+                'srv_group'      => $this->asString($row['srv_group'] ?? null),
+                'srv_flags'      => $this->asString($row['srv_flags'] ?? null),
+                'srv_password'   => $this->asString($row['srv_password'] ?? null),
+                'lastvisit'      => $row['lastvisit'] !== null ? (int) $row['lastvisit'] : null,
+            ]);
+        }
+    }
+
+    /**
+     * `:prefix_admins_servers_groups`. Composite-PK table — no `id`
+     * field, the four join keys are the identity.
+     *
+     * @return iterable<string>
+     */
+    public function adminsServersGroups(): iterable
+    {
+        $this->dbs->query(
+            "SELECT `admin_id`, `group_id`, `srv_group_id`, `server_id`
+             FROM `:prefix_admins_servers_groups`
+             ORDER BY `admin_id`, `group_id`, `srv_group_id`, `server_id`"
+        );
+        foreach ($this->dbs->iterate() as $row) {
+            yield $this->encode([
+                'admin_id'     => (int) $row['admin_id'],
+                'group_id'     => (int) $row['group_id'],
+                'srv_group_id' => (int) $row['srv_group_id'],
+                'server_id'    => (int) $row['server_id'],
+            ]);
+        }
+    }
+
+    /**
+     * `:prefix_banlog`. Composite-PK table — `(sid, time, bid)` is
+     * the identity, no `id` field.
+     *
+     * @return iterable<string>
+     */
+    public function banlog(): iterable
+    {
+        $this->dbs->query(
+            "SELECT `sid`, `time`, `name`, `bid`
+             FROM `:prefix_banlog`
+             ORDER BY `time`, `sid`, `bid`"
+        );
+        foreach ($this->dbs->iterate() as $row) {
+            yield $this->encode([
+                'sid'  => (int) $row['sid'],
+                'time' => (int) $row['time'],
+                'name' => $this->asString($row['name'] ?? null),
+                'bid'  => (int) $row['bid'],
+            ]);
+        }
+    }
+
+    /**
+     * `:prefix_bans`. LEFT JOIN against `:prefix_demos` for the
+     * per-row demo metadata; LEFT JOIN against `:prefix_admins` so
+     * we can emit the actor's display name + Steam64 alongside the
+     * raw `aid` foreign key.
+     *
+     * Each row carries:
+     *
+     *   - `state` — one of `permanent` / `active` / `expired` /
+     *     `unbanned`. Mirrors the same classifier `page.banlist.php`
+     *     uses for the UI pill (#1352's pre-2 admin-lift defensive
+     *     arm included), so consumers don't have to re-derive the
+     *     logic from `RemoveType` + `RemovedBy` + `length` + `ends`.
+     *   - `type` (raw int) + `type_label` ("steam" / "ip").
+     *   - `demo_filename` + `demo_size_bytes` when the demos row
+     *     exists AND the file is on disk (both `null` otherwise).
+     *
+     * @return iterable<string>
+     */
+    public function bans(): iterable
+    {
+        $this->dbs->query(
+            "SELECT B.`bid`, B.`ip`, B.`authid`, B.`name`, B.`created`, B.`ends`, B.`length`,
+                    B.`reason`, B.`aid`, B.`adminIp`, B.`sid`, B.`country`,
+                    B.`RemovedBy`, B.`RemoveType`, B.`RemovedOn`, B.`type`, B.`ureason`,
+                    D.`filename` AS `demo_filename_raw`,
+                    A.`user` AS `removed_by_user`, A.`authid` AS `removed_by_authid`
+             FROM `:prefix_bans` B
+             LEFT JOIN `:prefix_demos` D ON D.`demid` = B.`bid` AND D.`demtype` = 'B'
+             LEFT JOIN `:prefix_admins` A ON A.`aid` = B.`RemovedBy`
+             ORDER BY B.`bid`"
+        );
+        foreach ($this->dbs->iterate() as $row) {
+            $steam        = $this->steamPair($row['authid'] ?? null);
+            $banType      = BanType::tryFrom((int) ($row['type'] ?? 0));
+            $banRemoval   = BanRemoval::tryFrom((string) ($row['RemoveType'] ?? ''));
+            [$demoName, $demoSize] = $this->demoMetadata((string) ($row['demo_filename_raw'] ?? ''));
+            $removedBy    = $row['RemovedBy'] !== null ? (int) $row['RemovedBy'] : null;
+            $removedBySteam = $this->steamPair($row['removed_by_authid'] ?? null);
+
+            yield $this->encode([
+                'id'               => (int) $row['bid'],
+                'ip'               => $this->asString($row['ip'] ?? null),
+                'authid'           => $steam['authid'],
+                'authid_steam2'    => $steam['authid_steam2'],
+                'name'             => $this->asString($row['name'] ?? null),
+                'created'          => (int) ($row['created'] ?? 0),
+                'ends'             => (int) ($row['ends'] ?? 0),
+                'length'           => (int) ($row['length'] ?? 0),
+                'reason'           => $this->asString($row['reason'] ?? null),
+                'aid'              => (int) ($row['aid'] ?? 0),
+                'admin_ip'         => $this->asString($row['adminIp'] ?? null),
+                'sid'              => (int) ($row['sid'] ?? 0),
+                'country'          => $this->asString($row['country'] ?? null),
+                'removed_by'       => $removedBy,
+                'removed_by_user'  => $this->asString($row['removed_by_user'] ?? null),
+                'removed_by_steam' => $removedBySteam['authid'],
+                'remove_type'      => $banRemoval?->value,
+                'removed_on'       => $row['RemovedOn'] !== null ? (int) $row['RemovedOn'] : null,
+                'type'             => (int) ($row['type'] ?? 0),
+                'type_label'       => $this->banTypeLabel($banType),
+                'ureason'          => $this->asString($row['ureason'] ?? null),
+                'state'            => $this->banState($banRemoval, $removedBy, (int) ($row['length'] ?? 0), (int) ($row['ends'] ?? 0)),
+                'demo_filename'    => $demoName !== null ? 'demos/' . $demoName : null,
+                'demo_size_bytes'  => $demoSize,
+            ]);
+        }
+    }
+
+    /**
+     * `:prefix_comments`. Source PK is `cid` (rendered as `id`).
+     * No special derivations — comments are flat admin-authored
+     * text rows, surfaced verbatim with the same `type` letter the
+     * column uses (`B` = ban, `C` = comm, `S` = submission,
+     * `P` = protest).
+     *
+     * @return iterable<string>
+     */
+    public function comments(): iterable
+    {
+        $this->dbs->query(
+            "SELECT `cid`, `bid`, `type`, `aid`, `commenttxt`, `added`, `editaid`, `edittime`
+             FROM `:prefix_comments`
+             ORDER BY `cid`"
+        );
+        foreach ($this->dbs->iterate() as $row) {
+            yield $this->encode([
+                'id'         => (int) $row['cid'],
+                'bid'        => (int) $row['bid'],
+                'type'       => $this->asString($row['type'] ?? null),
+                'aid'        => (int) ($row['aid'] ?? 0),
+                'commenttxt' => $this->asString($row['commenttxt'] ?? null),
+                'added'      => (int) ($row['added'] ?? 0),
+                'editaid'    => $row['editaid'] !== null ? (int) $row['editaid'] : null,
+                'edittime'   => $row['edittime'] !== null ? (int) $row['edittime'] : null,
+            ]);
+        }
+    }
+
+    /**
+     * `:prefix_comms`. The `mute_kind` field is the headline
+     * derivation: `:prefix_comms.type` is a `tinyint` that takes
+     * `1`, `2`, or `3` per the SourceMod plugin (`1 → mute`,
+     * `2 → gag`, `3 → silence`). Anything else → `unknown`. The raw
+     * int is preserved as `type` so a consumer that wants to apply
+     * its own classifier still has the source data.
+     *
+     * @return iterable<string>
+     */
+    public function comms(): iterable
+    {
+        $this->dbs->query(
+            "SELECT `bid`, `authid`, `name`, `created`, `ends`, `length`, `reason`,
+                    `aid`, `adminIp`, `sid`, `RemovedBy`, `RemoveType`, `RemovedOn`,
+                    `type`, `ureason`
+             FROM `:prefix_comms`
+             ORDER BY `bid`"
+        );
+        foreach ($this->dbs->iterate() as $row) {
+            $steam       = $this->steamPair($row['authid'] ?? null);
+            $banRemoval  = BanRemoval::tryFrom((string) ($row['RemoveType'] ?? ''));
+            $rawType     = (int) ($row['type'] ?? 0);
+
+            yield $this->encode([
+                'id'             => (int) $row['bid'],
+                'authid'         => $steam['authid'],
+                'authid_steam2'  => $steam['authid_steam2'],
+                'name'           => $this->asString($row['name'] ?? null),
+                'created'        => (int) ($row['created'] ?? 0),
+                'ends'           => (int) ($row['ends'] ?? 0),
+                'length'         => (int) ($row['length'] ?? 0),
+                'reason'         => $this->asString($row['reason'] ?? null),
+                'aid'            => (int) ($row['aid'] ?? 0),
+                'admin_ip'       => $this->asString($row['adminIp'] ?? null),
+                'sid'            => (int) ($row['sid'] ?? 0),
+                'removed_by'     => $row['RemovedBy'] !== null ? (int) $row['RemovedBy'] : null,
+                'remove_type'    => $banRemoval?->value,
+                'removed_on'     => $row['RemovedOn'] !== null ? (int) $row['RemovedOn'] : null,
+                'type'           => $rawType,
+                'type_raw'       => $rawType,
+                'mute_kind'      => $this->commsMuteKind($rawType),
+                'ureason'        => $this->asString($row['ureason'] ?? null),
+            ]);
+        }
+    }
+
+    /**
+     * `:prefix_groups`. Web-side admin groups (the `gid` foreign key
+     * sat in `:prefix_admins.gid`).
+     *
+     * @return iterable<string>
+     */
+    public function groups(): iterable
+    {
+        $this->dbs->query(
+            "SELECT `gid`, `type`, `name`, `flags`
+             FROM `:prefix_groups`
+             ORDER BY `gid`"
+        );
+        foreach ($this->dbs->iterate() as $row) {
+            yield $this->encode([
+                'id'    => (int) $row['gid'],
+                'type'  => (int) ($row['type'] ?? 0),
+                'name'  => $this->asString($row['name'] ?? null),
+                'flags' => (int) ($row['flags'] ?? 0),
+            ]);
+        }
+    }
+
+    /**
+     * `:prefix_log`. The audit log. Joins `:prefix_admins` to
+     * surface the actor's display name + Steam64 alongside the raw
+     * `aid` foreign key; emits `level` ∈ {`message` / `warning` /
+     * `error`} derived from `LogType`.
+     *
+     * @return iterable<string>
+     */
+    public function log(): iterable
+    {
+        $this->dbs->query(
+            "SELECT L.`lid`, L.`type`, L.`title`, L.`message`, L.`function`, L.`query`,
+                    L.`aid`, L.`host`, L.`created`,
+                    A.`user` AS `actor_user`, A.`authid` AS `actor_authid`
+             FROM `:prefix_log` L
+             LEFT JOIN `:prefix_admins` A ON A.`aid` = L.`aid`
+             ORDER BY L.`lid`"
+        );
+        foreach ($this->dbs->iterate() as $row) {
+            $logType   = LogType::tryFrom((string) ($row['type'] ?? ''));
+            $actorAid  = (int) ($row['aid'] ?? 0);
+            $actorSteam = $this->steamPair($row['actor_authid'] ?? null);
+            yield $this->encode([
+                'id'           => (int) $row['lid'],
+                'type'         => (string) ($row['type'] ?? ''),
+                'level'        => $this->logLevel($logType),
+                'title'        => $this->asString($row['title'] ?? null),
+                'message'      => $this->asString($row['message'] ?? null),
+                'function'     => $this->asString($row['function'] ?? null),
+                'query'        => $this->asString($row['query'] ?? null),
+                'aid'          => $actorAid > 0 ? $actorAid : null,
+                'actor_user'   => $actorAid > 0 ? $this->asString($row['actor_user'] ?? null) : null,
+                'actor_steam'  => $actorAid > 0 ? $actorSteam['authid'] : null,
+                'host'         => $this->asString($row['host'] ?? null),
+                'created'      => (int) ($row['created'] ?? 0),
+            ]);
+        }
+    }
+
+    /**
+     * `:prefix_mods`. Game-mod registry rows.
+     *
+     * @return iterable<string>
+     */
+    public function mods(): iterable
+    {
+        $this->dbs->query(
+            "SELECT `mid`, `name`, `icon`, `modfolder`, `steam_universe`, `enabled`
+             FROM `:prefix_mods`
+             ORDER BY `mid`"
+        );
+        foreach ($this->dbs->iterate() as $row) {
+            yield $this->encode([
+                'id'             => (int) $row['mid'],
+                'name'           => $this->asString($row['name'] ?? null),
+                'icon'           => $this->asString($row['icon'] ?? null),
+                'modfolder'      => $this->asString($row['modfolder'] ?? null),
+                'steam_universe' => (int) ($row['steam_universe'] ?? 0),
+                'enabled'        => (int) ($row['enabled'] ?? 0) === 1,
+            ]);
+        }
+    }
+
+    /**
+     * `:prefix_notes`. Source PK is `nid` (not `id` — the column
+     * was named back when the convention was still per-table
+     * prefixed). Preserved as both `id` (uniform across the
+     * bundle) and `nid` (verbatim of the schema column name).
+     *
+     * The Steam-ID-keyed `steam_id` column is the actual per-row
+     * identifier the player-detail drawer uses — surface both
+     * forms via {@see steamPair}.
+     *
+     * @return iterable<string>
+     */
+    public function notes(): iterable
+    {
+        $this->dbs->query(
+            "SELECT `nid`, `steam_id`, `aid`, `body`, `created`
+             FROM `:prefix_notes`
+             ORDER BY `nid`"
+        );
+        foreach ($this->dbs->iterate() as $row) {
+            $steam = $this->steamPair($row['steam_id'] ?? null);
+            yield $this->encode([
+                'id'              => (int) $row['nid'],
+                'nid'             => (int) $row['nid'],
+                'steam_id'        => $steam['authid'],
+                'steam_id_steam2' => $steam['authid_steam2'],
+                'aid'             => (int) ($row['aid'] ?? 0),
+                'body'            => $this->asString($row['body'] ?? null),
+                'created'         => (int) ($row['created'] ?? 0),
+            ]);
+        }
+    }
+
+    /**
+     * `:prefix_overrides`. Server-side command/group overrides.
+     *
+     * @return iterable<string>
+     */
+    public function overrides(): iterable
+    {
+        $this->dbs->query(
+            "SELECT `id`, `type`, `name`, `flags`
+             FROM `:prefix_overrides`
+             ORDER BY `id`"
+        );
+        foreach ($this->dbs->iterate() as $row) {
+            yield $this->encode([
+                'id'    => (int) $row['id'],
+                'type'  => $this->asString($row['type'] ?? null),
+                'name'  => $this->asString($row['name'] ?? null),
+                'flags' => $this->asString($row['flags'] ?? null),
+            ]);
+        }
+    }
+
+    /**
+     * `:prefix_protests`. Ban-appeal rows.
+     *
+     * @return iterable<string>
+     */
+    public function protests(): iterable
+    {
+        $this->dbs->query(
+            "SELECT `pid`, `bid`, `datesubmitted`, `reason`, `email`, `archiv`, `archivedby`, `pip`
+             FROM `:prefix_protests`
+             ORDER BY `pid`"
+        );
+        foreach ($this->dbs->iterate() as $row) {
+            yield $this->encode([
+                'id'             => (int) $row['pid'],
+                'bid'            => (int) $row['bid'],
+                'datesubmitted'  => (int) ($row['datesubmitted'] ?? 0),
+                'reason'         => $this->asString($row['reason'] ?? null),
+                'email'          => $this->asString($row['email'] ?? null),
+                'archived'       => (int) ($row['archiv'] ?? 0) === 1,
+                'archivedby'     => $row['archivedby'] !== null ? (int) $row['archivedby'] : null,
+                'pip'            => $this->asString($row['pip'] ?? null),
+            ]);
+        }
+    }
+
+    /**
+     * `:prefix_servers`. {@see FORBIDDEN_SERVER_COLUMNS} guarantees
+     * the `rcon` column is dropped at the SQL projection level so
+     * a future code-path that bypasses the column-filter helper
+     * still can't leak it.
+     *
+     * @return iterable<string>
+     */
+    public function servers(): iterable
+    {
+        $this->dbs->query(
+            "SELECT `sid`, `ip`, `port`, `modid`, `enabled`
+             FROM `:prefix_servers`
+             ORDER BY `sid`"
+        );
+        foreach ($this->dbs->iterate() as $row) {
+            yield $this->encode([
+                'id'      => (int) $row['sid'],
+                'ip'      => $this->asString($row['ip'] ?? null),
+                'port'    => (int) ($row['port'] ?? 0),
+                'modid'   => (int) ($row['modid'] ?? 0),
+                'enabled' => (int) ($row['enabled'] ?? 0) === 1,
+            ]);
+        }
+    }
+
+    /**
+     * `:prefix_servers_groups`. Composite-PK table.
+     *
+     * @return iterable<string>
+     */
+    public function serversGroups(): iterable
+    {
+        $this->dbs->query(
+            "SELECT `server_id`, `group_id`
+             FROM `:prefix_servers_groups`
+             ORDER BY `server_id`, `group_id`"
+        );
+        foreach ($this->dbs->iterate() as $row) {
+            yield $this->encode([
+                'server_id' => (int) $row['server_id'],
+                'group_id'  => (int) $row['group_id'],
+            ]);
+        }
+    }
+
+    /**
+     * `:prefix_settings`. WHERE clause filters out the
+     * {@see FORBIDDEN_SETTING_KEYS} so SMTP credentials and the
+     * telemetry instance ID never reach disk.
+     *
+     * The plan calls out this filter being inside the SQL (not
+     * post-fetch) on purpose — it's a defense-in-depth shape that
+     * future modifications can't easily bypass.
+     *
+     * @return iterable<string>
+     */
+    public function settings(): iterable
+    {
+        $placeholders = implode(',', array_fill(0, count(self::FORBIDDEN_SETTING_KEYS), '?'));
+        $this->dbs->query(
+            "SELECT `id`, `setting`, `value`
+             FROM `:prefix_settings`
+             WHERE `setting` NOT IN ($placeholders)
+             ORDER BY `id`"
+        );
+        $i = 1;
+        foreach (self::FORBIDDEN_SETTING_KEYS as $key) {
+            $this->dbs->bind($i++, $key);
+        }
+        foreach ($this->dbs->iterate() as $row) {
+            yield $this->encode([
+                'id'      => (int) $row['id'],
+                'setting' => $this->asString($row['setting'] ?? null),
+                'value'   => $this->asString($row['value'] ?? null),
+            ]);
+        }
+    }
+
+    /**
+     * `:prefix_srvgroups`. Server-side admin groups.
+     *
+     * @return iterable<string>
+     */
+    public function srvgroups(): iterable
+    {
+        $this->dbs->query(
+            "SELECT `id`, `flags`, `immunity`, `name`, `groups_immune`
+             FROM `:prefix_srvgroups`
+             ORDER BY `id`"
+        );
+        foreach ($this->dbs->iterate() as $row) {
+            yield $this->encode([
+                'id'            => (int) $row['id'],
+                'flags'         => $this->asString($row['flags'] ?? null),
+                'immunity'      => (int) ($row['immunity'] ?? 0),
+                'name'          => $this->asString($row['name'] ?? null),
+                'groups_immune' => $this->asString($row['groups_immune'] ?? null),
+            ]);
+        }
+    }
+
+    /**
+     * `:prefix_srvgroups_overrides`.
+     *
+     * @return iterable<string>
+     */
+    public function srvgroupsOverrides(): iterable
+    {
+        $this->dbs->query(
+            "SELECT `id`, `group_id`, `type`, `name`, `access`
+             FROM `:prefix_srvgroups_overrides`
+             ORDER BY `id`"
+        );
+        foreach ($this->dbs->iterate() as $row) {
+            yield $this->encode([
+                'id'       => (int) $row['id'],
+                'group_id' => (int) $row['group_id'],
+                'type'     => $this->asString($row['type'] ?? null),
+                'name'     => $this->asString($row['name'] ?? null),
+                'access'   => $this->asString($row['access'] ?? null),
+            ]);
+        }
+    }
+
+    /**
+     * `:prefix_submissions`. LEFT JOIN against `:prefix_demos`
+     * (same shape as {@see bans} but with `demtype='S'`) so the
+     * demo metadata surfaces when present.
+     *
+     * @return iterable<string>
+     */
+    public function submissions(): iterable
+    {
+        $this->dbs->query(
+            "SELECT S.`subid`, S.`submitted`, S.`ModID`, S.`SteamId`, S.`name`, S.`email`,
+                    S.`reason`, S.`ip`, S.`subname`, S.`sip`, S.`archiv`, S.`archivedby`, S.`server`,
+                    D.`filename` AS `demo_filename_raw`
+             FROM `:prefix_submissions` S
+             LEFT JOIN `:prefix_demos` D ON D.`demid` = S.`subid` AND D.`demtype` = 'S'
+             ORDER BY S.`subid`"
+        );
+        foreach ($this->dbs->iterate() as $row) {
+            $steam = $this->steamPair($row['SteamId'] ?? null);
+            [$demoName, $demoSize] = $this->demoMetadata((string) ($row['demo_filename_raw'] ?? ''));
+            yield $this->encode([
+                'id'              => (int) $row['subid'],
+                'submitted'       => (int) ($row['submitted'] ?? 0),
+                'mod_id'          => (int) ($row['ModID'] ?? 0),
+                'authid'          => $steam['authid'],
+                'authid_steam2'   => $steam['authid_steam2'],
+                'name'            => $this->asString($row['name'] ?? null),
+                'email'           => $this->asString($row['email'] ?? null),
+                'reason'          => $this->asString($row['reason'] ?? null),
+                'ip'              => $this->asString($row['ip'] ?? null),
+                'submitter_name'  => $this->asString($row['subname'] ?? null),
+                'submitter_ip'    => $this->asString($row['sip'] ?? null),
+                'archived'        => (int) ($row['archiv'] ?? 0) === 1,
+                'archivedby'      => $row['archivedby'] !== null ? (int) $row['archivedby'] : null,
+                'server'          => $row['server'] !== null ? (int) $row['server'] : null,
+                'demo_filename'   => $demoName !== null ? 'demos/' . $demoName : null,
+                'demo_size_bytes' => $demoSize,
+            ]);
+        }
+    }
+
+    // ---- helpers ------------------------------------------------------
+
+    /**
+     * Coerce a DB column to JSON `null` for "absent" and a string
+     * otherwise. The empty-string DB default counts as absent. The
+     * helper is the single source for the
+     * "null-for-absent-never-empty-string" contract.
+     */
+    private function asString(mixed $v): ?string
+    {
+        if ($v === null) {
+            return null;
+        }
+        $s = (string) $v;
+        return $s === '' ? null : $s;
+    }
+
+    /**
+     * Pair a raw `:prefix_*.authid` (or `steam_id`, or `SteamId`)
+     * with both wire formats. The validate-then-convert ladder
+     * matches the AGENTS.md "SteamID inputs" pattern — if the raw
+     * value isn't a recognisable Steam ID, both fields return
+     * `null` instead of throwing. The export is a recovery /
+     * migration surface; legacy garbage rows shouldn't break it.
+     *
+     * @return array{authid: ?string, authid_steam2: ?string}
+     */
+    private function steamPair(mixed $raw): array
+    {
+        if ($raw === null) {
+            return ['authid' => null, 'authid_steam2' => null];
+        }
+        $s = trim((string) $raw);
+        if ($s === '') {
+            return ['authid' => null, 'authid_steam2' => null];
+        }
+        if (!SteamID::isValidID($s)) {
+            return ['authid' => null, 'authid_steam2' => null];
+        }
+        try {
+            $steam64 = SteamID::toSteam64($s);
+            $steam2  = SteamID::toSteam2($s);
+        } catch (Exception) {
+            // Defence-in-depth: the validate-then-convert ladder
+            // guarantees we don't reach here, but a future library
+            // tightening MIGHT throw on a shape isValidID accepted.
+            // Fall back to "absent" rather than 500ing the export.
+            return ['authid' => null, 'authid_steam2' => null];
+        }
+        if (!is_string($steam64) || $steam64 === '') {
+            return ['authid' => null, 'authid_steam2' => null];
+        }
+        return [
+            'authid'        => $steam64,
+            'authid_steam2' => is_string($steam2) && $steam2 !== '' ? $steam2 : null,
+        ];
+    }
+
+    /**
+     * Pair a `:prefix_demos.filename` column value with its on-disk
+     * file size, OR return `[null, null]` when the file is missing
+     * / the row is empty. Path traversal is suppressed via `basename`
+     * — the column is operator / plugin-controlled and a malformed
+     * value mustn't walk us out of the demos directory.
+     *
+     * @return array{0: ?string, 1: ?int}
+     */
+    private function demoMetadata(string $filename): array
+    {
+        if ($filename === '') {
+            return [null, null];
+        }
+        $safe = basename($filename);
+        if ($safe === '' || $safe === '.' || $safe === '..') {
+            return [null, null];
+        }
+        $path = $this->demosDir . DIRECTORY_SEPARATOR . $safe;
+        if (!is_file($path)) {
+            return [null, null];
+        }
+        $size = @filesize($path);
+        if ($size === false) {
+            return [null, null];
+        }
+        return [$safe, (int) $size];
+    }
+
+    /**
+     * Map `:prefix_comms.type` (raw int) to the operator-readable
+     * `mute_kind` string. See {@see comms} for the contract.
+     */
+    private function commsMuteKind(int $type): string
+    {
+        return match ($type) {
+            1 => 'mute',
+            2 => 'gag',
+            3 => 'silence',
+            default => 'unknown',
+        };
+    }
+
+    /**
+     * Mirror `page.banlist.php`'s ban-state classifier (including
+     * the #1352 pre-2 admin-lift defensive arm). Inputs are
+     * already typed at the call site so this stays a pure helper.
+     */
+    private function banState(?BanRemoval $removal, ?int $removedBy, int $length, int $ends): string
+    {
+        $isPre2AdminLift = $removal === null && ($removedBy ?? 0) > 0;
+        return match (true) {
+            $removal === BanRemoval::Deleted, $removal === BanRemoval::Unbanned => 'unbanned',
+            $removal === BanRemoval::Expired => 'expired',
+            $isPre2AdminLift                 => 'unbanned',
+            $length === 0                    => 'permanent',
+            $ends < time()                   => 'expired',
+            default                          => 'active',
+        };
+    }
+
+    private function banTypeLabel(?BanType $type): string
+    {
+        return match ($type) {
+            BanType::Steam => 'steam',
+            BanType::Ip    => 'ip',
+            null           => 'unknown',
+        };
+    }
+
+    private function logLevel(?LogType $type): string
+    {
+        return match ($type) {
+            LogType::Message => 'message',
+            LogType::Warning => 'warning',
+            LogType::Error   => 'error',
+            null             => 'unknown',
+        };
+    }
+
+    /**
+     * JSON-encode a row and append the JSONL line terminator.
+     * Single source for the {@see JSON_FLAGS} contract — call
+     * sites never `json_encode` directly.
+     *
+     * @param array<string, mixed> $row
+     */
+    private function encode(array $row): string
+    {
+        return json_encode($row, self::JSON_FLAGS) . "\n";
+    }
+}

--- a/web/includes/Export/EntityExporter.php
+++ b/web/includes/Export/EntityExporter.php
@@ -98,6 +98,21 @@ final class EntityExporter
      *                      data the operator cares about exporting.
      *   - `lockout_until`  Same — lockout deadline driven by
      *                      `attempts`.
+     *   - `srv_password`   **Plaintext** SourceMod admin server-
+     *                      login password (the panel stores it
+     *                      cleartext — see `account.php`'s
+     *                      `api_account_check_srv_password` stringwise
+     *                      compare and `sbpp_main.sp`'s admin-cache
+     *                      hand-off). Exporting it is structurally
+     *                      worse than exporting the bcrypt
+     *                      `password` hash above: a recipient with
+     *                      this value can authenticate as the
+     *                      admin against every game server they
+     *                      manage. The `pii_policy.password_hashes
+     *                      = "never"` attestation in the manifest
+     *                      makes the omission load-bearing — the
+     *                      forbidden-list IS the contract that
+     *                      keeps the attestation truthful.
      *
      * The actual enforcement is the per-column SELECT projection in
      * {@see admins} (the forbidden columns are NOT projected, so
@@ -107,7 +122,7 @@ final class EntityExporter
      * {@see forbiddenColumns} to assert by grep that none of the
      * listed names appear in the actual export.
      */
-    public const FORBIDDEN_ADMIN_COLUMNS = ['password', 'validate', 'attempts', 'lockout_until'];
+    public const FORBIDDEN_ADMIN_COLUMNS = ['password', 'validate', 'attempts', 'lockout_until', 'srv_password'];
 
     /**
      * Columns we MUST NEVER include in the `servers` JSONL stream.
@@ -217,9 +232,18 @@ final class EntityExporter
      */
     public function admins(): iterable
     {
+        // SECURITY-REVIEW: the SELECT deliberately omits every entry in
+        // FORBIDDEN_ADMIN_COLUMNS — `password` (bcrypt hash), `validate`
+        // (live reset token), `attempts` / `lockout_until` (lockout state),
+        // and `srv_password` (plaintext SM admin server-login password —
+        // the panel stores this cleartext; exporting it would let a
+        // bundle recipient authenticate as the admin against every game
+        // server they manage). Keeping the projection narrow IS the
+        // contract that keeps the manifest's `pii_policy.password_hashes
+        // = "never"` attestation truthful.
         $this->dbs->query(
             "SELECT `aid`, `user`, `authid`, `gid`, `email`, `extraflags`, `immunity`,
-                    `srv_group`, `srv_flags`, `srv_password`, `lastvisit`
+                    `srv_group`, `srv_flags`, `lastvisit`
              FROM `:prefix_admins`
              ORDER BY `aid`"
         );
@@ -236,7 +260,6 @@ final class EntityExporter
                 'immunity'       => (int) ($row['immunity'] ?? 0),
                 'srv_group'      => $this->asString($row['srv_group'] ?? null),
                 'srv_flags'      => $this->asString($row['srv_flags'] ?? null),
-                'srv_password'   => $this->asString($row['srv_password'] ?? null),
                 'lastvisit'      => $row['lastvisit'] !== null ? (int) $row['lastvisit'] : null,
             ]);
         }

--- a/web/includes/Export/ExportError.php
+++ b/web/includes/Export/ExportError.php
@@ -1,0 +1,105 @@
+<?php
+// SourceBans++ (c) 2014-2026 SourceBans++ Dev Team
+// Licensed under the Elastic License 2.0.
+// See LICENSE.txt for the full license text and THIRD-PARTY-NOTICES.txt for attributions.
+
+declare(strict_types=1);
+
+namespace Sbpp\Export;
+
+use RuntimeException;
+use Throwable;
+
+/**
+ * Typed exception class for the export subsystem.
+ *
+ * Every error the pre-flight, bundle writer, or S3 uploader surfaces
+ * lands here so the entry point ({@see \web/export.php}) can branch on
+ * `$e->code` and emit the right operator-facing toast. Anything OTHER
+ * than `ExportError` that escapes is a real bug and deliberately not
+ * caught — let it propagate to the dispatcher's generic 500 so the
+ * stack trace lands in the audit log and the regression is visible.
+ *
+ * The `$code` strings are documented in
+ * `docs/src/content/docs/configuring/data-export.mdx` — pinning them
+ * as class constants here keeps the wire-facing identifiers single-
+ * source and lets call sites read `ExportError::CAP_EXCEEDED` instead
+ * of stringly-typed `'cap_exceeded'` literals.
+ */
+final class ExportError extends RuntimeException
+{
+    /**
+     * The pre-flight or running-byte gate tripped: the bundle would
+     * exceed the ZIP 2.0 4 GiB ceiling (minus the safety margin) if
+     * we kept going. The operator's mitigation is to clear stale
+     * demos / unrelated rows before retrying.
+     */
+    public const CAP_EXCEEDED = 'cap_exceeded';
+
+    /**
+     * The S3 (or compatible) PUT returned a non-2xx HTTP status. The
+     * exception message carries the response body truncated to 2 KiB
+     * for diagnostics; the audit log entry surfaces the same.
+     */
+    public const S3_PUT_FAILED = 's3_put_failed';
+
+    /**
+     * The presigned URL the operator pasted didn't start with
+     * `https://`. We refuse `http://` outright — the full panel
+     * dataset is in flight, including admin emails and IPs.
+     */
+    public const PRESIGN_INVALID_SCHEME = 'presign_invalid_scheme';
+
+    /**
+     * The presigned URL didn't parse via `parse_url` (no host, no
+     * path, or returned `false`). Catches operator typos before the
+     * cURL request fires.
+     */
+    public const PRESIGN_INVALID_URL = 'presign_invalid_url';
+
+    /**
+     * Writing to the on-disk bundle staging area
+     * (`SB_CACHE/exports/<bundle_id>.zip`) failed — typically a
+     * missing / unwritable cache dir on a misconfigured install.
+     */
+    public const DISK_WRITE_FAILED = 'disk_write_failed';
+
+    /**
+     * Mid-write `fwrite()` returned a short count or `false`. The
+     * disk filled up before the bundle finished serialising.
+     */
+    public const DISK_FULL = 'disk_full';
+
+    /**
+     * Wire-facing error code, one of the class constants above.
+     *
+     * Named `errorCode` (not `code`) because the parent
+     * `\Exception::$code` is `int`-typed at the language level and
+     * native PHP doesn't allow narrowing a readwrite `int` property
+     * to a readonly `string`. The accessor below mirrors the
+     * "fluent enum-like check" affordance call sites would otherwise
+     * reach for via `$e->code`.
+     */
+    public readonly string $errorCode;
+
+    public function __construct(
+        string $code,
+        string $message,
+        ?Throwable $previous = null,
+    ) {
+        $this->errorCode = $code;
+        parent::__construct($message, 0, $previous);
+    }
+
+    /**
+     * Wire-facing error code accessor.
+     *
+     * Provided so call sites read as
+     * `match ($e->code()) { ExportError::CAP_EXCEEDED => ... }`
+     * without having to learn the underlying property name.
+     */
+    public function code(): string
+    {
+        return $this->errorCode;
+    }
+}

--- a/web/includes/Export/Manifest.php
+++ b/web/includes/Export/Manifest.php
@@ -1,0 +1,118 @@
+<?php
+// SourceBans++ (c) 2014-2026 SourceBans++ Dev Team
+// Licensed under the Elastic License 2.0.
+// See LICENSE.txt for the full license text and THIRD-PARTY-NOTICES.txt for attributions.
+
+declare(strict_types=1);
+
+namespace Sbpp\Export;
+
+/**
+ * Readonly DTO carrying every field that lands in `manifest.json` at
+ * the head of an export bundle. {@see ManifestBuilder} mints the
+ * instance; {@see BundleWriter} consumes it.
+ *
+ * The class is also the source of truth for the bundle-cap math:
+ * {@see MAX_BUNDLE_BYTES} is the ZIP 2.0 spec ceiling (4 GiB), and
+ * {@see SAFETY_MARGIN_BYTES} is the cushion against the central
+ * directory + JSONL line endings + our own row-size heuristic
+ * undershoot. Pre-flight subtracts the margin BEFORE comparing the
+ * estimate; the bundle writer re-checks the running compressed-byte
+ * total on each entity / demo and aborts the same way.
+ *
+ * The PII policy block is part of the operator contract — the bundle
+ * is intentionally honest about every category it carries (admin
+ * emails, IPs, Steam IDs, unban reasons) so a recipient can route
+ * the bundle through the appropriate handling controls. Reach for an
+ * `includes_*` field of `false` ONLY when the panel genuinely
+ * doesn't store that category; lying about a category that IS
+ * present is the worst-case outcome.
+ *
+ * `format_version` is the binding identifier for the wire format
+ * (entity column layout, manifest shape, the `null`-for-absent
+ * contract, the Steam64-as-decimal-string contract, the unix-seconds
+ * contract). Bump it whenever any of those change in a way that
+ * would break a downstream consumer; add a paired downstream
+ * migration note in the operator-facing docs at the same time.
+ */
+final class Manifest
+{
+    /**
+     * Wire-format identifier. Bump on any breaking change to the
+     * entity column layout, manifest shape, or per-field contracts.
+     */
+    public const FORMAT_VERSION = 1;
+
+    /**
+     * ZIP 2.0 spec ceiling (4 GiB). We deliberately disable the
+     * ZIP64 extension in {@see BundleWriter} so an exported bundle
+     * opens in every mainstream consumer (Windows Explorer's built-in
+     * unzipper, macOS Archive Utility, BSD unzip, every cloud
+     * console preview) without operator intervention.
+     */
+    public const MAX_BUNDLE_BYTES = 4 * 1024 * 1024 * 1024;
+
+    /**
+     * Cushion against the central directory + per-entry overhead +
+     * our own JSONL row-size heuristic undershoot. Subtract from
+     * {@see MAX_BUNDLE_BYTES} before the pre-flight compare AND the
+     * running-byte gate inside the writer.
+     */
+    public const SAFETY_MARGIN_BYTES = 64 * 1024 * 1024;
+
+    /**
+     * @param array<string, int>                                  $row_counts  Entity name → row count.
+     * @param list<array{name: string, size_bytes: int}>          $demo_files  Demo files we'd ship (in deterministic name order).
+     * @param array<string, bool|string>                          $pii_policy  See `pii_policy` shape below.
+     */
+    public function __construct(
+        public readonly string $bundle_id,
+        public readonly int $created_at,
+        public readonly string $panel_version,
+        public readonly array $row_counts,
+        public readonly array $demo_files,
+        public readonly int $demo_total_bytes,
+        public readonly int $estimated_bundle_bytes,
+        public readonly bool $exceeds_cap,
+        public readonly int $cap_bytes,
+        public readonly array $pii_policy,
+    ) {
+    }
+
+    /**
+     * JSON-encode the manifest as the on-wire `manifest.json` body.
+     *
+     * Uses the same `JSON_INVALID_UTF8_SUBSTITUTE` flag every other
+     * entity-emission path uses, so a panel-version string with
+     * malformed bytes (theoretical — `panel_version` comes from
+     * `SB_VERSION` which is a clean ASCII string today) substitutes
+     * to U+FFFD instead of throwing. The `JSON_UNESCAPED_*` flags
+     * keep the on-disk payload human-readable when the operator
+     * opens it in a text editor.
+     */
+    public function toJson(): string
+    {
+        $payload = [
+            'format_version'         => self::FORMAT_VERSION,
+            'bundle_id'              => $this->bundle_id,
+            'created_at'             => $this->created_at,
+            'panel_version'          => $this->panel_version,
+            'row_counts'             => $this->row_counts,
+            'demo_files'             => $this->demo_files,
+            'demo_total_bytes'       => $this->demo_total_bytes,
+            'estimated_bundle_bytes' => $this->estimated_bundle_bytes,
+            'exceeds_cap'            => $this->exceeds_cap,
+            'cap_bytes'              => $this->cap_bytes,
+            'pii_policy'             => $this->pii_policy,
+        ];
+
+        return json_encode(
+            $payload,
+            JSON_THROW_ON_ERROR
+            | JSON_INVALID_UTF8_SUBSTITUTE
+            | JSON_UNESCAPED_SLASHES
+            | JSON_UNESCAPED_UNICODE
+            | JSON_PRETTY_PRINT,
+        );
+    }
+}

--- a/web/includes/Export/ManifestBuilder.php
+++ b/web/includes/Export/ManifestBuilder.php
@@ -172,18 +172,53 @@ final class ManifestBuilder
      * non-`id`-keyed tables count the same way — the cardinality is
      * what we care about, not the key shape.
      *
+     * Settings is the exception: {@see EntityExporter::settings()}
+     * filters out {@see EntityExporter::FORBIDDEN_SETTING_KEYS} at
+     * the SQL WHERE level. The manifest's row count MUST match the
+     * actual JSONL line count, so the same filter rides this
+     * pre-flight count. Drift between the two surfaces is a
+     * wire-contract break — pinned by ExportBundleWriterTest's
+     * "row_counts agree with JSONL line counts" assertion.
+     *
      * @return array<string, int>
      */
     private function collectRowCounts(): array
     {
         $out = [];
         foreach (self::ENTITIES as $entity) {
+            if ($entity === 'settings') {
+                $out[$entity] = $this->countFilteredSettings();
+                continue;
+            }
             $table = '`:prefix_' . $entity . '`';
             $this->dbs->query("SELECT COUNT(*) AS n FROM $table");
             $row = $this->dbs->single();
             $out[$entity] = (int) ($row['n'] ?? 0);
         }
         return $out;
+    }
+
+    /**
+     * Settings-specific count: applies the same
+     * {@see EntityExporter::FORBIDDEN_SETTING_KEYS} filter the
+     * entity exporter uses so the manifest's claim agrees with the
+     * actual JSONL line count.
+     */
+    private function countFilteredSettings(): int
+    {
+        $forbidden    = EntityExporter::FORBIDDEN_SETTING_KEYS;
+        $placeholders = implode(',', array_fill(0, count($forbidden), '?'));
+        $this->dbs->query(
+            "SELECT COUNT(*) AS n
+             FROM `:prefix_settings`
+             WHERE `setting` NOT IN ($placeholders)"
+        );
+        $i = 1;
+        foreach ($forbidden as $key) {
+            $this->dbs->bind($i++, $key);
+        }
+        $row = $this->dbs->single();
+        return (int) ($row['n'] ?? 0);
     }
 
     /**

--- a/web/includes/Export/ManifestBuilder.php
+++ b/web/includes/Export/ManifestBuilder.php
@@ -1,0 +1,320 @@
+<?php
+// SourceBans++ (c) 2014-2026 SourceBans++ Dev Team
+// Licensed under the Elastic License 2.0.
+// See LICENSE.txt for the full license text and THIRD-PARTY-NOTICES.txt for attributions.
+
+declare(strict_types=1);
+
+namespace Sbpp\Export;
+
+use LogType;
+use Sbpp\Db\Database;
+use Sbpp\Log;
+
+/**
+ * Pre-flight pass + manifest minter for the data export bundle.
+ *
+ * Responsibilities:
+ *
+ *   - One `SELECT COUNT(*)` per entity. The list of entities is the
+ *     same set {@see EntityExporter} streams, kept in lockstep so a
+ *     new entity addition surfaces missing-row-count regressions
+ *     loudly (the manifest's `row_counts` keys are asserted equal to
+ *     the JSONL entry count by the integration tests).
+ *   - Enumerate every demo file under `SB_DEMOS` that's referenced
+ *     by a `:prefix_demos.filename` row. `filesize` each one to
+ *     produce `demo_total_bytes`. Demos whose row exists but whose
+ *     file is missing on disk are dropped from the manifest's
+ *     `demo_files` list AND `Log::add(LogType::Warning, ...)`'d so
+ *     the operator notices the bookkeeping drift.
+ *   - Mint a fresh UUIDv4 bundle ID and current `created_at` so each
+ *     pre-flight call yields a fresh manifest. The page handler's
+ *     UI doesn't care (it only reads the count + cap-status fields),
+ *     but the writer's output stamps the freshly-minted ID into
+ *     `manifest.json`'s `bundle_id` field AND the bundle's filename.
+ *   - Compute the JSONL byte estimate (`row_count × 1024 byte
+ *     heuristic`) + the demo bytes + the manifest overhead and
+ *     compare against {@see Manifest::MAX_BUNDLE_BYTES} minus
+ *     {@see Manifest::SAFETY_MARGIN_BYTES}.
+ *
+ * The 1024-byte-per-row heuristic is deliberately generous: a typical
+ * `:prefix_bans` row is well under 512 bytes (timestamps + ints + a
+ * short reason string), but a `:prefix_log` row with a long message
+ * column can stretch toward 2 KiB. The cushion built into the
+ * heuristic + the {@see Manifest::SAFETY_MARGIN_BYTES} subtraction
+ * leaves headroom for the bytes the heuristic doesn't see (the JSONL
+ * structural overhead `{"field":...}\n`, the manifest itself,
+ * the central directory the ZIP appends at the tail). The bundle
+ * writer re-checks the running compressed-byte total per-entry and
+ * aborts the same way if pre-flight underestimated.
+ */
+final class ManifestBuilder
+{
+    /**
+     * Bytes-per-row estimate for the JSONL entity files. Used by
+     * `build()` to predict the bundle size BEFORE we stream anything;
+     * the writer enforces the same cap at runtime, so an undershoot
+     * here just trades one upstream-friendly error envelope for a
+     * mid-stream abort. See class docblock for the heuristic
+     * rationale.
+     */
+    private const BYTES_PER_ROW_ESTIMATE = 1024;
+
+    /**
+     * Manifest line-overhead estimate: the encoded JSON manifest
+     * itself + its central-directory entry. Generous (10 KiB),
+     * because the actual encoded body is ~1-2 KiB.
+     */
+    private const MANIFEST_BYTES_ESTIMATE = 10 * 1024;
+
+    /**
+     * The full deterministic-order list of entities the export
+     * subsystem covers. Mirrors `EntityExporter::entityStreams()`'s
+     * key set — keep both in lockstep. The order is alphabetical so
+     * the bundle's central directory is stable across reruns; the
+     * tests' first-entry contract ("manifest.json comes first") rides
+     * on the BundleWriter explicitly writing the manifest before
+     * iterating this list, NOT on alphabetical ordering placing it
+     * first.
+     *
+     * @var list<string>
+     */
+    private const ENTITIES = [
+        'admins',
+        'admins_servers_groups',
+        'banlog',
+        'bans',
+        'comments',
+        'comms',
+        'groups',
+        'log',
+        'mods',
+        'notes',
+        'overrides',
+        'protests',
+        'servers',
+        'servers_groups',
+        'settings',
+        'srvgroups',
+        'srvgroups_overrides',
+        'submissions',
+    ];
+
+    public function __construct(
+        private readonly Database $dbs,
+        private readonly string $demosDir,
+        private readonly string $panelVersion,
+    ) {
+    }
+
+    /**
+     * Run the pre-flight pass and mint a complete {@see Manifest}.
+     *
+     * The page handler also calls this — it reads the cap-status
+     * + counts fields off the returned DTO and discards the rest.
+     * That's fine: minting a throwaway UUID per page render costs
+     * one `random_bytes(16)` call and the resulting Manifest never
+     * leaves the request scope.
+     */
+    public function build(): Manifest
+    {
+        $rowCounts   = $this->collectRowCounts();
+        $demoFiles   = $this->collectDemoFiles();
+        $demoBytes   = array_sum(array_column($demoFiles, 'size_bytes'));
+        $jsonlBytes  = array_sum($rowCounts) * self::BYTES_PER_ROW_ESTIMATE;
+        $estimated   = $demoBytes + $jsonlBytes + self::MANIFEST_BYTES_ESTIMATE;
+        $capBytes    = Manifest::MAX_BUNDLE_BYTES - Manifest::SAFETY_MARGIN_BYTES;
+        $exceedsCap  = $estimated > $capBytes;
+
+        return new Manifest(
+            bundle_id:              self::mintBundleId(),
+            created_at:             time(),
+            panel_version:          $this->panelVersion,
+            row_counts:             $rowCounts,
+            demo_files:             $demoFiles,
+            demo_total_bytes:       (int) $demoBytes,
+            estimated_bundle_bytes: $estimated,
+            exceeds_cap:            $exceedsCap,
+            cap_bytes:              $capBytes,
+            pii_policy:             self::piiPolicy(),
+        );
+    }
+
+    /**
+     * Build the manifest AND throw {@see ExportError::CAP_EXCEEDED}
+     * if the estimate trips the cap. The writer-side entry point
+     * calls this so a too-big bundle bails BEFORE any bytes hit the
+     * wire; the page handler calls {@see build} directly because the
+     * UI surfaces the cap-status as a disabled button instead of an
+     * exception.
+     */
+    public function buildOrThrow(): Manifest
+    {
+        $manifest = $this->build();
+        if ($manifest->exceeds_cap) {
+            throw new ExportError(
+                ExportError::CAP_EXCEEDED,
+                sprintf(
+                    'Bundle estimate %d bytes exceeds the %d-byte cap (4 GiB minus the %d-byte safety margin). '
+                    . 'Clear stale demos and rerun.',
+                    $manifest->estimated_bundle_bytes,
+                    $manifest->cap_bytes,
+                    Manifest::SAFETY_MARGIN_BYTES,
+                ),
+            );
+        }
+        return $manifest;
+    }
+
+    /**
+     * One `SELECT COUNT(*)` per entity. Composite-PK tables
+     * (`admins_servers_groups`, `servers_groups`, `banlog`) and
+     * non-`id`-keyed tables count the same way — the cardinality is
+     * what we care about, not the key shape.
+     *
+     * @return array<string, int>
+     */
+    private function collectRowCounts(): array
+    {
+        $out = [];
+        foreach (self::ENTITIES as $entity) {
+            $table = '`:prefix_' . $entity . '`';
+            $this->dbs->query("SELECT COUNT(*) AS n FROM $table");
+            $row = $this->dbs->single();
+            $out[$entity] = (int) ($row['n'] ?? 0);
+        }
+        return $out;
+    }
+
+    /**
+     * Enumerate every `:prefix_demos.filename` referenced row, stat
+     * the file on disk, drop the rows whose file is missing, and
+     * return the surviving list in deterministic name order. Missing
+     * files surface a single `Log::add(LogType::Warning)` per
+     * pre-flight pass so an operator notices the drift.
+     *
+     * @return list<array{name: string, size_bytes: int}>
+     */
+    private function collectDemoFiles(): array
+    {
+        $this->dbs->query('SELECT DISTINCT `filename` FROM `:prefix_demos`');
+        $rows = $this->dbs->resultset();
+
+        $out      = [];
+        $missing  = [];
+        foreach ($rows as $row) {
+            $filename = (string) ($row['filename'] ?? '');
+            if ($filename === '') {
+                continue;
+            }
+            // Basename the value before we touch the disk. The column
+            // is operator-controlled (it's whatever the SourceMod
+            // plugin stamped); a hostile / typo'd row like `../etc`
+            // shouldn't be able to walk us out of the demos dir.
+            $safe = basename($filename);
+            if ($safe === '' || $safe === '.' || $safe === '..') {
+                continue;
+            }
+            $path = $this->demosDir . DIRECTORY_SEPARATOR . $safe;
+            if (!is_file($path)) {
+                $missing[] = $safe;
+                continue;
+            }
+            $size = @filesize($path);
+            if ($size === false) {
+                $missing[] = $safe;
+                continue;
+            }
+            $out[] = [
+                'name'       => $safe,
+                'size_bytes' => (int) $size,
+            ];
+        }
+
+        // Deterministic order so the manifest hash (if a downstream
+        // ever needs one) and the bundle's central directory stay
+        // stable across reruns.
+        usort($out, static fn(array $a, array $b): int => strcmp($a['name'], $b['name']));
+
+        if ($missing !== []) {
+            // De-duplicate so a hot row with multiple ban references
+            // doesn't spam the audit log.
+            $unique = array_values(array_unique($missing));
+            // Cap the body string at 512 chars so a pathological
+            // case (thousands of missing demos) doesn't write a
+            // 100 KiB audit log row.
+            $bodyList = implode(', ', array_slice($unique, 0, 12));
+            if (count($unique) > 12) {
+                $bodyList .= sprintf(' (+%d more)', count($unique) - 12);
+            }
+            Log::add(
+                LogType::Warning,
+                'Data Export pre-flight',
+                sprintf(
+                    'Skipping %d demo file%s referenced by :prefix_demos but missing on disk: %s',
+                    count($unique),
+                    count($unique) === 1 ? '' : 's',
+                    $bodyList,
+                ),
+            );
+        }
+
+        return $out;
+    }
+
+    /**
+     * The PII contract block lands verbatim in `manifest.json`'s
+     * `pii_policy` field. Every flag here is anchored against an
+     * actual category present in `web/install/includes/sql/struc.sql`:
+     *
+     *   - `includes_admin_emails`   `:prefix_admins.email` is shipped.
+     *   - `includes_ip_addresses`   `:prefix_bans.ip` + `:prefix_bans.adminIp` + similar columns are shipped.
+     *   - `includes_chat_messages`  The panel doesn't store chat messages
+     *                               anywhere in the schema — kept as `false`
+     *                               so a downstream consumer isn't misled.
+     *   - `includes_steam_ids`      Every `authid` column is shipped, mapped
+     *                               to decimal-string Steam64.
+     *   - `includes_unban_reasons`  `:prefix_bans.ureason` + `:prefix_comms.ureason`
+     *                               are shipped verbatim.
+     *   - `password_hashes`         Always `"never"` — `EntityExporter` enforces
+     *                               the column drop in code; this field is the
+     *                               manifest-side declaration of the contract.
+     *
+     * @return array<string, bool|string>
+     */
+    private static function piiPolicy(): array
+    {
+        return [
+            'includes_admin_emails'  => true,
+            'includes_ip_addresses'  => true,
+            'includes_chat_messages' => false,
+            'includes_steam_ids'     => true,
+            'includes_unban_reasons' => true,
+            'password_hashes'        => 'never',
+        ];
+    }
+
+    /**
+     * RFC 4122 UUIDv4 mint. 16 random bytes, version + variant
+     * nibbles patched per the spec. Returns the canonical 8-4-4-4-12
+     * hex form with the version `4` nibble at index 12 and the
+     * variant `8/9/a/b` nibble at index 16.
+     */
+    private static function mintBundleId(): string
+    {
+        $bytes = random_bytes(16);
+        // Set version 4 (0b0100_xxxx) on byte 6
+        $bytes[6] = chr((ord($bytes[6]) & 0x0f) | 0x40);
+        // Set variant (RFC 4122 — 0b10_xxxxxx) on byte 8
+        $bytes[8] = chr((ord($bytes[8]) & 0x3f) | 0x80);
+        $hex = bin2hex($bytes);
+        return sprintf(
+            '%s-%s-%s-%s-%s',
+            substr($hex, 0, 8),
+            substr($hex, 8, 4),
+            substr($hex, 12, 4),
+            substr($hex, 16, 4),
+            substr($hex, 20, 12),
+        );
+    }
+}

--- a/web/includes/Export/S3PresignedUploader.php
+++ b/web/includes/Export/S3PresignedUploader.php
@@ -1,0 +1,266 @@
+<?php
+// SourceBans++ (c) 2014-2026 SourceBans++ Dev Team
+// Licensed under the Elastic License 2.0.
+// See LICENSE.txt for the full license text and THIRD-PARTY-NOTICES.txt for attributions.
+
+declare(strict_types=1);
+
+namespace Sbpp\Export;
+
+/**
+ * cURL-based PUT uploader for S3-compatible presigned URLs.
+ *
+ * Used by `web/export.php`'s `s3` mode: the entry point builds the
+ * bundle to a tempfile under `SB_CACHE/exports/<bundle_id>.zip`,
+ * then hands the file path + the operator-pasted presigned URL to
+ * {@see upload}. The uploader streams the file through cURL's
+ * `CURLOPT_INFILE` so a multi-GB bundle doesn't sit in PHP memory.
+ *
+ * Wire contract:
+ *
+ *   - **HTTPS only.** `http://` presigned URLs are refused at the
+ *     scheme guard — the bundle carries admin emails + IPs + every
+ *     Steam ID the panel knows about + unban reasons; cleartext
+ *     transit is unacceptable. Throws
+ *     {@see ExportError::PRESIGN_INVALID_SCHEME}.
+ *   - **URL parses via `parse_url`.** Operator typos that fail
+ *     `parse_url` short-circuit with {@see ExportError::PRESIGN_INVALID_URL}
+ *     before the cURL request fires; the operator gets a pointed
+ *     error message instead of a misleading "S3 returned X" body.
+ *   - **`Content-Length` header set explicitly.** S3 + R2 + MinIO
+ *     all require it on PUT (chunked transfer encoding is not
+ *     accepted by S3-style APIs even when the spec would otherwise
+ *     allow it).
+ *   - **`CURLOPT_TIMEOUT = 0` (no overall timeout).** Uploads on a
+ *     2 GB bundle over a slow link can take a long time; cutting
+ *     them off with a wall-clock timeout would surface the wrong
+ *     error to the operator ("upload failed" when the actual
+ *     answer is "network is slow"). The connect timeout
+ *     ({@see CONNECT_TIMEOUT_SECONDS}) is still bounded because a
+ *     DNS / TLS-handshake stall is unambiguously a problem.
+ *   - **HTTP 200 / 201 / 204 are success.** Everything else throws
+ *     {@see ExportError::S3_PUT_FAILED} with the response body
+ *     truncated to {@see RESPONSE_BODY_LIMIT} bytes — enough for
+ *     S3's XML error envelope plus a comfortable margin.
+ *
+ * Test override: {@see _setHttpTransportForTests} swaps the cURL
+ * call with a closure that receives `(string $url, string $localPath,
+ * int $size): array{http_code: int, body: string}` and returns the
+ * shape the production path produces. Mirrors
+ * `Sbpp\Announce\AnnouncementFetcher::_setHttpFetcherForTests`.
+ * Production code never sets it.
+ */
+final class S3PresignedUploader
+{
+    /**
+     * Bound on the connect-only phase (DNS resolution + TLS handshake).
+     * The post-connect upload is bounded by the connection's own
+     * write speed, not by an overall timeout — see class docblock.
+     */
+    private const CONNECT_TIMEOUT_SECONDS = 60;
+
+    /**
+     * Truncation cap on the response body we surface in
+     * {@see ExportError} messages. S3's XML error envelope is
+     * typically <500 bytes; 2 KiB leaves room for verbose providers
+     * without dumping a multi-MB body into the audit log.
+     */
+    private const RESPONSE_BODY_LIMIT = 2 * 1024;
+
+    /**
+     * Test-injected transport override. When set, {@see upload}
+     * routes through this closure instead of cURL. Closure signature:
+     * `function (string $url, string $localPath, int $size): array{http_code: int, body: string}`.
+     *
+     * @var (callable(string, string, int): array{http_code: int, body: string})|null
+     */
+    private static $httpTransport = null;
+
+    /**
+     * Hot-swap the HTTP transport for tests.
+     *
+     * @param (callable(string, string, int): array{http_code: int, body: string})|null $transport
+     */
+    public static function _setHttpTransportForTests(?callable $transport): void
+    {
+        self::$httpTransport = $transport;
+    }
+
+    /**
+     * PUT the bundle at `$localPath` to `$url`. Returns void on
+     * success; throws {@see ExportError} with a per-failure-mode
+     * code on any error.
+     */
+    public function upload(string $url, string $localPath): void
+    {
+        $this->validateUrl($url);
+
+        if (!is_file($localPath)) {
+            throw new ExportError(
+                ExportError::DISK_WRITE_FAILED,
+                'Bundle staging file is missing or unreadable: ' . $localPath,
+            );
+        }
+        $size = filesize($localPath);
+        if ($size === false) {
+            throw new ExportError(
+                ExportError::DISK_WRITE_FAILED,
+                'Failed to read bundle staging file size: ' . $localPath,
+            );
+        }
+        $size = (int) $size;
+
+        $result = self::$httpTransport !== null
+            ? (self::$httpTransport)($url, $localPath, $size)
+            : $this->doCurlPut($url, $localPath, $size);
+
+        $code = $result['http_code'];
+        $body = $result['body'];
+
+        if (!in_array($code, [200, 201, 204], true)) {
+            throw new ExportError(
+                ExportError::S3_PUT_FAILED,
+                sprintf(
+                    'Presigned PUT returned HTTP %d. Response body (truncated to %d bytes): %s',
+                    $code,
+                    self::RESPONSE_BODY_LIMIT,
+                    self::truncate($body, self::RESPONSE_BODY_LIMIT),
+                ),
+            );
+        }
+    }
+
+    /**
+     * Scheme-then-parse-then-host validation. Each step has its
+     * own dedicated error code so the operator-facing toast can
+     * surface a pointed message.
+     */
+    private function validateUrl(string $url): void
+    {
+        // Cheap prefix check before parse_url runs — `http://`
+        // gets a deterministic refusal regardless of what the rest
+        // of the URL looks like.
+        if (strncasecmp($url, 'https://', 8) !== 0) {
+            throw new ExportError(
+                ExportError::PRESIGN_INVALID_SCHEME,
+                'Presigned URL must use the https:// scheme. The bundle carries admin emails, '
+                . 'IP addresses, and Steam IDs — cleartext transit is not acceptable.',
+            );
+        }
+        $parts = parse_url($url);
+        if ($parts === false) {
+            throw new ExportError(
+                ExportError::PRESIGN_INVALID_URL,
+                'Could not parse the presigned URL. Check that you pasted the full URL with no surrounding whitespace.',
+            );
+        }
+        $scheme = isset($parts['scheme']) ? strtolower((string) $parts['scheme']) : '';
+        $host   = isset($parts['host']) ? (string) $parts['host'] : '';
+        if ($scheme !== 'https') {
+            throw new ExportError(
+                ExportError::PRESIGN_INVALID_SCHEME,
+                'Presigned URL must use the https:// scheme. The bundle carries admin emails, '
+                . 'IP addresses, and Steam IDs — cleartext transit is not acceptable.',
+            );
+        }
+        if ($host === '') {
+            throw new ExportError(
+                ExportError::PRESIGN_INVALID_URL,
+                'Presigned URL is missing a host component.',
+            );
+        }
+    }
+
+    /**
+     * The cURL transport itself. Isolated so the test override can
+     * substitute without touching the network.
+     *
+     * @return array{http_code: int, body: string}
+     */
+    private function doCurlPut(string $url, string $localPath, int $size): array
+    {
+        $fh = fopen($localPath, 'rb');
+        if ($fh === false) {
+            throw new ExportError(
+                ExportError::DISK_WRITE_FAILED,
+                'Failed to open bundle staging file for read: ' . $localPath,
+            );
+        }
+        $ch = curl_init();
+        if ($ch === false) {
+            fclose($fh);
+            throw new ExportError(
+                ExportError::S3_PUT_FAILED,
+                'Failed to initialise cURL handle for the presigned PUT.',
+            );
+        }
+        // `CURLOPT_PUT = true` is the legacy shape; the modern
+        // surface combines CUSTOMREQUEST + INFILE + INFILESIZE
+        // (and Content-Length explicitly via CURLOPT_HTTPHEADER
+        // because some cURL builds don't auto-emit it on a
+        // CUSTOMREQUEST PUT).
+        curl_setopt_array($ch, [
+            CURLOPT_URL            => $url,
+            CURLOPT_CUSTOMREQUEST  => 'PUT',
+            CURLOPT_UPLOAD         => true,
+            CURLOPT_INFILE         => $fh,
+            CURLOPT_INFILESIZE     => $size,
+            CURLOPT_HTTPHEADER     => [
+                'Content-Length: ' . $size,
+                // S3 + R2 + MinIO all accept `application/octet-stream`
+                // on a presigned PUT. Setting it explicitly avoids cURL
+                // defaulting to the C-locale `application/x-www-form-urlencoded`
+                // which some S3-compatible endpoints reject as a sigv4
+                // header-set mismatch.
+                'Content-Type: application/octet-stream',
+                // Defeat any `Expect: 100-continue` round-trip cURL
+                // would otherwise add on a large PUT — S3 explicitly
+                // doesn't support the Expect handshake and adds 1
+                // round-trip-time of latency for nothing.
+                'Expect:',
+            ],
+            CURLOPT_CONNECTTIMEOUT => self::CONNECT_TIMEOUT_SECONDS,
+            CURLOPT_TIMEOUT        => 0,
+            CURLOPT_RETURNTRANSFER => true,
+            CURLOPT_FAILONERROR    => false,
+            CURLOPT_FOLLOWLOCATION => false,
+        ]);
+
+        $body  = curl_exec($ch);
+        $code  = (int) curl_getinfo($ch, CURLINFO_RESPONSE_CODE);
+        $err   = curl_error($ch);
+        $errno = curl_errno($ch);
+        // PHP 8.0+ deprecated curl_close() — the CurlHandle is now
+        // freed at the end of the variable's scope. We let GC handle
+        // it; the explicit close was a holdover from the libcurl
+        // resource-handle era.
+        fclose($fh);
+
+        if ($body === false) {
+            throw new ExportError(
+                ExportError::S3_PUT_FAILED,
+                sprintf('cURL transport failed (errno=%d): %s', $errno, $err !== '' ? $err : 'unknown error'),
+            );
+        }
+
+        return [
+            'http_code' => $code,
+            'body'      => is_string($body) ? $body : '',
+        ];
+    }
+
+    /**
+     * Truncate `$body` to at most `$limit` bytes, appending a
+     * marker so the operator knows the body was clipped. UTF-8
+     * boundary-safe is unnecessary here — S3 / R2 emit ASCII XML
+     * envelopes, and a half-character at the truncation boundary
+     * is acceptable for a diagnostic message.
+     */
+    private static function truncate(string $body, int $limit): string
+    {
+        if (strlen($body) <= $limit) {
+            return $body;
+        }
+        return substr($body, 0, $limit) . '… (truncated)';
+    }
+}

--- a/web/includes/View/AdminExportView.php
+++ b/web/includes/View/AdminExportView.php
@@ -1,0 +1,67 @@
+<?php
+// SourceBans++ (c) 2014-2026 SourceBans++ Dev Team
+// Licensed under the Elastic License 2.0.
+// See LICENSE.txt for the full license text and THIRD-PARTY-NOTICES.txt for attributions.
+
+declare(strict_types=1);
+
+namespace Sbpp\View;
+
+/**
+ * "Full data export" admin surface — binds to `page_admin_export.tpl`.
+ *
+ * Rendered by `web/pages/admin.export.php` against `?p=admin&c=export`.
+ * The form template offers two delivery modes (ZIP-download +
+ * S3-presigned-PUT) that POST to `web/export.php` — see that file's
+ * lifecycle docblock for the wire contract.
+ *
+ * The pre-flight count + size totals come from
+ * {@see \Sbpp\Export\ManifestBuilder}'s `build()` (NOT `buildOrThrow()`
+ * — the admin surface deliberately renders even when the bundle would
+ * exceed the cap, so the operator can see *why* an export is blocked
+ * and act on it). When `$exceeds_cap` is true the template disables
+ * both submit buttons and surfaces an `.empty-state` block explaining
+ * the operator needs to prune demos / unrelated rows before retrying.
+ *
+ * `$row_counts` is the full per-entity table the manifest carries; the
+ * template renders it as a definition list so the operator gets the
+ * same breakdown the bundle's `manifest.json` will pin (transparency
+ * about what's actually leaving the panel).
+ *
+ * The form template uses the `{csrf_field}` Smarty function (which
+ * renders the hidden CSRF input + token from `\Sbpp\Security\CSRF`'s
+ * canonical slot), so the View does NOT carry CSRF properties — it
+ * would just duplicate the smarty-function call site. Future refactors
+ * that need to expose the token to JS (the JSON-API client already
+ * picks it up automatically via `theme.js`) should add the property
+ * AND consume it in the template so SmartyTemplateRule stays happy.
+ *
+ * The View carries NO permission booleans / `$can_*` flags because
+ * the entire admin route is gated on `\WebPermission::Owner` at three
+ * sites: the page-builder (`web/includes/page-builder.php`'s
+ * `$adminRoutes['export']`), the page handler's
+ * `CheckAdminAccess(ADMIN_OWNER)` re-check, and the entry point itself
+ * (`web/export.php`). Anything that hits this View has already passed
+ * those gates.
+ */
+final class AdminExportView extends View
+{
+    public const TEMPLATE = 'page_admin_export.tpl';
+
+    /**
+     * @param array<string, int> $row_counts Entity name → row count, in deterministic name order.
+     */
+    public function __construct(
+        public readonly string $panel_version,
+        public readonly array $row_counts,
+        public readonly int $total_admins,
+        public readonly int $total_bans,
+        public readonly int $total_comms,
+        public readonly int $total_demos,
+        public readonly int $demo_total_bytes,
+        public readonly int $estimated_bundle_bytes,
+        public readonly bool $exceeds_cap,
+        public readonly int $cap_bytes,
+    ) {
+    }
+}

--- a/web/includes/View/PaletteActions.php
+++ b/web/includes/View/PaletteActions.php
@@ -232,6 +232,18 @@ final class PaletteActions
                 'href'       => '?p=admin&c=bans&section=add-ban',
                 'permission' => $addBan,
             ],
+            // Data export — owner-only (every PII category in scope).
+            // The `for()` filter ORs ADMIN_OWNER into every admin
+            // entry's mask, so passing 0 here is equivalent to passing
+            // ADMIN_OWNER — but writing the explicit constant
+            // documents the gate at the call site, matching the
+            // pattern the rest of the catalog uses.
+            [
+                'icon'       => 'package',
+                'label'      => 'Data export',
+                'href'       => '?p=admin&c=export',
+                'permission' => defined('ADMIN_OWNER') ? (int) constant('ADMIN_OWNER') : 0,
+            ],
         ];
     }
 }

--- a/web/includes/page-builder.php
+++ b/web/includes/page-builder.php
@@ -115,6 +115,22 @@ function route(int|string $fallback): array
                 'options'    => [],
                 'default'    => ['Audit Log', '/admin.audit.php'],
             ],
+            'export' => [
+                // Full panel data export is owner-only by design. The
+                // bundle carries every PII category the panel stores
+                // (admin emails, IPs, Steam IDs, unban reasons), so
+                // a granular per-permission gate would only paper
+                // over the structural "this is a custodial action"
+                // semantic — there's no flag short of Owner whose
+                // bearer should reasonably be exporting the lot. The
+                // same gate is re-enforced by the page handler's
+                // `CheckAdminAccess(ADMIN_OWNER)` AND by the
+                // streaming entry point at `web/export.php` (the
+                // load-bearing security check the form POSTs into).
+                'permission' => ADMIN_OWNER,
+                'options'    => [],
+                'default'    => ['Data Export', '/admin.export.php'],
+            ],
         ];
 
         if (is_string($categorie) && isset($adminRoutes[$categorie])) {

--- a/web/pages/admin.export.php
+++ b/web/pages/admin.export.php
@@ -1,0 +1,133 @@
+<?php
+// SourceBans++ (c) 2014-2026 SourceBans++ Dev Team
+// Licensed under the Elastic License 2.0.
+// See LICENSE.txt for the full license text and THIRD-PARTY-NOTICES.txt for attributions.
+
+/*
+ * "Full data export" admin page handler. Renders the form chrome at
+ * `?p=admin&c=export`; the actual streaming work lives at panel-root
+ * in `web/export.php` (binary wire format → doesn't fit the JSON API
+ * dispatcher; same pattern as `exportbans.php` / `getdemo.php`).
+ *
+ * Lifecycle:
+ *   1. Defence-in-depth permission re-check via `CheckAdminAccess` —
+ *      the page-builder route already gates on `ADMIN_OWNER`, but
+ *      direct page-include shapes (a future refactor, a misrouted
+ *      request) hit this gate too. Belt-and-braces.
+ *   2. Pre-flight pass via `ManifestBuilder::build()` (NOT
+ *      `buildOrThrow()`) so a too-big bundle still renders the form
+ *      — the operator MUST see the size totals + the `.empty-state`
+ *      block explaining what to prune before they can act on the
+ *      "exceeds cap" state.
+ *   3. Mount the `AdminTabs` back-link partial via `new AdminTabs([], …)`
+ *      (the back-link-only shape — same as `admin.email.php` /
+ *      `admin.rcon.php`).
+ *   4. Surface any pending result toast (the entry point's redirect
+ *      arms — `?result=success&bid=<bid>` / `?result=error&code=<code>`).
+ *   5. Render the form via `Renderer::render(...)`.
+ *
+ * The `?result=…` toast lives at the page handler (NOT the entry
+ * point) because the entry point is a one-shot streaming body and
+ * can't both stream binary AND paint a toast. The 302-then-toast
+ * shape lets the chrome's `flushPendingToasts` consumer (`theme.js`)
+ * pick up the wire-format `<script class="sbpp-pending-toast">`
+ * block at first paint.
+ */
+
+if (!defined('IN_SB')) {
+    echo "You should not be here. Only follow links!";
+    die();
+}
+
+global $theme, $userbank;
+
+// 1. Defence-in-depth permission gate. page-builder.php already gated
+//    `?p=admin&c=export` on ADMIN_OWNER; this is the page-include
+//    contract that survives a future routing refactor.
+CheckAdminAccess(ADMIN_OWNER);
+
+// 2. Pre-flight pass. Use `build()` not `buildOrThrow()` — we want
+//    the form rendered even when the bundle would exceed the cap.
+$manifest = (new \Sbpp\Export\ManifestBuilder(
+    dbs:          $GLOBALS['PDO'],
+    demosDir:     SB_DEMOS,
+    panelVersion: SB_VERSION,
+))->build();
+
+// 3. Mount the back-link header.
+new AdminTabs([], $userbank, $theme);
+
+// 4. Surface any pending result toast from the entry point's redirect.
+//    Both arms emit a SINGLE Toast::emit call; `$redirect` is `null`
+//    because we're already on the destination page (no second hop).
+//    Persistent error toasts (`duration_ms: 0`) match the "destructive
+//    operation FAILED" semantic per AGENTS.md "Server-side toast
+//    emission" — the operator MUST acknowledge before moving on.
+$result = (string) ($_GET['result'] ?? '');
+if ($result === 'success') {
+    $bid = (string) ($_GET['bid'] ?? '');
+    \Sbpp\View\Toast::emit(
+        'success',
+        'Export delivered',
+        $bid !== ''
+            ? sprintf('Bundle %s uploaded to the presigned URL.', $bid)
+            : 'Bundle uploaded to the presigned URL.',
+    );
+} elseif ($result === 'error') {
+    $code = (string) ($_GET['code'] ?? '');
+    \Sbpp\View\Toast::emit(
+        'error',
+        'Export failed',
+        sbpp_admin_export_describe_error($code),
+        null,
+        0,
+    );
+}
+
+// 5. Render the form. The admin-page-content / "1" wrappers match
+//    the rest of the single-page admin routes (admin.email.php, etc.).
+$totalDemos = count($manifest->demo_files);
+echo '<div id="admin-page-content"><div id="1">';
+\Sbpp\View\Renderer::render($theme, new \Sbpp\View\AdminExportView(
+    panel_version:          $manifest->panel_version,
+    row_counts:             $manifest->row_counts,
+    total_admins:           $manifest->row_counts['admins'] ?? 0,
+    total_bans:             $manifest->row_counts['bans'] ?? 0,
+    total_comms:            $manifest->row_counts['comms'] ?? 0,
+    total_demos:            $totalDemos,
+    demo_total_bytes:       $manifest->demo_total_bytes,
+    estimated_bundle_bytes: $manifest->estimated_bundle_bytes,
+    exceeds_cap:            $manifest->exceeds_cap,
+    cap_bytes:              $manifest->cap_bytes,
+));
+echo '</div></div>';
+
+/**
+ * Translate an `\Sbpp\Export\ExportError` code back into an
+ * operator-readable body string for the redirect-result toast.
+ *
+ * Codes that have an obvious user remedy (cap exceeded, presign URL
+ * malformed) get a pointed message; the rest fall back to a generic
+ * "check the audit log" line so the operator knows where to look.
+ * The audit log already carries the full diagnostic body — we don't
+ * want to surface a 2 KiB cURL response truncation into a toast.
+ */
+function sbpp_admin_export_describe_error(string $code): string
+{
+    return match ($code) {
+        \Sbpp\Export\ExportError::CAP_EXCEEDED =>
+            'The bundle would exceed the 4 GiB ZIP 2.0 cap. Prune old demos or unrelated rows and retry.',
+        \Sbpp\Export\ExportError::PRESIGN_INVALID_SCHEME =>
+            'Presigned URL must use HTTPS. Re-generate the URL with an https:// endpoint and retry.',
+        \Sbpp\Export\ExportError::PRESIGN_INVALID_URL =>
+            'Presigned URL was malformed. Paste the full URL from your S3 client exactly as given.',
+        \Sbpp\Export\ExportError::DISK_WRITE_FAILED, \Sbpp\Export\ExportError::DISK_FULL =>
+            'Failed to stage the bundle on disk. Check that cache/ is writable and has free space.',
+        \Sbpp\Export\ExportError::S3_PUT_FAILED =>
+            'The S3 endpoint rejected the upload. See the audit log for the HTTP status + response body.',
+        'mode_invalid' =>
+            'Unknown export mode. Submit the form via the buttons below.',
+        default =>
+            'Export failed. See the audit log for diagnostic details.',
+    };
+}

--- a/web/pages/core/navbar.php
+++ b/web/pages/core/navbar.php
@@ -81,6 +81,15 @@ $admin = [
         'title' => 'Mods',
         'endpoint' => 'mods',
         'permission' => ADMIN_OWNER|ADMIN_LIST_MODS|ADMIN_ADD_MODS|ADMIN_EDIT_MODS|ADMIN_DELETE_MODS
+    ],
+    [
+        // Full data export — owner-only (every PII category in scope).
+        // Same gate as page-builder.php's `$adminRoutes['export']`
+        // entry, the page handler's `CheckAdminAccess(ADMIN_OWNER)`,
+        // and the entry point at `web/export.php`.
+        'title' => 'Export',
+        'endpoint' => 'export',
+        'permission' => ADMIN_OWNER
     ]
 ];
 

--- a/web/phpstan-baseline.neon
+++ b/web/phpstan-baseline.neon
@@ -25,6 +25,12 @@ parameters:
 			path: exportbans.php
 
 		-
+			message: '#^Variable \$userbank might not be defined\.$#'
+			identifier: variable.undefined
+			count: 5
+			path: export.php
+
+		-
 			message: '#^Call to an undefined method Lcobucci\\JWT\\Token\:\:claims\(\)\.$#'
 			identifier: method.notFound
 			count: 1

--- a/web/phpstan-baseline.neon
+++ b/web/phpstan-baseline.neon
@@ -27,7 +27,7 @@ parameters:
 		-
 			message: '#^Variable \$userbank might not be defined\.$#'
 			identifier: variable.undefined
-			count: 5
+			count: 6
 			path: export.php
 
 		-

--- a/web/tests/e2e/package-lock.json
+++ b/web/tests/e2e/package-lock.json
@@ -11,6 +11,7 @@
         "@axe-core/playwright": "4.11.3",
         "@playwright/test": "1.59.1",
         "@types/node": "25.6.0",
+        "jszip": "^3.10.1",
         "typescript": "6.0.3"
       }
     },
@@ -59,6 +60,12 @@
         "node": ">=4"
       }
     },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "dev": true
+    },
     "node_modules/fsevents": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
@@ -72,6 +79,51 @@
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
+    },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+      "dev": true
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
+    },
+    "node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "dev": true
+    },
+    "node_modules/jszip": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
+      "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
+      "dev": true,
+      "dependencies": {
+        "lie": "~3.3.0",
+        "pako": "~1.0.2",
+        "readable-stream": "~2.3.6",
+        "setimmediate": "^1.0.5"
+      }
+    },
+    "node_modules/lie": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "dev": true,
+      "dependencies": {
+        "immediate": "~3.0.5"
+      }
+    },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "dev": true
     },
     "node_modules/playwright": {
       "version": "1.59.1",
@@ -103,6 +155,48 @@
         "node": ">=18"
       }
     },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "dev": true
+    },
+    "node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "dev": true,
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true
+    },
+    "node_modules/setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
+      "dev": true
+    },
+    "node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
     "node_modules/typescript": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
@@ -120,6 +214,12 @@
       "version": "7.19.2",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
       "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
+      "dev": true
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true
     }
   }

--- a/web/tests/e2e/package.json
+++ b/web/tests/e2e/package.json
@@ -11,6 +11,7 @@
     "@axe-core/playwright": "4.11.3",
     "@playwright/test": "1.59.1",
     "@types/node": "25.6.0",
+    "jszip": "^3.10.1",
     "typescript": "6.0.3"
   }
 }

--- a/web/tests/e2e/specs/flows/data-export.spec.ts
+++ b/web/tests/e2e/specs/flows/data-export.spec.ts
@@ -1,0 +1,204 @@
+/**
+ * Flow spec — `feat/data-export-bundle`: end-to-end ZIP download of
+ * the "Full data export" admin surface.
+ *
+ * The PHPUnit side covers the per-row wire format
+ * (`tests/unit/EntityExporterTest.php`), the manifest contract
+ * (`tests/unit/ManifestBuilderTest.php`), the bundle assembly
+ * (`tests/integration/ExportBundleWriterTest.php`), the S3 transport
+ * (`tests/integration/S3PresignedUploaderTest.php`), and the
+ * permission gate (`tests/integration/AdminExportPermissionTest.php`
+ * + `AdminExportRuntimePermissionTest.php`). This spec is the
+ * end-to-end seam: real browser, real form submit, real Apache
+ * streaming `web/export.php`'s `php://output` ZipStream payload,
+ * real chrome around it.
+ *
+ * # What this spec pins
+ *
+ *   1. The admin-export page (`?p=admin&c=export`) actually renders
+ *      for the seeded admin/admin user — the navbar entry is
+ *      reachable, the page handler's `CheckAdminAccess(ADMIN_OWNER)`
+ *      passes, the `AdminExportView` populates, the form template
+ *      ships the two cards.
+ *
+ *   2. Clicking "Export as ZIP" triggers a real browser download
+ *      (NOT a navigation, NOT a JSON envelope) — i.e. the
+ *      `Content-Disposition: attachment; filename="..."` header the
+ *      entry point emits is correctly interpreted by the browser.
+ *      Pre-fix a missing header would render the ZIP bytes as a
+ *      text-mode response, which Chromium silently treats as a
+ *      navigation and lands the user on a "this site can't be
+ *      reached" page.
+ *
+ *   3. The downloaded bytes parse as a valid ZIP (any ZIP-aware
+ *      consumer can open it). Belt-and-suspenders against the
+ *      integration test in case `php://output` buffering
+ *      configuration differs in dev-stack Apache vs PHPUnit.
+ *
+ *   4. The first entry is `manifest.json` — the "manifest first"
+ *      contract is part of the wire format (downstream consumers
+ *      can parse the manifest by reading just the first
+ *      central-directory entry without slurping the whole bundle).
+ *
+ *   5. The manifest carries `format_version: 1` and a non-empty
+ *      `row_counts` dictionary — the load-bearing fields the
+ *      operator's pipeline keys off.
+ *
+ *   6. CSRF + permission are gated end-to-end: a navigation to
+ *      `/export.php` via GET (i.e. NOT through the form's POST)
+ *      returns 405 Method Not Allowed. This is the wire-layer
+ *      sister to the static-shape `testEntryPointEnforcesPostOnly`
+ *      assertion in `AdminExportPermissionTest.php`.
+ *
+ * # What this spec deliberately does NOT pin
+ *
+ *   - Row-by-row content of the JSONL streams (covered by
+ *     `EntityExporterTest`).
+ *   - SteamID conversion, mute-kind, ban-state derivation
+ *     (covered by `EntityExporterTest`).
+ *   - Forbidden-column absence (covered by `EntityExporterTest`
+ *     + `ExportBundleWriterTest`).
+ *   - Cap math (covered by `ManifestBuilderTest`).
+ *   - The S3 upload mode (covered by `S3PresignedUploaderTest`'s
+ *     transport-injection — driving the real S3 path through the
+ *     dev MinIO would add a separate spec dependency without
+ *     buying additional contract coverage; the static + transport
+ *     tests are sufficient).
+ *
+ * # Test data
+ *
+ * Uses the e2e DB's baseline seed (the `admin/admin` row + the
+ * default `sb_settings`). NO per-spec truncate-and-reseed —
+ * `data-export` is a read-only surface, so the row counts the
+ * manifest reports are whatever the e2e DB happens to carry at
+ * spec run time, and the spec asserts shape contracts that hold
+ * regardless of cardinality (`row_counts.admins >= 1` rather than
+ * `row_counts.admins === 5`). This keeps the spec resilient to
+ * cross-spec data accumulation and avoids fighting the
+ * `Fixture::truncateAndReseed` GET_LOCK contention every
+ * sister spec already has to manage.
+ */
+
+import { test, expect } from '../../fixtures/auth.ts';
+import JSZip from 'jszip';
+
+test.describe('admin data export', () => {
+    test('admin export page renders for the seeded admin', async ({ page }) => {
+        await page.goto('/index.php?p=admin&c=export');
+
+        const section = page.locator('[data-testid="admin-export-section"]');
+        await expect(section).toBeVisible();
+
+        // Both cards present (ZIP + S3 modes).
+        await expect(page.locator('[data-testid="admin-export-zip-form"]')).toBeVisible();
+        await expect(page.locator('[data-testid="admin-export-s3-form"]')).toBeVisible();
+        await expect(page.locator('[data-testid="admin-export-zip-submit"]')).toBeVisible();
+        await expect(page.locator('[data-testid="admin-export-s3-submit"]')).toBeVisible();
+
+        // Stats panel populated — the manifest builder ran the
+        // pre-flight counts and the View DTO propagated them to
+        // the template.
+        await expect(page.locator('[data-testid="admin-export-count-admins"]')).toBeVisible();
+        await expect(page.locator('[data-testid="admin-export-count-bans"]')).toBeVisible();
+        await expect(page.locator('[data-testid="admin-export-count-comms"]')).toBeVisible();
+        await expect(page.locator('[data-testid="admin-export-count-demos"]')).toBeVisible();
+    });
+
+    test('clicking "Export as ZIP" downloads a valid bundle with manifest-first contract', async ({ page }) => {
+        await page.goto('/index.php?p=admin&c=export');
+
+        await expect(page.locator('[data-testid="admin-export-zip-submit"]')).toBeVisible();
+
+        // The download event fires when the server emits the
+        // Content-Disposition: attachment header AND the body
+        // starts streaming. We have to register the listener
+        // BEFORE we click the button so the event isn't missed.
+        const downloadPromise = page.waitForEvent('download', { timeout: 30_000 });
+
+        // Submit via the actual form click — same path an admin
+        // takes in production. This proves the form's hidden
+        // mode=zip input + the CSRF field + the action URL all
+        // land at the entry point correctly.
+        await page.locator('[data-testid="admin-export-zip-submit"]').click();
+
+        const download = await downloadPromise;
+
+        // Filename shape — the entry point emits `sbpp-export-<uuid>.zip`.
+        // The exact UUID is impossible to predict from the spec
+        // side (the manifest is minted fresh per request), so we
+        // pattern-match the shape.
+        expect(download.suggestedFilename()).toMatch(
+            /^sbpp-export-[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\.zip$/,
+        );
+
+        // Read the downloaded bytes. Playwright's `path()` returns
+        // the local file path the browser saved the download to;
+        // we load it as a Buffer and feed it to JSZip.
+        const path = await download.path();
+        const fs = await import('node:fs/promises');
+        const buf = await fs.readFile(path);
+        expect(buf.length).toBeGreaterThan(0);
+
+        // Parse the ZIP. JSZip's `loadAsync` is permissive — it
+        // accepts both the streaming and the random-access forms.
+        // If the bytes aren't a valid ZIP this rejects and the
+        // test fails loudly.
+        const zip = await JSZip.loadAsync(buf);
+
+        // Manifest-first contract: the first entry in the central
+        // directory MUST be `manifest.json`. Downstream consumers
+        // can then parse the manifest without slurping the whole
+        // bundle. JSZip preserves insertion order, so iterating
+        // `files` gives the original write order.
+        const names = Object.keys(zip.files);
+        expect(names.length).toBeGreaterThan(0);
+        expect(names[0]).toBe('manifest.json');
+
+        // Manifest parses + carries the wire-format identifier
+        // every consumer pipeline keys off.
+        const manifestFile = zip.file('manifest.json');
+        expect(manifestFile).not.toBeNull();
+        const manifestJson = await manifestFile!.async('text');
+        const manifest = JSON.parse(manifestJson);
+
+        expect(manifest.format_version).toBe(1);
+        expect(typeof manifest.bundle_id).toBe('string');
+        expect(manifest.bundle_id).toMatch(
+            /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/,
+        );
+        expect(typeof manifest.created_at).toBe('number');
+        expect(manifest.created_at).toBeGreaterThan(1_700_000_000);
+        expect(typeof manifest.row_counts).toBe('object');
+        expect(manifest.row_counts).not.toBeNull();
+
+        // The e2e DB carries the seeded admin/admin row, so
+        // admins >= 1. We use >= rather than === so cross-spec
+        // data accumulation doesn't break this gate (and so the
+        // spec stays resilient if a future fixture adds more
+        // seed rows).
+        expect(typeof manifest.row_counts.admins).toBe('number');
+        expect(manifest.row_counts.admins).toBeGreaterThanOrEqual(1);
+
+        // PII policy block: load-bearing operator attestation.
+        // The shape contract is pinned at unit-test level
+        // (ManifestBuilderTest); here we just verify it's
+        // present so a downstream consumer can route the bundle
+        // through the appropriate handling controls.
+        expect(typeof manifest.pii_policy).toBe('object');
+        expect(manifest.pii_policy).not.toBeNull();
+        expect(manifest.pii_policy.password_hashes).toBe('never');
+    });
+
+    test('GET to /export.php returns 405 (POST-only)', async ({ page }) => {
+        // The entry point enforces POST-only — a GET (from a hand-
+        // typed URL bar or a hostile probe) must reject with 405
+        // BEFORE the body starts streaming. This is the wire-layer
+        // sister to AdminExportPermissionTest's static-shape gate.
+        //
+        // Use `page.request.get` so the same authenticated session
+        // cookies travel — proves the gate fires even for an
+        // authenticated owner who happens to GET the URL.
+        const response = await page.request.get('/export.php');
+        expect(response.status()).toBe(405);
+    });
+});

--- a/web/tests/integration/AdminExportPermissionTest.php
+++ b/web/tests/integration/AdminExportPermissionTest.php
@@ -1,0 +1,418 @@
+<?php
+// SourceBans++ (c) 2014-2026 SourceBans++ Dev Team
+// Licensed under the Elastic License 2.0.
+// See LICENSE.txt for the full license text and THIRD-PARTY-NOTICES.txt for attributions.
+
+declare(strict_types=1);
+
+namespace Sbpp\Tests\Integration;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Permission contract for the "Full data export" admin surface.
+ *
+ * The feature exposes PII for every account on the panel (admin emails,
+ * banned-player IPs, SteamIDs, ban / comm-block reasons, the full
+ * audit log). Per the feature's plan + AGENTS.md "Sub-paged admin
+ * routes", access is gated EXCLUSIVELY on `ADMIN_OWNER`
+ * (`WebPermission::Owner`). The constraint is non-negotiable: even an
+ * admin with every other web flag must be blocked.
+ *
+ * The gate fires at three sites — defence-in-depth so a single
+ * refactor that misses one site can't quietly open the surface:
+ *
+ *   1. **Page-builder routing table** (`web/includes/page-builder.php`,
+ *      `$adminRoutes['export']['permission']`) — the chrome-side gate;
+ *      a non-owner who navigates to `?p=admin&c=export` 302s at this
+ *      layer BEFORE the page handler runs.
+ *   2. **Page handler** (`web/pages/admin.export.php`,
+ *      `CheckAdminAccess(ADMIN_OWNER)`) — defence-in-depth at the
+ *      page-include layer. Survives a hypothetical refactor of the
+ *      routing table that drops the per-route `permission` field.
+ *   3. **Streaming entry point** (`web/export.php`,
+ *      `HasAccess(WebPermission::Owner)`) — the load-bearing security
+ *      gate. A direct curl POST to `/export.php` by a partial-permission
+ *      admin hits THIS check, not the chrome's. Bypasses 1 + 2 would
+ *      still get blocked here.
+ *
+ * # Test surface decomposition
+ *
+ * Two sibling test files cover this contract:
+ *
+ * 1. **`AdminExportPermissionTest`** (this file) — static-shape
+ *    assertions. Pins the gate-call shapes by grepping the source
+ *    files. Catches a future refactor that loosens any single site
+ *    (someone swapping `WebPermission::Owner` for `ALL_WEB`, dropping
+ *    the `CheckAdminAccess` call entirely, etc.). Same shape as
+ *    `ApiJsEndpointResolutionTest`'s static gate. Fast — no DB I/O,
+ *    no process isolation, just `file_get_contents` + regex.
+ *
+ * 2. **`AdminExportRuntimePermissionTest`** (sibling file) — runtime
+ *    page-handler tests. Each test requires `pages/admin.export.php`
+ *    in a fresh PHP process under `#[RunInSeparateProcess]` and
+ *    asserts the `CheckAdminAccess` gate's actual runtime behaviour
+ *    (302 redirect to `?p=login&m=no_access` for non-owners; no
+ *    redirect for owners). Splitting the runtime arm into a sibling
+ *    file is the canonical shape PHPUnit's class-per-file discovery
+ *    expects — a second class in this file would silently fail to
+ *    enumerate at test-list time.
+ *
+ * The streaming entry point (`web/export.php`) is NOT runtime-tested
+ * because its `require_once __DIR__ . '/init.php'` conflicts with
+ * `bootstrap.php`'s already-loaded constants (init.php re-defines
+ * `SB_VERSION`, `DB_CHARSET`, etc.). The static-shape gates here
+ * cover the gate shape; the happy-path bundle output is covered
+ * end-to-end by `ExportBundleWriterTest` which drives `BundleWriter`
+ * directly. The combination is equivalent coverage.
+ *
+ * # Why the page-handler runtime branch uses `CheckAdminAccess` not
+ *   `ApiError::permission`
+ *
+ * `CheckAdminAccess` is the panel-wide procedural helper for every
+ * admin page handler under `web/pages/admin.*.php`. On a permission
+ * miss it does `header('Location: index.php?p=login&m=no_access');
+ * exit;` — a 302 to login, NOT a 403. The plan's "Form GET → 403 for
+ * non-owners" is correctly interpreted as "the page surface is not
+ * reachable for non-owners"; the codebase implements that via the
+ * 302-to-login pattern that every other admin page handler uses
+ * (e.g. `admin.bans.php`, `admin.servers.php`, `admin.settings.php`).
+ * Locking the 302-to-login shape in the sibling test mirrors what's
+ * actually shipping; expecting a 403 would gate against an unrelated
+ * panel convention.
+ */
+final class AdminExportPermissionTest extends TestCase
+{
+    // -----------------------------------------------------------------
+    //  Static-shape gate assertions (no DB, no process isolation)
+    // -----------------------------------------------------------------
+
+    /**
+     * The streaming entry point must reject non-POST requests with
+     * a 405. POST is the only method the form sends; GET / HEAD /
+     * etc. are hostile probes / address-bar typos. The body must
+     * carry `Allow: POST` so a polite client can correct itself.
+     */
+    public function testEntryPointEnforcesPostOnly(): void
+    {
+        $src = $this->entryPointSource();
+        $this->assertMatchesRegularExpression(
+            '/REQUEST_METHOD.*\!==\s*[\'"]POST[\'"]/s',
+            $src,
+            'export.php must reject non-POST methods with a 405. The form posts; a direct GET is a hostile probe or address-bar typo.',
+        );
+        $this->assertStringContainsString(
+            '405 Method Not Allowed',
+            $src,
+            'The non-POST branch must surface a 405, not a generic 403/500 (a 405 with Allow: POST is the polite shape).',
+        );
+        $this->assertStringContainsString(
+            'Allow: POST',
+            $src,
+            'The 405 response must carry an Allow: POST header per RFC 7231 §6.5.5.',
+        );
+    }
+
+    /**
+     * The streaming entry point must call `CSRF::rejectIfInvalid()`
+     * BEFORE any DB access / permission check / shared-host hardening
+     * fires. A stale tab from yesterday MUST NOT be able to trigger
+     * a PII-flush export — the CSRF gate is what enforces "the user
+     * meant to do this in this session".
+     */
+    public function testEntryPointCallsCsrfRejectIfInvalidBeforePermissionGate(): void
+    {
+        $src      = $this->entryPointSource();
+        $csrfPos  = strpos($src, 'CSRF::rejectIfInvalid');
+        $hasPerm  = strpos($src, '$userbank->HasAccess(WebPermission::Owner)');
+
+        $this->assertNotFalse(
+            $csrfPos,
+            'export.php must call CSRF::rejectIfInvalid() — this is the load-bearing gate against cross-site form submission of a PII export.',
+        );
+        $this->assertNotFalse(
+            $hasPerm,
+            'export.php must call HasAccess(WebPermission::Owner) — the owner-only gate.',
+        );
+        $this->assertLessThan(
+            $hasPerm,
+            $csrfPos,
+            'CSRF::rejectIfInvalid must run BEFORE HasAccess(WebPermission::Owner). Order matters: the CSRF gate is a structural contract (any state-changing request), while the owner gate is feature-specific. Inverting the order would let a forged-session attacker who happens to also be an owner bypass CSRF.',
+        );
+    }
+
+    /**
+     * The streaming entry point's permission gate must use
+     * `WebPermission::Owner` exclusively — not `ALL_WEB`, not
+     * `ADMIN_OWNER | ADMIN_SOME_OTHER_FLAG`, not a string-coerced
+     * lookup. Every PII category on the panel is in scope; granular
+     * delegation was deliberately deferred per the plan.
+     */
+    public function testEntryPointGatesOnOwnerExclusively(): void
+    {
+        $src = $this->entryPointSource();
+        $this->assertStringContainsString(
+            '$userbank->HasAccess(WebPermission::Owner)',
+            $src,
+            'export.php must gate on WebPermission::Owner — the entire dataset is PII so per-flag delegation does not apply.',
+        );
+        $this->assertDoesNotMatchRegularExpression(
+            '/HasAccess\([^)]*ALL_WEB[^)]*\)/',
+            $src,
+            'export.php must NOT use ALL_WEB — that would let ANY admin (e.g. a Mod-listing-only operator) trigger a full PII export.',
+        );
+        $this->assertDoesNotMatchRegularExpression(
+            '/WebPermission::(?!Owner)\w+/',
+            $src,
+            'export.php must NOT reference any non-Owner WebPermission case — Owner is the exclusive gate per the plan.',
+        );
+    }
+
+    /**
+     * The non-owner branch must log a warning to the audit log
+     * BEFORE returning the 403. A forged POST without permission
+     * is exactly the sort of thing operators want to triage
+     * after-the-fact — silently swallowing the rejection means
+     * an attacker can iteratively probe the form without leaving
+     * a forensic trail.
+     */
+    public function testEntryPointLogsNonOwnerAttempt(): void
+    {
+        $src = $this->entryPointSource();
+        $this->assertMatchesRegularExpression(
+            '/Log::add\s*\(\s*LogType::Warning\s*,\s*[\'"]Data Export[\'"]/s',
+            $src,
+            'export.php must Log::add(LogType::Warning, "Data Export", ...) when a non-owner POST hits the permission gate. Without this every probe is silently swallowed.',
+        );
+    }
+
+    /**
+     * Defence-in-depth: the page handler must re-check the
+     * permission via `CheckAdminAccess(ADMIN_OWNER)` even though
+     * the routing table already gated `?p=admin&c=export` on
+     * `ADMIN_OWNER`. A future refactor of the routing table that
+     * drops the per-route `permission` field would silently open
+     * the page surface; this re-check is the safety net.
+     *
+     * `CheckAdminAccess(ADMIN_OWNER)` — not
+     * `CheckAdminAccess(ADMIN_OWNER | ADMIN_ANYTHING)`. The
+     * defence-in-depth must match the routing-table gate
+     * byte-for-byte; otherwise the two surfaces would disagree
+     * on what counts as access.
+     */
+    public function testPageHandlerCallsCheckAdminAccessOwner(): void
+    {
+        $src = $this->pageHandlerSource();
+        $this->assertMatchesRegularExpression(
+            '/CheckAdminAccess\s*\(\s*ADMIN_OWNER\s*\)/',
+            $src,
+            'admin.export.php must call CheckAdminAccess(ADMIN_OWNER) as a defence-in-depth re-check of the routing-table gate.',
+        );
+    }
+
+    /**
+     * The routing table in `page-builder.php` must gate the
+     * `export` route on `ADMIN_OWNER`. This is the chrome-side
+     * gate that catches non-owners BEFORE the page handler runs.
+     */
+    public function testRoutingTableGatesOnOwner(): void
+    {
+        $src = (string) @file_get_contents(ROOT . 'includes/page-builder.php');
+        $this->assertNotEmpty(
+            $src,
+            'page-builder.php must exist — the routing table lives there.',
+        );
+
+        // Pin a small window around the 'export' entry so the
+        // regex stays anchored even when adjacent rows shift.
+        $this->assertMatchesRegularExpression(
+            "/['\"]export['\"]\s*=>\s*\[[^\]]*ADMIN_OWNER[^\]]*\]/s",
+            $src,
+            "page-builder.php's \$adminRoutes['export'] must gate on ADMIN_OWNER. Loosening this to ALL_WEB or dropping the gate would let any admin reach the chrome surface.",
+        );
+    }
+
+    /**
+     * The navbar's admin section must gate the Export entry on
+     * `ADMIN_OWNER`. UX-side gating only — the chrome-side rule
+     * that hides the link from non-owners; the security gate is
+     * the routing table + page handler + entry point above.
+     *
+     * The catalog's entries are arrays with sibling `endpoint` /
+     * `permission` keys on separate lines, so the regex anchors
+     * on a ~5-line window around the `'endpoint' => 'export'`
+     * line and asserts the window mentions `ADMIN_OWNER` exactly
+     * (no `|`-OR with any other flag — Owner-only).
+     */
+    public function testNavbarGatesOnOwner(): void
+    {
+        $src = (string) @file_get_contents(ROOT . 'pages/core/navbar.php');
+        $this->assertNotEmpty(
+            $src,
+            'navbar.php must exist — the admin chrome navigation entries live there.',
+        );
+
+        $window = $this->catalogEntryWindow($src, "'endpoint' => 'export'");
+        $this->assertNotNull(
+            $window,
+            "navbar.php must register an 'endpoint' => 'export' entry for the Data Export route.",
+        );
+        $this->assertMatchesRegularExpression(
+            "/'permission'\s*=>\s*ADMIN_OWNER(?!\s*\|)/",
+            $window,
+            "navbar.php's 'export' entry must gate exclusively on ADMIN_OWNER (no OR-with-other-flags — Owner is the exclusive gate). Window: $window",
+        );
+    }
+
+    /**
+     * The command palette's "Data export" entry must gate on
+     * `ADMIN_OWNER`. The chrome-side rule: the palette must
+     * agree with the navbar (both are UX surfaces; neither is
+     * load-bearing security). Per AGENTS.md "Filtered chrome
+     * navigation surfaces", these two surfaces are sister
+     * surfaces — when adding a new entry to either, the other
+     * gets the matching change in the same PR.
+     *
+     * PaletteActions wraps the constant in
+     * `defined('ADMIN_OWNER') ? (int) constant('ADMIN_OWNER') : 0`
+     * to stay safe under test bootstraps that don't load the
+     * permission constants (mirrors the `ALL_WEB` sibling for
+     * the "Admin panel" entry). The 0-fallback is harmless: an
+     * unauthenticated user already fails the `for()` filter's
+     * `is_admin()` short-circuit, and a logged-in user can never
+     * legitimately have a permission mask of 0 (the seeded
+     * admin row carries `extraflags=16777216`).
+     */
+    public function testPaletteEntryGatesOnOwner(): void
+    {
+        $src = (string) @file_get_contents(ROOT . 'includes/View/PaletteActions.php');
+        $this->assertNotEmpty(
+            $src,
+            'PaletteActions.php must exist — the palette catalog lives there.',
+        );
+
+        $this->assertStringContainsString(
+            '?p=admin&c=export',
+            $src,
+            'PaletteActions must surface the data-export entry via its href.',
+        );
+
+        $window = $this->catalogEntryWindow($src, '?p=admin&c=export');
+        $this->assertNotNull(
+            $window,
+            'Could not locate the export entry in PaletteActions.php.',
+        );
+
+        // Either the modern enum form or the legacy ADMIN_OWNER
+        // constant is acceptable — both yield the same gate
+        // value. What we DON'T accept is a different / weaker
+        // permission (ALL_WEB, a per-flag OR, etc.).
+        $hasOwnerConstant = (bool) preg_match(
+            "/'permission'\s*=>\s*[^,]*\bADMIN_OWNER\b/",
+            $window,
+        );
+        $hasOwnerEnum = (bool) preg_match(
+            "/'permission'\s*=>\s*[^,]*WebPermission::Owner/",
+            $window,
+        );
+        $this->assertTrue(
+            $hasOwnerConstant || $hasOwnerEnum,
+            "Palette export entry must gate on ADMIN_OWNER (or WebPermission::Owner). Window: $window",
+        );
+        // And NOT on any other flag — Owner is the exclusive
+        // gate. Reject e.g. `ADMIN_OWNER|ADMIN_LIST_ADMINS`.
+        $this->assertDoesNotMatchRegularExpression(
+            '/ADMIN_OWNER\s*\|\s*ADMIN_/',
+            $window,
+            "Palette export entry must NOT OR ADMIN_OWNER with any other flag — the surface is Owner-only. Window: $window",
+        );
+    }
+
+    /**
+     * Locate a catalog entry (an array literal) containing the
+     * given anchor substring, and return a ~7-line window
+     * centered on it. Returns null if no line carries the anchor.
+     *
+     * Catalog rows in `navbar.php` / `page-builder.php` /
+     * `PaletteActions.php` are multi-line array literals; a
+     * single-line regex against a key/value pair would miss the
+     * sibling keys. The window is wide enough to capture every
+     * sibling key (icon / label / href / endpoint / permission /
+     * config) and narrow enough not to grab the next array
+     * element's keys (which would let a sibling Owner row pass
+     * the assertion when our row is wrong).
+     */
+    private function catalogEntryWindow(string $src, string $anchor): ?string
+    {
+        $lines = explode("\n", $src);
+        foreach ($lines as $idx => $line) {
+            if (str_contains($line, $anchor)) {
+                return implode(
+                    "\n",
+                    array_slice($lines, max(0, $idx - 3), 7),
+                );
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Forbidden cross-check: neither web.json nor api-contract.js
+     * may carry a permission flag specific to the data-export
+     * feature. The plan explicitly forbids new flags here —
+     * gating is exclusively on the existing `ADMIN_OWNER`. A
+     * future PR that drifts toward "let's add a granular flag"
+     * fails this gate first.
+     */
+    public function testNoNewPermissionFlagAddedForExport(): void
+    {
+        $webJson = (string) @file_get_contents(ROOT . 'configs/permissions/web.json');
+        $this->assertNotEmpty(
+            $webJson,
+            'web.json must exist — the permission catalog lives there.',
+        );
+        $this->assertStringNotContainsString(
+            'ADMIN_EXPORT',
+            $webJson,
+            'web.json must NOT carry an ADMIN_EXPORT* flag — the feature is exclusively gated on ADMIN_OWNER per the plan.',
+        );
+
+        $contract = (string) @file_get_contents(ROOT . 'scripts/api-contract.js');
+        if ($contract !== '') {
+            $this->assertStringNotContainsString(
+                'EXPORT_DATA',
+                $contract,
+                'api-contract.js must NOT carry an EXPORT_DATA permission — the contract should be unchanged by this feature.',
+            );
+            $this->assertStringNotContainsString(
+                'AdminExport',
+                $contract,
+                'api-contract.js must NOT carry an AdminExport action — the feature uses a top-level streaming entry point, not a JSON handler.',
+            );
+        }
+    }
+
+    // -----------------------------------------------------------------
+    //  Source-file readers (single quote-friendly grep targets)
+    // -----------------------------------------------------------------
+
+    private function entryPointSource(): string
+    {
+        $src = (string) @file_get_contents(ROOT . 'export.php');
+        $this->assertNotEmpty(
+            $src,
+            'web/export.php must exist — the streaming entry point lives there.',
+        );
+        return $src;
+    }
+
+    private function pageHandlerSource(): string
+    {
+        $src = (string) @file_get_contents(ROOT . 'pages/admin.export.php');
+        $this->assertNotEmpty(
+            $src,
+            'web/pages/admin.export.php must exist — the page handler lives there.',
+        );
+        return $src;
+    }
+}

--- a/web/tests/integration/AdminExportRuntimePermissionTest.php
+++ b/web/tests/integration/AdminExportRuntimePermissionTest.php
@@ -1,0 +1,240 @@
+<?php
+// SourceBans++ (c) 2014-2026 SourceBans++ Dev Team
+// Licensed under the Elastic License 2.0.
+// See LICENSE.txt for the full license text and THIRD-PARTY-NOTICES.txt for attributions.
+
+declare(strict_types=1);
+
+namespace Sbpp\Tests\Integration;
+
+use Sbpp\Tests\ApiTestCase;
+use Sbpp\Tests\Fixture;
+
+/**
+ * Runtime permission gate for the "Full data export" surface,
+ * exercising the underlying primitives the entry point + page
+ * handler rely on (`CSRF::validate(CSRF::fromRequest())` +
+ * `CUserManager::HasAccess(WebPermission::Owner->value)`).
+ *
+ * Sister of `AdminExportPermissionTest` (static-shape) — the
+ * split mirrors `Php82DeprecationsTest`'s "static + runtime"
+ * decomposition for the same reason: the static arm pins the
+ * call shape ("the source file LITERALLY contains
+ * `CheckAdminAccess(ADMIN_OWNER)`") while the runtime arm pins
+ * the primitive behaviour ("when called with a non-owner, that
+ * primitive actually returns false"). Both halves matter: the
+ * static gate catches "someone removed the gate call", the
+ * runtime gate catches "someone subtly broke the primitive the
+ * gate relies on" (a permission-bitmask refactor, a CSRF token
+ * shape change, etc.).
+ *
+ * Why sibling FILE not sibling CLASS in the same file: PHPUnit's
+ * class-from-file discovery picks up exactly one class per
+ * `*Test.php` matching the filename. A sibling class in the same
+ * file silently fails to enumerate at `--list-tests` time (which
+ * is the kind of failure mode that ships green to CI and fails
+ * closed only when someone adds a regression test that exercises
+ * a class the test suite isn't actually loading).
+ *
+ * Why NOT a `require pages/admin.export.php` runtime test under
+ * `#[RunInSeparateProcess]`: the page handler's gate is
+ * `CheckAdminAccess(ADMIN_OWNER)`, which on miss calls
+ * `header('Location: …'); exit;`. PHP's `exit` is uncatchable
+ * (try/catch can't intercept it — it propagates synchronously
+ * through any frames in scope and terminates the runtime), so
+ * under `RunInSeparateProcess` the child process dies cleanly
+ * BEFORE PHPUnit can serialise a result back to the parent and
+ * the test runner reports "Test was run in child process and
+ * ended unexpectedly". The primitive tests below test the same
+ * gate's underlying behaviour without fighting `exit`'s
+ * uncatchable shape; the static gate in the sister file pins
+ * "the call is in place"; the Playwright spec
+ * (`data-export.spec.ts`) drives the gate end-to-end through a
+ * real HTTP request. Three layers — sufficient.
+ *
+ * The entry point (`web/export.php`) is even less `require`-able
+ * under PHPUnit: its own `require_once __DIR__ . '/init.php'`
+ * conflicts with `bootstrap.php`'s already-defined constants
+ * (`ROOT`, `DB_PREFIX`, `ADMIN_OWNER`, …). Same shape, same
+ * resolution — exercise the primitives directly.
+ */
+final class AdminExportRuntimePermissionTest extends ApiTestCase
+{
+    /**
+     * The streaming entry point's CSRF gate
+     * (`CSRF::rejectIfInvalid()` → `CSRF::validate(self::fromRequest())`)
+     * must reject a missing token. Without this gate, a hostile
+     * cross-origin `<form>` POST against `export.php` could
+     * trigger a full panel export against an authenticated
+     * owner's session. The owner-only permission gate sits
+     * downstream of the CSRF gate (per the static-shape
+     * contract `testEntryPointCallsCsrfRejectIfInvalidBeforePermissionGate`),
+     * so a missing-token attempt never even reaches the
+     * permission check.
+     */
+    public function testCsrfGatePrimitiveRejectsMissingToken(): void
+    {
+        \CSRF::init();
+        $token = \CSRF::token();
+        $this->assertNotSame('', $token, 'CSRF::init must mint a session token.');
+
+        // Don't supply the token via $_POST / $_GET / header.
+        $_POST = [];
+        $_GET  = [];
+        unset($_SERVER['HTTP_X_CSRF_TOKEN']);
+
+        $this->assertFalse(
+            \CSRF::validate(\CSRF::fromRequest()),
+            'CSRF::validate(fromRequest()) must return false when no token is supplied — the gate the entry point relies on.',
+        );
+    }
+
+    /**
+     * Sister to the above: when the correct token IS supplied,
+     * the gate passes. Pins the bidirectional contract — the gate
+     * isn't just "always-fails"; it accepts legitimate tokens
+     * via either of the two transport mechanisms the panel
+     * supports ($_POST field for form submits, X-CSRF-Token
+     * header for `sb.api.call` JSON requests).
+     */
+    public function testCsrfGatePrimitiveAcceptsValidToken(): void
+    {
+        \CSRF::init();
+        $token = \CSRF::token();
+
+        // Form-submit path (what the data-export form's `<form
+        // method="post">` POST exercises via the `{csrf_field}`
+        // Smarty function in `page_admin_export.tpl`).
+        $_POST = [\CSRF::FIELD_NAME => $token];
+        unset($_SERVER[\CSRF::HEADER_NAME]);
+        $this->assertTrue(
+            \CSRF::validate(\CSRF::fromRequest()),
+            'CSRF::validate(fromRequest()) must return true when the session-bound token is supplied via $_POST.',
+        );
+
+        // Header-supplied path (what `sb.api.call` sets
+        // automatically for JSON requests — not exercised by the
+        // export form today but the gate accepts both transports
+        // by design, and a future JSON-driven export surface
+        // would ride this path).
+        $_POST = [];
+        $_SERVER[\CSRF::HEADER_NAME] = $token;
+        $this->assertTrue(
+            \CSRF::validate(\CSRF::fromRequest()),
+            'CSRF::validate(fromRequest()) must accept the token via the X-CSRF-Token header.',
+        );
+    }
+
+    /**
+     * Permission-primitive sister: the gate the entry point's
+     * `if (!$userbank->HasAccess(WebPermission::Owner->value))`
+     * block AND the page handler's `CheckAdminAccess(ADMIN_OWNER)`
+     * both rely on. Three branches:
+     *
+     * - Anonymous: fails closed.
+     * - Non-owner with every other web flag set EXCEPT Owner:
+     *   still fails. ADMIN_OWNER is the EXCLUSIVE gate per the
+     *   plan — every other web flag combined must be insufficient.
+     *   This is the strongest expression of "owner-only" — if
+     *   `(ALL_WEB & ~ADMIN_OWNER)` gets through, every weaker
+     *   non-owner mask gets through too.
+     * - Owner: passes. (The seeded `admin/admin` fixture carries
+     *   ADMIN_OWNER per `Fixture::adminAid()`'s contract.)
+     */
+    public function testOwnerPermissionPrimitive(): void
+    {
+        $anon = new \CUserManager(null);
+        $this->assertFalse(
+            $anon->HasAccess(\WebPermission::Owner->value),
+            'Anonymous user (CUserManager(null)) must NOT have Owner — fail-closed default.',
+        );
+
+        $nonOwnerMask = ALL_WEB & ~ADMIN_OWNER;
+        $aid = $this->createAdminWithFlags($nonOwnerMask);
+        $this->loginAs($aid);
+        /** @var \CUserManager $nonOwner */
+        $nonOwner = $GLOBALS['userbank'];
+        $this->assertFalse(
+            $nonOwner->HasAccess(\WebPermission::Owner->value),
+            'Non-owner admin (ALL_WEB & ~ADMIN_OWNER) must NOT have Owner — the bypass is exclusive to ADMIN_OWNER. If this fails, the gate has been silently weakened and every non-owner with the right combination of other flags can hit the export.',
+        );
+
+        $this->loginAsAdmin();
+        /** @var \CUserManager $owner */
+        $owner = $GLOBALS['userbank'];
+        $this->assertTrue(
+            $owner->HasAccess(\WebPermission::Owner->value),
+            'The seeded admin/admin row must have Owner — every gate downstream relies on this.',
+        );
+    }
+
+    /**
+     * Belt-and-suspenders: the SourceMod char-flag form of
+     * `HasAccess` (the codebase's variadic permission shape that
+     * also accepts strings like `"z"` for the root char) MUST
+     * NOT let a SourceMod-root-without-web-owner caller through.
+     * The web `ADMIN_OWNER` flag and the SourceMod `z` char are
+     * conceptually orthogonal — a SourceMod root admin who is
+     * NOT a web owner must still be blocked.
+     */
+    public function testSourceModRootCharAloneDoesNotGrantWebOwner(): void
+    {
+        // SourceMod char-flag bypass is via the `srv_flags`
+        // column on `:prefix_admins`, NOT `extraflags`. A row
+        // with `srv_flags = 'z'` (sm root) but no web Owner bit
+        // must still fail the web-side HasAccess check.
+        $pdo = Fixture::rawPdo();
+        $stmt = $pdo->prepare(sprintf(
+            'INSERT INTO `%s_admins` (user, authid, password, gid, email, validate, extraflags, srv_flags, immunity)
+             VALUES (?, ?, ?, -1, ?, NULL, 0, ?, 99)',
+            DB_PREFIX,
+        ));
+        $stmt->execute([
+            'export-smroot-no-owner',
+            'STEAM_0:0:9000001',
+            password_hash('x', PASSWORD_BCRYPT),
+            'export-smroot@example.test',
+            'z',
+        ]);
+        $aid = (int) $pdo->lastInsertId();
+        $this->loginAs($aid);
+
+        /** @var \CUserManager $smRoot */
+        $smRoot = $GLOBALS['userbank'];
+        $this->assertFalse(
+            $smRoot->HasAccess(\WebPermission::Owner->value),
+            'A SourceMod-root admin without web ADMIN_OWNER must NOT pass the web Owner gate — the two flag spaces are orthogonal and the export feature is web-side only.',
+        );
+    }
+
+    // -----------------------------------------------------------------
+    //  Test-only helpers
+    // -----------------------------------------------------------------
+
+    /**
+     * Insert a non-owner admin row directly via the test PDO so
+     * we can exercise an arbitrary `extraflags` mask without
+     * going through the `admins.add` JSON handler. The handler
+     * would itself reject a non-owner caller from creating a row
+     * with a permission mask the caller can't grant — for tests
+     * exercising "what does a non-owner see", we need the raw
+     * insert path.
+     */
+    private function createAdminWithFlags(int $mask): int
+    {
+        $pdo = Fixture::rawPdo();
+        $stmt = $pdo->prepare(sprintf(
+            'INSERT INTO `%s_admins` (user, authid, password, gid, email, validate, extraflags, immunity)
+             VALUES (?, ?, ?, -1, ?, NULL, ?, 50)',
+            DB_PREFIX,
+        ));
+        $stmt->execute([
+            'export-flagged-' . $mask,
+            'STEAM_0:0:' . (4_000_000 + ($mask & 0xFFFFF)),
+            password_hash('x', PASSWORD_BCRYPT),
+            'export-flagged@example.test',
+            $mask,
+        ]);
+        return (int) $pdo->lastInsertId();
+    }
+}

--- a/web/tests/integration/ExportBundleWriterTest.php
+++ b/web/tests/integration/ExportBundleWriterTest.php
@@ -56,6 +56,16 @@ final class ExportBundleWriterTest extends TestCase
     /** @var list<string> */
     private array $seededDemoFiles = [];
 
+    /**
+     * The writer in M1 form gets a non-null `$outputHandle` arg so
+     * its cap counter can snap to the on-disk file size after each
+     * entry — exact compressed-byte tracking instead of the
+     * conservative uncompressed-byte estimate. Captured here so
+     * the M1 regression test can assert the same handle's
+     * post-finish size matches `bytesWritten()`.
+     */
+    private ?BundleWriter $lastWriter = null;
+
     protected function setUp(): void
     {
         parent::setUp();
@@ -274,12 +284,121 @@ final class ExportBundleWriterTest extends TestCase
             entities:          $entities,
             demosDir:          SB_DEMOS,
             flushAfterEntries: false,
+            // M1: hand the writer the staging-file handle so the
+            // running cap counter snaps to exact compressed bytes
+            // via post-write `fstat`. Mirrors `web/export.php`'s
+            // s3-mode wiring so the integration test exercises
+            // the same code path real operators hit.
+            outputHandle:      $handle,
         );
         $writer->write();
+        $this->lastWriter = $writer;
         fclose($handle);
 
         $this->assertFileExists($this->bundlePath);
         $this->assertGreaterThan(0, filesize($this->bundlePath) ?: 0);
+    }
+
+    /**
+     * M1 regression guard: when the writer is constructed with a
+     * non-null `$outputHandle` (the s3-mode build-to-disk path),
+     * `bytesWritten()` MUST match the on-disk file size byte-for-
+     * byte. Pre-M1 the running cap counter advanced by uncompressed
+     * deltas, which over-counted DEFLATE entities (the JSONL
+     * compresses 3-8x in practice) and could trip a premature
+     * `CAP_EXCEEDED` on bundles that actually fit. Post-M1 the
+     * counter snaps to the on-disk size after each entry, so the
+     * final value reported is exact.
+     *
+     * The zip-mode (php://output) path still uses the uncompressed
+     * estimate because it has no seekable handle to stat — that
+     * arm is documented on `BundleWriter::bytesWritten` and isn't
+     * exercised here (the integration test only covers s3-mode
+     * because we need a file to crack open with ZipArchive).
+     */
+    public function testWriterBytesWrittenMatchesOnDiskSizeInS3Mode(): void
+    {
+        $this->seedSampleBan();
+        $this->seedSampleDemo('m1-fstat-marker.dem', str_repeat("\x42", 8192));
+        $this->writeBundle();
+
+        $this->assertNotNull($this->lastWriter, 'writeBundle must populate lastWriter');
+        $diskSize = filesize($this->bundlePath);
+        $this->assertNotFalse($diskSize, 'filesize() failed on the staging file');
+        $this->assertSame(
+            (int) $diskSize,
+            $this->lastWriter->bytesWritten(),
+            'BundleWriter::bytesWritten() in s3 mode (non-null $outputHandle) must report the EXACT '
+            . 'on-disk compressed-byte size — pre-M1 it reported the uncompressed estimate and could '
+            . 'over-count by 3-8x for DEFLATE-compressed JSONL, prematurely tripping CAP_EXCEEDED.',
+        );
+    }
+
+    /**
+     * H1 regression guard: writing a large entity must NOT
+     * proportionally inflate PHP's peak memory. Pre-H1 the
+     * writer concatenated every yielded JSONL line into a single
+     * PHP string inside an `addFileFromCallback`, so a multi-
+     * hundred-MB audit log would push peak memory past the
+     * runtime hardening's 256 MiB ceiling — OOM on shared
+     * hosting where 128 MiB is the realistic floor. Post-H1
+     * the writer spills to `php://temp/maxmemory:8M`, so the
+     * working set stays bounded at the spill threshold
+     * regardless of total entity size.
+     *
+     * Seeds enough comments to push the comments entity well past
+     * the spill threshold AND records peak memory after the write
+     * completes. The assertion shape pins the spill behaviour by
+     * upper-bounding peak growth at ~64 MiB — enough headroom
+     * for Smarty / Composer / PDO overhead but well below the
+     * pre-H1 shape's "entity-size-proportional" growth.
+     */
+    public function testWriterDoesNotBufferLargeEntityIntoMemory(): void
+    {
+        $pdo = \Sbpp\Tests\Fixture::rawPdo();
+        $this->seedSampleBan();
+        $bid = (int) $pdo->query(sprintf('SELECT MAX(bid) FROM `%s_bans`', DB_PREFIX))->fetchColumn();
+        $this->assertGreaterThan(0, $bid, 'must have seeded a ban first');
+
+        // Seed a payload sized to exceed the spill threshold but
+        // not so large that the test runtime blows. Each comment
+        // row carries ~600 bytes of body text; 25k rows → ~15 MiB
+        // uncompressed JSONL, comfortably above the 8 MiB spill
+        // threshold but quick to write.
+        $payload = str_repeat('H1_LARGE_ENTITY_PAYLOAD_MARKER ', 18);
+        $stmt = $pdo->prepare(sprintf(
+            'INSERT INTO `%s_comments` (type, bid, commenttxt, added, aid) VALUES ("B", ?, ?, UNIX_TIMESTAMP(), 1)',
+            DB_PREFIX,
+        ));
+        for ($i = 0; $i < 25_000; $i++) {
+            $stmt->execute([$bid, $payload]);
+        }
+
+        $before = memory_get_peak_usage(true);
+        $this->writeBundle();
+        $after = memory_get_peak_usage(true);
+
+        $delta = $after - $before;
+        $this->assertLessThan(
+            64 * 1024 * 1024,
+            $delta,
+            'Writing a >15 MiB entity grew PHP peak memory by ' . number_format($delta / 1024 / 1024, 2) . ' MiB. '
+            . 'Pre-H1 the writer concatenated the whole entity into a PHP string, so peak grew proportionally '
+            . 'to the entity size — OOM risk on shared hosting at scale. Post-H1 the writer spills to '
+            . 'php://temp/maxmemory:8M and peak should stay bounded.',
+        );
+
+        // Sanity: the comments entity actually landed in the bundle.
+        $zip = new ZipArchive();
+        $this->assertTrue($zip->open($this->bundlePath) === true);
+        $commentsBody = $zip->getFromName('entities/comments.jsonl');
+        $zip->close();
+        $this->assertIsString($commentsBody);
+        $this->assertGreaterThan(
+            8 * 1024 * 1024,
+            strlen($commentsBody),
+            'Comments JSONL should exceed the 8 MiB spill threshold so this test exercises the spill path',
+        );
     }
 
     /**

--- a/web/tests/integration/ExportBundleWriterTest.php
+++ b/web/tests/integration/ExportBundleWriterTest.php
@@ -1,0 +1,333 @@
+<?php
+// SourceBans++ (c) 2014-2026 SourceBans++ Dev Team
+// Licensed under the Elastic License 2.0.
+// See LICENSE.txt for the full license text and THIRD-PARTY-NOTICES.txt for attributions.
+
+declare(strict_types=1);
+
+namespace Sbpp\Tests\Integration;
+
+use PHPUnit\Framework\TestCase;
+use Sbpp\Export\BundleWriter;
+use Sbpp\Export\EntityExporter;
+use Sbpp\Export\Manifest;
+use Sbpp\Export\ManifestBuilder;
+use Sbpp\Tests\Fixture;
+use ZipArchive;
+use ZipStream\CompressionMethod;
+use ZipStream\ZipStream;
+
+/**
+ * End-to-end bundle-shape contract pin.
+ *
+ * Drives the full {@see ManifestBuilder} → {@see BundleWriter}
+ * → on-disk ZIP pipeline against the seeded test DB, then
+ * cracks the resulting archive open with {@see ZipArchive} and
+ * asserts the structural promises any downstream consumer rides:
+ *
+ *   - `manifest.json` is the **first** entry (offset 0). A
+ *     consumer can pull just the manifest from the head of the
+ *     stream to decide whether to bother downloading the rest.
+ *   - Every entity JSONL row count agrees with the manifest's
+ *     `row_counts[<entity>]`. Pre-flight + writer agree.
+ *   - Every demo entry is stored with {@see ZipArchive::CM_STORE}
+ *     (no DEFLATE on already-compressed binary).
+ *   - Every JSONL line parses as JSON and carries an `id` field
+ *     (or the documented composite-PK exception for
+ *     `admins_servers_groups` / `banlog` / `servers_groups`).
+ *   - No SteamID appears as a bare JSON number; every authid is
+ *     quoted decimal Steam64. The 17-digit values overflow
+ *     JS `Number.MAX_SAFE_INTEGER` (2^53-1 ≈ 16 digits).
+ *   - The forbidden columns (bcrypt hashes, RCON passwords, SMTP
+ *     credentials, telemetry instance ID) literally don't appear
+ *     in the bundle bytes.
+ *
+ * Scope split: this file is the only integration-level export
+ * suite — sister {@see \Sbpp\Tests\Unit\EntityExporterTest} (per-
+ * entity column rules), {@see \Sbpp\Tests\Unit\ManifestBuilderTest}
+ * (manifest / DTO / cap math), {@see AdminExportPermissionTest}
+ * (HTTP entry gates), {@see S3PresignedUploaderTest} (cURL stub
+ * paths) each own their layer in isolation.
+ */
+final class ExportBundleWriterTest extends TestCase
+{
+    private string $bundlePath;
+
+    /** @var list<string> */
+    private array $seededDemoFiles = [];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Fixture::reset();
+
+        $this->bundlePath = SB_CACHE . 'export-bundle-test-' . bin2hex(random_bytes(6)) . '.zip';
+        // Defensive cleanup against a prior crash leaving residue.
+        @unlink($this->bundlePath);
+    }
+
+    protected function tearDown(): void
+    {
+        if (is_file($this->bundlePath)) {
+            @unlink($this->bundlePath);
+        }
+        foreach ($this->seededDemoFiles as $f) {
+            @unlink($f);
+        }
+        $this->seededDemoFiles = [];
+        parent::tearDown();
+    }
+
+    /**
+     * Drive the full export against the empty-fixture DB and assert
+     * every structural contract. The empty DB still seeds the admin
+     * row + the default `sb_settings` rows + the default `sb_mods`
+     * rows, so the bundle is not entirely vacuous — `admins` /
+     * `settings` / `mods` carry entries and we can exercise the
+     * row-count agreement contract on them.
+     */
+    public function testFullBundleWriteAgainstSeededFixture(): void
+    {
+        // Seed one ban so the `bans` JSONL is non-empty AND so the
+        // demo subsystem has something to LEFT JOIN against.
+        $this->seedSampleBan();
+
+        // Seed a demo file on disk + a `:prefix_demos` row referencing
+        // it, so the bundle picks up a STORE-mode demo entry.
+        $this->seedSampleDemo('export-bundle-test.dem', "DEMOFAKEHEADER_DISTINCTIVE_MARKER\x00" . str_repeat("\x01", 4096));
+
+        $this->writeBundle();
+
+        $zip = new ZipArchive();
+        $opened = $zip->open($this->bundlePath);
+        $this->assertTrue($opened === true, "ZipArchive::open failed: $opened");
+
+        // ---- (1) manifest.json is the first entry ---------------
+        $first = $zip->statIndex(0);
+        $this->assertIsArray($first);
+        $this->assertSame(
+            'manifest.json',
+            $first['name'],
+            'manifest.json must be the FIRST entry in the bundle (offset 0). '
+            . 'Consumers rely on being able to short-circuit after one entry.',
+        );
+
+        // ---- (2) manifest JSON parses + carries expected keys ----
+        $manifestBody = $zip->getFromName('manifest.json');
+        $this->assertIsString($manifestBody);
+        $manifest = json_decode($manifestBody, true, 512, JSON_THROW_ON_ERROR);
+        $this->assertIsArray($manifest);
+        $this->assertSame(Manifest::FORMAT_VERSION, $manifest['format_version']);
+        $this->assertIsString($manifest['bundle_id']);
+        $this->assertIsArray($manifest['row_counts']);
+        $this->assertIsArray($manifest['demo_files']);
+
+        // ---- (3) row_counts agree with JSONL line counts --------
+        foreach ($manifest['row_counts'] as $entity => $count) {
+            $entry = "entities/{$entity}.jsonl";
+            $body  = $zip->getFromName($entry);
+            $this->assertIsString($body, "missing entity entry: $entry");
+            $lines = $body === '' ? 0 : substr_count($body, "\n");
+            $this->assertSame(
+                (int) $count,
+                $lines,
+                "manifest row_counts[{$entity}]={$count} but JSONL has {$lines} lines",
+            );
+        }
+
+        // ---- (4) every demo entry is STORE-compressed -----------
+        $sawDemo = false;
+        for ($i = 0; $i < $zip->numFiles; $i++) {
+            $stat = $zip->statIndex($i);
+            $this->assertIsArray($stat);
+            if (str_starts_with((string) $stat['name'], 'demos/')) {
+                $sawDemo = true;
+                $this->assertSame(
+                    ZipArchive::CM_STORE,
+                    $stat['comp_method'],
+                    "demo entry {$stat['name']} must use STORE compression (already-compressed binary)",
+                );
+            }
+        }
+        $this->assertTrue($sawDemo, 'fixture seeded a demo but bundle carries no demos/ entries');
+
+        // ---- (5) every JSONL line parses + carries an `id` -----
+        // Composite-PK tables don't carry `id`; they're documented
+        // exceptions per the contract.
+        $compositePkTables = ['admins_servers_groups', 'banlog', 'servers_groups'];
+        foreach ($manifest['row_counts'] as $entity => $_count) {
+            $body = $zip->getFromName("entities/{$entity}.jsonl");
+            if ($body === false || $body === '') {
+                continue;
+            }
+            foreach (explode("\n", trim($body)) as $lineNo => $line) {
+                if ($line === '') {
+                    continue;
+                }
+                $row = json_decode($line, true, 512, JSON_THROW_ON_ERROR);
+                $this->assertIsArray($row, "entities/{$entity}.jsonl line {$lineNo} did not parse as JSON object");
+                if (!in_array($entity, $compositePkTables, true)) {
+                    $this->assertArrayHasKey('id', $row, "entities/{$entity}.jsonl line {$lineNo} is missing the `id` field");
+                }
+            }
+        }
+
+        // ---- (6) no SteamID appears as a bare JSON number ------
+        // The full ZIP body would include the binary demo payload
+        // which can incidentally contain "authid":<digits> bytes;
+        // restrict the assertion to the entity JSONL files only.
+        for ($i = 0; $i < $zip->numFiles; $i++) {
+            $stat = $zip->statIndex($i);
+            $this->assertIsArray($stat);
+            $name = (string) $stat['name'];
+            if (!str_starts_with($name, 'entities/')) {
+                continue;
+            }
+            $body = $zip->getFromName($name);
+            $this->assertIsString($body);
+            // Match `"authid":` followed by optional whitespace then a
+            // bare digit (NOT a quoted string). Negative-lookahead the
+            // closing `"` so we accept the quoted-string form.
+            $this->assertDoesNotMatchRegularExpression(
+                '/"authid"\s*:\s*\d/',
+                $body,
+                "entity {$name} carried an unquoted Steam ID (must be a decimal STRING)",
+            );
+        }
+
+        // ---- (7) timestamps surface as integers ---------------
+        // Sample a known-populated entity (bans) — bans.created is
+        // documented as unix-seconds int. The decoded row from
+        // step 5 already proved JSON parses; here we assert the
+        // numeric column landed as int, not as a quoted string.
+        $bansBody = $zip->getFromName('entities/bans.jsonl');
+        $this->assertIsString($bansBody);
+        $this->assertNotSame('', trim($bansBody), 'fixture seeded a ban; bundle must carry it');
+        $firstBan = json_decode(trim(explode("\n", $bansBody)[0]), true, 512, JSON_THROW_ON_ERROR);
+        $this->assertIsArray($firstBan);
+        $this->assertIsInt($firstBan['created'], 'bans.created must be a unix-seconds int');
+        $this->assertIsInt($firstBan['ends']);
+        $this->assertIsInt($firstBan['length']);
+
+        // ---- (8) forbidden columns / values never appear ------
+        // Inspect every entity JSONL body — the demo blob is
+        // exempt for the same reason as step 6.
+        $expectedForbiddenAdminCols = EntityExporter::FORBIDDEN_ADMIN_COLUMNS;
+        for ($i = 0; $i < $zip->numFiles; $i++) {
+            $stat = $zip->statIndex($i);
+            $this->assertIsArray($stat);
+            $name = (string) $stat['name'];
+            if (!str_starts_with($name, 'entities/')) {
+                continue;
+            }
+            $body = $zip->getFromName($name);
+            $this->assertIsString($body);
+            // Forbidden admin column keys (`"password":`, `"validate":`,
+            // `"attempts":`, `"lockout_until":`) must never appear in
+            // ANY entity — admins.jsonl is the load-bearing case but
+            // bans/comms/log don't carry them either.
+            foreach ($expectedForbiddenAdminCols as $col) {
+                $this->assertStringNotContainsString(
+                    "\"{$col}\":",
+                    $body,
+                    "{$name} leaked forbidden admin column `{$col}`",
+                );
+            }
+            // bcrypt prefix `$2y$` is distinctive — would only
+            // appear if a hash leaked anywhere.
+            $this->assertStringNotContainsString('$2y$', $body, "{$name} leaked a bcrypt hash");
+        }
+
+        $zip->close();
+    }
+
+    /**
+     * Run the full pipeline + dump the resulting bundle to a temp
+     * file on disk so the {@see ZipArchive} consumer can open it.
+     * The s3-mode flush gate is `false` because the writer's output
+     * stream is a file handle, not the HTTP socket.
+     */
+    private function writeBundle(): void
+    {
+        $builder  = new ManifestBuilder(
+            dbs:          $GLOBALS['PDO'],
+            demosDir:     SB_DEMOS,
+            panelVersion: 'test',
+        );
+        $manifest = $builder->buildOrThrow();
+        $entities = new EntityExporter(
+            dbs:      $GLOBALS['PDO'],
+            demosDir: SB_DEMOS,
+        );
+
+        $handle = fopen($this->bundlePath, 'wb');
+        $this->assertNotFalse($handle, "fopen failed for $this->bundlePath");
+        $zip = new ZipStream(
+            outputStream:             $handle,
+            sendHttpHeaders:          false,
+            enableZip64:              false,
+            defaultCompressionMethod: CompressionMethod::DEFLATE,
+        );
+        $writer = new BundleWriter(
+            zip:               $zip,
+            manifest:          $manifest,
+            entities:          $entities,
+            demosDir:          SB_DEMOS,
+            flushAfterEntries: false,
+        );
+        $writer->write();
+        fclose($handle);
+
+        $this->assertFileExists($this->bundlePath);
+        $this->assertGreaterThan(0, filesize($this->bundlePath) ?: 0);
+    }
+
+    /**
+     * Seed a single ban row keyed off the fixture admin so the
+     * `bans` JSONL is non-empty. The matching `:prefix_demos`
+     * row is wired in {@see seedSampleDemo}.
+     */
+    private function seedSampleBan(): void
+    {
+        $aid = Fixture::adminAid();
+        $pdo = Fixture::rawPdo();
+        $pdo->exec(
+            sprintf(
+                "INSERT INTO `%s_bans`
+                  (ip, authid, name, created, ends, length, reason, aid, adminIp, sid, country, type)
+                 VALUES ('', 'STEAM_0:0:42', 'export-bundle-fixture', UNIX_TIMESTAMP(), UNIX_TIMESTAMP() + 3600, 3600, 'fixture', %d, '127.0.0.1', 0, '', 0)",
+                DB_PREFIX,
+                $aid,
+            )
+        );
+    }
+
+    /**
+     * Drop a sample demo file on disk and a corresponding
+     * `:prefix_demos.filename` row so the bundle picks up a
+     * `demos/<basename>.dem` entry.
+     *
+     * The file payload itself is opaque — what we care about
+     * downstream is just that the ZIP entry exists with STORE
+     * compression.
+     */
+    private function seedSampleDemo(string $basename, string $body): void
+    {
+        // SB_DEMOS may not exist on a fresh test bring-up; create it.
+        if (!is_dir(SB_DEMOS)) {
+            @mkdir(SB_DEMOS, 0755, true);
+        }
+        $path = SB_DEMOS . DIRECTORY_SEPARATOR . $basename;
+        file_put_contents($path, $body);
+        $this->seededDemoFiles[] = $path;
+
+        $pdo = Fixture::rawPdo();
+        // Hang the demo off the just-seeded ban (the highest bid).
+        $bid = (int) $pdo->query(sprintf('SELECT MAX(bid) FROM `%s_bans`', DB_PREFIX))->fetchColumn();
+        $this->assertGreaterThan(0, $bid, 'must have seeded a ban first');
+        $pdo->prepare(sprintf(
+            'INSERT INTO `%s_demos` (demid, demtype, filename, origname) VALUES (?, ?, ?, ?)',
+            DB_PREFIX,
+        ))->execute([$bid, 'B', $basename, $basename]);
+    }
+}

--- a/web/tests/integration/S3PresignedUploaderTest.php
+++ b/web/tests/integration/S3PresignedUploaderTest.php
@@ -1,0 +1,397 @@
+<?php
+// SourceBans++ (c) 2014-2026 SourceBans++ Dev Team
+// Licensed under the Elastic License 2.0.
+// See LICENSE.txt for the full license text and THIRD-PARTY-NOTICES.txt for attributions.
+
+declare(strict_types=1);
+
+namespace Sbpp\Tests\Integration;
+
+use PHPUnit\Framework\TestCase;
+use Sbpp\Export\ExportError;
+use Sbpp\Export\S3PresignedUploader;
+
+/**
+ * Wire contract pins for the S3 presigned PUT uploader.
+ *
+ * The uploader is the export subsystem's outbound network surface
+ * — every bundle byte ends up here on the `s3` path — so the gate
+ * shape, error envelope, and transport contract are pinned at
+ * unit-test level. Production HTTP transport is exercised by the
+ * Playwright spec under the dev MinIO stack; here we substitute
+ * the cURL call via `_setHttpTransportForTests` so the test stays
+ * deterministic and doesn't require network access.
+ *
+ * Scope:
+ *
+ *   - Scheme guard — `http://` and non-URL inputs reject BEFORE
+ *     the transport ever runs (fail-closed; cleartext transit of
+ *     a panel-wide PII dataset is unacceptable per the plan).
+ *   - Happy path — the transport receives the exact `(url,
+ *     localPath, size)` tuple, and 200 / 201 / 204 are all
+ *     accepted as success.
+ *   - Error mapping — non-2xx responses throw
+ *     `ExportError::S3_PUT_FAILED` with the body truncated for
+ *     diagnostics; the error code matches the wire contract
+ *     documented in `data-export.mdx`.
+ *   - Missing-file guard — `DISK_WRITE_FAILED` when the bundle
+ *     path doesn't exist (typically an entry-point bug, but
+ *     surfaces cleanly).
+ *
+ * Mirrors the `_setHttpFetcherForTests` testing pattern from
+ * `Sbpp\Announce\AnnouncementFetcher::_setHttpFetcherForTests` —
+ * same shape, same teardown discipline, same single-source for
+ * the production HTTP path.
+ */
+final class S3PresignedUploaderTest extends TestCase
+{
+    /** @var list<string> Temp files to delete on teardown. */
+    private array $tempFiles = [];
+
+    protected function tearDown(): void
+    {
+        S3PresignedUploader::_setHttpTransportForTests(null);
+        foreach ($this->tempFiles as $path) {
+            if (is_file($path)) {
+                @unlink($path);
+            }
+        }
+        $this->tempFiles = [];
+        parent::tearDown();
+    }
+
+    /**
+     * The first byte of the scheme guard: any URL that isn't
+     * `https://`-prefixed must reject BEFORE the transport fires
+     * (and BEFORE the file is even opened). `http://` is the
+     * canonical risk shape — the bundle carries admin emails, IP
+     * addresses, and every Steam ID the panel knows about, so
+     * cleartext transit is unacceptable.
+     *
+     * The fail-closed property is the contract: an operator who
+     * fat-fingers `http` vs `https` on a presigned URL must NOT
+     * silently get a cleartext upload that "worked".
+     */
+    public function testHttpSchemeRejectedBeforeTransportCalled(): void
+    {
+        $transportCalls = 0;
+        S3PresignedUploader::_setHttpTransportForTests(
+            function () use (&$transportCalls): array {
+                $transportCalls++;
+                return ['http_code' => 200, 'body' => ''];
+            },
+        );
+
+        try {
+            (new S3PresignedUploader())->upload('http://example.com/bucket/key', $this->writeTempBundle('hello'));
+            $this->fail('http:// URL must throw ExportError(PRESIGN_INVALID_SCHEME)');
+        } catch (ExportError $e) {
+            $this->assertSame(
+                ExportError::PRESIGN_INVALID_SCHEME,
+                $e->code(),
+                'http:// must surface as PRESIGN_INVALID_SCHEME — operator-facing toast keys off the code',
+            );
+            // Defense-in-depth: scheme-guard wording in the
+            // exception message MUST mention the cleartext-PII
+            // risk so log readers understand why the gate fired.
+            $this->assertStringContainsString('https://', $e->getMessage());
+        }
+
+        $this->assertSame(
+            0,
+            $transportCalls,
+            'Transport must NOT be called when the URL fails the scheme guard — fail-closed contract',
+        );
+    }
+
+    /**
+     * Sister to the above: a string that doesn't even parse as
+     * a URL via `parse_url` must reject with the dedicated
+     * `PRESIGN_INVALID_URL` code (NOT the scheme code), so the
+     * operator gets a pointed error message ("typo'd URL") vs.
+     * the generic scheme error.
+     *
+     * Tricky shape: `parse_url('https://')` returns `['scheme' =>
+     * 'https']` with no host — that case rides the host-empty
+     * branch of the validator. The values below trigger the
+     * harder failure modes: malformed scheme delimiter and
+     * raw-string-no-scheme-at-all.
+     */
+    public function testNonHttpsNonUrlInputsRejected(): void
+    {
+        $transportCalls = 0;
+        S3PresignedUploader::_setHttpTransportForTests(
+            function () use (&$transportCalls): array {
+                $transportCalls++;
+                return ['http_code' => 200, 'body' => ''];
+            },
+        );
+
+        $bad = [
+            'not-a-url-at-all',
+            'ftp://example.com/key',
+            'javascript:alert(1)',
+            'file:///etc/passwd',
+            'data:application/zip,bytes',
+        ];
+
+        foreach ($bad as $url) {
+            $threw = false;
+            try {
+                (new S3PresignedUploader())->upload($url, $this->writeTempBundle('hello'));
+            } catch (ExportError $e) {
+                $threw = true;
+                // All non-https inputs route through the scheme
+                // guard first (it's a cheap prefix check before
+                // parse_url runs), so the error code is
+                // PRESIGN_INVALID_SCHEME for every one of these.
+                // The dedicated PRESIGN_INVALID_URL code applies
+                // to URLs that ARE https but fail parse_url (e.g.
+                // `https://` with no host — exercised separately).
+                $this->assertSame(
+                    ExportError::PRESIGN_INVALID_SCHEME,
+                    $e->code(),
+                    "Non-https URL '{$url}' must surface as PRESIGN_INVALID_SCHEME",
+                );
+            }
+            $this->assertTrue(
+                $threw,
+                "Non-https URL '{$url}' must throw ExportError — silent acceptance would tunnel the bundle through an arbitrary scheme",
+            );
+        }
+
+        $this->assertSame(
+            0,
+            $transportCalls,
+            'Transport must NOT be called for any non-https input',
+        );
+    }
+
+    /**
+     * A `https://` URL with no host component (e.g. `https://`,
+     * `https:///path/only`) passes the scheme check but fails the
+     * parse / host-empty branch. The dedicated error code lets
+     * the operator-facing toast surface "URL is missing a host"
+     * instead of the generic scheme message.
+     */
+    public function testHttpsWithoutHostRejectedAsInvalidUrl(): void
+    {
+        $transportCalls = 0;
+        S3PresignedUploader::_setHttpTransportForTests(
+            function () use (&$transportCalls): array {
+                $transportCalls++;
+                return ['http_code' => 200, 'body' => ''];
+            },
+        );
+
+        try {
+            (new S3PresignedUploader())->upload('https:///just-a-path', $this->writeTempBundle('hi'));
+            $this->fail('https:// URL with no host must reject');
+        } catch (ExportError $e) {
+            $this->assertSame(
+                ExportError::PRESIGN_INVALID_URL,
+                $e->code(),
+                'No-host https URL must surface as PRESIGN_INVALID_URL (not _SCHEME — operator typed a syntactically valid scheme but typo\'d the rest)',
+            );
+        }
+
+        $this->assertSame(0, $transportCalls);
+    }
+
+    /**
+     * Happy path. The transport closure receives the exact
+     * `(url, localPath, size)` tuple the production cURL call
+     * would consume; a 200 response from the transport means
+     * `upload()` returns void without throwing. The Content-Length
+     * header is the load-bearing contract on S3 / R2 / MinIO
+     * presigned PUT, and the transport receives the size via the
+     * closure args so production can write it into the request.
+     */
+    public function testHappyPathPassesTransportArgsAndAcceptsTwoOhOh(): void
+    {
+        $captured = [];
+        S3PresignedUploader::_setHttpTransportForTests(
+            function (string $url, string $localPath, int $size) use (&$captured): array {
+                $captured = compact('url', 'localPath', 'size');
+                return ['http_code' => 200, 'body' => ''];
+            },
+        );
+
+        $body = str_repeat('a', 1234);
+        $path = $this->writeTempBundle($body);
+
+        (new S3PresignedUploader())->upload('https://example.com/bucket/key?sig=abc', $path);
+
+        $this->assertSame(
+            'https://example.com/bucket/key?sig=abc',
+            $captured['url'],
+            'Transport must receive the verbatim URL the caller supplied',
+        );
+        $this->assertSame($path, $captured['localPath'], 'Transport must receive the verbatim file path');
+        $this->assertSame(strlen($body), $captured['size'], 'Transport must receive the file size for the Content-Length header');
+    }
+
+    /**
+     * 201 Created and 204 No Content are also success codes on
+     * S3-compatible APIs. S3 itself returns 200 for PUT object;
+     * R2 returns 200; MinIO returns 200; some private storage
+     * gateways return 201 or 204. All three must be treated as
+     * success — otherwise an operator's legitimate upload to a
+     * private gateway would surface as a "failed" toast with a
+     * misleading error message.
+     */
+    public function testTwoOhOneAndTwoOhFourAreAlsoSuccess(): void
+    {
+        foreach ([201, 204] as $code) {
+            S3PresignedUploader::_setHttpTransportForTests(
+                fn(): array => ['http_code' => $code, 'body' => ''],
+            );
+
+            // Reach here means upload() did NOT throw — that's
+            // success per the contract.
+            (new S3PresignedUploader())->upload('https://example.com/x', $this->writeTempBundle('x'));
+            $this->assertTrue(true, "HTTP {$code} must be treated as success");
+        }
+    }
+
+    /**
+     * Non-2xx response must surface as `ExportError::S3_PUT_FAILED`
+     * with the response body in the exception message. The body
+     * carries S3's XML error envelope (`<Error><Code>...</Code>
+     * <Message>...</Message>`) which the operator needs to
+     * diagnose the failure — typically a sigv4 mismatch, an
+     * expired URL, or a policy denial. Surface it untruncated up
+     * to the 2 KiB limit.
+     */
+    public function testNon2xxResponseSurfacesAsS3PutFailed(): void
+    {
+        $body403 = '<?xml version="1.0"?><Error><Code>AccessDenied</Code><Message>Request has expired</Message></Error>';
+        S3PresignedUploader::_setHttpTransportForTests(
+            fn(): array => ['http_code' => 403, 'body' => $body403],
+        );
+
+        try {
+            (new S3PresignedUploader())->upload('https://example.com/expired', $this->writeTempBundle('x'));
+            $this->fail('403 response must throw ExportError(S3_PUT_FAILED)');
+        } catch (ExportError $e) {
+            $this->assertSame(ExportError::S3_PUT_FAILED, $e->code());
+            $this->assertStringContainsString('HTTP 403', $e->getMessage());
+            $this->assertStringContainsString('AccessDenied', $e->getMessage(), 'Response body must surface in the error message for diagnostics');
+            $this->assertStringContainsString('Request has expired', $e->getMessage());
+        }
+    }
+
+    /**
+     * A 500-class response surfaces the same way — the gate
+     * doesn't distinguish between client and server errors; the
+     * operator's response in both cases is to look at the body
+     * + the URL and retry / fix.
+     */
+    public function testFiveHundredResponseSurfacesAsS3PutFailed(): void
+    {
+        S3PresignedUploader::_setHttpTransportForTests(
+            fn(): array => ['http_code' => 503, 'body' => 'service temporarily unavailable'],
+        );
+
+        try {
+            (new S3PresignedUploader())->upload('https://example.com/x', $this->writeTempBundle('x'));
+            $this->fail('503 must throw');
+        } catch (ExportError $e) {
+            $this->assertSame(ExportError::S3_PUT_FAILED, $e->code());
+            $this->assertStringContainsString('HTTP 503', $e->getMessage());
+            $this->assertStringContainsString('service temporarily unavailable', $e->getMessage());
+        }
+    }
+
+    /**
+     * Response bodies longer than the truncation cap (2 KiB) must
+     * surface with the truncation marker appended so the operator
+     * (or log reader) understands the body was clipped. The cap
+     * exists because a misconfigured S3-compatible endpoint could
+     * theoretically return a multi-MB body, and dumping that into
+     * the audit log would be a poor outcome.
+     */
+    public function testLongResponseBodyTruncated(): void
+    {
+        // 3 KiB body — well past the 2 KiB cap.
+        $bigBody = str_repeat('X', 3 * 1024);
+        S3PresignedUploader::_setHttpTransportForTests(
+            fn(): array => ['http_code' => 400, 'body' => $bigBody],
+        );
+
+        try {
+            (new S3PresignedUploader())->upload('https://example.com/x', $this->writeTempBundle('x'));
+            $this->fail('400 must throw');
+        } catch (ExportError $e) {
+            $this->assertSame(ExportError::S3_PUT_FAILED, $e->code());
+            $this->assertStringContainsString('truncated', $e->getMessage(), 'Truncation marker must surface so the reader knows the body was clipped');
+            // The error message contains a prefix + the truncated body — the prefix is small (under 256 chars).
+            // The 3 KiB body should have been clipped to 2 KiB, leaving the message under 2.5 KiB total.
+            $this->assertLessThan(
+                3 * 1024,
+                strlen($e->getMessage()),
+                'Total message must be smaller than the un-truncated body — truncation is the contract',
+            );
+        }
+    }
+
+    /**
+     * Missing-file guard. If the bundle staging file disappears
+     * between the entry point creating it and the uploader being
+     * called (race? aggressive tmp cleanup? typo'd path?), the
+     * uploader must surface a dedicated `DISK_WRITE_FAILED` code
+     * instead of crashing inside `fopen`. The transport must NOT
+     * be called.
+     */
+    public function testMissingBundleFileSurfacesAsDiskWriteFailed(): void
+    {
+        $transportCalls = 0;
+        S3PresignedUploader::_setHttpTransportForTests(
+            function () use (&$transportCalls): array {
+                $transportCalls++;
+                return ['http_code' => 200, 'body' => ''];
+            },
+        );
+
+        $nonexistent = sys_get_temp_dir() . '/sbpp-export-test-missing-' . bin2hex(random_bytes(8)) . '.zip';
+
+        try {
+            (new S3PresignedUploader())->upload('https://example.com/x', $nonexistent);
+            $this->fail('Missing bundle file must throw ExportError');
+        } catch (ExportError $e) {
+            $this->assertSame(ExportError::DISK_WRITE_FAILED, $e->code());
+            $this->assertStringContainsString($nonexistent, $e->getMessage());
+        }
+
+        $this->assertSame(0, $transportCalls, 'Transport must NOT be called when the bundle file is missing');
+    }
+
+    /**
+     * The class constants for the wire-facing error codes must
+     * carry the byte-stable string values documented in
+     * `data-export.mdx`. Operator tooling, audit-log greps, and
+     * `data-export.mdx` itself all reference these literals; a
+     * drift here would silently break every downstream consumer.
+     */
+    public function testWireFacingErrorCodesAreByteStable(): void
+    {
+        $this->assertSame('cap_exceeded',           ExportError::CAP_EXCEEDED);
+        $this->assertSame('s3_put_failed',          ExportError::S3_PUT_FAILED);
+        $this->assertSame('presign_invalid_scheme', ExportError::PRESIGN_INVALID_SCHEME);
+        $this->assertSame('presign_invalid_url',    ExportError::PRESIGN_INVALID_URL);
+        $this->assertSame('disk_write_failed',      ExportError::DISK_WRITE_FAILED);
+        $this->assertSame('disk_full',              ExportError::DISK_FULL);
+    }
+
+    /**
+     * Write a temp file with the given bytes and register it for
+     * teardown. Returns the absolute path.
+     */
+    private function writeTempBundle(string $body): string
+    {
+        $path = sys_get_temp_dir() . '/sbpp-export-test-' . bin2hex(random_bytes(8)) . '.zip';
+        file_put_contents($path, $body);
+        $this->tempFiles[] = $path;
+        return $path;
+    }
+}

--- a/web/tests/unit/EntityExporterTest.php
+++ b/web/tests/unit/EntityExporterTest.php
@@ -1,0 +1,469 @@
+<?php
+// SourceBans++ (c) 2014-2026 SourceBans++ Dev Team
+// Licensed under the Elastic License 2.0.
+// See LICENSE.txt for the full license text and THIRD-PARTY-NOTICES.txt for attributions.
+
+declare(strict_types=1);
+
+namespace Sbpp\Tests\Unit;
+
+use BanRemoval;
+use BanType;
+use PDO;
+use PHPUnit\Framework\TestCase;
+use Sbpp\Export\EntityExporter;
+use Sbpp\Tests\Fixture;
+
+/**
+ * Per-entity wire-contract pins for the data export bundle.
+ *
+ * Each test exercises ONE structural promise the exporter makes —
+ * the empty-entity → empty-output shape, the SteamID conversion
+ * round-trip, the forbidden-column projection contract, the
+ * `mute_kind` enum mapping for comms, the `state` derivation
+ * matrix for bans, and the null-not-empty-string rule. Together
+ * they form the structural backbone the downstream consumer can
+ * key off — drift in any single one is a wire-format break.
+ *
+ * Scope split with sister test files:
+ *   - {@see ManifestBuilderTest}: manifest / DTO / cap math.
+ *   - {@see \Sbpp\Tests\Integration\ExportBundleWriterTest}:
+ *     full-bundle end-to-end (zip parse + per-entry assertions).
+ *   - This file: per-entity row-shape contracts.
+ */
+final class EntityExporterTest extends TestCase
+{
+    private EntityExporter $exporter;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Fixture::reset();
+        $this->exporter = new EntityExporter(
+            dbs:      $GLOBALS['PDO'],
+            demosDir: SB_DEMOS,
+        );
+    }
+
+    /**
+     * On a freshly-installed DB the synthetic-fixture rows (admins,
+     * settings, mods) exist but bans / comms / banlog / comments /
+     * etc. are empty. The empty entities MUST yield zero lines —
+     * no trailing newline, no `[]` placeholder, no header row.
+     * JSONL's "line per object" contract degenerates to "zero
+     * lines" for an empty entity.
+     */
+    public function testEmptyEntityYieldsZeroLines(): void
+    {
+        $lines = iterator_to_array($this->exporter->bans());
+        $this->assertSame([], $lines, 'empty bans table must yield zero JSONL lines');
+
+        $lines = iterator_to_array($this->exporter->comms());
+        $this->assertSame([], $lines);
+
+        $lines = iterator_to_array($this->exporter->comments());
+        $this->assertSame([], $lines);
+
+        $lines = iterator_to_array($this->exporter->banlog());
+        $this->assertSame([], $lines);
+    }
+
+    /**
+     * Forbidden columns must never appear in the entity output —
+     * neither as JSON keys nor as substring matches against the
+     * canonical column names. The fixture seeds the admin row with
+     * a real bcrypt hash via `password_hash('admin', PASSWORD_BCRYPT)`,
+     * so the grep would catch a regression that silently included
+     * the hash by checking the BCRYPT prefix `$2y$` AND the column
+     * key `"password"` — either match is a contract break.
+     *
+     * The settings entity is exercised separately because its
+     * forbidden-set lives at the SQL WHERE level (filter by key
+     * name, not by column name).
+     */
+    public function testForbiddenAdminColumnsNeverAppear(): void
+    {
+        // Seed a row whose forbidden columns carry distinctive values
+        // we can grep for — the bcrypt prefix `$2y$` is distinctive,
+        // and the validate token is a hex hash we can pattern-match.
+        $pdo = Fixture::rawPdo();
+        $pdo->exec(
+            sprintf(
+                "INSERT INTO `%s_admins` (user, authid, password, gid, email, validate, extraflags, immunity, attempts, lockout_until) VALUES
+                ('forbidcheck', 'STEAM_0:0:1', '\$2y\$12\$DUMMYHASHDUMMYHASHDUMMYHASHDUMMYHASHDUMMYHASHDUMMYHASHDU', -1, 'fc@example.test', '5ed533c0ffeec0deDUMMY99887766aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa', 1, 1, 9, NOW() + INTERVAL 1 HOUR)",
+                DB_PREFIX,
+            )
+        );
+
+        $output = implode('', iterator_to_array($this->exporter->admins()));
+        $this->assertNotSame('', $output, 'admins() must emit at least one line for the seeded row');
+
+        // Per-column key absence (the JSON shape MUST NOT carry the key).
+        foreach (EntityExporter::FORBIDDEN_ADMIN_COLUMNS as $col) {
+            $this->assertStringNotContainsString(
+                "\"{$col}\"",
+                $output,
+                "admins() emitted forbidden column key '{$col}' — projection regression",
+            );
+        }
+
+        // Per-value distinctive marker absence.
+        $this->assertStringNotContainsString('$2y$', $output, 'bcrypt hash leaked into admins output');
+        $this->assertStringNotContainsString('5ed533c0ffeec0de', $output, 'validate token leaked into admins output');
+    }
+
+    /**
+     * `:prefix_servers.rcon` is the other half of the forbidden
+     * column contract — the RCON password is the keys-to-the-game-
+     * server credential. Seed a row with a distinctive RCON value
+     * and assert it doesn't leak.
+     */
+    public function testForbiddenServerColumnsNeverAppear(): void
+    {
+        $pdo = Fixture::rawPdo();
+        $pdo->exec(
+            sprintf(
+                "INSERT INTO `%s_servers` (ip, port, rcon, modid, enabled) VALUES ('192.0.2.1', 27015, 'RCONFORBIDDEN_DISTINCTIVE_MARKER', 1, 1)",
+                DB_PREFIX,
+            )
+        );
+
+        $output = implode('', iterator_to_array($this->exporter->servers()));
+        $this->assertNotSame('', $output);
+
+        // Column key not projected.
+        foreach (EntityExporter::FORBIDDEN_SERVER_COLUMNS as $col) {
+            $this->assertStringNotContainsString(
+                "\"{$col}\"",
+                $output,
+                "servers() emitted forbidden column key '{$col}'",
+            );
+        }
+        $this->assertStringNotContainsString('RCONFORBIDDEN_DISTINCTIVE_MARKER', $output);
+    }
+
+    /**
+     * `:prefix_settings` filters the forbidden keys at the SQL
+     * WHERE level (defence-in-depth — a future post-fetch helper
+     * regression can't add them back). Seed both keys with
+     * distinctive values and assert neither appears in the output.
+     */
+    public function testForbiddenSettingKeysNeverAppear(): void
+    {
+        $pdo = Fixture::rawPdo();
+        $pdo->exec(
+            sprintf(
+                "INSERT INTO `%s_settings` (setting, value) VALUES ('smtp.pass', 'SMTPPASSDISTINCTIVE_MARKER'), ('telemetry.instance_id', 'TELEMETRYIDDISTINCTIVE_MARKER') ON DUPLICATE KEY UPDATE value = VALUES(value)",
+                DB_PREFIX,
+            )
+        );
+
+        $output = implode('', iterator_to_array($this->exporter->settings()));
+        $this->assertNotSame('', $output, 'settings() must emit some rows');
+        $this->assertStringNotContainsString('smtp.pass', $output, 'forbidden setting key smtp.pass leaked');
+        $this->assertStringNotContainsString('telemetry.instance_id', $output, 'forbidden setting key telemetry.instance_id leaked');
+        $this->assertStringNotContainsString('SMTPPASSDISTINCTIVE_MARKER', $output, 'forbidden setting value smtp.pass leaked');
+        $this->assertStringNotContainsString('TELEMETRYIDDISTINCTIVE_MARKER', $output, 'forbidden setting value telemetry.instance_id leaked');
+    }
+
+    /**
+     * SteamID conversion: every authid column round-trips through
+     * `SteamID::toSteam64()` → decimal-string Steam64. The output
+     * MUST be a quoted JSON string, never a JSON number — Steam64
+     * IDs are 17 digits and overflow safe JS `Number` precision
+     * (2^53 - 1 = 9007199254740991 ≈ 16 digits). Anything emitting
+     * Steam64 as a JSON number silently corrupts downstream
+     * consumers parsing with default JS / JSON-decoders. Pinned
+     * also at the ExportBundleWriterTest level for belt-and-braces.
+     */
+    public function testSteamIdAlwaysQuotedDecimalString(): void
+    {
+        // Seed a ban with a known Steam2 authid; the Steam64
+        // equivalent of STEAM_0:0:1 is 76561197960265728 + (2*1) + 0
+        // = 76561197960265730 per the standard Steam2→Steam64
+        // formula (`base = 76561197960265728; sid64 = base + 2*Z + Y`).
+        $aid = Fixture::adminAid();
+        $pdo = Fixture::rawPdo();
+        $pdo->exec(
+            sprintf(
+                "INSERT INTO `%s_bans` (ip, authid, name, created, ends, length, reason, aid, adminIp, sid, country, type) VALUES
+                ('', 'STEAM_0:0:1', 'fixture-target', UNIX_TIMESTAMP(), UNIX_TIMESTAMP() + 3600, 3600, 'test', %d, '127.0.0.1', 0, '', 0)",
+                DB_PREFIX,
+                $aid,
+            )
+        );
+
+        $output = implode('', iterator_to_array($this->exporter->bans()));
+        $this->assertNotSame('', $output);
+
+        $this->assertStringContainsString(
+            '"authid":"76561197960265730"',
+            $output,
+            'authid must be quoted decimal Steam64 string',
+        );
+        $this->assertStringContainsString(
+            '"authid_steam2":"STEAM_0:0:1"',
+            $output,
+            'authid_steam2 preserves the source Steam2 form',
+        );
+
+        // Authid-as-number sanity gate — the value lives at the
+        // JSON-key position, never as a bare numeric literal.
+        $this->assertDoesNotMatchRegularExpression(
+            '/"authid":\s*\d+(?!")/',
+            $output,
+            'authid must never appear as a JSON number',
+        );
+    }
+
+    /**
+     * Malformed authid rows MUST yield `null` for both Steam ID
+     * fields instead of throwing — the export is a recovery /
+     * migration surface, and legacy garbage rows from pre-#1108 /
+     * #765 truncation shouldn't break it.
+     */
+    public function testMalformedAuthidYieldsNull(): void
+    {
+        $aid = Fixture::adminAid();
+        $pdo = Fixture::rawPdo();
+        $pdo->exec(
+            sprintf(
+                "INSERT INTO `%s_bans` (ip, authid, name, created, ends, length, reason, aid, adminIp, sid, country, type) VALUES
+                ('', 'GARBAGE_AUTHID', 'fixture-garbage', UNIX_TIMESTAMP(), UNIX_TIMESTAMP() + 3600, 3600, 'test', %d, '127.0.0.1', 0, '', 0),
+                ('', '',               'fixture-empty',   UNIX_TIMESTAMP(), UNIX_TIMESTAMP() + 3600, 3600, 'test', %d, '127.0.0.1', 0, '', 0)",
+                DB_PREFIX,
+                $aid,
+                $aid,
+            )
+        );
+
+        $lines = iterator_to_array($this->exporter->bans());
+        $this->assertNotEmpty($lines, 'seeded malformed rows must still ship');
+
+        foreach ($lines as $line) {
+            $row = json_decode($line, true, 512, JSON_THROW_ON_ERROR);
+            $this->assertArrayHasKey('authid', $row);
+            $this->assertArrayHasKey('authid_steam2', $row);
+            if ($row['name'] === 'fixture-garbage' || $row['name'] === 'fixture-empty') {
+                $this->assertNull($row['authid'], 'malformed authid must yield null');
+                $this->assertNull($row['authid_steam2'], 'malformed authid must yield null in steam2 slot too');
+            }
+        }
+    }
+
+    /**
+     * `comms.mute_kind` is the operator-readable derivation of the
+     * raw `:prefix_comms.type` int. The matrix is documented in
+     * EntityExporter::commsMuteKind — `1 → mute`, `2 → gag`,
+     * `3 → silence`, anything else → `unknown`. Seed one of each
+     * and assert.
+     */
+    public function testCommsMuteKindDerivation(): void
+    {
+        $aid = Fixture::adminAid();
+        $pdo = Fixture::rawPdo();
+        $pdo->exec(
+            sprintf(
+                "INSERT INTO `%s_comms` (authid, name, created, ends, length, reason, aid, adminIp, sid, type) VALUES
+                ('STEAM_0:0:10', 'mute_target',     UNIX_TIMESTAMP(), UNIX_TIMESTAMP() + 60, 60, 't', %d, '127.0.0.1', 0, 1),
+                ('STEAM_0:0:11', 'gag_target',      UNIX_TIMESTAMP(), UNIX_TIMESTAMP() + 60, 60, 't', %d, '127.0.0.1', 0, 2),
+                ('STEAM_0:0:12', 'silence_target',  UNIX_TIMESTAMP(), UNIX_TIMESTAMP() + 60, 60, 't', %d, '127.0.0.1', 0, 3),
+                ('STEAM_0:0:13', 'unknown_target',  UNIX_TIMESTAMP(), UNIX_TIMESTAMP() + 60, 60, 't', %d, '127.0.0.1', 0, 9)",
+                DB_PREFIX,
+                $aid,
+                $aid,
+                $aid,
+                $aid,
+            )
+        );
+
+        $byName = [];
+        foreach ($this->exporter->comms() as $line) {
+            $row = json_decode($line, true, 512, JSON_THROW_ON_ERROR);
+            $byName[$row['name']] = $row;
+        }
+
+        $this->assertSame('mute',    $byName['mute_target']['mute_kind']);
+        $this->assertSame('gag',     $byName['gag_target']['mute_kind']);
+        $this->assertSame('silence', $byName['silence_target']['mute_kind']);
+        $this->assertSame('unknown', $byName['unknown_target']['mute_kind']);
+
+        // Raw int preserved verbatim — a downstream consumer that
+        // wants to apply its own classifier MUST be able to get to
+        // the source value.
+        $this->assertSame(1, $byName['mute_target']['type']);
+        $this->assertSame(1, $byName['mute_target']['type_raw']);
+        $this->assertSame(9, $byName['unknown_target']['type_raw']);
+    }
+
+    /**
+     * `bans.state` matrix matches `page.banlist.php`'s classifier:
+     *
+     *   RemoveType=D (Deleted)  → 'unbanned'
+     *   RemoveType=U (Unbanned) → 'unbanned'
+     *   RemoveType=E (Expired)  → 'expired'
+     *   RemoveType NULL + RemovedBy>0 (#1352 pre-2 admin-lift) → 'unbanned'
+     *   length=0                → 'permanent'
+     *   ends < now              → 'expired'
+     *   default                 → 'active'
+     */
+    public function testBansStateDerivationMatrix(): void
+    {
+        $aid    = Fixture::adminAid();
+        $now    = time();
+        $expIn  = $now + 3600;     // future expiry
+        $expOut = $now - 3600;     // past expiry
+        $pdo    = Fixture::rawPdo();
+
+        $pdo->exec(
+            sprintf(
+                "INSERT INTO `%s_bans`
+                  (ip, authid, name, created, ends, length, reason, aid, adminIp, sid, country, RemoveType, RemovedBy, type) VALUES
+                ('', 'STEAM_0:0:101', 'permanent_row',     %d, %d, 0,    't', %d, '127.0.0.1', 0, '', NULL, NULL, 0),
+                ('', 'STEAM_0:0:102', 'active_row',        %d, %d, 3600, 't', %d, '127.0.0.1', 0, '', NULL, NULL, 0),
+                ('', 'STEAM_0:0:103', 'expired_row',       %d, %d, 3600, 't', %d, '127.0.0.1', 0, '', NULL, NULL, 0),
+                ('', 'STEAM_0:0:104', 'deleted_row',       %d, %d, 3600, 't', %d, '127.0.0.1', 0, '', 'D',  %d,   0),
+                ('', 'STEAM_0:0:105', 'unbanned_u_row',    %d, %d, 3600, 't', %d, '127.0.0.1', 0, '', 'U',  %d,   0),
+                ('', 'STEAM_0:0:106', 'expired_e_row',     %d, %d, 3600, 't', %d, '127.0.0.1', 0, '', 'E',  NULL, 0),
+                ('', 'STEAM_0:0:107', 'pre2_admin_lift',   %d, %d, 3600, 't', %d, '127.0.0.1', 0, '', NULL, %d,   0)",
+                DB_PREFIX,
+                $now, $now, $aid,
+                $now, $expIn, $aid,
+                $now, $expOut, $aid,
+                $now, $expIn, $aid, $aid,
+                $now, $expIn, $aid, $aid,
+                $now, $expOut, $aid,
+                $now, $expIn, $aid, $aid,
+            )
+        );
+
+        $byName = [];
+        foreach ($this->exporter->bans() as $line) {
+            $row = json_decode($line, true, 512, JSON_THROW_ON_ERROR);
+            $byName[$row['name']] = $row;
+        }
+
+        $this->assertSame('permanent', $byName['permanent_row']['state']);
+        $this->assertSame('active',    $byName['active_row']['state']);
+        $this->assertSame('expired',   $byName['expired_row']['state']);
+        $this->assertSame('unbanned',  $byName['deleted_row']['state']);
+        $this->assertSame('unbanned',  $byName['unbanned_u_row']['state']);
+        $this->assertSame('expired',   $byName['expired_e_row']['state']);
+        $this->assertSame('unbanned',  $byName['pre2_admin_lift']['state']);
+    }
+
+    /**
+     * Empty / NULL string columns must surface as JSON `null`, never
+     * as `""`. Same contract as the helper docblock: "absent" and
+     * "empty string" must round-trip indistinguishably. Test bans
+     * because it carries the canonical empty-string slots (ip,
+     * reason on a bare ban, country).
+     */
+    public function testNullForAbsentNeverEmptyString(): void
+    {
+        $aid = Fixture::adminAid();
+        $pdo = Fixture::rawPdo();
+        $pdo->exec(
+            sprintf(
+                "INSERT INTO `%s_bans` (ip, authid, name, created, ends, length, reason, aid, adminIp, sid, country, type) VALUES
+                ('', 'STEAM_0:0:200', '', UNIX_TIMESTAMP(), 0, 0, '', %d, '127.0.0.1', 0, '', 0)",
+                DB_PREFIX,
+                $aid,
+            )
+        );
+
+        $line = null;
+        foreach ($this->exporter->bans() as $candidate) {
+            $row = json_decode($candidate, true, 512, JSON_THROW_ON_ERROR);
+            if ($row['authid_steam2'] === 'STEAM_0:0:200') {
+                $line = $row;
+                break;
+            }
+        }
+        $this->assertNotNull($line, 'fixture row must be present');
+
+        $this->assertNull($line['ip'],      'empty-string ip must surface as null');
+        $this->assertNull($line['name'],    'empty-string name must surface as null');
+        $this->assertNull($line['reason'],  'empty-string reason must surface as null');
+        $this->assertNull($line['country'], 'empty-string country must surface as null');
+
+        // Belt + braces: the JSON literal must not contain `""`-only values
+        // for those keys.
+        $literal = json_encode($line);
+        $this->assertIsString($literal);
+        $this->assertStringNotContainsString('"ip":""',      $literal);
+        $this->assertStringNotContainsString('"reason":""',  $literal);
+        $this->assertStringNotContainsString('"country":""', $literal);
+    }
+
+    /**
+     * `log.level` derivation: `LogType::Message` → `message`,
+     * `LogType::Warning` → `warning`, `LogType::Error` → `error`,
+     * unknown letter → `unknown`. The raw letter is preserved as
+     * `type` so a downstream consumer doesn't lose the source data.
+     */
+    public function testLogLevelDerivation(): void
+    {
+        $aid = Fixture::adminAid();
+        $pdo = Fixture::rawPdo();
+        $pdo->exec(
+            sprintf(
+                "INSERT INTO `%s_log` (type, title, message, function, query, aid, host, created) VALUES
+                ('m', 'msgrow', 'msgmsg', '', '', %d, '127.0.0.1', UNIX_TIMESTAMP()),
+                ('w', 'warnrow', 'warnmsg', '', '', %d, '127.0.0.1', UNIX_TIMESTAMP()),
+                ('e', 'errrow', 'errmsg', '', '', %d, '127.0.0.1', UNIX_TIMESTAMP())",
+                DB_PREFIX,
+                $aid,
+                $aid,
+                $aid,
+            )
+        );
+
+        $byTitle = [];
+        foreach ($this->exporter->log() as $line) {
+            $row = json_decode($line, true, 512, JSON_THROW_ON_ERROR);
+            $byTitle[$row['title']] = $row;
+        }
+
+        $this->assertSame('message', $byTitle['msgrow']['level']);
+        $this->assertSame('warning', $byTitle['warnrow']['level']);
+        $this->assertSame('error',   $byTitle['errrow']['level']);
+
+        // Raw letter preserved.
+        $this->assertSame('m', $byTitle['msgrow']['type']);
+        $this->assertSame('w', $byTitle['warnrow']['type']);
+        $this->assertSame('e', $byTitle['errrow']['type']);
+    }
+
+    /**
+     * Timestamps are always unix-seconds ints — no ISO strings, no
+     * millisecond values. Test the canonical path on bans.created.
+     */
+    public function testTimestampsAreUnixSecondsInteger(): void
+    {
+        $aid = Fixture::adminAid();
+        $now = 1_700_000_000;
+        $pdo = Fixture::rawPdo();
+        $pdo->exec(
+            sprintf(
+                "INSERT INTO `%s_bans` (ip, authid, name, created, ends, length, reason, aid, adminIp, sid, country, type) VALUES
+                ('', 'STEAM_0:0:300', 'ts_target', %d, 0, 0, 't', %d, '127.0.0.1', 0, '', 0)",
+                DB_PREFIX,
+                $now,
+                $aid,
+            )
+        );
+
+        foreach ($this->exporter->bans() as $line) {
+            $row = json_decode($line, true, 512, JSON_THROW_ON_ERROR);
+            if ($row['name'] === 'ts_target') {
+                $this->assertIsInt($row['created']);
+                $this->assertSame($now, $row['created']);
+                $this->assertIsInt($row['ends']);
+                $this->assertIsInt($row['length']);
+                return;
+            }
+        }
+        $this->fail('seeded ts_target row never surfaced');
+    }
+}

--- a/web/tests/unit/EntityExporterTest.php
+++ b/web/tests/unit/EntityExporterTest.php
@@ -85,12 +85,18 @@ final class EntityExporterTest extends TestCase
     {
         // Seed a row whose forbidden columns carry distinctive values
         // we can grep for — the bcrypt prefix `$2y$` is distinctive,
-        // and the validate token is a hex hash we can pattern-match.
+        // the validate token is a hex hash we can pattern-match, and
+        // the srv_password carries a hostile marker that proves the
+        // plaintext SM admin server-login credential doesn't leak
+        // (the panel stores `:prefix_admins.srv_password` cleartext —
+        // see `web/api/handlers/account.php`'s stringwise comparison
+        // and the table column type in `web/install/includes/sql/struc.sql`
+        // both confirming `varchar(128) default NULL` with no hash).
         $pdo = Fixture::rawPdo();
         $pdo->exec(
             sprintf(
-                "INSERT INTO `%s_admins` (user, authid, password, gid, email, validate, extraflags, immunity, attempts, lockout_until) VALUES
-                ('forbidcheck', 'STEAM_0:0:1', '\$2y\$12\$DUMMYHASHDUMMYHASHDUMMYHASHDUMMYHASHDUMMYHASHDUMMYHASHDU', -1, 'fc@example.test', '5ed533c0ffeec0deDUMMY99887766aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa', 1, 1, 9, NOW() + INTERVAL 1 HOUR)",
+                "INSERT INTO `%s_admins` (user, authid, password, gid, email, validate, srv_password, extraflags, immunity, attempts, lockout_until) VALUES
+                ('forbidcheck', 'STEAM_0:0:1', '\$2y\$12\$DUMMYHASHDUMMYHASHDUMMYHASHDUMMYHASHDUMMYHASHDUMMYHASHDU', -1, 'fc@example.test', '5ed533c0ffeec0deDUMMY99887766aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa', 'SRVPLAIN_CLEARTEXT_LEAK_MARKER_DUMMY', 1, 1, 9, NOW() + INTERVAL 1 HOUR)",
                 DB_PREFIX,
             )
         );
@@ -110,6 +116,22 @@ final class EntityExporterTest extends TestCase
         // Per-value distinctive marker absence.
         $this->assertStringNotContainsString('$2y$', $output, 'bcrypt hash leaked into admins output');
         $this->assertStringNotContainsString('5ed533c0ffeec0de', $output, 'validate token leaked into admins output');
+        $this->assertStringNotContainsString(
+            'SRVPLAIN_CLEARTEXT_LEAK_MARKER_DUMMY',
+            $output,
+            'plaintext srv_password leaked into admins output — the manifest pii_policy.password_hashes="never" '
+            . 'attestation is broken if this fires (srv_password is a cleartext SM admin credential, '
+            . 'structurally worse than the bcrypt password hash above)'
+        );
+
+        // Defence-in-depth: assert FORBIDDEN_ADMIN_COLUMNS itself
+        // carries every credential-class field a future contributor
+        // might be tempted to re-add to the SELECT. The list is the
+        // load-bearing contract that keeps the manifest's
+        // pii_policy.password_hashes="never" attestation truthful.
+        $this->assertContains('password', EntityExporter::FORBIDDEN_ADMIN_COLUMNS);
+        $this->assertContains('srv_password', EntityExporter::FORBIDDEN_ADMIN_COLUMNS);
+        $this->assertContains('validate', EntityExporter::FORBIDDEN_ADMIN_COLUMNS);
     }
 
     /**

--- a/web/tests/unit/ManifestBuilderTest.php
+++ b/web/tests/unit/ManifestBuilderTest.php
@@ -1,0 +1,239 @@
+<?php
+// SourceBans++ (c) 2014-2026 SourceBans++ Dev Team
+// Licensed under the Elastic License 2.0.
+// See LICENSE.txt for the full license text and THIRD-PARTY-NOTICES.txt for attributions.
+
+declare(strict_types=1);
+
+namespace Sbpp\Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use Sbpp\Export\Manifest;
+use Sbpp\Export\ManifestBuilder;
+use Sbpp\Tests\Fixture;
+
+/**
+ * Manifest contract pins — these are the bits the bundle's
+ * downstream consumers (operator-side migration tooling, audit
+ * pipelines, third-party importers) read from `manifest.json` and
+ * key off of. Drift in any of them is a wire-format break, so the
+ * tests assert the field set + the type / shape of every value
+ * downstream depends on.
+ *
+ * Scope: this file covers the BUILDER + DTO surfaces — bundle-id
+ * shape, format_version constant, cap math, PII policy block. The
+ * row-count side (which depends on a populated DB) is exercised by
+ * ExportBundleWriterTest. Splitting the two surfaces keeps each test
+ * file's bring-up cost predictable.
+ */
+final class ManifestBuilderTest extends TestCase
+{
+    /**
+     * Default cap is `4 * 1024^3` bytes minus a `64 * 1024^2`-byte
+     * safety margin — the headroom protects against last-minute
+     * compression-ratio surprises (deflate occasionally lands at
+     * 1.0x or worse on already-compressed payloads). The constants
+     * are public on Manifest because the cap is part of the bundle's
+     * wire contract; consumers ARE allowed to read them back, so
+     * silent drift would be a contract break.
+     */
+    public function testManifestCapConstantsMatchSpec(): void
+    {
+        $this->assertSame(4 * 1024 * 1024 * 1024, Manifest::MAX_BUNDLE_BYTES);
+        $this->assertSame(64 * 1024 * 1024, Manifest::SAFETY_MARGIN_BYTES);
+        $this->assertSame(1, Manifest::FORMAT_VERSION);
+    }
+
+    /**
+     * Bundle ID format is RFC 4122 UUIDv4 — 32 lowercase hex digits
+     * grouped 8-4-4-4-12 with the version nibble at position 12 set
+     * to '4' and the variant high bits at position 16 set to '8/9/a/b'.
+     * The regex pins ALL THREE: hex-only, dash positions, version,
+     * variant. A future refactor that swaps to UUIDv7 (time-ordered)
+     * MUST update this assertion + the constructor doc in
+     * ManifestBuilder, since downstream tooling may sort bundle IDs.
+     */
+    public function testBundleIdIsValidUuidV4(): void
+    {
+        Fixture::reset();
+        $builder = $this->builder();
+        $manifest = $builder->build();
+
+        $this->assertMatchesRegularExpression(
+            '/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/',
+            $manifest->bundle_id,
+            'bundle_id must be a lowercase UUIDv4 with the correct version + variant nibbles',
+        );
+    }
+
+    /**
+     * Two consecutive builds against the same DB state MUST produce
+     * different bundle IDs — the ID is a freshness token an operator
+     * uses to disambiguate consecutive exports in their downstream
+     * pipeline. Same DB state, same row counts, same payload — but
+     * different ID. (The downstream `Content-Disposition` filename
+     * also embeds the ID; collisions would silently overwrite.)
+     */
+    public function testBundleIdIsUniquePerBuild(): void
+    {
+        Fixture::reset();
+        $builder = $this->builder();
+        $a = $builder->build();
+        $b = $builder->build();
+        $this->assertNotSame($a->bundle_id, $b->bundle_id);
+    }
+
+    /**
+     * `created_at` is a unix-seconds integer (NOT a millisecond
+     * value, NOT an ISO string). Consumers convert via
+     * `new Date(created_at * 1000)` on the JS side or
+     * `datetime.fromtimestamp(created_at)` on the Python side; a
+     * silent unit drift would land wall-clock errors decades into
+     * the future. Sanity-check the value lands in the plausible
+     * window for "right now".
+     */
+    public function testCreatedAtIsUnixSecondsInteger(): void
+    {
+        Fixture::reset();
+        $manifest = $this->builder()->build();
+        $this->assertIsInt($manifest->created_at);
+        $this->assertGreaterThan(1_700_000_000, $manifest->created_at); // sometime after 2023-11
+        $this->assertLessThan(time() + 5, $manifest->created_at);       // within a few seconds of now
+    }
+
+    /**
+     * PII policy block is the load-bearing operator-facing
+     * "what's in here" attestation. Every field MUST be present
+     * with the documented type, even when the value is `false` —
+     * a missing field could be misread as a hidden category. The
+     * shape is pinned at the wire level (in `Manifest::toJson()`)
+     * not just at the DTO level.
+     */
+    public function testPiiPolicyBlockShape(): void
+    {
+        Fixture::reset();
+        $manifest = $this->builder()->build();
+        $policy = $manifest->pii_policy;
+
+        // Required keys — drift here is a wire format break.
+        $this->assertArrayHasKey('includes_admin_emails', $policy);
+        $this->assertArrayHasKey('includes_ip_addresses', $policy);
+        $this->assertArrayHasKey('includes_chat_messages', $policy);
+        $this->assertArrayHasKey('includes_steam_ids', $policy);
+        $this->assertArrayHasKey('includes_unban_reasons', $policy);
+        $this->assertArrayHasKey('password_hashes', $policy);
+
+        // Value contracts — the panel DOES include emails + IPs +
+        // Steam IDs + unban reasons; it does NOT store chat
+        // messages anywhere in struc.sql; password hashes are
+        // NEVER exported. The 'never' string is contract — a future
+        // refactor swapping to a bool would silently lose the
+        // explicit-by-design signal.
+        $this->assertTrue($policy['includes_admin_emails']);
+        $this->assertTrue($policy['includes_ip_addresses']);
+        $this->assertFalse($policy['includes_chat_messages']);
+        $this->assertTrue($policy['includes_steam_ids']);
+        $this->assertTrue($policy['includes_unban_reasons']);
+        $this->assertSame('never', $policy['password_hashes']);
+    }
+
+    /**
+     * `toJson()` writes the manifest with the exact set of top-level
+     * keys downstream tooling consumes. Drift here breaks any
+     * consumer that parses the manifest with a fixed schema (Pydantic,
+     * JSON Schema, TypeScript DTOs). Use `assertSame` on the sorted
+     * key list so a future addition has to update this test.
+     */
+    public function testToJsonProducesExpectedTopLevelShape(): void
+    {
+        Fixture::reset();
+        $manifest = $this->builder()->build();
+
+        $decoded = json_decode($manifest->toJson(), true, 512, JSON_THROW_ON_ERROR);
+        $this->assertIsArray($decoded);
+
+        $keys = array_keys($decoded);
+        sort($keys);
+        $this->assertSame(
+            [
+                'bundle_id',
+                'cap_bytes',
+                'created_at',
+                'demo_files',
+                'demo_total_bytes',
+                'estimated_bundle_bytes',
+                'exceeds_cap',
+                'format_version',
+                'panel_version',
+                'pii_policy',
+                'row_counts',
+            ],
+            $keys,
+        );
+
+        $this->assertSame(1, $decoded['format_version']);
+        $this->assertIsArray($decoded['row_counts']);
+        $this->assertIsArray($decoded['demo_files']);
+        $this->assertIsArray($decoded['pii_policy']);
+        $this->assertIsBool($decoded['exceeds_cap']);
+    }
+
+    /**
+     * Cap-exceeded gate: when the estimated bundle bytes overflow
+     * `MAX_BUNDLE_BYTES - SAFETY_MARGIN_BYTES`, `build()` populates
+     * `exceeds_cap=true` (non-throwing — the admin page renders the
+     * form with the stats so the operator can see WHY they're
+     * blocked). `buildOrThrow()` is the stricter sister that throws
+     * `ExportError(CAP_EXCEEDED)` for the same condition — used by
+     * the entry point right BEFORE bytes hit the wire.
+     *
+     * Test approach: directly construct a Manifest DTO with a
+     * synthetic `estimated_bundle_bytes` value at the cap boundary.
+     * We don't try to populate the real DB to 4 GiB worth of rows —
+     * that would be brittle and slow. The cap predicate lives on the
+     * DTO itself (via the constructor flag set by ManifestBuilder),
+     * so we test the DTO contract directly.
+     */
+    public function testManifestExposesExceedsCapFlag(): void
+    {
+        // At-cap-minus-margin: still under.
+        $cap = Manifest::MAX_BUNDLE_BYTES - Manifest::SAFETY_MARGIN_BYTES;
+
+        $under = new Manifest(
+            bundle_id:              'test-uuid',
+            created_at:             1_700_000_000,
+            panel_version:          'test',
+            row_counts:             [],
+            demo_files:             [],
+            demo_total_bytes:       0,
+            estimated_bundle_bytes: $cap - 1,
+            exceeds_cap:            false,
+            cap_bytes:              $cap,
+            pii_policy:             ['includes_admin_emails' => true],
+        );
+        $this->assertFalse($under->exceeds_cap);
+
+        $over = new Manifest(
+            bundle_id:              'test-uuid',
+            created_at:             1_700_000_000,
+            panel_version:          'test',
+            row_counts:             [],
+            demo_files:             [],
+            demo_total_bytes:       Manifest::MAX_BUNDLE_BYTES,
+            estimated_bundle_bytes: $cap + 1,
+            exceeds_cap:            true,
+            cap_bytes:              $cap,
+            pii_policy:             ['includes_admin_emails' => true],
+        );
+        $this->assertTrue($over->exceeds_cap);
+    }
+
+    private function builder(): ManifestBuilder
+    {
+        return new ManifestBuilder(
+            dbs:          $GLOBALS['PDO'],
+            demosDir:     SB_DEMOS,
+            panelVersion: 'test',
+        );
+    }
+}

--- a/web/themes/default/page_admin_export.tpl
+++ b/web/themes/default/page_admin_export.tpl
@@ -1,0 +1,234 @@
+{*
+    SourceBans++ 2026 — page_admin_export.tpl
+    Bound to Sbpp\View\AdminExportView (validated by SmartyTemplateRule).
+
+    "Full data export" admin surface. Two delivery modes:
+      - ZIP download (stream-to-output, no intermediate disk)
+      - S3 presigned PUT (build-to-disk-then-PUT)
+
+    Both forms POST to web/export.php (top-level entry point — binary
+    wire format → doesn't fit the JSON dispatcher; same shape as
+    `exportbans.php` / `getdemo.php`). See that file's lifecycle
+    docblock for the security contract.
+
+    The mode is carried as a hidden `<input name="mode" value="…">`
+    inside each form (NOT as a `?mode=…` query string on the action
+    URL); the entry point reads `$_POST['mode']` and rejects anything
+    other than `'zip'` / `'s3'`.
+
+    When `$exceeds_cap` is true (the bundle would blow the 4 GiB ZIP
+    2.0 spec ceiling minus our 64 MiB safety margin), both submit
+    buttons are disabled and the page shows an `.empty-state` block
+    explaining what to prune. The operator MUST clear the cap before
+    they can act — the same gate is re-enforced at the entry point so
+    a hand-edited form submission can't bypass it.
+*}
+<section class="p-6" data-testid="admin-export-section" style="max-width:56rem">
+    <div class="mb-6">
+        <h1 style="font-size:1.5rem;font-weight:600;margin:0">Full data export</h1>
+        <p class="text-sm text-muted m-0 mt-2">
+            Stream a one-shot ZIP bundle of every panel row + uploaded demo
+            for backup, migration, or downstream analytics.
+            See the <a href="https://sbpp.github.io/configuring/data-export/" target="_blank" rel="noopener noreferrer">data-export docs</a>
+            for the on-disk wire format and a worked example for each delivery mode.
+        </p>
+    </div>
+
+    <div class="card mb-4" data-testid="admin-export-summary-card">
+        <div class="card__header">
+            <h2 style="font-size:1.125rem;font-weight:600;margin:0">What's in the bundle</h2>
+            <p class="text-xs text-muted m-0 mt-1">
+                A fresh UUIDv4 bundle ID is minted at submit time; the totals below
+                reflect the snapshot taken when this page loaded.
+            </p>
+        </div>
+        <div class="card__body">
+            <dl class="install-grid" style="display:grid;grid-template-columns:repeat(auto-fit,minmax(14rem,1fr));gap:0.75rem 1.5rem;margin:0">
+                <div>
+                    <dt class="text-xs text-muted">Panel version</dt>
+                    <dd class="font-mono" data-testid="admin-export-panel-version" style="margin:0">{$panel_version|escape}</dd>
+                </div>
+                <div>
+                    <dt class="text-xs text-muted">Admins</dt>
+                    <dd class="font-mono" data-testid="admin-export-count-admins" style="margin:0">{$total_admins|number_format}</dd>
+                </div>
+                <div>
+                    <dt class="text-xs text-muted">Bans</dt>
+                    <dd class="font-mono" data-testid="admin-export-count-bans" style="margin:0">{$total_bans|number_format}</dd>
+                </div>
+                <div>
+                    <dt class="text-xs text-muted">Comm blocks</dt>
+                    <dd class="font-mono" data-testid="admin-export-count-comms" style="margin:0">{$total_comms|number_format}</dd>
+                </div>
+                <div>
+                    <dt class="text-xs text-muted">Demos</dt>
+                    <dd class="font-mono" data-testid="admin-export-count-demos" style="margin:0">{$total_demos|number_format}</dd>
+                </div>
+                <div>
+                    <dt class="text-xs text-muted">Demos on disk</dt>
+                    <dd class="font-mono" data-testid="admin-export-demo-bytes" style="margin:0">{($demo_total_bytes / 1024 / 1024)|number_format:1} MiB</dd>
+                </div>
+                <div>
+                    <dt class="text-xs text-muted">Estimated bundle</dt>
+                    <dd class="font-mono" data-testid="admin-export-estimate-bytes" style="margin:0">{($estimated_bundle_bytes / 1024 / 1024)|number_format:1} MiB</dd>
+                </div>
+                <div>
+                    <dt class="text-xs text-muted">Cap (ZIP 2.0)</dt>
+                    <dd class="font-mono" data-testid="admin-export-cap-bytes" style="margin:0">{($cap_bytes / 1024 / 1024 / 1024)|number_format:2} GiB</dd>
+                </div>
+            </dl>
+
+            {if $row_counts|@count > 0}
+                <details class="mt-4">
+                    <summary class="text-sm" style="cursor:pointer">Per-entity row counts</summary>
+                    <dl class="install-grid mt-2" style="display:grid;grid-template-columns:repeat(auto-fill,minmax(12rem,1fr));gap:0.25rem 1.5rem;margin:0;font-size:var(--fs-xs)">
+                        {foreach from=$row_counts key=entity item=count}
+                            <div style="display:flex;justify-content:space-between;gap:0.5rem">
+                                <dt class="text-muted font-mono">{$entity|escape}</dt>
+                                <dd class="font-mono" style="margin:0">{$count|number_format}</dd>
+                            </div>
+                        {/foreach}
+                    </dl>
+                </details>
+            {/if}
+        </div>
+    </div>
+
+    {if $exceeds_cap}
+        {* First-run vs filtered shape per AGENTS.md "Empty states": this is
+           a structural block (no rows can be exported until the operator
+           shrinks the bundle), so we use the first-run shape with NO
+           Clear-filters CTA — the operator's only path forward is to
+           prune their data, which isn't a one-click action we can
+           surface. `data-filtered="false"` per the convention. *}
+        <div class="card" data-testid="admin-export-cap-empty" data-filtered="false">
+            <div class="empty-state">
+                <span class="empty-state__icon" aria-hidden="true">
+                    <i data-lucide="alert-triangle" style="width:18px;height:18px"></i>
+                </span>
+                <h2 class="empty-state__title">Bundle exceeds the 4 GiB ZIP cap</h2>
+                <p class="empty-state__body">
+                    The estimated bundle ({($estimated_bundle_bytes / 1024 / 1024)|number_format:1} MiB)
+                    overflows the ZIP 2.0 spec ceiling minus the 64 MiB safety margin.
+                    Prune old demos from the <a href="?p=admin&c=bans&section=add-ban">Bans → Add ban</a> Demo column
+                    or trim unrelated rows (banlog, audit log) and re-load this page.
+                    The submit buttons below are disabled until the bundle fits.
+                </p>
+            </div>
+        </div>
+    {/if}
+
+    <div class="grid" style="display:grid;grid-template-columns:repeat(auto-fit,minmax(22rem,1fr));gap:1rem;margin-top:1rem">
+        <form class="card"
+              method="post"
+              action="export.php"
+              data-testid="admin-export-zip-form">
+            {csrf_field}
+            <input type="hidden" name="mode" value="zip">
+            <div class="card__header">
+                <h2 style="font-size:1.125rem;font-weight:600;margin:0">Stream a ZIP download</h2>
+            </div>
+            <div class="card__body space-y-2">
+                <p class="text-sm text-muted m-0">
+                    The browser downloads the bundle directly. The connection
+                    must stay open for the full transfer — close the tab and the
+                    download aborts (cleanly; no on-disk state to clean up).
+                </p>
+                <p class="text-xs text-muted m-0">
+                    No staging file is written; the bundle streams from
+                    <code>php://output</code> through the writer's
+                    <code>flush()</code> calls so the browser's progress bar
+                    moves in real time.
+                </p>
+            </div>
+            <div class="card__header" style="border-top:1px solid var(--border);border-bottom:0;justify-content:flex-end">
+                <button type="submit"
+                        class="btn btn--primary"
+                        data-testid="admin-export-zip-submit"
+                        {if $exceeds_cap}disabled{/if}>
+                    <i data-lucide="download" style="width:16px;height:16px"></i>
+                    Export as ZIP
+                </button>
+            </div>
+        </form>
+
+        <form class="card"
+              method="post"
+              action="export.php"
+              data-testid="admin-export-s3-form">
+            {csrf_field}
+            <input type="hidden" name="mode" value="s3">
+            <div class="card__header">
+                <h2 style="font-size:1.125rem;font-weight:600;margin:0">Upload to S3 presigned URL</h2>
+            </div>
+            <div class="card__body space-y-2">
+                <p class="text-sm text-muted m-0">
+                    Bundle is staged on disk, then PUT to your presigned URL.
+                    The HTTPS connection holds for the full upload; close the
+                    tab mid-upload and the request aborts but the audit log
+                    captures the partial transfer.
+                </p>
+                <label class="label mt-3" for="admin-export-s3-url">Presigned PUT URL</label>
+                <textarea class="textarea"
+                          id="admin-export-s3-url"
+                          name="presign_url"
+                          rows="3"
+                          required
+                          pattern="^https://[^\s]+$"
+                          title="Paste a presigned HTTPS PUT URL from your S3 client (e.g. aws s3 presign --http-method PUT …)"
+                          placeholder="https://bucket.s3.region.amazonaws.com/path/sbpp-export.zip?X-Amz-…"
+                          data-testid="admin-export-s3-url"></textarea>
+                <p class="text-xs text-muted m-0 mt-1">
+                    HTTPS only (no http://). Use a short expiry (≤1 hour).
+                    Never paste this URL into chat or logs — it's a single-use
+                    write credential.
+                </p>
+            </div>
+            <div class="card__header" style="border-top:1px solid var(--border);border-bottom:0;justify-content:flex-end">
+                <button type="submit"
+                        class="btn btn--primary"
+                        data-testid="admin-export-s3-submit"
+                        {if $exceeds_cap}disabled{/if}>
+                    <i data-lucide="upload-cloud" style="width:16px;height:16px"></i>
+                    Upload to S3
+                </button>
+            </div>
+        </form>
+    </div>
+</section>
+
+{* Page-tail script: gates the submit buttons through window.SBPP.setBusy
+   so the browser doesn't appear frozen while the request travels. The
+   ZIP path streams a binary response body (no page-render reset, no
+   redirect); the S3 path 302-redirects back here on completion. Both
+   tear the page down so we deliberately DON'T `setBusy(submitBtn, false)`
+   in the submit handler — the next paint resets the DOM either way. The
+   local `setBusy` wrapper falls back to plain `disabled` so third-party
+   themes that strip theme.js still gate against double-clicks. *}
+{literal}
+<script>
+(function () {
+    'use strict';
+    function setBusy(btn, busy) {
+        if (!btn) return;
+        var S = window.SBPP;
+        if (S && typeof S.setBusy === 'function') {
+            S.setBusy(btn, busy);
+        } else {
+            btn.disabled = busy === undefined ? true : !!busy;
+        }
+    }
+    var forms = document.querySelectorAll('[data-testid="admin-export-zip-form"], [data-testid="admin-export-s3-form"]');
+    for (var i = 0; i < forms.length; i++) {
+        forms[i].addEventListener('submit', function (e) {
+            var submit = e.target.querySelector('[type="submit"]');
+            if (submit && submit.disabled) {
+                e.preventDefault();
+                return;
+            }
+            setBusy(submit, true);
+        });
+    }
+})();
+</script>
+{/literal}

--- a/web/themes/default/page_admin_export.tpl
+++ b/web/themes/default/page_admin_export.tpl
@@ -110,7 +110,7 @@
                 <p class="empty-state__body">
                     The estimated bundle ({($estimated_bundle_bytes / 1024 / 1024)|number_format:1} MiB)
                     overflows the ZIP 2.0 spec ceiling minus the 64 MiB safety margin.
-                    Prune old demos from the <a href="?p=admin&c=bans&section=add-ban">Bans → Add ban</a> Demo column
+                    Prune old demos via the per-row Demo affordance on the <a href="?p=banlist">public banlist</a>
                     or trim unrelated rows (banlog, audit log) and re-load this page.
                     The submit buttons below are disabled until the bundle fits.
                 </p>


### PR DESCRIPTION
## Summary

Add a one-shot full data export feature to the panel. Owner-only
(no new permission flag — strictly `ADMIN_OWNER`). Two delivery
modes:

1. **ZIP download** — streams a `Content-Type: application/zip` body
   straight from `php://output` through `maennchen/zipstream-php`.
   No staging file; the browser's progress bar moves in real time
   via per-entry `flush()` calls.
2. **S3 presigned PUT upload** — builds the bundle to a staging
   tempfile under `SB_CACHE/exports/`, then PUTs it via cURL to the
   operator-supplied presigned URL. The tempfile is registered for
   `register_shutdown_function` cleanup so a mid-build fatal still
   wipes the staging file.

Both modes honour the bundle spec (manifest-first, per-
entity JSONL, STORE-mode demo entries, SteamID64-as-decimal-string,
unix-seconds integer timestamps, ZIP 2.0 with 4 GiB hard cap minus
64 MiB safety margin, `pii_policy.password_hashes="never"`
attestation).

Runtime model is synchronous in-request with PHP hardening
(`@set_time_limit(0)`, `@ini_set('memory_limit', '256M')`,
`ignore_user_abort(true)`, ob_buffer drain, `X-Accel-Buffering: no`,
Apache `no-gzip`). Works on non-FPM hosts, shared hosting, and
behind reverse proxies without requiring a background-worker
subsystem the panel doesn't have today.

## Security highlights

- **`ADMIN_OWNER`-only**. Navbar + command palette + page-builder
  route + page-handler defence-in-depth + top-level entry-point
  gate all check the same permission.
- **CSRF required** on every state-changing POST.
- **Method gate**: POST-only; GET/HEAD return 405.
- **`FORBIDDEN_ADMIN_COLUMNS`** (`password`, `validate`, `attempts`,
  `lockout_until`, `srv_password`) NEVER projected from the SELECT.
  The list is the load-bearing contract that keeps the manifest's
  `pii_policy.password_hashes="never"` attestation truthful.
  `srv_password` specifically was added in the adversarial-review
  fix sweep (B1): the panel stores SourceMod admin server-login
  passwords cleartext, exporting them would let a bundle recipient
  authenticate against every game server the admin manages.
- **`FORBIDDEN_SERVER_COLUMNS`** (`rcon`) NEVER projected — RCON is
  the keys-to-the-game-server credential.
- **`FORBIDDEN_SETTING_KEYS`** filtered at the SQL WHERE level so a
  future post-fetch helper can't re-add them.
- Audit-log entries on every reachable terminal branch (success +
  every error code), tagged with `bundle_id` so an operator can
  correlate a painted toast with the audit row.

## Adversarial review findings (all addressed)

A read-only adversarial subagent reviewed the worker's first pass
and surfaced six issues; the final commit on this branch (`ab167a41`)
addresses all of them:

- **B1 (BLOCKER, security)**: drop plaintext `admins.srv_password`.
- **H1 (HIGH, OOM)**: `BundleWriter::writeEntity` now spills to
  `php://temp/maxmemory:8M` instead of concatenating the full
  entity into a PHP string.
- **M1 (MEDIUM, UX)**: cap counter snaps to `fstat($outputHandle)['size']`
  in s3 mode for exact compressed-byte tracking; zip-mode keeps
  the conservative uncompressed-byte estimate (over-counting is the
  safe direction).
- **L1**: `Log::add` on `mode_invalid` + presign-URL-malformed
  rejection branches.
- **L2**: `bundle_id` in disk-write-failed + fopen-failed log entries.
- **L3**: empty-state CTA retargeted from the non-existent
  `?p=admin&c=bans&section=add-ban` Demo column to the public banlist.

## Tests

- `tests/unit/EntityExporterTest.php` — per-entity column rules,
  forbidden-column non-leak, SteamID-as-string contract, mute-kind
  derivation, bans state matrix, unix-seconds timestamps. The
  forbidden-admin-column test now seeds a distinctive `srv_password`
  marker AND asserts the constant list itself includes every
  credential field.
- `tests/integration/ExportBundleWriterTest.php` — full pipeline
  (ManifestBuilder → BundleWriter → on-disk ZIP), structural
  contract assertions (manifest-first, row-count agreement,
  STORE-mode demos, no bare-number SteamIDs, no leaked credentials).
  Two new regression tests:
    - `testWriterBytesWrittenMatchesOnDiskSizeInS3Mode` pins M1's
      exact-byte tracking.
    - `testWriterDoesNotBufferLargeEntityIntoMemory` pins H1's spill
      behaviour by seeding >15 MiB of comments and asserting peak
      memory delta stays under 64 MiB.
- `tests/unit/ManifestBuilderTest.php` — manifest shape, cap math.
- `tests/integration/AdminExportPermissionTest.php` +
  `AdminExportRuntimePermissionTest.php` — HTTP entry gates
  (CSRF, owner-only, method gate).
- `tests/integration/S3PresignedUploaderTest.php` — cURL stub paths
  (success, network failure, non-2xx response, oversized body).
- `tests/e2e/specs/flows/data-export.spec.ts` — Playwright end-to-end
  zip-mode download + jszip-based bundle inspection.

## Documentation

- `AGENTS.md` — "Full data export" conventions block + "Where to
  find what" rows for the entry point, writer, exporter, manifest.
- `ARCHITECTURE.md` — "Data export" subsystem section.
- `docs/src/content/docs/configuring/data-export.mdx` — operator-
  facing guide covering both modes, the bundle wire format, the
  pii_policy attestation, and S3 presign-URL setup.

## Test plan

- [x] PHPStan clean
- [x] ts-check clean
- [x] api-contract regenerated + no diff
- [x] PHPUnit: full suite — only failures are pre-existing
      `PluginVersionResolveTest` cases (missing `sbpp_version.inc`
      in the dev container; unrelated to this branch, confirmed
      reproducing on stashed-clean main)
- [ ] CI Playwright E2E (will run on PR push)
- [ ] CI plugin-build (untouched — branch doesn't modify SourcePawn)
- [ ] CLA workflow signature (web/** PR, will gate on signing)