### PR TITLE
docs: ban emdash in user-facing copy, tighten data-export wordings

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1225,6 +1225,50 @@ The regression guards are paired:
  regression but not, say, a future `animation-play-state: paused`
  sneaking in via a parent rule.
 
+### User-facing text style (panel UI + docs)
+
+Every string the operator reads in the panel or on the docs site
+follows three rules:
+
+- **No emdash (`—`).** Use a comma, period, parentheses, or split
+ the sentence. The character is hard to type on most keyboards
+ and reads as AI-generated padding to many contributors. Hyphen
+ (`-`) is fine; en-dash (`–`) is fine in numeric ranges only.
+- **Terse.** One thought per sentence. Trim filler clauses
+ (`as you can see`, `please note that`, `it's worth mentioning`).
+ If a sentence can lose half its words and keep its meaning, lose
+ them.
+- **Don't over-explain.** Trust the operator. Say what they need
+ to do; skip the rationale unless it changes the action. The
+ docs page can carry one paragraph of context per section, not
+ three.
+
+Applies to:
+
+- Panel UI text in `web/themes/default/**/*.tpl` (toast titles +
+ bodies, button labels, form help text, empty-state copy, alert
+ banners, install-wizard chrome).
+- User-facing strings emitted from PHP page handlers
+ (`\Sbpp\View\Toast::emit(...)` titles + bodies, `echo` output,
+ inline `<div>` banners, error-page text).
+- Docs prose under `docs/src/content/docs/**/*.{md,mdx}` (any
+ page rendered to sbpp.github.io).
+
+Does NOT apply to:
+
+- `AGENTS.md`, `ARCHITECTURE.md`, `CONTRIBUTING.md`, `CLA.md`,
+ `docker/README.md`, `docs/README.md` (contributor-facing).
+- PHP / JS / Smarty code comments and docblocks.
+- Audit-log entries (`Log::add(...)` bodies are diagnostic, not
+ UX surface).
+- Test names, fixture data, snapshot bodies, and other
+ contributor-facing strings.
+
+Reach for the rewrite shape, not the strip-and-leave shape: an
+emdash usually marks a clause that's either a parenthetical
+(swap to parens), a continuation (period + new sentence), or
+filler (delete the clause).
+
 ### Server-side toast emission (`Sbpp\View\Toast::emit`)
 
 PHP page handlers that need to surface a toast (success / error
@@ -4309,10 +4353,22 @@ contributions without contacting every contributor individually.
   pane shape from `page_admin_settings_settings.tpl` (calls
   `system.preview_intro_text`, server-renders through `IntroRenderer`).
 - Ad-hoc per-page empty-state copy → use the shared `.empty-state`
-  layout + the first-run-vs-filtered split documented under
-  "Empty states" above. Inconsistent voice and missing CTAs are what
-  #1207's empty-state audit caught; future surfaces stay on the
-  unified pattern.
+ layout + the first-run-vs-filtered split documented under
+ "Empty states" above. Inconsistent voice and missing CTAs are what
+ #1207's empty-state audit caught; future surfaces stay on the
+ unified pattern.
+- Emdash (`—`) in user-facing text (panel `.tpl`, page-handler
+ `Toast::emit` strings, docs `.md` / `.mdx` prose) → split the
+ sentence, swap to parentheses, or delete the clause. Per
+ "User-facing text style" above. Hyphen / en-dash are fine; the
+ emdash specifically reads as filler and is hard to type. The rule
+ does NOT apply to contributor docs (`AGENTS.md`, `ARCHITECTURE.md`,
+ etc.) or code comments.
+- Verbose user-facing copy that explains the system to the operator
+ ("As you can see…", "Please note that…", "It's worth mentioning…",
+ multi-paragraph rationale before the action) → say what to do,
+ skip the why unless the why changes the action. One thought per
+ sentence. Per "User-facing text style" above.
 - Markdown-rendering admin display text client-side → use the
   server-side `system.preview_intro_text` action (same `IntroRenderer`
   the public dashboard uses). A bundled JS Markdown library would
@@ -4808,6 +4864,7 @@ contributions without contacting every contributor individually.
 | Sanitise a player display name received from an operator-controlled URL query parameter (the `?name=…` smart-default pre-fill arm on `?p=admin&c=bans&section=add-ban` + `?p=admin&c=comms`) | `Sbpp\Util\PlayerName::sanitisePrefill(string $raw): string` (`web/includes/Util/PlayerName.php`, #1440). Single source for the strip set + UTF-8 validation + codepoint cap; both page handlers (`web/pages/admin.bans.php` + `web/pages/admin.comms.php`) call it so the contract stays byte-identical across the two surfaces. Pipeline: `trim` → `preg_replace` against `PlayerName::SANITISE_STRIP_REGEX` (ASCII controls `\x00-\x1F` + `\x7F` + C1 controls `\x80-\x9F` + soft hyphen `U+00AD` + ZWSP `U+200B` + line/paragraph separators `U+2028`/`U+2029` + bidi format/override `U+202A-U+202E` + bidi isolate `U+2066-U+2069` + BOM `U+FEFF`) → `mb_check_encoding(..., 'UTF-8')` (drop entirely on malformed input) → `mb_substr(..., 0, PlayerName::MAX_CODEPOINTS=128, 'UTF-8')` to the `varchar(128)` schema width of `:prefix_bans.name` / `:prefix_comms.name`. The bidi-control strip is the load-bearing defence against right-to-left override (`U+202E`) name-spoofing attacks where a hostile in-game name visually renders as a different string in the form's `<input>` than what's actually stored. The codepoint-based truncation (NOT byte-based) handles 4-byte emoji without slicing mid-character. Use this helper for any future operator-controlled query-parameter that pre-fills a `varchar(128) player.name` form field; do not hand-roll a parallel strip regex (the pre-#1440 reviewer-feedback iteration was a duplicated inline `preg_replace` across both page handlers — centralisation is the contract). Regression guards: `web/tests/integration/AdminBansAddSmartDefaultTest.php` + `web/tests/integration/AdminCommsAddSmartDefaultTest.php` (`hostileNamePrefillProvider` covers every codepoint class in the strip regex + 4-byte emoji + invalid UTF-8 + 128-codepoint cap; `testNameWithoutSteamPrefillsNicknameOnly` + `testValidNameWithInvalidSteamPrefillsNicknameOnly` pin the `?name=` / `?steam=` orthogonality contract); `web/tests/e2e/specs/flows/server-player-context-menu.spec.ts` (`encodes special characters in the name parameter (#1440)` — end-to-end `encodeURIComponent` round-trip from the menu's `data-name` attribute through the form's rendered `value="…"`). |
 | Cache an A2S `GetInfo + GetPlayers` round-trip / add another public server-query handler | `web/includes/Servers/SourceQueryCache.php` (`Sbpp\Servers\SourceQueryCache::fetch($ip, $port, $ttl=30)` — per-`(ip, port)` on-disk cache under `SB_CACHE/srvquery/`, atomic tempfile + `rename()` writes mirroring `system.check_version`'s release cache; both success and failure cache so an unreachable server costs ONE A2S probe per ~30s window). The sibling `Sbpp\Servers\RconStatusCache` (`SB_CACHE/srvstatus/`) follows the same shape for RCON `status` round-trips — used by `api_servers_host_players` to surface per-player SteamIDs to admins (see the context-menu row above). Every public handler under `web/api/handlers/servers.php` (`api_servers_host_players` / `host_property` / `host_players_list` / `players`) goes through this — never call `new SourceQuery()` directly from a handler. The cache stamps user-agnostic data only; the handler stamps per-caller fields (`is_owner`, `can_ban`, the per-call `trunchostname`) on top. Per-tile JS debounce on the public servers page lives in `web/themes/default/page_servers.tpl` (`loadTile()` flips `tile.__sbppLoading` + the Re-query button's `disabled` attr while a probe is in flight, releases both in the success / error tails). The matching JS gate on the toggle button has been the precedent since v2.0.0; #1311 brought the refresh button onto the same shape. Tests: `web/tests/integration/SourceQueryCacheTest.php` (cache shape + coalescing + TTL + invalidation, drives `setProbeOverrideForTesting()` so the assertion is deterministic without UDP) + `testHostPlayersCoalescesRapidRepeatCallsViaCache` / `testHostPlayersNegativeCachesUnreachableServers` in `web/tests/api/ServersTest.php` (handler-shape coverage). E2E: `web/tests/e2e/specs/flows/server-refresh-debounce.spec.ts`. |
 | Render admin-authored Markdown to safe HTML | `web/includes/Markup/IntroRenderer.php` (`Sbpp\Markup`) |
+| Write or edit a user-facing string (panel UI text, toast body, docs page) | See "User-facing text style (panel UI + docs)" under Conventions. Three rules: no emdash (`—`), terse, don't over-explain. Applies to `web/themes/default/**/*.tpl`, `\Sbpp\View\Toast::emit` titles + bodies, `echo` output from page handlers, and every `docs/src/content/docs/**/*.{md,mdx}` page. Does NOT apply to `AGENTS.md` / `ARCHITECTURE.md` / contributor docs / code comments / audit-log entries / test fixtures. Anti-pattern entries paired under "Anti-patterns". |
 | Build / extend the anonymous opt-out daily telemetry payload (#1126) | `web/includes/Telemetry/Telemetry.php` (`Sbpp\Telemetry\Telemetry` — `tickIfDue`, `collect`, `send`) + `web/includes/Telemetry/Schema1.php` (`Sbpp\Telemetry\Schema1::payloadFieldNames()`, drives the extractor parity test) + `web/includes/Telemetry/schema-1.lock.json` (vendored from [sbpp/cf-analytics](https://github.com/sbpp/cf-analytics) — manual sync via `make sync-telemetry-schema`). Tick is registered at the tail of `init.php` via `register_shutdown_function`; on FPM, `fastcgi_finish_request()` flushes the response BEFORE the cURL POST so telemetry never delays a panel page. Slot reservation is atomic (`UPDATE :prefix_settings WHERE CAST(value AS UNSIGNED) <= :threshold`) at the START of the attempt, so a flapping endpoint costs one ping/day, not one ping/request. Audit-log only enable/disable transitions, never individual pings. The in-panel disclosure surface is the help-icon copy in `page_admin_settings_features.tpl`; the upgrade-time disclosure lives in `docs/src/content/docs/updating/1.8-to-2.0.mdx` (no first-login modal). |
 | Add or edit a project announcement (the admin-only banner on the home dashboard) | Edit `docs/public/announcements.json` (the source of truth — Astro publishes it as a static asset at `https://sbpp.github.io/announcements.json`). Each entry: `id` (≤64 chars, **required**), `title` (**required**), `body_md` (CommonMark, optional — rendered through `Sbpp\Markup\IntroRenderer` so raw HTML is escaped + `javascript:` / `data:` URLs are stripped), `url` (optional `http(s)://` only — non-http schemes rejected at the parser), `published_at` (optional ISO-8601 or unix int — drives the sort order; entries without it sort below dated entries), `expires_at` (optional — the parser drops entries past this timestamp). Sorted newest-first by the panel; convention is to also place the newest entry at the top of the array so reviewers see the most relevant change first. The deploy chain is automatic: a push to `main` that touches `docs/` fires `.github/workflows/docs-deploy-trigger.yml` which lands the file at `https://sbpp.github.io/announcements.json` within minutes. The starter file ships as `[]` (empty array). NEVER write to the cache file (`SB_CACHE/announcements.json`) directly — the panel's shutdown hook owns that path. |
 | Add or edit a project sponsor, funding platform, or sponsor tier | Edit `docs/src/data/sponsors.json` (the single source of truth). Three top-level keys: `platforms` (`{id, name, url, description?, icon?}` — the funding channels; GitHub Sponsors today, append Open Collective / Patreon / etc. as they're approved), `tiers` (`{id, name, monthlyMinUsd?, description?}` — ordered list driving the sponsor-roll display order), `sponsors` (`{name, url?, logo?, tier?, since?}` — `tier` matches a `tiers[].id`; missing/empty/unknown places the sponsor in the "Individual supporters" bucket). The component `docs/src/components/Sponsors.astro` renders the file on the canonical `/sponsor/` landing page (`docs/src/content/docs/sponsor.mdx`, `template: splash`, intentionally absent from the sidebar in `astro.config.mjs`); the topbar heart icon, the per-page footer link in `docs/src/components/Footer.astro`, and `.github/FUNDING.yml`'s `custom:` URL all route there. Adding a new platform / sponsor is a one-line append here — no component, config, or template edit needed. Companion issue #1417 will surface the same data on the panel footer; a future README-injector script will read the same file into the main `README.md`'s `<!-- sponsors:start --> ... <!-- sponsors:end -->` markers. The starter file ships with one `platforms` entry (GitHub Sponsors) and empty `tiers` + `sponsors` arrays. Issue #1416. |

--- a/docs/src/content/docs/configuring/data-export.mdx
+++ b/docs/src/content/docs/configuring/data-export.mdx
@@ -1,6 +1,6 @@
 ---
 title: Full data export
-description: How to stream a one-shot ZIP bundle of every panel row plus uploaded demos, either as a browser download or via a presigned S3 PUT URL.
+description: Stream a one-shot ZIP bundle of every panel row and uploaded demo, either as a browser download or via a presigned S3 PUT URL.
 sidebar:
   order: 2
   label: Full data export
@@ -8,49 +8,38 @@ sidebar:
 
 import { Aside, Code, Tabs, TabItem } from '@astrojs/starlight/components';
 
-The panel ships a built-in "Full data export" surface that streams a
-one-shot ZIP bundle of every row in the database plus every uploaded
-demo. The bundle is suitable for:
+The panel ships a built-in "Full data export" surface that produces a
+one-shot ZIP bundle of every database row plus every uploaded demo.
+Use it for:
 
-- Backups — the bundle is self-contained; restore by feeding the
-  JSONL streams into a downstream importer.
-- Migration to a different host — same shape as backup, but typically
-  paired with a fresh install on the target.
-- Downstream analytics — the JSONL is JSON-line per row with stable
-  schema, easy to feed into BigQuery / DuckDB / pandas / etc.
+- Backups. The bundle is self-contained.
+- Migration to a different host.
+- Downstream analytics. The JSONL is one row per line with a stable schema.
 
 <Aside type="caution">
-The bundle contains the **full panel dataset**, including admin
-email addresses, IP addresses, every Steam ID the panel knows about,
-admin-authored unban reasons, comments, and notes. **Password
-hashes are NEVER exported** (panel rule), but the bundle is still
-high-sensitivity PII. Treat it accordingly: encrypted storage,
-short-lived presigned URLs, no posting the URL in chat or public
-logs.
+The bundle contains the **full panel dataset**: admin emails, IP
+addresses, every Steam ID, unban reasons, comments, and notes.
+**Password hashes are never exported.** The bundle is still
+high-sensitivity PII. Use encrypted storage and short-lived
+presigned URLs. Don't post the URL anywhere public.
 </Aside>
 
 ## Permission
 
-Access is gated on the `OWNER` permission flag — the same flag that
-gates Settings, the in-panel admin/group/server editors, and every
-other "this changes how the panel works" surface. There is **no
-delegated "data export" flag** by design: every row in the panel is
-in scope (admin emails, ban authids, comment text), so a partial-
-permission admin who can export everything is functionally an owner
-anyway. If you need to share read-only data with a non-owner (e.g.
-an audit pipeline), generate the bundle yourself and hand the
-recipient just the rows they need.
+Export is gated on `OWNER` only. There's no delegated flag: the
+bundle covers every row, so a delegated holder is functionally an
+owner anyway. To share read-only data with a non-owner, generate
+the bundle yourself and hand them just the rows they need.
 
-You reach the surface from:
+Reach the surface from:
 
-- The sidebar's **Admin → Export** entry (owner-only — non-owners
-  don't see it).
-- The command palette (Ctrl/Cmd+K → "Data export").
+- Sidebar: **Admin → Export** (owner-only).
+- Command palette (Ctrl/Cmd+K): "Data export".
 - Direct URL: `?p=admin&c=export`.
 
 ## What's in the bundle
 
-Every bundle is a ZIP 2.0 file with the same overall shape:
+Every bundle is a ZIP 2.0 file with this layout:
 
 ```
 sbpp-export-<uuid>.zip
@@ -78,45 +67,38 @@ sbpp-export-<uuid>.zip
 │   └── submissions.jsonl
 └── demos/
     ├── <filename>.dem
-    └── …
+    └── ...
 ```
 
-**`manifest.json` is always the first entry in the central
-directory.** Downstream consumers can read just the manifest by
-parsing the first central-directory entry without slurping the
-whole bundle into memory. The manifest carries:
+`manifest.json` is always the first central-directory entry, so
+consumers can read it without slurping the whole bundle. Fields:
 
-- `format_version`: integer (currently `1`). Bump triggers a
-  documented migration on the consumer side.
-- `bundle_id`: UUIDv4 string. Unique per export attempt; persisted
-  in the panel's audit log so an operator can correlate a downstream
-  bundle with the source export.
+- `format_version`: integer (currently `1`). Bumps trigger a
+  documented consumer-side migration.
+- `bundle_id`: UUIDv4 string. Unique per attempt. Logged in the
+  audit trail.
 - `created_at`: integer unix seconds (UTC).
-- `panel_version`: string (matches the `data-version` footer hook in
-  the panel chrome).
-- `row_counts`: dict of `<entity>: <int>`. The byte-for-byte count
-  of JSONL lines in each `entities/<entity>.jsonl`. Lets a consumer
-  size-check the import before parsing.
-- `demo_total_bytes`: integer. Sum of every demo file on disk that
-  the bundle includes.
-- `estimated_bundle_bytes`: integer. The pre-flight estimate the
-  cap check ran against (sum of demos + JSONL byte estimate).
-- `pii_policy`: dict documenting what's in scope:
+- `panel_version`: string matching the panel chrome's
+  `data-version` footer hook.
+- `row_counts`: dict of `<entity>: <int>`. Lets a consumer
+  size-check before parsing.
+- `demo_total_bytes`: integer. Sum of every demo on disk in
+  this bundle.
+- `estimated_bundle_bytes`: integer. The pre-flight estimate
+  the cap check ran against.
+- `pii_policy`: dict declaring what's in scope:
   - `includes_admin_emails: true`
   - `includes_ip_addresses: true`
-  - `includes_chat_messages: false` — the panel doesn't store chat
-    messages anywhere in its schema; this field declares the
-    category as out-of-scope so a downstream consumer doesn't have
-    to guess.
+  - `includes_chat_messages: false` (the panel doesn't store
+    chat messages).
   - `includes_steam_ids: true`
   - `includes_unban_reasons: true`
-  - `password_hashes: "never"` — load-bearing operator
-    attestation. Always literally `"never"`; the panel will never
-    emit `admins.password` regardless of caller permission.
+  - `password_hashes: "never"`. Operator attestation. Always
+    literally `"never"`.
 
 ### JSONL wire format
 
-Each `entities/<entity>.jsonl` file is one JSON object per line,
+Each `entities/<entity>.jsonl` is one JSON object per line, with a
 trailing newline:
 
 ```jsonl
@@ -124,120 +106,96 @@ trailing newline:
 {"id":43,"user":"bob","authid":"76561197960265729","authid_steam2":"STEAM_0:1:1","created":1717000100,"email":"bob@example.test","immunity":50}
 ```
 
-Wire-format contracts:
+Contracts:
 
-- **`null` for absent values** — never an empty string, never an
-  omitted field. A consumer iterates `Object.keys()` confident the
-  set is stable per entity.
-- **Timestamps are unix-seconds integers (UTC)** — `created`,
+- **`null` for absent values.** Never an empty string, never an
+  omitted field. Consumers can iterate `Object.keys()` confident
+  the set is stable per entity.
+- **Timestamps are unix-seconds integers (UTC).** `created`,
   `ends`, `RemovedOn`, etc. all share this shape regardless of
-  whether the source column was `int` or `datetime`.
-- **Steam64 IDs are decimal strings** (`"76561197960265728"`), not
-  JSON numbers — Steam64 values exceed the JavaScript `Number.MAX_SAFE_INTEGER`
-  and would silently round-trip wrong through JSON parsers that
-  use double-precision floats. The `authid_steam2` sister field
-  preserves the legacy `STEAM_X:Y:Z` shape for consumers that
-  prefer it.
-- **Source primary keys are renamed to `id`** — `admins.aid` →
-  `id`, `bans.bid` → `id`, etc. Cross-entity foreign keys keep
-  their original names (`bans.aid`, `comments.bid`, …) so the
-  graph is recoverable.
+  the source column type.
+- **Steam64 IDs are decimal strings** (`"76561197960265728"`),
+  not JSON numbers. Steam64 exceeds JavaScript's
+  `Number.MAX_SAFE_INTEGER`. The `authid_steam2` field carries
+  the legacy `STEAM_X:Y:Z` shape.
+- **Source primary keys are renamed to `id`** (`admins.aid` →
+  `id`, `bans.bid` → `id`, etc.). Cross-entity foreign keys keep
+  their original names so the graph is recoverable.
 
 ### Per-entity derivations
 
-A few entities carry derived fields the underlying DB columns
-don't:
+A few entities carry derived fields:
 
-- `comms.mute_kind`: one of `"mute"`, `"gag"`, `"silence"`, or
-  `"unknown"`. Maps from `:prefix_comms.type` (1/2/3 respectively);
-  `type_raw` is the source int for consumers that prefer the raw
-  shape.
-- `bans.state`: one of `"active"`, `"expired"`, `"unbanned"`,
-  `"deleted"`, `"permanent"`. Derived from `length` + `ends` +
-  `RemoveType` + `RemovedBy` using the same classifier the panel's
-  banlist page uses. `RemoveType` / `removed_by` / `removed_on` /
-  `ureason` are preserved verbatim too.
-- `bans.demo_filename` / `bans.demo_size_bytes` (and the matching
-  pair on `submissions`): present (`"demos/<basename>.dem"` +
-  size in bytes) when a `:prefix_demos` row references the ban;
-  `null` otherwise. Lets a consumer cross-reference the `demos/`
-  directory without re-running the JOIN.
-- `log.level`: one of `"message"`, `"warning"`, `"error"`. Maps
-  from `:prefix_log.type` (`m`/`w`/`e`). `actor_user` and
-  `actor_steam` are joined from `:prefix_admins` when `aid` is
-  non-null.
+- `comms.mute_kind`: `"mute"`, `"gag"`, `"silence"`, or
+  `"unknown"` (from `:prefix_comms.type` 1/2/3). `type_raw` is
+  the source int.
+- `bans.state`: `"active"`, `"expired"`, `"unbanned"`,
+  `"deleted"`, or `"permanent"`. Same classifier the banlist
+  page uses. `RemoveType` / `removed_by` / `removed_on` /
+  `ureason` are preserved verbatim.
+- `bans.demo_filename` / `bans.demo_size_bytes` (and the same
+  pair on `submissions`): set when a `:prefix_demos` row
+  references the ban; `null` otherwise.
+- `log.level`: `"message"`, `"warning"`, or `"error"` (from
+  `:prefix_log.type` `m`/`w`/`e`). `actor_user` and `actor_steam`
+  are joined from `:prefix_admins` when `aid` is non-null.
 
-### What's NEVER in the bundle
+### What's never in the bundle
 
-The following fields are stripped at the SQL layer (`SELECT`
-omits them or `WHERE` filters them out) so they never reach the
-JSONL even when the requesting admin is an owner. Operator
-attestation matches what the manifest's `pii_policy` block
-declares:
+These fields are stripped at the SQL layer and never reach the
+JSONL, regardless of permission:
 
-- `admins.password` — bcrypt hash. Stripped.
-- `admins.validate` / `admins.attempts` / `admins.lockout_until` —
-  password-reset token + lockout state. Stripped.
-- `servers.rcon` — RCON password. Stripped.
-- `settings` rows whose key is `smtp.pass` (SMTP credential) or
-  `telemetry.instance_id` (random identifier; deliberately
-  panel-local).
+- `admins.password` (bcrypt hash).
+- `admins.validate` / `admins.attempts` / `admins.lockout_until`
+  (password-reset token + lockout state).
+- `servers.rcon` (RCON password).
+- `settings` rows keyed `smtp.pass` (SMTP credential) or
+  `telemetry.instance_id` (panel-local).
 
 The forbidden list is hard-coded in
-`web/includes/Export/EntityExporter.php`. Reaching into the code
-to relax the filter (e.g. for a "full backup including bcrypt
-hashes" workflow) is unsupported and will silently invalidate the
-manifest's `password_hashes: "never"` attestation that downstream
-consumers rely on.
+`web/includes/Export/EntityExporter.php`. Relaxing it (e.g. for a
+"full backup including hashes" workflow) is unsupported and
+silently invalidates the manifest's `password_hashes: "never"`
+attestation.
 
 ## Two delivery modes
 
-The form ships two submit buttons. They differ in how the bundle
-reaches its destination:
+The form ships two submit buttons:
 
 <Tabs>
 <TabItem label="ZIP download">
 
 The browser downloads the bundle directly. Apache streams from
-`php://output` through the writer's `flush()` calls so the
-browser's progress bar moves in real time as each entity / demo
-lands. No on-disk staging file — close the tab mid-download and
-the panel cleans up immediately (no orphaned state).
+`php://output` so the progress bar moves in real time. No on-disk
+staging file. Closing the tab aborts cleanly.
 
-**When to use**: ad-hoc backups, one-off audits, debugging a
-particular row's wire shape, anything where a human is sitting in
-front of the panel waiting.
+**Use for**: ad-hoc backups, one-off audits, debugging a row's
+wire shape.
 
-**When not to use**: when the bundle is multi-GiB and your laptop
-is on a flaky hotel wifi (the connection has to stay open for the
-full transfer; abort and you start over). Switch to S3 mode for
-unattended uploads.
+**Skip when**: the bundle is multi-GiB and your network is flaky
+(the connection has to stay open for the full transfer; abort and
+you start over). Use S3 mode instead.
 
 </TabItem>
 <TabItem label="S3 presigned PUT">
 
-The panel builds the bundle to a temp file under
-`cache/exports/`, then HTTPS-PUTs it to your operator-supplied
-presigned URL. The PUT travels server-to-server (no operator
-browser in the loop); you get a redirect-back toast when the upload
-finishes (success or failure). The staging file is unlinked
-immediately after the upload acknowledges.
+The panel stages the bundle to a temp file under `cache/exports/`,
+then HTTPS-PUTs it to your presigned URL. The PUT is
+server-to-server. You get a redirect-back toast on completion.
+The staging file is unlinked once the upload acknowledges.
 
-**When to use**: scheduled backups, multi-GiB bundles where the
-browser-to-panel hop is the bottleneck, hand-off to cloud
-analytics pipelines.
+**Use for**: scheduled backups, multi-GiB bundles, hand-off to
+cloud analytics.
 
-**When not to use**: when you don't have an S3-compatible
-destination — AWS S3, Cloudflare R2, MinIO, Wasabi, Backblaze
-B2 (with `--check-eligible-for-batch-api` style auth), etc. all
-work; raw FTP / SCP / Dropbox do not.
+**Skip when**: you don't have an S3-compatible destination. AWS
+S3, Cloudflare R2, MinIO, Wasabi, Backblaze B2 all work. Raw FTP
+/ SCP / Dropbox don't.
 
 <Aside type="caution">
 The presigned URL is a **single-use write credential**. Anyone
-who sees it can PUT arbitrary content to your bucket until the
-URL expires. Use a short expiry (≤1 hour), generate the URL
-fresh per export, and never paste it into chat / public logs /
-issue trackers.
+with the URL can PUT to your bucket until it expires. Use a
+short expiry (1 hour or less), generate fresh per export, and
+never paste it into chat, public logs, or issue trackers.
 </Aside>
 
 </TabItem>
@@ -245,7 +203,7 @@ issue trackers.
 
 ## Generating a presigned PUT URL
 
-Pick the workflow that matches your S3-compatible destination:
+Pick the workflow that matches your destination:
 
 <Tabs>
 <TabItem label="AWS S3">
@@ -257,14 +215,14 @@ aws s3 presign \
     --expires-in 3600
 ```
 
-Output is the presigned URL — paste it directly into the panel
-form. The URL is valid for one hour (3600 seconds) from generation.
+The output is the presigned URL. Paste it into the panel form.
+Valid for one hour (3600 seconds).
 
 </TabItem>
 <TabItem label="Cloudflare R2">
 
-R2 uses the same SigV4 signing scheme as AWS S3. With the `aws`
-CLI configured against an R2 token:
+R2 uses the same SigV4 signing as AWS S3. With the `aws` CLI
+configured against an R2 token:
 
 ```bash
 aws s3 presign \
@@ -274,8 +232,8 @@ aws s3 presign \
     --endpoint-url https://<account-id>.r2.cloudflarestorage.com
 ```
 
-Alternatively use the R2 dashboard's "Generate URL" tool or
-`wrangler r2 object put` with the `--presign` flag.
+The R2 dashboard's "Generate URL" tool and `wrangler r2 object put
+--presign` also work.
 
 </TabItem>
 <TabItem label="MinIO">
@@ -287,97 +245,82 @@ mc alias set myminio https://minio.example.com ACCESS_KEY SECRET_KEY
 mc share upload --expire 1h myminio/your-bucket/path/sbpp-export.zip
 ```
 
-The `share upload` output prints both a `curl` command and the
-raw presigned URL. Copy just the URL into the panel form.
+`share upload` prints both a `curl` command and the raw URL. Copy
+just the URL into the panel form.
 
 </TabItem>
 </Tabs>
 
 ## Cap: 4 GiB minus 64 MiB safety margin
 
-The panel enforces a hard cap of **4 GiB minus 64 MiB** on the
-estimated bundle size. The cap comes from the ZIP 2.0 spec ceiling
-(4 GiB per archive / per-entry) — we deliberately don't enable
-ZIP64 because not every downstream tool supports it cleanly, and
-the safety margin gives the in-stream writer headroom to land
-without tripping the cap mid-stream.
+The panel enforces a hard cap of 4 GiB minus 64 MiB on the
+estimated bundle. The cap comes from the ZIP 2.0 spec ceiling;
+ZIP64 is not enabled because consumer support is uneven. The
+margin gives the writer headroom.
 
 When the cap is exceeded:
 
-- The admin export page renders the form with **both submit
-  buttons disabled**.
-- An `.empty-state` block appears explaining the situation and
-  pointing at the typical remediation: prune old demos via the
-  bans list, or trim unrelated rows (banlog, audit log).
-- The cap is re-enforced at the entry point's pre-flight pass, so
-  a hand-edited stale-tab POST also bounces.
+- The export page disables both submit buttons.
+- An empty-state block points at the typical fix: prune demos via
+  the bans list, or trim banlog / audit-log rows.
+- The cap is re-checked at the entry point, so a stale-tab POST
+  also bounces.
 
-If you genuinely need to export a >4 GiB dataset, the right move
-is to split: prune the demos directory of anything not currently
-under active appeal, run the export, then restore the demos
-afterward. Future versions may add a chunked / multipart S3
-upload mode for very large bundles; the current architecture
-explicitly chooses one-shot simplicity.
+For a genuinely larger dataset, prune the demos directory of
+anything not under active appeal, run the export, then restore.
+A future version may add chunked / multipart S3 upload.
 
 ## Audit log
 
-Every export attempt — success or failure — lands an entry in the
-panel's audit log (`?p=admin&c=audit`). The entry carries:
+Every attempt (success or failure) lands a row in
+`?p=admin&c=audit`. The row carries:
 
 - The acting admin's `aid` and Steam ID.
 - The mode (`zip` or `s3`).
-- The bundle's UUIDv4 (so a downstream "where did this file come
-  from?" question is answerable from the audit row).
-- On success: the estimated and actual bundle byte count.
+- The bundle's UUIDv4.
+- On success: estimated and actual bundle byte count.
 - On failure: the `ExportError` code (e.g. `cap_exceeded`,
-  `s3_put_failed`, `presign_invalid_url`) and a truncated copy of
-  the underlying error message for diagnostics.
+  `s3_put_failed`, `presign_invalid_url`) and a truncated copy
+  of the underlying error message.
 
-If your panel sits behind a SIEM or audit-forwarder, the bundle
-export is a load-bearing event to monitor — every successful
-export is a PII-class data flow off the panel.
+If you forward audit logs to a SIEM, treat each successful export
+as a PII-class data flow.
 
-## Security model summary
+## Security model
 
 | Aspect | Contract |
 | ------ | -------- |
-| Permission | `OWNER` only. No delegated flag; not configurable. |
-| CSRF | Every POST is gated through `Sbpp\Security\CSRF`. A stale tab cannot trigger an export. |
-| Transport (ZIP) | TLS where the panel is reachable via TLS (operator concern). |
-| Transport (S3) | `https://` only. The panel refuses `http://` URLs server-side regardless of caller. |
-| Password hashes | Never emitted. Hard-coded SQL filter. |
-| Audit | Every attempt logged with acting admin + bundle ID + outcome. |
-| Staging file | Removed immediately on upload completion or process exit (shutdown hook). |
-| Presigned URL | Single-use. Operator generates, panel uses once. The panel does not store the URL anywhere persistent. |
+| Permission | `OWNER` only. Not configurable. |
+| CSRF | Required on every POST. |
+| Transport (ZIP) | TLS where the panel is reachable via TLS. |
+| Transport (S3) | `https://` only. The panel refuses `http://` server-side. |
+| Password hashes | Never emitted. SQL filter. |
+| Audit | Every attempt logged with admin + bundle ID + outcome. |
+| Staging file | Removed on upload completion or process exit. |
+| Presigned URL | Single-use. Operator generates; panel uses once. Not stored. |
 
 ## Troubleshooting
 
-**"Export failed — The bundle would exceed the 4 GiB ZIP 2.0 cap"**
+**"Bundle exceeds the 4 GiB cap"**
 :   See the cap section above. Prune demos or split the export.
 
-**"Export failed — Presigned URL must use HTTPS"**
-:   You pasted an `http://` URL. Re-generate with HTTPS.
-    The panel refuses cleartext transit for a PII-class dataset
-    server-side; flipping it to permit `http://` is unsupported.
+**"Presigned URL must use HTTPS"**
+:   You pasted an `http://` URL. Regenerate with HTTPS. Cleartext
+    transit is unsupported.
 
-**"Export failed — The S3 endpoint rejected the upload"**
-:   The audit log carries the HTTP status + response body. Common
-    causes: presigned URL expired (regenerate with a longer expiry),
-    SigV4 signature mismatch (clock skew between the panel and
-    your S3 client — sync via NTP), bucket policy denies PUT
-    (check the bucket's IAM policy).
+**"S3 rejected the upload"**
+:   Audit log carries the HTTP status and response. Common
+    causes: URL expired (regenerate with longer expiry), SigV4
+    signature mismatch (clock skew; sync NTP), bucket policy
+    denies PUT.
 
 **ZIP download stops partway through**
-:   Either the operator closed the tab (audit log shows a
-    truncated bundle for that aid) or the panel hit the
-    `cap_exceeded` gate mid-stream. The latter shouldn't happen
-    in production because the pre-flight pass gates first, but a
-    pathological "the on-disk demo file grew between pre-flight
-    and stream" race is possible. Re-run; the second pass picks
-    up the larger size.
+:   Either you closed the tab (the audit log shows a truncated
+    bundle for that aid) or the panel hit `cap_exceeded`
+    mid-stream. The pre-flight pass blocks the latter in
+    practice; if it does happen, re-run.
 
 **Want a partial export (just bans, not demos)**
-:   Not currently supported by the chrome — V1 is one-shot
-    full-dataset. The wire format makes a manual partial-extract
-    trivial (`unzip sbpp-export-*.zip entities/bans.jsonl`) so a
-    consumer-side filter is the supported workflow.
+:   Not supported by the form. V1 is one-shot full-dataset.
+    Extract what you need from the bundle:
+    `unzip sbpp-export-*.zip entities/bans.jsonl`.

--- a/web/pages/admin.export.php
+++ b/web/pages/admin.export.php
@@ -116,18 +116,18 @@ function sbpp_admin_export_describe_error(string $code): string
 {
     return match ($code) {
         \Sbpp\Export\ExportError::CAP_EXCEEDED =>
-            'The bundle would exceed the 4 GiB ZIP 2.0 cap. Prune old demos or unrelated rows and retry.',
+            'Bundle exceeds the 4 GiB cap. Prune demos or rows and retry.',
         \Sbpp\Export\ExportError::PRESIGN_INVALID_SCHEME =>
-            'Presigned URL must use HTTPS. Re-generate the URL with an https:// endpoint and retry.',
+            'Presigned URL must use HTTPS. Regenerate it and retry.',
         \Sbpp\Export\ExportError::PRESIGN_INVALID_URL =>
-            'Presigned URL was malformed. Paste the full URL from your S3 client exactly as given.',
+            'Presigned URL is malformed. Paste the full URL from your S3 client.',
         \Sbpp\Export\ExportError::DISK_WRITE_FAILED, \Sbpp\Export\ExportError::DISK_FULL =>
-            'Failed to stage the bundle on disk. Check that cache/ is writable and has free space.',
+            'Could not stage the bundle. Check that cache/ is writable and has free space.',
         \Sbpp\Export\ExportError::S3_PUT_FAILED =>
-            'The S3 endpoint rejected the upload. See the audit log for the HTTP status + response body.',
+            'S3 rejected the upload. See the audit log for the HTTP status and response.',
         'mode_invalid' =>
-            'Unknown export mode. Submit the form via the buttons below.',
+            'Unknown export mode. Use the form buttons.',
         default =>
-            'Export failed. See the audit log for diagnostic details.',
+            'Export failed. See the audit log.',
     };
 }

--- a/web/themes/default/page_admin_export.tpl
+++ b/web/themes/default/page_admin_export.tpl
@@ -27,10 +27,10 @@
     <div class="mb-6">
         <h1 style="font-size:1.5rem;font-weight:600;margin:0">Full data export</h1>
         <p class="text-sm text-muted m-0 mt-2">
-            Stream a one-shot ZIP bundle of every panel row + uploaded demo
-            for backup, migration, or downstream analytics.
+            Download a ZIP bundle of every panel row and uploaded demo.
+            Use it for backups, migration, or analytics.
             See the <a href="https://sbpp.github.io/configuring/data-export/" target="_blank" rel="noopener noreferrer">data-export docs</a>
-            for the on-disk wire format and a worked example for each delivery mode.
+            for the wire format and per-mode setup.
         </p>
     </div>
 
@@ -38,8 +38,7 @@
         <div class="card__header">
             <h2 style="font-size:1.125rem;font-weight:600;margin:0">What's in the bundle</h2>
             <p class="text-xs text-muted m-0 mt-1">
-                A fresh UUIDv4 bundle ID is minted at submit time; the totals below
-                reflect the snapshot taken when this page loaded.
+                Each export gets a fresh bundle ID. Counts below are a snapshot from page load.
             </p>
         </div>
         <div class="card__body">
@@ -106,13 +105,12 @@
                 <span class="empty-state__icon" aria-hidden="true">
                     <i data-lucide="alert-triangle" style="width:18px;height:18px"></i>
                 </span>
-                <h2 class="empty-state__title">Bundle exceeds the 4 GiB ZIP cap</h2>
+                <h2 class="empty-state__title">Bundle exceeds the 4 GiB cap</h2>
                 <p class="empty-state__body">
-                    The estimated bundle ({($estimated_bundle_bytes / 1024 / 1024)|number_format:1} MiB)
-                    overflows the ZIP 2.0 spec ceiling minus the 64 MiB safety margin.
-                    Prune old demos via the per-row Demo affordance on the <a href="?p=banlist">public banlist</a>
-                    or trim unrelated rows (banlog, audit log) and re-load this page.
-                    The submit buttons below are disabled until the bundle fits.
+                    Estimated bundle is {($estimated_bundle_bytes / 1024 / 1024)|number_format:1} MiB.
+                    Prune demos on the <a href="?p=banlist">public banlist</a> or
+                    trim banlog / audit-log rows, then reload.
+                    Submit is disabled until the bundle fits.
                 </p>
             </div>
         </div>
@@ -130,15 +128,11 @@
             </div>
             <div class="card__body space-y-2">
                 <p class="text-sm text-muted m-0">
-                    The browser downloads the bundle directly. The connection
-                    must stay open for the full transfer — close the tab and the
-                    download aborts (cleanly; no on-disk state to clean up).
+                    The browser downloads the bundle directly.
+                    Keep the tab open until it finishes; closing it aborts the transfer.
                 </p>
                 <p class="text-xs text-muted m-0">
-                    No staging file is written; the bundle streams from
-                    <code>php://output</code> through the writer's
-                    <code>flush()</code> calls so the browser's progress bar
-                    moves in real time.
+                    No staging file. The progress bar moves in real time.
                 </p>
             </div>
             <div class="card__header" style="border-top:1px solid var(--border);border-bottom:0;justify-content:flex-end">
@@ -163,10 +157,8 @@
             </div>
             <div class="card__body space-y-2">
                 <p class="text-sm text-muted m-0">
-                    Bundle is staged on disk, then PUT to your presigned URL.
-                    The HTTPS connection holds for the full upload; close the
-                    tab mid-upload and the request aborts but the audit log
-                    captures the partial transfer.
+                    Panel stages the bundle on disk, then PUTs it to your URL.
+                    Closing the tab cancels the upload; the audit log records the attempt.
                 </p>
                 <label class="label mt-3" for="admin-export-s3-url">Presigned PUT URL</label>
                 <textarea class="textarea"
@@ -175,13 +167,12 @@
                           rows="3"
                           required
                           pattern="^https://[^\s]+$"
-                          title="Paste a presigned HTTPS PUT URL from your S3 client (e.g. aws s3 presign --http-method PUT …)"
-                          placeholder="https://bucket.s3.region.amazonaws.com/path/sbpp-export.zip?X-Amz-…"
+                          title="Paste a presigned HTTPS PUT URL from your S3 client (e.g. aws s3 presign --http-method PUT)"
+                          placeholder="https://bucket.s3.region.amazonaws.com/path/sbpp-export.zip?X-Amz-..."
                           data-testid="admin-export-s3-url"></textarea>
                 <p class="text-xs text-muted m-0 mt-1">
-                    HTTPS only (no http://). Use a short expiry (≤1 hour).
-                    Never paste this URL into chat or logs — it's a single-use
-                    write credential.
+                    HTTPS only. Use a short expiry (1 hour or less).
+                    The URL is a single-use write credential; don't paste it in chat or logs.
                 </p>
             </div>
             <div class="card__header" style="border-top:1px solid var(--border);border-bottom:0;justify-content:flex-end">


### PR DESCRIPTION
## Summary

Follow-up to #1475 (full data export). Two paired changes:

- **New Conventions block in `AGENTS.md`** — `User-facing text style (panel UI + docs)`. Three rules: no emdash (`—`), terse, don't over-explain. Scoped to the surfaces operators read: `web/themes/default/**/*.tpl`, `\Sbpp\View\Toast::emit` titles + bodies, `echo` output from page handlers, and every `docs/src/content/docs/**/*.{md,mdx}` page. Explicit carve-out for contributor docs (`AGENTS.md`, `ARCHITECTURE.md`, etc.), PHP/JS/Smarty code comments, audit-log entries, and test fixtures. Paired Anti-patterns entries pin the rule.
- **Wording fixes on the surfaces #1475 added**:
  - `web/themes/default/page_admin_export.tpl` — page intro, bundle summary, cap-exceeded body, ZIP and S3 form descriptions.
  - `web/pages/admin.export.php` — `sbpp_admin_export_describe_error()` error-code translations.
  - `docs/src/content/docs/configuring/data-export.mdx` — every section rewritten for terseness; emdashes removed.

The rule covers the *user-visible* surface only. `AGENTS.md` and code comments still use emdashes freely; both halves of the carve-out are documented.

## Test plan

- [x] `./sbpp.sh phpstan` — clean.
- [x] `./sbpp.sh ts-check` — clean (no JS touched).
- [x] `./sbpp.sh test --filter='ExportBundleWriterTest|EntityExporterTest|ManifestBuilderTest|AdminExport|S3PresignedUploaderTest'` — 44 tests, 603 assertions, green.
- [x] No test pinned the rewritten strings (verified by `rg` against `web/tests/`).
- [x] `rg "—"` over `docs/src/content/docs/configuring/data-export.mdx`, the rendered surface of `web/themes/default/page_admin_export.tpl`, and the user-facing strings in `web/pages/admin.export.php` returns zero matches.
- [ ] Manual smoke: render `?p=admin&c=export` as owner, trigger an `error` redirect via `?result=error&code=presign_invalid_scheme`, confirm the toast body reads as expected.

## Notes

- Tag mapping unchanged. No DB migration. No new permission flag.
- The merge-commit subject of #1475 itself carries an emdash; the rule applies prospectively to user-facing strings, not to historical commit history.