### PR TITLE
fix(bans): keep validated SteamID-of-record on IP-type bans; hide synthetic community id (#1486)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -833,9 +833,13 @@ of the diff ship together or not at all.
   `ApiError('validation', …, 'steam')` envelope (each test now
   includes the `STEAM_0:0:1\n` / `[U:1:1]\n` / `76561197960265728\n`
   newline-bypass cases as #1423 follow-up #4 regression guards);
-  `web/tests/api/BansTest.php::testAddIpTypeAlwaysWritesEmptyAuthid`
-  pins the IP-type empty-`authid` contract (valid Steam input +
-  garbage + newline-bypass all write empty); the kickit / blockit
+  `web/tests/api/BansTest.php::testAddIpTypeKeepsValidatedSteamOfRecord`
+  pins the #1486 IP-type Steam-of-record contract (valid Steam input
+  is kept alongside the IP, no Steam input writes empty, garbage +
+  newline-bypass are rejected with a `validation` envelope on the
+  `steam` field BEFORE any row is written — the shape gate still runs
+  on the IP-type branch so a junk value can't 500 or get stored); the
+  kickit / blockit
   `SteamID::compare()` pre-`isValidID()` gate is pinned by
   `KickitTest::testKickPlayerReturnsNotFoundForMalformedSteamId` /
   `testKickPlayerReturnsNotFoundForMalformedIp` and
@@ -859,20 +863,25 @@ of the diff ship together or not at all.
      the operator's raw input on the bounce so they see exactly
      what they typed and can correct the typo without re-typing
      everything else).
-   - `admin.edit.ban.php` ON IP-TYPE bans hard-codes
-     `$_POST['steam'] = ''` regardless of whatever the operator
-     typed in the Steam ID field — the column is the *steam id*
-     of the banned player; on an IP-type ban there is no steam id,
-     so the canonical value is the schema's `NOT NULL default ''`
-     empty string (matching `api_bans_add`'s same-PR fix). The
-     pre-#1423-follow-up-#4 shape (the `82e8c3d2` "canonicalise on
-     IP-type" nit) preserved the canonical-on-valid case but
-     failed to suppress the raw-on-invalid case AND continued
-     writing the canonicalised SteamID into `:authid` for IP-only
-     bans — both shapes are wrong. The form-side input remains
-     visible on the IP-type bounce path (re-emit through the
-     template `placeholder`, NOT a stale value), but the DB write
-     is divorced from it.
+   - `admin.edit.ban.php` ON IP-TYPE bans keeps a *validated* Steam
+     ID-of-record when the operator filled both fields (#1486 — parity
+     with `api_bans_add`'s IP-type branch), and writes the schema's
+     `NOT NULL default ''` empty string when the Steam ID field was
+     left blank. Enforcement stays IP-only (the SourceMod plugin
+     matches an IP ban on the `ip` column alone), so the stored authid
+     is inert plugin-side; it exists so the ban detail / banlist can
+     show which account the IP belonged to. The validate-before-convert
+     gate is still load-bearing: a non-empty Steam ID is run through
+     `SteamID::isValidID()` BEFORE `toSteam2()` so a garbage value
+     bounces with `$validationErrors['steam']` (raw input preserved on
+     the bounce, same as the Steam-branch typo path) instead of
+     escaping the converter as a 500 page render. Pre-#1486 the branch
+     hard-cleared `$_POST['steam'] = ''` regardless of input, dropping
+     a SteamID the operator deliberately typed; #1486 reversed that to
+     keep-when-valid. (The older `82e8c3d2` "canonicalise on IP-type"
+     nit had a worse shape still — it stored a *canonicalised* SteamID
+     but failed to suppress the raw-on-invalid case; #1486's
+     validate-then-convert ladder fixes both.)
    - `page.submit.php` doesn't call `SteamID::toSteam2()` at all —
      it stores the raw user-input verbatim in `:prefix_submissions`
      and the moderation queue resolves the canonical form on
@@ -4336,37 +4345,42 @@ contributions without contacting every contributor individually.
   + `BansTest.php` + `AdminsTest.php` (the
   `"STEAM_0:0:1\n"` / `"[U:1:1]\n"` / `"76561197960265728\n"`
   cases pin the wire-side behavior).
-- Storing the operator-typed Steam ID in `:prefix_bans.authid`
-  on an IP-type ban (the `82e8c3d2` "canonicalise valid IDs on
-  IP-type bans to match pre-tighter behaviour" nit shape) → the
-  `:authid` column is the *steam id* of the banned player. On
-  an IP-type ban (`BanType::Ip = 1`) there is no steam id, by
-  definition; the canonical "no steam id" value is the schema's
-  `NOT NULL default ''` empty string. The `82e8c3d2` nit aimed
-  to preserve "pre-tightening behavior" for the case where the
-  operator typed a valid-looking SteamID into the form's
-  Steam ID box and then flipped the type radio to "IP-type" —
-  pre-tightening the unconditional `toSteam2($rawSteam)` would
-  have stored the canonicalised value in `:authid` AND the
-  unconditional run would have raised on `garbage` and 500'd
-  the page. The nit canonicalised the valid case (good
-  intention) but didn't suppress the storage path (the bug it
-  carried), AND failed to defend the invalid-input branch on
-  the IP-type arm (the 500 was still reachable via
-  `?type=1&steam=garbage`). The right shape is: hard-code
-  `$_POST['steam'] = ''` for `$banType === BanType::Ip` and
-  let the operator's form input remain visible only as
-  client-side echo (template `placeholder`, NOT a stale value).
-  Matches the `api_bans_add` write-side fix in the same PR
-  (`$steam = $banType === BanType::Ip ? '' : ...`). The
-  asymmetry pre-#1423-follow-up-#4 (page handler stored
-  canonicalised, JSON handler stored empty) was its own bug
-  class — third-party callers POSTing to the iframe-routed
-  page handler vs. the JSON dispatcher produced inconsistent
-  DB state for the same logical input. Regression guard:
-  `web/tests/api/BansTest.php::testAddIpTypeAlwaysWritesEmptyAuthid`
-  (valid Steam input + garbage + newline-bypass all write
-  empty `authid` on `type=1`).
+- Storing an UNVALIDATED operator-typed Steam ID in
+  `:prefix_bans.authid` on an IP-type ban → as of #1486 an IP-type
+  ban DOES keep a Steam ID-of-record when the operator fills both
+  fields (the schema has always had separate `ip` + `authid`
+  columns; enforcement stays IP-only because the SourceMod plugin
+  matches an IP ban on the `ip` column alone, so the stored authid
+  is inert plugin-side and exists only so the ban detail / banlist
+  can show which account the IP belonged to). What stays forbidden
+  is storing it WITHOUT the shape gate: the value MUST pass
+  `SteamID::isValidID()` (page handler) / `HANDLER_STRICT_REGEX`
+  (JSON handler) BEFORE `toSteam2()`, exactly like the Steam-type
+  branch. Skipping the gate re-opens two bug classes — (a) a junk
+  value (`?type=1&steam=garbage`) escapes `toSteam2()` as
+  `Exception('Invalid SteamID input!')` → 500 (the #1420 / #1423
+  follow-up #4 class), and (b) a malformed authid lands on disk and
+  the drawer / banlist later derive a synthetic `community_id`
+  (`STEAM_0:0:0`) off it (#1486's display bug). The right shape is
+  the validate-then-convert ladder: empty Steam ID → write `''`
+  (nothing recorded); non-empty → shape-gate → `toSteam2()` → store;
+  bad shape → `validation` envelope (JSON) / `$validationErrors['steam']`
+  bounce with raw input preserved (page handler). Both surfaces
+  (`api_bans_add` + `admin.edit.ban.php`) share the ladder so the
+  JSON dispatcher and the iframe-routed page handler can't diverge
+  on the same logical input. The pre-#1486 shape hard-cleared
+  `authid` for `type=1`, silently dropping a SteamID the operator
+  deliberately typed; the older `82e8c3d2` "canonicalise on IP-type"
+  nit stored a *canonicalised* value but failed to suppress the
+  raw-on-invalid path — both are superseded by the gated keep.
+  Regression guard:
+  `web/tests/api/BansTest.php::testAddIpTypeKeepsValidatedSteamOfRecord`
+  (valid Steam input kept alongside the IP, empty input writes
+  empty `authid`, garbage + newline-bypass rejected with a
+  `validation` envelope on the `steam` field before any row is
+  written) +
+  `web/tests/integration/SteamIDValidationOrderTest.php` (pins the
+  validate-before-convert order in `admin.edit.ban.php`).
 - Calling `SteamID::compare($a, $b)` (or any other
   `SteamID::*` method that funnels through `toSteam64()` /
   `resolveInputID()`) with operator-controlled input that

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -836,9 +836,11 @@ of the diff ship together or not at all.
   `web/tests/api/BansTest.php::testAddIpTypeKeepsValidatedSteamOfRecord`
   pins the #1486 IP-type Steam-of-record contract (valid Steam input
   is kept alongside the IP, no Steam input writes empty, garbage +
-  newline-bypass are rejected with a `validation` envelope on the
-  `steam` field BEFORE any row is written — the shape gate still runs
-  on the IP-type branch so a junk value can't 500 or get stored); the
+  non-trimmable malformed shapes — mid-string `\n` — are rejected with
+  a `validation` envelope on the `steam` field BEFORE any row is
+  written, while a trailing-newline `STEAM_0:0:1\n` trims to a valid
+  `STEAM_0:0:1` and is kept; the shape gate still runs on the IP-type
+  branch so a junk value can't 500 or get stored); the
   kickit / blockit
   `SteamID::compare()` pre-`isValidID()` gate is pinned by
   `KickitTest::testKickPlayerReturnsNotFoundForMalformedSteamId` /
@@ -4376,9 +4378,10 @@ contributions without contacting every contributor individually.
   Regression guard:
   `web/tests/api/BansTest.php::testAddIpTypeKeepsValidatedSteamOfRecord`
   (valid Steam input kept alongside the IP, empty input writes
-  empty `authid`, garbage + newline-bypass rejected with a
-  `validation` envelope on the `steam` field before any row is
-  written) +
+  empty `authid`, garbage + non-trimmable malformed shapes — mid-string
+  `\n` — rejected with a `validation` envelope on the `steam` field
+  before any row is written, trailing-newline trims to a valid value
+  and is kept) +
   `web/tests/integration/SteamIDValidationOrderTest.php` (pins the
   validate-before-convert order in `admin.edit.ban.php`).
 - Calling `SteamID::compare($a, $b)` (or any other

--- a/web/api/handlers/bans.php
+++ b/web/api/handlers/bans.php
@@ -71,19 +71,29 @@ function api_bans_add(array $params): array
         if (!preg_match(SteamID::HANDLER_STRICT_REGEX, $rawSteam)) {
             throw new ApiError('validation', 'Please enter a valid Steam ID or Community ID', 'steam');
         }
+    } elseif ($rawSteam !== '') {
+        // #1486: IP-type ban where the operator ALSO filled the Steam ID
+        // field. Keep it as a record-of-fact alongside the IP instead of
+        // silently dropping the input. Enforcement stays IP-only — the
+        // SourceMod plugin matches an IP ban purely on the `ip` column
+        // (sbpp_main.sp: `(type=0 AND authid…) OR (type=1 AND ip…)`), so
+        // this authid is inert plugin-side; it exists only so the ban
+        // detail / banlist can show which account the IP belonged to.
+        //
+        // The shape gate is still load-bearing: an unvalidated
+        // `toSteam2('garbage')` throws `Invalid SteamID input!` and the
+        // dispatcher's `Throwable` fallback turns it into a 500 envelope
+        // (the #1420 / #1423 follow-up #4 bug class). Validate before
+        // convert so the recorded id can't be corrupt and the add can't
+        // 500. An empty Steam ID field on an IP ban is fine (no record).
+        if (!preg_match(SteamID::HANDLER_STRICT_REGEX, $rawSteam)) {
+            throw new ApiError('validation', 'Please enter a valid Steam ID or Community ID', 'steam');
+        }
     }
-    // For IP-typed bans the `:authid` column is the *steam id*, of which
-    // there is none — write empty string regardless of whatever the
-    // caller passed in `$rawSteam`. Pre-#1423 follow-up #4 the handler
-    // converted any non-empty `$rawSteam` here without re-running the
-    // shape gate (which was Steam-branch-only), so a hostile / typo'd
-    // caller passing `type=1&steam=garbage&ip=1.2.3.4` triggered
-    // `toSteam2('garbage')` → `Exception('Invalid SteamID input!')` →
-    // `Api::handle` `Throwable` fallback → 500 envelope (the bug class
-    // #1420 was supposed to close, surfacing on the IP-type branch the
-    // original review didn't cover). The page-handler sibling
-    // (`admin.edit.ban.php`) carries the matching write-side fix.
-    $steam = $banType === BanType::Ip ? '' : ($rawSteam === '' ? '' : SteamID::toSteam2($rawSteam));
+    // Steam bans require a SteamID; IP bans keep it only when one was
+    // typed (empty otherwise). The shape gate above guarantees this
+    // conversion cannot throw on either branch.
+    $steam = $rawSteam === '' ? '' : SteamID::toSteam2($rawSteam);
     if (empty($ip) && $banType === BanType::Ip) {
         throw new ApiError('validation', 'You must type an IP', 'ip');
     }
@@ -891,15 +901,20 @@ function api_bans_detail(array $params): array
         $state = 'active';
     }
 
+    // An IP-type ban carries a SteamID only when the operator typed one
+    // (#1486 made it a record-of-fact); otherwise authid is empty. Some
+    // legacy rows also hold malformed authids (#900). Gate steam2 on the
+    // shape check so toSteam3() / the community id below never derive a
+    // synthetic value from an empty or junk authid.
     $steam2 = $authid !== '' && SteamID::isValidID($authid) ? $authid : '';
-    // Some legacy rows hold malformed authids (#900); fall back to a
-    // canonical placeholder so toSteam3() doesn't blow up the response.
     $steam3 = $steam2 !== '' ? (string)SteamID::toSteam3($steam2) : '';
-    // #1486: community_id is computed in SQL straight off BA.authid. An
-    // empty authid (IP-type ban — see api_bans_add's IP-type branch and
-    // testAddIpTypeAlwaysWritesEmptyAuthid) collapses the arithmetic to the
-    // base 76561197960265728 (STEAM_0:0:0), which the drawer rendered as a
-    // bogus "Community" id. Gate it on the same validity check as steam2/3.
+    // #1486: community_id is computed in SQL straight off BA.authid, so an
+    // empty authid (IP-type ban with no recorded SteamID) or a malformed
+    // one collapses the arithmetic to the base 76561197960265728
+    // (STEAM_0:0:0) — the bogus "Community" id the drawer used to paint.
+    // Gate it on the same validity check as steam2/3 so it surfaces ONLY
+    // when there's a real SteamID behind it (Steam bans, or IP bans where
+    // the operator recorded one).
     $communityId = $steam2 !== '' ? (string)$row['community_id'] : '';
 
     $removedByName = null;

--- a/web/api/handlers/bans.php
+++ b/web/api/handlers/bans.php
@@ -895,6 +895,12 @@ function api_bans_detail(array $params): array
     // Some legacy rows hold malformed authids (#900); fall back to a
     // canonical placeholder so toSteam3() doesn't blow up the response.
     $steam3 = $steam2 !== '' ? (string)SteamID::toSteam3($steam2) : '';
+    // #1486: community_id is computed in SQL straight off BA.authid. An
+    // empty authid (IP-type ban — see api_bans_add's IP-type branch and
+    // testAddIpTypeAlwaysWritesEmptyAuthid) collapses the arithmetic to the
+    // base 76561197960265728 (STEAM_0:0:0), which the drawer rendered as a
+    // bogus "Community" id. Gate it on the same validity check as steam2/3.
+    $communityId = $steam2 !== '' ? (string)$row['community_id'] : '';
 
     $removedByName = null;
     if ($row['RemovedBy'] !== null && (int)$row['RemovedBy'] > 0 && !$hideAdmin) {
@@ -942,7 +948,7 @@ function api_bans_detail(array $params): array
             'type'         => $type,
             'steam_id'     => $steam2,
             'steam_id_3'   => $steam3,
-            'community_id' => (string)$row['community_id'],
+            'community_id' => $communityId,
             'ip'           => $hideIps || $banIp === '' ? null : $banIp,
             'country'      => !empty($row['country']) && trim((string)$row['country']) !== '' ? (string)$row['country'] : null,
         ],

--- a/web/api/handlers/comms.php
+++ b/web/api/handlers/comms.php
@@ -503,6 +503,13 @@ function api_comms_detail(array $params): array
 
     $steam2 = $authid !== '' && SteamID::isValidID($authid) ? $authid : '';
     $steam3 = $steam2 !== '' ? (string)SteamID::toSteam3($steam2) : '';
+    // #1486: community_id is computed in SQL straight off C.authid. A
+    // comm block can't be IP-typed, but a malformed/empty legacy authid
+    // (#900) collapses the arithmetic to the base 76561197960265728
+    // (STEAM_0:0:0). Gate it on the same validity check as steam2/3 so the
+    // drawer never paints a synthetic "Community" id (parity with
+    // api_bans_detail).
+    $communityId = $steam2 !== '' ? (string)$row['community_id'] : '';
 
     $removedByName = null;
     if ($row['RemovedBy'] !== null && (int)$row['RemovedBy'] > 0 && !$hideAdmin) {
@@ -553,7 +560,7 @@ function api_comms_detail(array $params): array
             'name'         => (string)$row['name'],
             'steam_id'     => $steam2,
             'steam_id_3'   => $steam3,
-            'community_id' => (string)$row['community_id'],
+            'community_id' => $communityId,
             // Comm rows don't store an IP — `:prefix_comms` has no `ip`
             // column. Always null; the field is only here so the
             // drawer's `renderOverviewPane` can read `player.ip`

--- a/web/pages/admin.edit.ban.php
+++ b/web/pages/admin.edit.ban.php
@@ -143,22 +143,16 @@ if (isset($_POST['name'])) {
     // pass. Empty input is its own error message; non-empty-but-bad
     // is "please enter a valid…".
     //
-    // The IP-type branch writes `:authid = ''` regardless of whatever
-    // happened to be in the Steam ID input. The column is the *steam
-    // id* of the banned player; on an IP-type ban there is no steam
-    // id, so the canonical value is the schema's `NOT NULL default ''`
-    // empty string — matching the API handler (`api_bans_add`'s
-    // INTENT pre-#1423 follow-up #4, fully enforced after that PR)
-    // and matching the v1.x library's "throw on garbage" outcome
-    // (pre-tightening the unconditional `toSteam2($rawSteam)` would
-    // have raised on `garbage` and the page died with a 500; storing
-    // user-typed garbage into `:authid` is a regression introduced
-    // by the 82e8c3d2 "canonicalise valid IDs on IP-type bans" nit
-    // that preserved the canonical-on-valid case but failed to
-    // suppress the raw-on-invalid case). The form-side input remains
-    // visible on the IP-type bounce path (re-emit through the
-    // `placeholder` on the template, NOT a stale value), but the DB
-    // write is divorced from it.
+    // #1486: the IP-type branch keeps the Steam ID as a record-of-fact
+    // when the operator filled both fields, instead of dropping it. The
+    // SourceMod plugin enforces an IP ban on the `ip` column ONLY
+    // (sbpp_main.sp: `(type=0 AND authid…) OR (type=1 AND ip…)`), so the
+    // stored authid is inert plugin-side; it exists so the ban detail /
+    // banlist can show which account the IP belonged to. The shape gate
+    // still runs before `toSteam2()` so a garbage value can't escape as
+    // an uncaught Exception (500 page render) — same validate-then-convert
+    // ladder as the Steam branch, mirrored in `api_bans_add`. An empty
+    // Steam ID field on an IP ban records nothing.
     if ($postBanType === BanType::Steam) {
         if ($rawSteam === '') {
             $error++;
@@ -178,14 +172,22 @@ if (isset($_POST['name'])) {
             // through the shared `ID_PATTERNS` table.
             $_POST['steam'] = \SteamID\SteamID::toSteam2($rawSteam);
         }
-    } else {
-        // IP-type ban: clear the steam slot for the DB write below
-        // (`:authid = $_POST['steam']` rides this). Whatever the
-        // operator happened to type in the Steam ID field stays
-        // visible in `$rawSteam` for any client-side echo, but it
-        // does NOT land in the DB. See the block comment above for
-        // the schema rationale.
+    } elseif ($rawSteam === '') {
+        // IP-type ban, no Steam ID typed: nothing to record.
         $_POST['steam'] = '';
+    } elseif (!\SteamID\SteamID::isValidID($rawSteam)) {
+        // IP-type ban with a typed Steam ID-of-record: validate its shape
+        // before converting so a garbage value can't escape `toSteam2()`
+        // as an uncaught Exception. Bounce with the raw input preserved,
+        // same as the Steam-branch typo path above.
+        $error++;
+        $validationErrors['steam'] = 'Please enter a valid Steam ID or Community ID';
+        $_POST['steam'] = $rawSteam;
+    } else {
+        // Keep the canonical Steam ID alongside the IP (record-of-fact;
+        // enforcement is IP-only). Parity with `api_bans_add`'s IP-type
+        // branch.
+        $_POST['steam'] = \SteamID\SteamID::toSteam2($rawSteam);
     }
 
     if ($error === 0 && empty($_POST['ip']) && $postBanType === BanType::Ip) {

--- a/web/tests/api/BansTest.php
+++ b/web/tests/api/BansTest.php
@@ -255,18 +255,36 @@ final class BansTest extends ApiTestCase
         $this->assertSame('steam', $env['error']['field']);
         $this->assertNull($this->row('bans', ['ip' => '203.0.113.43']), 'garbage steam must NOT create an IP ban row');
 
-        // 4) Newline-bypass `steam` with `type=1`. Same shape gate
-        //    (`HANDLER_STRICT_REGEX` carries the `D` modifier), same
-        //    rejection.
+        // 4) Non-trimmable malformed `steam` with `type=1`. The handler
+        //    trims `$rawSteam` first, so a trailing newline (`STEAM_0:0:1\n`)
+        //    is stripped to the valid `STEAM_0:0:1` (see case 5) — the gate
+        //    only has to catch shapes `trim()` can't fix. A MID-string
+        //    newline is the canonical such case, mirroring the Steam-branch
+        //    lockstep in testAddRejectsInvalidSteamIdShapeForType0.
         $env = $this->api('bans.add', [
-            'nickname' => 'IpType_newlineSteam', 'type' => 1,
-            'steam' => "STEAM_0:0:1\n", 'ip' => '203.0.113.44',
-            'length' => 0, 'reason' => 'ip ban with newline steam input',
+            'nickname' => 'IpType_malformedSteam', 'type' => 1,
+            'steam' => "STEAM_0:0:1\nGARBAGE", 'ip' => '203.0.113.44',
+            'length' => 0, 'reason' => 'ip ban with malformed steam input',
             'fromsub' => 0,
         ]);
         $this->assertEnvelopeError($env, 'validation');
         $this->assertSame('steam', $env['error']['field']);
-        $this->assertNull($this->row('bans', ['ip' => '203.0.113.44']), 'newline-bypass steam must NOT create an IP ban row');
+        $this->assertNull($this->row('bans', ['ip' => '203.0.113.44']), 'malformed steam must NOT create an IP ban row');
+
+        // 5) Trailing-newline `steam` with `type=1`: `trim()` strips it to
+        //    the valid `STEAM_0:0:1`, which is then kept as the record (the
+        //    handler is symmetric with the Steam branch here — the regex's
+        //    own newline-bypass rejection is pinned at the library level by
+        //    SteamIDValidationTest::testHandlerStrictRegexRejectsNewlineBypass).
+        $env = $this->api('bans.add', [
+            'nickname' => 'IpType_trailingNewline', 'type' => 1,
+            'steam' => "STEAM_0:0:1\n", 'ip' => '203.0.113.46',
+            'length' => 0, 'reason' => 'ip ban with trailing-newline steam',
+            'fromsub' => 0,
+        ]);
+        $this->assertTrue($env['ok'], 'trailing-newline trims to a valid steam and is kept');
+        $row = $this->row('bans', ['ip' => '203.0.113.46']);
+        $this->assertSame('STEAM_0:0:1', (string) $row['authid'], 'trimmed steam is stored on the IP ban');
     }
 
     public function testAddValidationNegativeLength(): void

--- a/web/tests/api/BansTest.php
+++ b/web/tests/api/BansTest.php
@@ -525,6 +525,38 @@ final class BansTest extends ApiTestCase
             . 'api_bans_detail (parity with the page handler\'s SQL filter)');
     }
 
+    public function testDetailIpTypeBanReportsNoSteamOrCommunityId(): void
+    {
+        // #1486: an IP-type ban stores an empty authid (see
+        // testAddIpTypeAlwaysWritesEmptyAuthid). community_id is computed in
+        // SQL straight off authid, so an empty authid collapsed the
+        // arithmetic to the base 76561197960265728 (STEAM_0:0:0) and the
+        // drawer rendered a bogus "Community" id. steam_id / steam_id_3 were
+        // already gated on SteamID::isValidID(); community_id must match.
+        // The report's scenario is "fill out both IP and SteamID, pick IP
+        // type" — the SteamID is dropped and the IP is the row's real
+        // identity, so it must still surface. Assert as admin so
+        // banlist.hideplayerips can't mask the IP regardless of seed defaults.
+        $this->loginAsAdmin();
+        $pdo = Fixture::rawPdo();
+        $pdo->prepare(sprintf(
+            'INSERT INTO `%s_bans` (created, type, ip, authid, name, ends, length, reason, aid, adminIp)
+             VALUES (UNIX_TIMESTAMP(), 1, ?, "", ?, UNIX_TIMESTAMP(), 0, ?, ?, "127.0.0.1")',
+            DB_PREFIX
+        ))->execute(['203.0.113.77', 'IpOnly', 'ip-type ban', Fixture::adminAid()]);
+        $bid = (int) $pdo->lastInsertId();
+
+        $env = $this->api('bans.detail', ['bid' => $bid]);
+        $this->assertTrue($env['ok'], json_encode($env));
+        $this->assertSame(1, $env['data']['player']['type'], 'seeded ban is IP-type');
+        $this->assertSame('', $env['data']['player']['steam_id']);
+        $this->assertSame('', $env['data']['player']['steam_id_3']);
+        $this->assertSame('', $env['data']['player']['community_id'],
+            'IP-type ban (empty authid) must not surface a synthetic community id (#1486)');
+        $this->assertSame('203.0.113.77', $env['data']['player']['ip'],
+            'IP-type ban must still surface the IP as the row identity (#1486)');
+    }
+
     public function testAddCommentInsertsRow(): void
     {
         $this->loginAsAdmin();

--- a/web/tests/api/BansTest.php
+++ b/web/tests/api/BansTest.php
@@ -198,69 +198,75 @@ final class BansTest extends ApiTestCase
     }
 
     /**
-     * #1423 follow-up #4 — pre-fix the IP-type ban path had two bugs:
+     * #1486 — IP-type bans keep a Steam ID-of-record when the operator
+     * fills both fields, instead of silently dropping it. The schema has
+     * always had room (separate `ip` + `authid` columns); the previous
+     * code hard-cleared `authid` for `type=1`. Enforcement stays IP-only
+     * (the SourceMod plugin matches an IP ban on the `ip` column alone),
+     * so the recorded authid is inert plugin-side; it exists so the ban
+     * detail / banlist can show which account the IP belonged to.
      *
-     *   1. Stored whatever the caller passed in `$rawSteam` into
-     *      `:prefix_bans.authid` if it happened to be a valid shape
-     *      (the `$rawSteam === '' ? '' : SteamID::toSteam2($rawSteam)`
-     *      ternary ignored `$banType`). On an IP-type ban the
-     *      `:authid` column is the *steam id*, of which there is
-     *      none — the schema's `NOT NULL default ''` is the
-     *      canonical "no steam id" value.
-     *   2. Raised a generic 500 (`SteamID::toSteam2('garbage')` →
-     *      `Exception('Invalid SteamID input!')` → `Api::handle`
-     *      `Throwable` fallback) when the caller's `$rawSteam` was
-     *      non-empty AND failed the library shape gate. The
-     *      Steam-branch `preg_match` doesn't run on IP-type bans
-     *      (its `if ($banType === BanType::Steam)` short-circuits),
-     *      so a hostile caller posting `type=1&steam=garbage`
-     *      reliably 500'd the panel.
-     *
-     * The fix hard-codes `$steam = ''` for `$banType === BanType::Ip`
-     * — whatever the caller passed in `$rawSteam` is irrelevant on
-     * an IP-type ban; the column is empty by definition.
+     * The shape gate from #1423 follow-up #4 is preserved: a non-empty
+     * Steam ID on an IP ban is validated BEFORE `toSteam2()` so a garbage
+     * value can't escape as `Exception('Invalid SteamID input!')` → 500
+     * envelope. Garbage now returns a structured `validation` error on
+     * the `steam` field instead of either 500ing (the original bug) or
+     * being silently swallowed (the pre-#1486 drop). An empty Steam ID
+     * field on an IP ban records nothing.
      */
-    public function testAddIpTypeAlwaysWritesEmptyAuthid(): void
+    public function testAddIpTypeKeepsValidatedSteamOfRecord(): void
     {
         $this->loginAsAdmin();
         // 1) Valid Steam-shape `steam` with `type=1` (IP-type ban).
-        //    Pre-fix this would have canonicalised + stored
-        //    `STEAM_0:1:9999` in `:authid`; the fix writes empty.
+        //    The canonical SteamID is stored alongside the IP.
         $env = $this->api('bans.add', [
             'nickname' => 'IpType_validSteam', 'type' => 1,
             'steam' => 'STEAM_0:1:9999', 'ip' => '203.0.113.42',
             'length' => 0, 'reason' => 'ip ban with steam input',
             'fromsub' => 0,
         ]);
-        $this->assertTrue($env['ok'], 'IP-type ban should succeed regardless of steam input');
+        $this->assertTrue($env['ok'], 'IP-type ban with a valid steam should succeed');
         $row = $this->row('bans', ['ip' => '203.0.113.42']);
-        $this->assertSame('', (string) $row['authid'], 'IP-type ban must write empty authid');
+        $this->assertSame('STEAM_0:1:9999', (string) $row['authid'], 'IP-type ban keeps the recorded steam');
         $this->assertSame('1', (string) $row['type']);
 
-        // 2) Garbage `steam` with `type=1`. Pre-fix this raised
-        //    `Exception('Invalid SteamID input!')` → 500 envelope.
-        //    Post-fix the IP-type branch never reaches the converter.
+        // 2) No `steam` typed with `type=1`: nothing recorded, empty authid.
+        $env = $this->api('bans.add', [
+            'nickname' => 'IpType_noSteam', 'type' => 1,
+            'steam' => '', 'ip' => '203.0.113.45',
+            'length' => 0, 'reason' => 'ip ban without steam input',
+            'fromsub' => 0,
+        ]);
+        $this->assertTrue($env['ok'], 'IP-type ban with no steam should succeed');
+        $row = $this->row('bans', ['ip' => '203.0.113.45']);
+        $this->assertSame('', (string) $row['authid'], 'IP-type ban without steam writes empty authid');
+
+        // 3) Garbage `steam` with `type=1`. Pre-#1423-follow-up-#4 this
+        //    raised `Exception('Invalid SteamID input!')` → 500 envelope.
+        //    The shape gate now rejects it with a structured validation
+        //    error (NOT a 500, NOT a silent drop).
         $env = $this->api('bans.add', [
             'nickname' => 'IpType_garbageSteam', 'type' => 1,
             'steam' => 'garbage', 'ip' => '203.0.113.43',
             'length' => 0, 'reason' => 'ip ban with garbage steam input',
             'fromsub' => 0,
         ]);
-        $this->assertTrue($env['ok'], 'IP-type ban must NOT 500 on garbage steam input');
-        $row = $this->row('bans', ['ip' => '203.0.113.43']);
-        $this->assertSame('', (string) $row['authid']);
+        $this->assertEnvelopeError($env, 'validation');
+        $this->assertSame('steam', $env['error']['field']);
+        $this->assertNull($this->row('bans', ['ip' => '203.0.113.43']), 'garbage steam must NOT create an IP ban row');
 
-        // 3) Newline-bypass `steam` with `type=1`. Same shape, different
-        //    expected outcome: the IP-type branch ignores it entirely.
+        // 4) Newline-bypass `steam` with `type=1`. Same shape gate
+        //    (`HANDLER_STRICT_REGEX` carries the `D` modifier), same
+        //    rejection.
         $env = $this->api('bans.add', [
             'nickname' => 'IpType_newlineSteam', 'type' => 1,
             'steam' => "STEAM_0:0:1\n", 'ip' => '203.0.113.44',
             'length' => 0, 'reason' => 'ip ban with newline steam input',
             'fromsub' => 0,
         ]);
-        $this->assertTrue($env['ok']);
-        $row = $this->row('bans', ['ip' => '203.0.113.44']);
-        $this->assertSame('', (string) $row['authid']);
+        $this->assertEnvelopeError($env, 'validation');
+        $this->assertSame('steam', $env['error']['field']);
+        $this->assertNull($this->row('bans', ['ip' => '203.0.113.44']), 'newline-bypass steam must NOT create an IP ban row');
     }
 
     public function testAddValidationNegativeLength(): void
@@ -527,15 +533,16 @@ final class BansTest extends ApiTestCase
 
     public function testDetailIpTypeBanReportsNoSteamOrCommunityId(): void
     {
-        // #1486: an IP-type ban stores an empty authid (see
-        // testAddIpTypeAlwaysWritesEmptyAuthid). community_id is computed in
-        // SQL straight off authid, so an empty authid collapsed the
-        // arithmetic to the base 76561197960265728 (STEAM_0:0:0) and the
+        // #1486: an IP-type ban with NO recorded SteamID stores an empty
+        // authid (the operator only filled the IP field). community_id is
+        // computed in SQL straight off authid, so an empty authid collapsed
+        // the arithmetic to the base 76561197960265728 (STEAM_0:0:0) and the
         // drawer rendered a bogus "Community" id. steam_id / steam_id_3 were
         // already gated on SteamID::isValidID(); community_id must match.
-        // The report's scenario is "fill out both IP and SteamID, pick IP
-        // type" — the SteamID is dropped and the IP is the row's real
-        // identity, so it must still surface. Assert as admin so
+        // (The "filled both fields" case now keeps the SteamID — see
+        // testAddIpTypeKeepsValidatedSteamOfRecord; this test pins the
+        // IP-only shape where the guard is load-bearing.) The IP is the
+        // row's real identity, so it must still surface. Assert as admin so
         // banlist.hideplayerips can't mask the IP regardless of seed defaults.
         $this->loginAsAdmin();
         $pdo = Fixture::rawPdo();

--- a/web/tests/api/CommsTest.php
+++ b/web/tests/api/CommsTest.php
@@ -616,6 +616,28 @@ final class CommsTest extends ApiTestCase
         $this->assertSame('Permanent', $env['data']['block']['length_human']);
     }
 
+    public function testDetailMalformedAuthidReportsNoSteamOrCommunityId(): void
+    {
+        // #1486 (parity with api_bans_detail): a comm block can't be
+        // IP-typed, but a malformed legacy authid (#900) made community_id
+        // collapse to the base 76561197960265728 (STEAM_0:0:0) since it's
+        // computed in SQL straight off authid. 'STEAM_0:0:' (empty Z) is the
+        // realistic comms corruption shape — non-empty, so it exits through
+        // the SteamID::isValidID()===false arm of the gate rather than the
+        // empty-authid short-circuit the bans test covers, exercising the
+        // other branch of the same guard. steam_id / steam_id_3 were already
+        // gated on isValidID(); community_id must match so the drawer never
+        // paints a synthetic id.
+        $cid = $this->seedComm('STEAM_0:0:', 'malformed-authid');
+
+        $env = $this->api('comms.detail', ['cid' => $cid]);
+        $this->assertTrue($env['ok'], json_encode($env));
+        $this->assertSame('', $env['data']['player']['steam_id']);
+        $this->assertSame('', $env['data']['player']['steam_id_3']);
+        $this->assertSame('', $env['data']['player']['community_id'],
+            'malformed authid must not surface a synthetic community id (#1486)');
+    }
+
     // -- comms.player_history with `authid` parameter (#COMMS-DRAWER) ------
 
     public function testPlayerHistoryAcceptsAuthidWithoutBid(): void


### PR DESCRIPTION
## Summary

Fixes #1486. The report: ban a player by **IP** while *also* filling the Steam ID field, and the ban detail drawer rendered a bogus `STEAM_0:0:0` "Community" id.

Two parts, one per commit:

1. **`fix(drawer)` — hide the synthetic community id.** `community_id` is computed in SQL straight off `BA.authid`. An empty (or malformed) `authid` collapsed the arithmetic to the base `76561197960265728` (`STEAM_0:0:0`). `api_bans_detail` / `api_comms_detail` now gate `community_id` on the same `SteamID::isValidID()` check already guarding `steam_id` / `steam_id_3`, so it surfaces only when there's a real SteamID behind it.

2. **`feat(bans)` — keep the SteamID instead of dropping it.** Root-cause of the user's follow-up ("I don't think we should drop the SteamID if both are filled out — is this a schema limitation?"). It was **not** a schema limitation: `:prefix_bans` has always had separate `ip` + `authid` columns. The handler was hard-clearing `authid` for `type=1`. Now, when the operator fills both fields on an IP-type ban, the SteamID is **kept as a record-of-fact** alongside the IP.

### Why keeping it is safe

Enforcement stays **IP-only**. The SourceMod plugin matches an IP ban on the `ip` column alone (`sbpp_main.sp`: `(type=0 AND authid…) OR (type=1 AND ip…)`), so the stored `authid` is inert plugin-side. It exists purely so the ban detail / banlist can show *which account the IP belonged to*. This also removes a pre-existing asymmetry: the handler already retained a typed **IP** on a Steam-type ban, but dropped a typed **SteamID** on an IP-type ban.

### Security gate preserved

The #1420 / #1423-follow-up-#4 validate-before-convert contract is intact. A non-empty Steam ID on an IP ban is shape-gated (`HANDLER_STRICT_REGEX` in the JSON handler, `SteamID::isValidID()` in the page handler) **before** `toSteam2()`, so a garbage value (`?type=1&steam=garbage`, newline-bypass, etc.) returns a structured `validation` error on the `steam` field rather than escaping the converter as a 500 or being silently swallowed. Empty Steam ID field → nothing recorded.

## Changes

- `web/api/handlers/bans.php` — `api_bans_add` keeps a validated SteamID on IP bans; `api_bans_detail` community-id guard + comment.
- `web/pages/admin.edit.ban.php` — same keep-when-valid behavior via the validate-then-convert ladder; rationale comment updated.
- `web/tests/api/BansTest.php` — `testAddIpTypeAlwaysWritesEmptyAuthid` → `testAddIpTypeKeepsValidatedSteamOfRecord` (kept-on-valid, empty-on-blank, `validation`-rejected on garbage/newline with no row written); detail test asserts the IP still surfaces.
- `AGENTS.md` — reversed the IP-type empty-`authid` contract + anti-pattern in lockstep (the residual anti-pattern is storing an *unvalidated* SteamID, not storing one at all).

## Test plan

- [ ] CI: PHPUnit (`BansTest`, `CommsTest`, `SteamIDValidationOrderTest`), PHPStan, API-contract, E2E.
- [x] `php -l` clean on all modified PHP files.
- [x] `SteamIDValidationOrderTest` validate-before-convert order preserved in `admin.edit.ban.php` (first `isValidID` precedes first `toSteam2`).
- [ ] Manual: IP ban + valid Steam ID → row stores both, drawer shows the SteamID, no `STEAM_0:0:0`.
- [ ] Manual: IP ban + empty Steam ID → empty `authid`, drawer shows IP only.
- [ ] Manual: IP ban + garbage Steam ID → inline "Please enter a valid Steam ID or Community ID", no 500, no row.