### PR TITLE
refactor(synthesizer): route on-disk letter codes through BanRemoval + LogType enums

### DIFF
--- a/web/tests/Synthesizer.php
+++ b/web/tests/Synthesizer.php
@@ -824,7 +824,9 @@ final class Synthesizer
                 }
             } else {
                 // Admin-removed (~15%).
-                $removeType = mt_rand(0, 1) === 0 ? 'U' : 'D';
+                $removeType = mt_rand(0, 1) === 0
+                    ? \BanRemoval::Unbanned->value
+                    : \BanRemoval::Deleted->value;
                 $removedBy  = $this->randomAdminAid();
                 $removedOn  = $created + mt_rand(60 * 60, 60 * 60 * 24 * 7);
                 if ($removedOn > $this->now) {
@@ -940,7 +942,7 @@ final class Synthesizer
                     $ends    = $created + $length;
                 }
             } else {
-                $removeType = 'U';
+                $removeType = \BanRemoval::Unbanned->value;
                 $removedBy  = $this->randomAdminAid();
                 $removedOn  = $created + mt_rand(60, 60 * 60 * 24);
                 if ($removedOn > $this->now) {
@@ -1225,27 +1227,30 @@ final class Synthesizer
         ));
         // Mix of action types so the audit log filter dropdown
         // (admin / message / type / date) has something to match.
+        $messageType = \LogType::Message->value;
+        $warningType = \LogType::Warning->value;
+        $errorType   = \LogType::Error->value;
         $events = [
-            ['m', 'Ban Added',       'admin added a ban for player'],
-            ['m', 'Ban Edited',      'admin edited a ban'],
-            ['m', 'Ban Unbanned',    'admin unbanned a player'],
-            ['m', 'Comment Added',   'admin added a comment for ban'],
-            ['m', 'Comment Edited',  'admin edited comment'],
-            ['m', 'Server Added',    'admin added server'],
-            ['m', 'Server Edited',   'admin edited server'],
-            ['m', 'Mod Added',       'admin added mod'],
-            ['m', 'Group Added',     'admin added group'],
-            ['m', 'Group Edited',    'admin edited group'],
-            ['m', 'Admin Added',     'admin added admin'],
-            ['m', 'Admin Edited',    'admin edited admin'],
-            ['m', 'Setting Updated', 'admin updated setting'],
-            ['m', 'Submission Archived', 'admin archived submission'],
-            ['m', 'Protest Archived',    'admin archived protest'],
-            ['w', 'Ban Failed',      'failed to add ban: server unreachable'],
-            ['w', 'RCON Failed',     'rcon command timed out'],
-            ['w', 'Permission Denied', 'admin attempted action without flag'],
-            ['e', 'Database Error',  'unexpected SQL state'],
-            ['e', 'Auth Failure',    'invalid login attempt'],
+            [$messageType, 'Ban Added',       'admin added a ban for player'],
+            [$messageType, 'Ban Edited',      'admin edited a ban'],
+            [$messageType, 'Ban Unbanned',    'admin unbanned a player'],
+            [$messageType, 'Comment Added',   'admin added a comment for ban'],
+            [$messageType, 'Comment Edited',  'admin edited comment'],
+            [$messageType, 'Server Added',    'admin added server'],
+            [$messageType, 'Server Edited',   'admin edited server'],
+            [$messageType, 'Mod Added',       'admin added mod'],
+            [$messageType, 'Group Added',     'admin added group'],
+            [$messageType, 'Group Edited',    'admin edited group'],
+            [$messageType, 'Admin Added',     'admin added admin'],
+            [$messageType, 'Admin Edited',    'admin edited admin'],
+            [$messageType, 'Setting Updated', 'admin updated setting'],
+            [$messageType, 'Submission Archived', 'admin archived submission'],
+            [$messageType, 'Protest Archived',    'admin archived protest'],
+            [$warningType, 'Ban Failed',      'failed to add ban: server unreachable'],
+            [$warningType, 'RCON Failed',     'rcon command timed out'],
+            [$warningType, 'Permission Denied', 'admin attempted action without flag'],
+            [$errorType,   'Database Error',  'unexpected SQL state'],
+            [$errorType,   'Auth Failure',    'invalid login attempt'],
         ];
         for ($i = 0; $i < $count; $i++) {
             $ev      = $events[mt_rand(0, count($events) - 1)];


### PR DESCRIPTION
Closes #1483.

## Summary

`web/tests/Synthesizer.php` was the last in-tree PHP-driven write path holding magic single-letter literals for two columns the project's backed enums already wrap. Three sites swapped to the canonical `$enum->value` shape — same on-disk bytes, intent visible at the call site:

| Site | Before | After |
| --- | --- | --- |
| `insertBans()` `RemoveType` (deterministic 50/50) | `mt_rand(0,1) === 0 ? 'U' : 'D'` | `mt_rand(0,1) === 0 ? \BanRemoval::Unbanned->value : \BanRemoval::Deleted->value` |
| `insertComms()` `RemoveType` | `'U'` | `\BanRemoval::Unbanned->value` |
| `insertAuditLog()` event-table type column | inline `'m'` / `'w'` / `'e'` per row | `$messageType` / `$warningType` / `$errorType` locals bound to `\LogType::*->value` once, referenced in every row |

The two `BanRemoval` calls are inside the per-iteration RNG ladders that drive the deterministic seed contract — the rewrites preserve the call order of every `mt_rand()`, the order in which the ternary's two branches are written, and the order in which `$events` rows fan out. Re-seeding with the same `--seed` still produces an identical DB state (verified by a paired re-run + row-count diff under `./sbpp.sh db-seed --scale=medium` × 2).

## Scope decision (`bans.type`)

The issue body's "Out of scope" section explicitly lists `bans.type` (`$isIpOnly ? 1 : 0`) as a fourth candidate that **was deliberately deferred** despite `BanType::Steam` / `BanType::Ip` existing. I considered extending the diff one line (the enum is int-backed so the wire format and RNG sequence would be byte-identical) but kept the original scope to respect the issue author's explicit boundary. The one-line conversion is a reasonable follow-up if/when desired.

## Why the change is safe

- **Deterministic seed contract preserved.** The 50/50 in `insertBans()` writes the ternary's two branches in the same order (`Unbanned` left, `Deleted` right) so `mt_rand(0,1) === 0`'s arm assignment never flips. `insertComms()` is unconditional. `insertAuditLog()` uses fresh locals; the `$events` array is rebuilt in the same row order.
- **Wire format unchanged.** `\BanRemoval::Unbanned->value === 'U'` / `Deleted->value === 'D'` / `\LogType::Message->value === 'm'` / `Warning->value === 'w'` / `Error->value === 'e'` — the on-disk single-character writes are byte-identical to what the seeder wrote pre-fix.
- **Dev-only surface.** `Synthesizer.php` refuses any `DB_NAME` other than `sourcebans`; `sourcebans_test` (PHPUnit) + `sourcebans_e2e` (Playwright) are unaffected by design.

## Quality gates

| Gate | Status |
| --- | --- |
| `./sbpp.sh phpstan` | ✓ no new errors |
| `./sbpp.sh test` | ✓ no new failures (the pre-existing `PluginVersionResolveTest` baseline failure was confirmed unrelated by stashing this diff and re-running) |
| `./sbpp.sh ts-check` | ✓ |
| `./sbpp.sh composer api-contract` | ✓ no diff |
| `./sbpp.sh db-seed --scale=small/medium` | ✓ runs clean; row counts identical across two same-seed runs |
| `./sbpp.sh db-seed --scale=large` | ✓ |

## Test plan

- [x] `./sbpp.sh db-seed` re-runs idempotently with the same seed and yields identical row counts.
- [x] Spot-check `:prefix_bans.RemoveType` distribution: contains only `''` / `'U'` / `'D'` / `'E'` post-seed; the seeder's contribution is a near-50/50 mix of `'U'` and `'D'` on the unbanned-row subset.
- [x] Spot-check `:prefix_comms.RemoveType`: contains only `''` / `'U'` on the seeder's contribution.
- [x] Spot-check `:prefix_log.type`: contains only `'m'` / `'w'` / `'e'`.

## Note on PHPStan coverage

`tests/*` is excluded from `staabm/phpstan-dba`, so the type-narrowing the enum unlocks for production write paths (`web/api/handlers/*.php`, `web/pages/*.php`) isn't checked statically here. The primary win is intent-readability + drift-safety: a future rename of `BanRemoval::Unbanned` would break every consumer in the gate, including this file at runtime.