### PR TITLE
fix(game): Harmonize SQL query formatting, truncation logging, and DataPack lifecycle

### DIFF
--- a/game/addons/sourcemod/scripting/sbpp_comms.sp
+++ b/game/addons/sourcemod/scripting/sbpp_comms.sp
@@ -353,22 +353,23 @@ public void VerifyBlock(int client)
 			MarkClientAsGagged(client);
 	}
 
-	char sClAuthYZEscaped[sizeof(g_sSteamIDs[]) * 2 + 1];
-	g_hDatabase.Escape(g_sSteamIDs[client][8], sClAuthYZEscaped, sizeof(sClAuthYZEscaped));
-
 	char Query[4096];
-	FormatEx(Query, sizeof(Query),
+	if (g_hDatabase.Format(Query, sizeof(Query),
 		"SELECT		(c.ends - UNIX_TIMESTAMP()) AS remaining, \
 					c.length, c.type, c.created, c.reason, a.user, \
 					IF (a.immunity>=g.immunity, a.immunity, IFNULL(g.immunity,0)) AS immunity, \
 					c.aid, c.sid, a.authid \
-		FROM		%s_comms	AS c \
-		LEFT JOIN	%s_admins	AS a  ON a.aid = c.aid \
-		LEFT JOIN	%s_srvgroups AS g  ON g.name = a.srv_group \
+		FROM		%!s_comms	AS c \
+		LEFT JOIN	%!s_admins	AS a  ON a.aid = c.aid \
+		LEFT JOIN	%!s_srvgroups AS g  ON g.name = a.srv_group \
 		WHERE		RemoveType IS NULL \
 						AND c.authid REGEXP '^STEAM_[0-9]:%s$' \
 						AND (length = '0' OR ends > UNIX_TIMESTAMP())",
-		DatabasePrefix, DatabasePrefix, DatabasePrefix, sClAuthYZEscaped);
+		DatabasePrefix, DatabasePrefix, DatabasePrefix, g_sSteamIDs[client][8]) >= sizeof(Query))
+	{
+		LogError("VerifyBlock query truncated for %L", client);
+		return;
+	}
 	#if defined LOG_QUERIES
 	LogToFile(logQuery, "VerifyBlock for: %s. QUERY: %s", g_sSteamIDs[client], Query);
 	#endif
@@ -1557,18 +1558,19 @@ public void Query_UnBlockSelect(Database db, DBResultSet results, const char[] e
 				newDataPack.WriteString(g_sName[target]);
 				newDataPack.WriteString(targetAuth);
 
-				char unbanReason[sizeof(reason) * 2 + 1];
-				db.Escape(reason, unbanReason, sizeof(unbanReason));
-
 				char query[2048];
-				Format(query, sizeof(query),
-					"UPDATE	%s_comms \
+				if (db.Format(query, sizeof(query),
+					"UPDATE	%!s_comms \
 					SET		RemovedBy = %d, \
 							RemoveType = 'U', \
 							RemovedOn = UNIX_TIMESTAMP(), \
 							ureason = '%s' \
 					WHERE	bid = %d",
-					DatabasePrefix, iAID, unbanReason, bid);
+					DatabasePrefix, iAID, reason, bid) >= sizeof(query))
+				{
+					LogError("Query_UnBlockSelect update query truncated");
+					continue;
+				}
 				#if defined LOG_QUERIES
 				LogToFile(logQuery, "Query_UnBlockSelect. QUERY: %s", query);
 				#endif
@@ -1713,12 +1715,6 @@ public void Query_ProcessQueue(Database db, DBResultSet results, const char[] er
 		if (!results.FetchRow())
 			continue;
 
-		char sAuthEscaped[sizeof(auth) * 2 + 1];
-		char banName[MAX_NAME_LENGTH * 2 + 1];
-		char banReason[sizeof(reason) * 2 + 1];
-		char sAdmAuthEscaped[sizeof(adminAuth) * 2 + 1];
-		char sAdmAuthYZEscaped[sizeof(adminAuth) * 2 + 1];
-
 		// if we get to here then there are rows in the queue pending processing
 		//steam_id TEXT, time INTEGER, start_time INTEGER, reason TEXT, name TEXT, admin_id TEXT, admin_ip TEXT, type INTEGER
 		int id = results.FetchInt(0);
@@ -1731,23 +1727,20 @@ public void Query_ProcessQueue(Database db, DBResultSet results, const char[] er
 		results.FetchString(7, adminIp, sizeof(adminIp));
 		int type = results.FetchInt(8);
 
-		if (DB_Connect()) {
-			db.Escape(auth, sAuthEscaped, sizeof(sAuthEscaped));
-			db.Escape(name, banName, sizeof(banName));
-			db.Escape(reason, banReason, sizeof(banReason));
-			db.Escape(adminAuth, sAdmAuthEscaped, sizeof(sAdmAuthEscaped));
-			db.Escape(adminAuth[8], sAdmAuthYZEscaped, sizeof(sAdmAuthYZEscaped));
-		}
-		else
+		if (!DB_Connect())
 			continue;
 		// all blocks should be entered into db!
 
-		FormatEx(query, sizeof(query),
-			"INSERT INTO	 %s_comms (authid, name, created, ends, length, reason, aid, adminIp, sid, type) \
+		if (db.Format(query, sizeof(query),
+			"INSERT INTO	 %!s_comms (authid, name, created, ends, length, reason, aid, adminIp, sid, type) \
 				VALUES		 ('%s', '%s', %d, %d, %d, '%s', \
-								IFNULL((SELECT aid FROM %s_admins WHERE authid = '%s' OR authid REGEXP '^STEAM_[0-9]:%s$'), '0'), \
+								IFNULL((SELECT aid FROM %!s_admins WHERE authid = '%s' OR authid REGEXP '^STEAM_[0-9]:%s$'), '0'), \
 								'%s', %d, %d)",
-			DatabasePrefix, sAuthEscaped, banName, startTime, (startTime + (time * 60)), (time * 60), banReason, DatabasePrefix, sAdmAuthEscaped, sAdmAuthYZEscaped, adminIp, serverID, type);
+			DatabasePrefix, auth, name, startTime, (startTime + (time * 60)), (time * 60), reason, DatabasePrefix, adminAuth, adminAuth[8], adminIp, serverID, type) >= sizeof(query))
+		{
+			LogError("Query_ProcessQueue insert query truncated");
+			continue;
+		}
 		#if defined LOG_QUERIES
 		LogToFile(logQuery, "Query_ProcessQueue. QUERY: %s", query);
 		#endif
@@ -1761,10 +1754,14 @@ public void Query_AddBlockFromQueue(Database db, DBResultSet results, const char
 	if (error[0] == '\0')
 	{
 		// The insert was successful so delete the record from the queue
-		FormatEx(query, sizeof(query),
+		if (SQLiteDB.Format(query, sizeof(query),
 			"DELETE FROM queue2 \
 			WHERE		id = %d",
-			data);
+			data) >= sizeof(query))
+		{
+			LogError("Query_AddBlockFromQueue delete query truncated");
+			return;
+		}
 		#if defined LOG_QUERIES
 		LogToFile(logQuery, "Query_AddBlockFromQueue. QUERY: %s", query);
 		#endif
@@ -2593,43 +2590,37 @@ stock void ProcessUnBlock(int client, int targetId = 0, int type, char[] sReason
 			}
 		}
 
-		// Pack everything into a data pack so we can retain it
-		DataPack dataPack = new DataPack();
-		dataPack.WriteCell(GetClientUserId2(client));
-		dataPack.WriteCell(g_iUserIDs[target]);
-		dataPack.WriteCell(type);
-		dataPack.WriteString(adminAuth);
-		dataPack.WriteString(targetAuth);
-		dataPack.WriteString(reason);
-
 		// Check current player status. If player has temporary punishment - don't get info from DB
 		if (DB_Connect())
 		{
-			char sAdminAuthEscaped[sizeof(adminAuth) * 2 + 1];
-			char sAdminAuthYZEscaped[sizeof(adminAuth) * 2 + 1];
-			char sTargetAuthEscaped[sizeof(targetAuth) * 2 + 1];
-			char sTargetAuthYZEscaped[sizeof(targetAuth) * 2 + 1];
-
-			g_hDatabase.Escape(adminAuth, sAdminAuthEscaped, sizeof(sAdminAuthEscaped));
-			g_hDatabase.Escape(adminAuth[8], sAdminAuthYZEscaped, sizeof(sAdminAuthYZEscaped));
-			g_hDatabase.Escape(targetAuth, sTargetAuthEscaped, sizeof(sTargetAuthEscaped));
-			g_hDatabase.Escape(targetAuth[8], sTargetAuthYZEscaped, sizeof(sTargetAuthYZEscaped));
-
 			char query[4096];
-			Format(query, sizeof(query),
+			if (g_hDatabase.Format(query, sizeof(query),
 				"SELECT		c.bid, \
-							IFNULL((SELECT aid FROM %s_admins WHERE authid = '%s' OR authid REGEXP '^STEAM_[0-9]:%s$'), '0') as iaid, \
+							IFNULL((SELECT aid FROM %!s_admins WHERE authid = '%s' OR authid REGEXP '^STEAM_[0-9]:%s$'), '0') as iaid, \
 							c.aid, \
 							IF (a.immunity>=g.immunity, a.immunity, IFNULL(g.immunity,0)) as immunity, \
 							c.type \
-				FROM		%s_comms	 AS c \
-				LEFT JOIN	%s_admins	AS a ON a.aid = c.aid \
-				LEFT JOIN	%s_srvgroups AS g ON g.name = a.srv_group \
+				FROM		%!s_comms	 AS c \
+				LEFT JOIN	%!s_admins	AS a ON a.aid = c.aid \
+				LEFT JOIN	%!s_srvgroups AS g ON g.name = a.srv_group \
 				WHERE		RemoveType IS NULL \
 								AND (c.authid = '%s' OR c.authid REGEXP '^STEAM_[0-9]:%s$') \
 								AND (length = '0' OR ends > UNIX_TIMESTAMP()) \
-								AND %s",
-				DatabasePrefix, sAdminAuthEscaped, sAdminAuthYZEscaped, DatabasePrefix, DatabasePrefix, DatabasePrefix, sTargetAuthEscaped, sTargetAuthYZEscaped, typeWHERE);
+								AND %!s",
+				DatabasePrefix, adminAuth, adminAuth[8], DatabasePrefix, DatabasePrefix, DatabasePrefix, targetAuth, targetAuth[8], typeWHERE) >= sizeof(query))
+			{
+				LogError("ProcessUnBlock select query truncated");
+				return;
+			}
+
+			// Pack everything into a data pack so we can retain it
+			DataPack dataPack = new DataPack();
+			dataPack.WriteCell(GetClientUserId2(client));
+			dataPack.WriteCell(g_iUserIDs[target]);
+			dataPack.WriteCell(type);
+			dataPack.WriteString(adminAuth);
+			dataPack.WriteString(targetAuth);
+			dataPack.WriteString(reason);
 
 			#if defined LOG_QUERIES
 			LogToFile(logQuery, "ProcessUnBlock. QUERY: %s", query);
@@ -2639,6 +2630,14 @@ stock void ProcessUnBlock(int client, int targetId = 0, int type, char[] sReason
 		}
 		else
 		{
+			DataPack dataPack = new DataPack();
+			dataPack.WriteCell(GetClientUserId2(client));
+			dataPack.WriteCell(g_iUserIDs[target]);
+			dataPack.WriteCell(type);
+			dataPack.WriteString(adminAuth);
+			dataPack.WriteString(targetAuth);
+			dataPack.WriteString(reason);
+
 			#if defined DEBUG
 			PrintToServer("Calling TempUnBlock from ProcessUnBlock");
 			#endif
@@ -2754,23 +2753,17 @@ stock void InsertTempBlock(int length, int type, const char[] name, const char[]
 {
 	LogMessage("Saving punishment for %s into queue", auth);
 
-	char banName[MAX_NAME_LENGTH * 2 + 1];
-	char banReason[256 * 2 + 1];
-	char sAuthEscaped[MAX_AUTHID_LENGTH * 2 + 1];
-	char sAdminAuthEscaped[MAX_AUTHID_LENGTH * 2 + 1];
 	char sQuery[4096], sQueryVal[2048];
 	char sQueryMute[2048], sQueryGag[2048];
 
-	// escaping everything
-	SQLiteDB.Escape(name, banName, sizeof(banName));
-	SQLiteDB.Escape(reason, banReason, sizeof(banReason));
-	SQLiteDB.Escape(auth, sAuthEscaped, sizeof(sAuthEscaped));
-	SQLiteDB.Escape(adminAuth, sAdminAuthEscaped, sizeof(sAdminAuthEscaped));
-
 	// steam_id time start_time reason name admin_id admin_ip
-	FormatEx(sQueryVal, sizeof(sQueryVal),
+	if (SQLiteDB.Format(sQueryVal, sizeof(sQueryVal),
 		"'%s', %d, %d, '%s', '%s', '%s', '%s'",
-		sAuthEscaped, length, GetTime(), banReason, banName, sAdminAuthEscaped, adminIp);
+		auth, length, GetTime(), reason, name, adminAuth, adminIp) >= sizeof(sQueryVal))
+	{
+		LogError("InsertTempBlock values query truncated");
+		return;
+	}
 
 	switch (type)
 	{
@@ -2783,9 +2776,13 @@ stock void InsertTempBlock(int length, int type, const char[] name, const char[]
 		}
 	}
 
-	FormatEx(sQuery, sizeof(sQuery),
+	if (SQLiteDB.Format(sQuery, sizeof(sQuery),
 		"INSERT INTO queue2 (steam_id, time, start_time, reason, name, admin_id, admin_ip, type) VALUES %s%s%s",
-		sQueryMute, type == TYPE_SILENCE ? ", " : "", sQueryGag);
+		sQueryMute, type == TYPE_SILENCE ? ", " : "", sQueryGag) >= sizeof(sQuery))
+	{
+		LogError("InsertTempBlock insert query truncated");
+		return;
+	}
 
 	#if defined LOG_QUERIES
 	LogToFile(logQuery, "InsertTempBlock. QUERY: %s", sQuery);
@@ -3158,41 +3155,41 @@ stock void SavePunishment(int admin = 0, int target, int type, int length = -1, 
 	if (DB_Connect())
 	{
 		// Accepts length in minutes, writes to db in seconds! In all over places in plugin - length is in minutes.
-		char banName[MAX_NAME_LENGTH * 2 + 1];
-		char banReason[256 * 2 + 1];
-		char sAuthidEscaped[MAX_AUTHID_LENGTH * 2 + 1];
-		char sAdminAuthIdEscaped[MAX_AUTHID_LENGTH * 2 + 1];
-		char sAdminAuthIdYZEscaped[MAX_AUTHID_LENGTH * 2 + 1];
 		char sQuery[4096], sQueryAdm[512], sQueryVal[1024];
 		char sQueryMute[1024], sQueryGag[1024];
 		sQueryMute[0] = 0;
 		sQueryGag[0]  = 0;
 
-		// escaping everything
-		g_hDatabase.Escape(sName, banName, sizeof(banName));
-		g_hDatabase.Escape(reason, banReason, sizeof(banReason));
-		g_hDatabase.Escape(targetAuth, sAuthidEscaped, sizeof(sAuthidEscaped));
-		g_hDatabase.Escape(adminAuth, sAdminAuthIdEscaped, sizeof(sAdminAuthIdEscaped));
-		g_hDatabase.Escape(adminAuth[8], sAdminAuthIdYZEscaped, sizeof(sAdminAuthIdYZEscaped));
-
 		// bid	authid	name	created ends lenght reason aid adminip	sid	removedBy removedType removedon type ureason
-		FormatEx(sQueryAdm, sizeof(sQueryAdm),
-			"IFNULL((SELECT aid FROM %s_admins WHERE authid = '%s' OR authid REGEXP '^STEAM_[0-9]:%s$'), 0)",
-			DatabasePrefix, sAdminAuthIdEscaped, sAdminAuthIdYZEscaped);
+		if (g_hDatabase.Format(sQueryAdm, sizeof(sQueryAdm),
+			"IFNULL((SELECT aid FROM %!s_admins WHERE authid = '%s' OR authid REGEXP '^STEAM_[0-9]:%s$'), 0)",
+			DatabasePrefix, adminAuth, adminAuth[8]) >= sizeof(sQueryAdm))
+		{
+			LogError("SavePunishment admin subquery truncated");
+			return;
+		}
 
 		if (length >= 0)
 		{
 			// authid name, created, ends, length, reason, aid, adminIp, sid
-			FormatEx(sQueryVal, sizeof(sQueryVal),
-				"'%s', '%s', UNIX_TIMESTAMP(), UNIX_TIMESTAMP() + %d, %d, '%s', %s, '%s', %d",
-				sAuthidEscaped, banName, length * 60, length * 60, banReason, sQueryAdm, adminIp, serverID);
+			if (g_hDatabase.Format(sQueryVal, sizeof(sQueryVal),
+				"'%s', '%s', UNIX_TIMESTAMP(), UNIX_TIMESTAMP() + %d, %d, '%s', %!s, '%s', %d",
+				targetAuth, sName, length * 60, length * 60, reason, sQueryAdm, adminIp, serverID) >= sizeof(sQueryVal))
+			{
+				LogError("SavePunishment values query truncated");
+				return;
+			}
 		}
 		else // Session mutes
 		{
 			// authid name, created, ends, length, reason, aid, adminIp, sid
-			FormatEx(sQueryVal, sizeof(sQueryVal),
-				"'%s', '%s', UNIX_TIMESTAMP(), UNIX_TIMESTAMP() + %d, %d, '%s', %s, '%s', %d",
-				sAuthidEscaped, banName, SESSION_MUTE_FALLBACK, -1, banReason, sQueryAdm, adminIp, serverID);
+			if (g_hDatabase.Format(sQueryVal, sizeof(sQueryVal),
+				"'%s', '%s', UNIX_TIMESTAMP(), UNIX_TIMESTAMP() + %d, %d, '%s', %!s, '%s', %d",
+				targetAuth, sName, SESSION_MUTE_FALLBACK, -1, reason, sQueryAdm, adminIp, serverID) >= sizeof(sQueryVal))
+			{
+				LogError("SavePunishment values query truncated");
+				return;
+			}
 		}
 
 		switch (type)
@@ -3209,9 +3206,13 @@ stock void SavePunishment(int admin = 0, int target, int type, int length = -1, 
 		}
 
 		// litle magic - one query for all actions (mute, gag or silence)
-		FormatEx(sQuery, sizeof(sQuery),
-			"INSERT INTO %s_comms (authid, name, created, ends, length, reason, aid, adminIp, sid, type) VALUES %s%s%s",
-			DatabasePrefix, sQueryMute, type == TYPE_SILENCE ? ", " : "", sQueryGag);
+		if (g_hDatabase.Format(sQuery, sizeof(sQuery),
+			"INSERT INTO %!s_comms (authid, name, created, ends, length, reason, aid, adminIp, sid, type) VALUES %!s%!s%!s",
+			DatabasePrefix, sQueryMute, type == TYPE_SILENCE ? ", " : "", sQueryGag) >= sizeof(sQuery))
+		{
+			LogError("SavePunishment insert query truncated");
+			return;
+		}
 
 		#if defined LOG_QUERIES
 		LogToFile(logQuery, "SavePunishment. QUERY: %s", sQuery);

--- a/game/addons/sourcemod/scripting/sbpp_comms.sp
+++ b/game/addons/sourcemod/scripting/sbpp_comms.sp
@@ -1569,6 +1569,7 @@ public void Query_UnBlockSelect(Database db, DBResultSet results, const char[] e
 					DatabasePrefix, iAID, reason, bid) >= sizeof(query))
 				{
 					LogError("Query_UnBlockSelect update query truncated");
+					delete newDataPack;
 					continue;
 				}
 				#if defined LOG_QUERIES

--- a/game/addons/sourcemod/scripting/sbpp_main.sp
+++ b/game/addons/sourcemod/scripting/sbpp_main.sp
@@ -348,8 +348,12 @@ public void OnClientAuthorized(int client, const char[] auth)
 	if (PlayerStatus[client])
 		return;
 
-	char Query[256];
-	FormatEx(Query, sizeof(Query), "SELECT bid, ip FROM %s_bans WHERE ((type = 0 AND authid REGEXP '^STEAM_[0-9]:%s$') OR (type = 1 AND ip = '%s')) AND (length = '0' OR ends > UNIX_TIMESTAMP()) AND RemoveType IS NULL", DatabasePrefix, g_sSteamIDs[client][8], g_sPlayerIP[client]);
+	char Query[512];
+	if (DB.Format(Query, sizeof(Query), "SELECT bid, ip FROM %!s_bans WHERE ((type = 0 AND authid REGEXP '^STEAM_[0-9]:%s$') OR (type = 1 AND ip = '%s')) AND (length = '0' OR ends > UNIX_TIMESTAMP()) AND RemoveType IS NULL", DatabasePrefix, g_sSteamIDs[client][8], g_sPlayerIP[client]) >= sizeof(Query))
+	{
+		LogError("OnClientAuthorized query truncated for %L", client);
+		return;
+	}
 
 	#if defined DEBUG
 	LogToFile(logFile, "Checking ban for: %s", g_sSteamIDs[client]);
@@ -565,6 +569,14 @@ public Action CommandBanIp(int client, int args)
 		strcopy(adminIp, sizeof(adminIp), g_sPlayerIP[client]);
 	}
 
+	char sQuery[256];
+	if (DB.Format(sQuery, sizeof(sQuery), "SELECT bid FROM %!s_bans WHERE type = 1 AND ip = '%s' AND (length = 0 OR ends > UNIX_TIMESTAMP()) AND RemoveType IS NULL",
+		DatabasePrefix, arg) >= sizeof(sQuery))
+	{
+		LogError("CommandBanIp query truncated");
+		return Plugin_Handled;
+	}
+
 	// Pack everything into a data pack so we can retain it
 	DataPack dataPack = new DataPack();
 	dataPack.WriteCell(client);
@@ -575,12 +587,6 @@ public Action CommandBanIp(int client, int args)
 	dataPack.WriteString(g_sSteamIDs[target]);
 	dataPack.WriteString(adminAuth);
 	dataPack.WriteString(adminIp);
-
-	char sQuery[256], argEscaped[sizeof(arg) * 2 + 1];
-	DB.Escape(arg, argEscaped, sizeof(argEscaped));
-
-	FormatEx(sQuery, sizeof(sQuery), "SELECT bid FROM %s_bans WHERE type = 1 AND ip     = '%s' AND (length = 0 OR ends > UNIX_TIMESTAMP()) AND RemoveType IS NULL",
-		DatabasePrefix, argEscaped);
 
 	DB.Query(SelectBanIpCallback, sQuery, dataPack, DBPrio_High);
 
@@ -620,22 +626,29 @@ public Action CommandUnban(int client, int args)
 		strcopy(adminAuth, sizeof(adminAuth), g_sSteamIDs[client]);
 	}
 
+	char query[256];
+
+	if (strncmp(arg, "STEAM_", 6) == 0)
+	{
+		if (DB.Format(query, sizeof(query), "SELECT bid FROM %!s_bans WHERE (type = 0 AND authid = '%s') AND (length = '0' OR ends > UNIX_TIMESTAMP()) AND RemoveType IS NULL", DatabasePrefix, arg) >= sizeof(query))
+		{
+			LogError("CommandUnban query truncated (steam)");
+			return Plugin_Handled;
+		}
+	} else {
+		if (DB.Format(query, sizeof(query), "SELECT bid FROM %!s_bans WHERE (type = 1 AND ip = '%s') AND (length = '0' OR ends > UNIX_TIMESTAMP()) AND RemoveType IS NULL", DatabasePrefix, arg) >= sizeof(query))
+		{
+			LogError("CommandUnban query truncated (ip)");
+			return Plugin_Handled;
+		}
+	}
+
 	// Pack everything into a data pack so we can retain it
 	DataPack dataPack = new DataPack();
 	dataPack.WriteCell(client);
 	dataPack.WriteString(Arguments[len]); // Reason
 	dataPack.WriteString(arg); // Steamid - IP
 	dataPack.WriteString(adminAuth); // Admin SteamID
-
-	char query[256], argEscaped[sizeof(arg) * 2 + 1];
-	DB.Escape(arg, argEscaped, sizeof(argEscaped));
-
-	if (strncmp(arg, "STEAM_", 6) == 0)
-	{
-		Format(query, sizeof(query), "SELECT bid FROM %s_bans WHERE (type = 0 AND authid = '%s') AND (length = '0' OR ends > UNIX_TIMESTAMP()) AND RemoveType IS NULL", DatabasePrefix, argEscaped);
-	} else {
-		Format(query, sizeof(query), "SELECT bid FROM %s_bans WHERE (type = 1 AND ip     = '%s') AND (length = '0' OR ends > UNIX_TIMESTAMP()) AND RemoveType IS NULL", DatabasePrefix, argEscaped);
-	}
 
 	DB.Query(SelectUnbanCallback, query, dataPack);
 
@@ -707,6 +720,14 @@ public Action CommandAddBan(int client, int args)
 		strcopy(adminIp, sizeof(adminIp), g_sPlayerIP[client]);
 	}
 
+	char sQuery[256];
+	if (DB.Format(sQuery, sizeof sQuery, "SELECT bid FROM %!s_bans WHERE type = 0 AND authid = '%s' AND (length = 0 OR ends > UNIX_TIMESTAMP()) AND RemoveType IS NULL",
+		DatabasePrefix, authid) >= sizeof(sQuery))
+	{
+		LogError("CommandAddBan query truncated");
+		return Plugin_Handled;
+	}
+
 	// Pack everything into a data pack so we can retain it
 	DataPack dataPack = new DataPack();
 	dataPack.WriteCell(client);
@@ -715,12 +736,6 @@ public Action CommandAddBan(int client, int args)
 	dataPack.WriteString(authid);
 	dataPack.WriteString(adminAuth);
 	dataPack.WriteString(adminIp);
-
-	char sQuery[256], authidEscaped[sizeof(authid) * 2 + 1];
-	DB.Escape(authid, authidEscaped, sizeof(authidEscaped));
-
-	FormatEx(sQuery, sizeof sQuery, "SELECT bid FROM %s_bans WHERE type = 0 AND authid = '%s' AND (length = 0 OR ends > UNIX_TIMESTAMP()) AND RemoveType IS NULL",
-		DatabasePrefix, authidEscaped);
 
 	DB.Query(SelectAddbanCallback, sQuery, dataPack, DBPrio_High);
 
@@ -1242,8 +1257,8 @@ public void VerifyInsert(Database db, DBResultSet results, const char[] error, D
 public void SelectBanIpCallback(Database db, DBResultSet results, const char[] error, DataPack dataPack)
 {
 	int admin, minutes;
-	char adminAuth[MAX_AUTHID_LENGTH], adminIp[16], banReason[256], ip[16], reason[128], Query[512];
-	char targetName[MAX_NAME_LENGTH], sTEscapedName[MAX_NAME_LENGTH * 2 + 1], targetAuth[MAX_AUTHID_LENGTH];
+	char adminAuth[MAX_AUTHID_LENGTH], adminIp[16], ip[16], reason[128], Query[2048];
+	char targetName[MAX_NAME_LENGTH], targetAuth[MAX_AUTHID_LENGTH];
 
 	dataPack.Reset();
 	admin = dataPack.ReadCell();
@@ -1254,8 +1269,6 @@ public void SelectBanIpCallback(Database db, DBResultSet results, const char[] e
 	dataPack.ReadString(targetAuth, sizeof(targetAuth));
 	dataPack.ReadString(adminAuth, sizeof(adminAuth));
 	dataPack.ReadString(adminIp, sizeof(adminIp));
-	DB.Escape(reason, banReason, sizeof(banReason));
-	DB.Escape(targetName, sTEscapedName, sizeof(sTEscapedName));
 
 	if (results == null)
 	{
@@ -1278,15 +1291,23 @@ public void SelectBanIpCallback(Database db, DBResultSet results, const char[] e
 	}
 	if (serverID == -1)
 	{
-		FormatEx(Query, sizeof(Query), "INSERT INTO %s_bans (type, ip, authid, name, created, ends, length, reason, aid, adminIp, sid, country) VALUES \
-						(1, '%s', '%s', '%s', UNIX_TIMESTAMP(), UNIX_TIMESTAMP() + %d, %d, '%s', (SELECT aid FROM %s_admins WHERE authid = '%s' OR authid REGEXP '^STEAM_[0-9]:%s$'), '%s', \
-						(SELECT sid FROM %s_servers WHERE ip = '%s' AND port = '%s' LIMIT 0,1), ' ')",
-			DatabasePrefix, ip, targetAuth, sTEscapedName, (minutes * 60), (minutes * 60), banReason, DatabasePrefix, adminAuth, adminAuth[8], adminIp, DatabasePrefix, ServerIp, ServerPort);
+		if (db.Format(Query, sizeof(Query), "INSERT INTO %!s_bans (type, ip, authid, name, created, ends, length, reason, aid, adminIp, sid, country) VALUES \
+						(1, '%s', '%s', '%s', UNIX_TIMESTAMP(), UNIX_TIMESTAMP() + %d, %d, '%s', (SELECT aid FROM %!s_admins WHERE authid = '%s' OR authid REGEXP '^STEAM_[0-9]:%s$'), '%s', \
+						(SELECT sid FROM %!s_servers WHERE ip = '%s' AND port = '%s' LIMIT 0,1), ' ')",
+			DatabasePrefix, ip, targetAuth, targetName, (minutes * 60), (minutes * 60), reason, DatabasePrefix, adminAuth, adminAuth[8], adminIp, DatabasePrefix, ServerIp, ServerPort) >= sizeof(Query))
+		{
+			LogError("SelectBanIpCallback insert query truncated");
+			return;
+		}
 	} else {
-		FormatEx(Query, sizeof(Query), "INSERT INTO %s_bans (type, ip, authid, name, created, ends, length, reason, aid, adminIp, sid, country) VALUES \
-						(1, '%s', '%s', '%s', UNIX_TIMESTAMP(), UNIX_TIMESTAMP() + %d, %d, '%s', (SELECT aid FROM %s_admins WHERE authid = '%s' OR authid REGEXP '^STEAM_[0-9]:%s$'), '%s', \
+		if (db.Format(Query, sizeof(Query), "INSERT INTO %!s_bans (type, ip, authid, name, created, ends, length, reason, aid, adminIp, sid, country) VALUES \
+						(1, '%s', '%s', '%s', UNIX_TIMESTAMP(), UNIX_TIMESTAMP() + %d, %d, '%s', (SELECT aid FROM %!s_admins WHERE authid = '%s' OR authid REGEXP '^STEAM_[0-9]:%s$'), '%s', \
 						%d, ' ')",
-			DatabasePrefix, ip, targetAuth, sTEscapedName, (minutes * 60), (minutes * 60), banReason, DatabasePrefix, adminAuth, adminAuth[8], adminIp, serverID);
+			DatabasePrefix, ip, targetAuth, targetName, (minutes * 60), (minutes * 60), reason, DatabasePrefix, adminAuth, adminAuth[8], adminIp, serverID) >= sizeof(Query))
+		{
+			LogError("SelectBanIpCallback insert query truncated");
+			return;
+		}
 	}
 
 	db.Query(InsertBanIpCallback, Query, dataPack, DBPrio_High);
@@ -1359,7 +1380,7 @@ public void InsertBanIpCallback(Database db, DBResultSet results, const char[] e
 public void SelectUnbanCallback(Database db, DBResultSet results, const char[] error, DataPack dataPack)
 {
 	int admin;
-	char arg[MAX_AUTHID_LENGTH], adminAuth[MAX_AUTHID_LENGTH], unbanReason[256];
+	char arg[MAX_AUTHID_LENGTH], adminAuth[MAX_AUTHID_LENGTH];
 	char reason[128];
 
 	dataPack.Reset();
@@ -1367,8 +1388,6 @@ public void SelectUnbanCallback(Database db, DBResultSet results, const char[] e
 	dataPack.ReadString(reason, sizeof(reason)); // Reason
 	dataPack.ReadString(arg, sizeof(arg)); // SteamID - IP
 	dataPack.ReadString(adminAuth, sizeof(adminAuth)); // Admin SteamID
-
-	db.Escape(reason, unbanReason, sizeof(unbanReason));
 
 	// If error is not an empty string the query failed
 	if (results == null)
@@ -1402,8 +1421,13 @@ public void SelectUnbanCallback(Database db, DBResultSet results, const char[] e
 		int bid = results.FetchInt(0);
 
 		char query[1024];
-		Format(query, sizeof(query), "UPDATE %s_bans SET RemovedBy = (SELECT aid FROM %s_admins WHERE authid = '%s' OR authid REGEXP '^STEAM_[0-9]:%s$'), RemoveType = 'U', RemovedOn = UNIX_TIMESTAMP(), ureason = '%s' WHERE bid = %d",
-			DatabasePrefix, DatabasePrefix, adminAuth, adminAuth[8], unbanReason, bid);
+		if (db.Format(query, sizeof(query), "UPDATE %!s_bans SET RemovedBy = (SELECT aid FROM %!s_admins WHERE authid = '%s' OR authid REGEXP '^STEAM_[0-9]:%s$'), RemoveType = 'U', RemovedOn = UNIX_TIMESTAMP(), ureason = '%s' WHERE bid = %d",
+			DatabasePrefix, DatabasePrefix, adminAuth, adminAuth[8], reason, bid) >= sizeof(query))
+		{
+			LogError("SelectUnbanCallback update query truncated");
+			delete dataPack;
+			return;
+		}
 
 		db.Query(InsertUnbanCallback, query, dataPack);
 	}
@@ -1451,7 +1475,7 @@ public void InsertUnbanCallback(Database db, DBResultSet results, const char[] e
 public void SelectAddbanCallback(Database db, DBResultSet results, const char[] error, DataPack dataPack)
 {
 	int admin, minutes;
-	char adminAuth[MAX_AUTHID_LENGTH], adminIp[16], authid[MAX_AUTHID_LENGTH], banReason[256], Query[512];
+	char adminAuth[MAX_AUTHID_LENGTH], adminIp[16], authid[MAX_AUTHID_LENGTH], Query[2048];
 	char reason[128];
 
 	dataPack.Reset();
@@ -1461,7 +1485,6 @@ public void SelectAddbanCallback(Database db, DBResultSet results, const char[] 
 	dataPack.ReadString(authid, sizeof(authid));
 	dataPack.ReadString(adminAuth, sizeof(adminAuth));
 	dataPack.ReadString(adminIp, sizeof(adminIp));
-	db.Escape(reason, banReason, sizeof(banReason));
 
 	if (results == null)
 	{
@@ -1485,15 +1508,23 @@ public void SelectAddbanCallback(Database db, DBResultSet results, const char[] 
 	}
 	if (serverID == -1)
 	{
-		FormatEx(Query, sizeof(Query), "INSERT INTO %s_bans (authid, name, created, ends, length, reason, aid, adminIp, sid, country) VALUES \
-						('%s', '', UNIX_TIMESTAMP(), UNIX_TIMESTAMP() + %d, %d, '%s', (SELECT aid FROM %s_admins WHERE authid = '%s' OR authid REGEXP '^STEAM_[0-9]:%s$'), '%s', \
-						(SELECT sid FROM %s_servers WHERE ip = '%s' AND port = '%s' LIMIT 0,1), ' ')",
-			DatabasePrefix, authid, (minutes * 60), (minutes * 60), banReason, DatabasePrefix, adminAuth, adminAuth[8], adminIp, DatabasePrefix, ServerIp, ServerPort);
+		if (db.Format(Query, sizeof(Query), "INSERT INTO %!s_bans (authid, name, created, ends, length, reason, aid, adminIp, sid, country) VALUES \
+						('%s', '', UNIX_TIMESTAMP(), UNIX_TIMESTAMP() + %d, %d, '%s', (SELECT aid FROM %!s_admins WHERE authid = '%s' OR authid REGEXP '^STEAM_[0-9]:%s$'), '%s', \
+						(SELECT sid FROM %!s_servers WHERE ip = '%s' AND port = '%s' LIMIT 0,1), ' ')",
+			DatabasePrefix, authid, (minutes * 60), (minutes * 60), reason, DatabasePrefix, adminAuth, adminAuth[8], adminIp, DatabasePrefix, ServerIp, ServerPort) >= sizeof(Query))
+		{
+			LogError("SelectAddbanCallback insert query truncated");
+			return;
+		}
 	} else {
-		FormatEx(Query, sizeof(Query), "INSERT INTO %s_bans (authid, name, created, ends, length, reason, aid, adminIp, sid, country) VALUES \
-						('%s', '', UNIX_TIMESTAMP(), UNIX_TIMESTAMP() + %d, %d, '%s', (SELECT aid FROM %s_admins WHERE authid = '%s' OR authid REGEXP '^STEAM_[0-9]:%s$'), '%s', \
+		if (db.Format(Query, sizeof(Query), "INSERT INTO %!s_bans (authid, name, created, ends, length, reason, aid, adminIp, sid, country) VALUES \
+						('%s', '', UNIX_TIMESTAMP(), UNIX_TIMESTAMP() + %d, %d, '%s', (SELECT aid FROM %!s_admins WHERE authid = '%s' OR authid REGEXP '^STEAM_[0-9]:%s$'), '%s', \
 						%d, ' ')",
-			DatabasePrefix, authid, (minutes * 60), (minutes * 60), banReason, DatabasePrefix, adminAuth, adminAuth[8], adminIp, serverID);
+			DatabasePrefix, authid, (minutes * 60), (minutes * 60), reason, DatabasePrefix, adminAuth, adminAuth[8], adminIp, serverID) >= sizeof(Query))
+		{
+			LogError("SelectAddbanCallback insert query truncated");
+			return;
+		}
 	}
 
 	db.Query(InsertAddbanCallback, Query, dataPack, DBPrio_High);
@@ -1548,9 +1579,7 @@ public void ProcessQueueCallback(Database db, DBResultSet results, const char[] 
 	char ip[16];
 	char adminAuth[MAX_AUTHID_LENGTH];
 	char adminIp[16];
-	char query[1024];
-	char banName[MAX_NAME_LENGTH];
-	char banReason[256];
+	char query[2048];
 	while (results.MoreRows)
 	{
 		// Oh noes! What happened?!
@@ -1566,26 +1595,32 @@ public void ProcessQueueCallback(Database db, DBResultSet results, const char[] 
 		results.FetchString(5, ip, sizeof(ip));
 		results.FetchString(6, adminAuth, sizeof(adminAuth));
 		results.FetchString(7, adminIp, sizeof(adminIp));
-		db.Escape(name, banName, sizeof(banName));
-		db.Escape(reason, banReason, sizeof(banReason));
 		if (startTime + time * 60 > GetTime() || time == 0)
 		{
 			// This ban is still valid and should be entered into the db
 			if (serverID == -1)
 			{
-				FormatEx(query, sizeof(query),
-					"INSERT INTO %s_bans (ip, authid, name, created, ends, length, reason, aid, adminIp, sid) VALUES  \
-						('%s', '%s', '%s', %d, %d, %d, '%s', (SELECT aid FROM %s_admins WHERE authid = '%s' OR authid REGEXP '^STEAM_[0-9]:%s$'), '%s', \
-						(SELECT sid FROM %s_servers WHERE ip = '%s' AND port = '%s' LIMIT 0,1))",
-					DatabasePrefix, ip, auth, banName, startTime, startTime + time * 60, time * 60, banReason, DatabasePrefix, adminAuth, adminAuth[8], adminIp, DatabasePrefix, ServerIp, ServerPort);
+				if (db.Format(query, sizeof(query),
+					"INSERT INTO %!s_bans (ip, authid, name, created, ends, length, reason, aid, adminIp, sid) VALUES  \
+						('%s', '%s', '%s', %d, %d, %d, '%s', (SELECT aid FROM %!s_admins WHERE authid = '%s' OR authid REGEXP '^STEAM_[0-9]:%s$'), '%s', \
+						(SELECT sid FROM %!s_servers WHERE ip = '%s' AND port = '%s' LIMIT 0,1))",
+					DatabasePrefix, ip, auth, name, startTime, startTime + time * 60, time * 60, reason, DatabasePrefix, adminAuth, adminAuth[8], adminIp, DatabasePrefix, ServerIp, ServerPort) >= sizeof(query))
+				{
+					LogError("ProcessQueueCallback insert query truncated");
+					continue;
+				}
 			}
 			else
 			{
-				FormatEx(query, sizeof(query),
-					"INSERT INTO %s_bans (ip, authid, name, created, ends, length, reason, aid, adminIp, sid) VALUES  \
-						('%s', '%s', '%s', %d, %d, %d, '%s', (SELECT aid FROM %s_admins WHERE authid = '%s' OR authid REGEXP '^STEAM_[0-9]:%s$'), '%s', \
+				if (db.Format(query, sizeof(query),
+					"INSERT INTO %!s_bans (ip, authid, name, created, ends, length, reason, aid, adminIp, sid) VALUES  \
+						('%s', '%s', '%s', %d, %d, %d, '%s', (SELECT aid FROM %!s_admins WHERE authid = '%s' OR authid REGEXP '^STEAM_[0-9]:%s$'), '%s', \
 						%d)",
-					DatabasePrefix, ip, auth, banName, startTime, startTime + time * 60, time * 60, banReason, DatabasePrefix, adminAuth, adminAuth[8], adminIp, serverID);
+					DatabasePrefix, ip, auth, name, startTime, startTime + time * 60, time * 60, reason, DatabasePrefix, adminAuth, adminAuth[8], adminIp, serverID) >= sizeof(query))
+				{
+					LogError("ProcessQueueCallback insert query truncated");
+					continue;
+				}
 			}
 			DataPack authPack = new DataPack();
 			authPack.WriteString(auth);
@@ -1593,7 +1628,11 @@ public void ProcessQueueCallback(Database db, DBResultSet results, const char[] 
 			db.Query(AddedFromSQLiteCallback, query, authPack);
 		} else {
 			// The ban is no longer valid and should be deleted from the queue
-			FormatEx(query, sizeof(query), "DELETE FROM queue WHERE steam_id = '%s'", auth);
+			if (SQLiteDB.Format(query, sizeof(query), "DELETE FROM queue WHERE steam_id = '%s'", auth) >= sizeof(query))
+			{
+				LogError("ProcessQueueCallback delete query truncated");
+				continue;
+			}
 			SQLiteDB.Query(ErrorCheckCallback, query);
 		}
 	}
@@ -1610,7 +1649,12 @@ public void AddedFromSQLiteCallback(Database db, DBResultSet results, const char
 	if (results != null)
 	{
 		// The insert was successful so delete the record from the queue
-		FormatEx(buffer, sizeof(buffer), "DELETE FROM queue WHERE steam_id = '%s'", auth);
+		if (SQLiteDB.Format(buffer, sizeof(buffer), "DELETE FROM queue WHERE steam_id = '%s'", auth) >= sizeof(buffer))
+		{
+			LogError("AddedFromSQLiteCallback delete query truncated");
+			delete dataPack;
+			return;
+		}
 		SQLiteDB.Query(ErrorCheckCallback, buffer);
 
 		// They are added to main banlist, so remove the temp ban
@@ -1636,7 +1680,6 @@ public void ServerInfoCallback(Database db, DBResultSet results, const char[] er
 	{
 		// get the game folder name used to determine the mod
 		char desc[64], query[512], rcon[128];
-		char descEscaped[sizeof(desc) * 2 + 1], rconEscaped[sizeof(rcon) * 2 + 1];
 		GetGameFolderName(desc, sizeof(desc));
 		Format(rcon, sizeof(rcon), "");
 
@@ -1649,9 +1692,11 @@ public void ServerInfoCallback(Database db, DBResultSet results, const char[] er
 			}
 		}
 
-		db.Escape(desc, descEscaped, sizeof(descEscaped));
-		db.Escape(rcon, rconEscaped, sizeof(rconEscaped));
-		FormatEx(query, sizeof(query), "INSERT INTO %s_servers (ip, port, rcon, modid) VALUES ('%s', '%s', '%s', (SELECT mid FROM %s_mods WHERE modfolder = '%s'))", DatabasePrefix, ServerIp, ServerPort, rconEscaped, DatabasePrefix, descEscaped);
+		if (db.Format(query, sizeof(query), "INSERT INTO %!s_servers (ip, port, rcon, modid) VALUES ('%s', '%s', '%s', (SELECT mid FROM %!s_mods WHERE modfolder = '%s'))", DatabasePrefix, ServerIp, ServerPort, rcon, DatabasePrefix, desc) >= sizeof(query))
+		{
+			LogError("ServerInfoCallback insert query truncated");
+			return;
+		}
 		db.Query(ErrorCheckCallback, query);
 	}
 }
@@ -1686,7 +1731,7 @@ public void VerifyBan(Database db, DBResultSet results, const char[] error, int 
 
 	if (results.RowCount > 0)
 	{
-		char buffer[40], Name[MAX_NAME_LENGTH], Query[512];
+		char buffer[40], Query[512];
 
 		// Amending to ban record's IP field
 		if (results.FetchRow())
@@ -1700,30 +1745,45 @@ public void VerifyBan(Database db, DBResultSet results, const char[] error, int 
 			{
 				char sQuery[256];
 
-				FormatEx(sQuery, sizeof sQuery, "UPDATE %s_bans SET `ip` = '%s' WHERE `bid` = '%d'", DatabasePrefix, clientIp, iBid);
-
-				DB.Query(SQL_OnIPMend, sQuery, client);
+				if (DB.Format(sQuery, sizeof sQuery, "UPDATE %!s_bans SET `ip` = '%s' WHERE `bid` = '%d'", DatabasePrefix, clientIp, iBid) < sizeof(sQuery))
+				{
+					DB.Query(SQL_OnIPMend, sQuery, client);
+				}
+				else
+				{
+					LogError("VerifyBan mend IP query truncated for %L", client);
+				}
 			}
 		}
 
-		DB.Escape(g_sName[client], Name, sizeof Name);
-
 		if (serverID == -1)
 		{
-			FormatEx(Query, sizeof(Query), "INSERT INTO %s_banlog (sid ,time ,name ,bid) VALUES  \
-				((SELECT sid FROM %s_servers WHERE ip = '%s' AND port = '%s' LIMIT 0,1), UNIX_TIMESTAMP(), '%s', \
-				(SELECT bid FROM %s_bans WHERE ((type = 0 AND authid REGEXP '^STEAM_[0-9]:%s$') OR (type = 1 AND ip = '%s')) AND RemoveType IS NULL LIMIT 0,1))",
-				DatabasePrefix, DatabasePrefix, ServerIp, ServerPort, Name, DatabasePrefix, clientAuth[8], clientIp);
+			if (db.Format(Query, sizeof(Query), "INSERT INTO %!s_banlog (sid ,time ,name ,bid) VALUES  \
+				((SELECT sid FROM %!s_servers WHERE ip = '%s' AND port = '%s' LIMIT 0,1), UNIX_TIMESTAMP(), '%s', \
+				(SELECT bid FROM %!s_bans WHERE ((type = 0 AND authid REGEXP '^STEAM_[0-9]:%s$') OR (type = 1 AND ip = '%s')) AND RemoveType IS NULL LIMIT 0,1))",
+				DatabasePrefix, DatabasePrefix, ServerIp, ServerPort, g_sName[client], DatabasePrefix, clientAuth[8], clientIp) < sizeof(Query))
+			{
+				db.Query(ErrorCheckCallback, Query, client, DBPrio_High);
+			}
+			else
+			{
+				LogError("VerifyBan banlog query truncated for %L", client);
+			}
 		}
 		else
 		{
-			FormatEx(Query, sizeof(Query), "INSERT INTO %s_banlog (sid ,time ,name ,bid) VALUES  \
+			if (db.Format(Query, sizeof(Query), "INSERT INTO %!s_banlog (sid ,time ,name ,bid) VALUES  \
 				(%d, UNIX_TIMESTAMP(), '%s', \
-				(SELECT bid FROM %s_bans WHERE ((type = 0 AND authid REGEXP '^STEAM_[0-9]:%s$') OR (type = 1 AND ip = '%s')) AND RemoveType IS NULL LIMIT 0,1))",
-				DatabasePrefix, serverID, Name, DatabasePrefix, clientAuth[8], clientIp);
+				(SELECT bid FROM %!s_bans WHERE ((type = 0 AND authid REGEXP '^STEAM_[0-9]:%s$') OR (type = 1 AND ip = '%s')) AND RemoveType IS NULL LIMIT 0,1))",
+				DatabasePrefix, serverID, g_sName[client], DatabasePrefix, clientAuth[8], clientIp) < sizeof(Query))
+			{
+				db.Query(ErrorCheckCallback, Query, client, DBPrio_High);
+			}
+			else
+			{
+				LogError("VerifyBan banlog query truncated for %L", client);
+			}
 		}
-
-		db.Query(ErrorCheckCallback, Query, client, DBPrio_High);
 
 		FormatEx(buffer, sizeof(buffer), "banid 5 %s", clientAuth);
 		ServerCommand(buffer);
@@ -2402,17 +2462,13 @@ public int Native_SBReportPlayer(Handle plugin, int numParams)
 
 	GetNativeString(3, sReason, iReasonLen);
 
-	char sREscapedName[MAX_NAME_LENGTH * 2 + 1], sTEscapedName[MAX_NAME_LENGTH * 2 + 1];
-	char[] sEscapedReason = new char[iReasonLen * 2 + 1];
-
-	DB.Escape(g_sName[iReporter], sREscapedName, sizeof sREscapedName);
-	DB.Escape(g_sName[iTarget], sTEscapedName, sizeof sTEscapedName);
-	DB.Escape(sReason, sEscapedReason, iReasonLen * 2 + 1);
-
-	char[] sQuery = new char[512 + (iReasonLen * 2 + 1)];
-
-	Format(sQuery, 512 + (iReasonLen * 2 + 1), "INSERT INTO %s_submissions (`submitted`, `modid`, `SteamId`, `name`, `email`, `reason`, `ip`, `subname`, `sip`, `archiv`, `server`)"
-	... "VALUES ('%d', 0, '%s', '%s', '%s', '%s', '%s', '%s', '%s', 0, '%d')", DatabasePrefix, iTime, g_sSteamIDs[iTarget], sTEscapedName, g_sSteamIDs[iReporter], sEscapedReason, g_sPlayerIP[iReporter], sREscapedName, g_sPlayerIP[iTarget], (serverID != -1) ? serverID : 0);
+	char[] sQuery = new char[768 + (iReasonLen * 2 + 1)];
+	if (DB.Format(sQuery, sizeof(sQuery), "INSERT INTO %!s_submissions (`submitted`, `modid`, `SteamId`, `name`, `email`, `reason`, `ip`, `subname`, `sip`, `archiv`, `server`)"
+	... "VALUES ('%d', 0, '%s', '%s', '%s', '%s', '%s', '%s', '%s', 0, '%d')", DatabasePrefix, iTime, g_sSteamIDs[iTarget], g_sName[iTarget], g_sSteamIDs[iReporter], sReason, g_sPlayerIP[iReporter], g_sName[iReporter], g_sPlayerIP[iTarget], (serverID != -1) ? serverID : 0) >= sizeof(sQuery))
+	{
+		ThrowNativeError(SP_ERROR_NATIVE, "Failed to build report query (buffer too small)");
+		return 0;
+	}
 
 	DataPack dataPack = new DataPack();
 
@@ -2550,22 +2606,26 @@ stock void UTIL_InsertBan(int time, const char[] Name, const char[] Authid, cons
 {
 	//new Handle:dummy;
 	//PruneBans(dummy);
-	char banName[MAX_NAME_LENGTH];
-	char banReason[256];
-	char Query[1024];
-	DB.Escape(Name, banName, sizeof(banName));
-	DB.Escape(Reason, banReason, sizeof(banReason));
+	char Query[2048];
 	if (serverID == -1)
 	{
-		FormatEx(Query, sizeof(Query), "INSERT INTO %s_bans (ip, authid, name, created, ends, length, reason, aid, adminIp, sid, country) VALUES \
-						('%s', '%s', '%s', UNIX_TIMESTAMP(), UNIX_TIMESTAMP() + %d, %d, '%s', IFNULL((SELECT aid FROM %s_admins WHERE authid = '%s' OR authid REGEXP '^STEAM_[0-9]:%s$'),'0'), '%s', \
-						(SELECT sid FROM %s_servers WHERE ip = '%s' AND port = '%s' LIMIT 0,1), ' ')",
-			DatabasePrefix, Ip, Authid, banName, (time * 60), (time * 60), banReason, DatabasePrefix, AdminAuthid, AdminAuthid[8], AdminIp, DatabasePrefix, ServerIp, ServerPort);
+		if (DB.Format(Query, sizeof(Query), "INSERT INTO %!s_bans (ip, authid, name, created, ends, length, reason, aid, adminIp, sid, country) VALUES \
+						('%s', '%s', '%s', UNIX_TIMESTAMP(), UNIX_TIMESTAMP() + %d, %d, '%s', IFNULL((SELECT aid FROM %!s_admins WHERE authid = '%s' OR authid REGEXP '^STEAM_[0-9]:%s$'),'0'), '%s', \
+						(SELECT sid FROM %!s_servers WHERE ip = '%s' AND port = '%s' LIMIT 0,1), ' ')",
+			DatabasePrefix, Ip, Authid, Name, (time * 60), (time * 60), Reason, DatabasePrefix, AdminAuthid, AdminAuthid[8], AdminIp, DatabasePrefix, ServerIp, ServerPort) >= sizeof(Query))
+		{
+			LogError("UTIL_InsertBan query truncated");
+			return;
+		}
 	} else {
-		FormatEx(Query, sizeof(Query), "INSERT INTO %s_bans (ip, authid, name, created, ends, length, reason, aid, adminIp, sid, country) VALUES \
-						('%s', '%s', '%s', UNIX_TIMESTAMP(), UNIX_TIMESTAMP() + %d, %d, '%s', IFNULL((SELECT aid FROM %s_admins WHERE authid = '%s' OR authid REGEXP '^STEAM_[0-9]:%s$'),'0'), '%s', \
+		if (DB.Format(Query, sizeof(Query), "INSERT INTO %!s_bans (ip, authid, name, created, ends, length, reason, aid, adminIp, sid, country) VALUES \
+						('%s', '%s', '%s', UNIX_TIMESTAMP(), UNIX_TIMESTAMP() + %d, %d, '%s', IFNULL((SELECT aid FROM %!s_admins WHERE authid = '%s' OR authid REGEXP '^STEAM_[0-9]:%s$'),'0'), '%s', \
 						%d, ' ')",
-			DatabasePrefix, Ip, Authid, banName, (time * 60), (time * 60), banReason, DatabasePrefix, AdminAuthid, AdminAuthid[8], AdminIp, serverID);
+			DatabasePrefix, Ip, Authid, Name, (time * 60), (time * 60), Reason, DatabasePrefix, AdminAuthid, AdminAuthid[8], AdminIp, serverID) >= sizeof(Query))
+		{
+			LogError("UTIL_InsertBan query truncated");
+			return;
+		}
 	}
 	DB.Query(VerifyInsert, Query, dataPack, DBPrio_High);
 }
@@ -2603,13 +2663,13 @@ stock void UTIL_InsertTempBan(int time, const char[] name, const char[] auth, co
 		KickClient(client, "%t\n\n%t", "Banned Check Site", WebsiteAddress, "Kick Reason", admin, reason, length);
 	}
 
-	char banName[MAX_NAME_LENGTH], banReason[256], query[512];
-
-	SQLiteDB.Escape(name, banName, sizeof(banName));
-	SQLiteDB.Escape(reason, banReason, sizeof(banReason));
-
-	FormatEx(query, sizeof(query), "INSERT INTO queue VALUES ('%s', %i, %i, '%s', '%s', '%s', '%s', '%s')",
-		auth, time, GetTime(), banReason, banName, ip, adminAuth, adminIp);
+	char query[1024];
+	if (SQLiteDB.Format(query, sizeof(query), "INSERT INTO queue VALUES ('%s', %i, %i, '%s', '%s', '%s', '%s', '%s')",
+		auth, time, GetTime(), reason, name, ip, adminAuth, adminIp) >= sizeof(query))
+	{
+		LogError("UTIL_InsertTempBan query truncated");
+		return;
+	}
 
 	SQLiteDB.Query(ErrorCheckCallback, query);
 }

--- a/game/addons/sourcemod/scripting/sbpp_main.sp
+++ b/game/addons/sourcemod/scripting/sbpp_main.sp
@@ -2462,9 +2462,10 @@ public int Native_SBReportPlayer(Handle plugin, int numParams)
 
 	GetNativeString(3, sReason, iReasonLen);
 
-	char[] sQuery = new char[768 + (iReasonLen * 2 + 1)];
-	if (DB.Format(sQuery, sizeof(sQuery), "INSERT INTO %!s_submissions (`submitted`, `modid`, `SteamId`, `name`, `email`, `reason`, `ip`, `subname`, `sip`, `archiv`, `server`)"
-	... "VALUES ('%d', 0, '%s', '%s', '%s', '%s', '%s', '%s', '%s', 0, '%d')", DatabasePrefix, iTime, g_sSteamIDs[iTarget], g_sName[iTarget], g_sSteamIDs[iReporter], sReason, g_sPlayerIP[iReporter], g_sName[iReporter], g_sPlayerIP[iTarget], (serverID != -1) ? serverID : 0) >= sizeof(sQuery))
+	int iQueryLen = 768 + (iReasonLen * 2 + 1);
+	char[] sQuery = new char[iQueryLen];
+	if (DB.Format(sQuery, iQueryLen, "INSERT INTO %!s_submissions (`submitted`, `modid`, `SteamId`, `name`, `email`, `reason`, `ip`, `subname`, `sip`, `archiv`, `server`)"
+	... "VALUES ('%d', 0, '%s', '%s', '%s', '%s', '%s', '%s', '%s', 0, '%d')", DatabasePrefix, iTime, g_sSteamIDs[iTarget], g_sName[iTarget], g_sSteamIDs[iReporter], sReason, g_sPlayerIP[iReporter], g_sName[iReporter], g_sPlayerIP[iTarget], (serverID != -1) ? serverID : 0) >= iQueryLen)
 	{
 		ThrowNativeError(SP_ERROR_NATIVE, "Failed to build report query (buffer too small)");
 		return 0;

--- a/game/addons/sourcemod/scripting/sbpp_main.sp
+++ b/game/addons/sourcemod/scripting/sbpp_main.sp
@@ -1216,6 +1216,8 @@ public void VerifyInsert(Database db, DBResultSet results, const char[] error, D
 	dataPack.ReadString(Name, sizeof(Name));
 	ReasonPack.ReadString(Reason, sizeof(Reason));
 
+	delete dataPack;
+
 	if (!time)
 	{
 		if (Reason[0] == '\0')
@@ -1278,6 +1280,7 @@ public void SelectBanIpCallback(Database db, DBResultSet results, const char[] e
 		else
 			PrintToServer("%s%t", Prefix, "Ban Fail");
 
+		delete dataPack;
 		return;
 	}
 	if (results.RowCount)
@@ -1287,6 +1290,7 @@ public void SelectBanIpCallback(Database db, DBResultSet results, const char[] e
 		else
 			PrintToServer("%s%t", Prefix, "Already Banned", ip);
 
+		delete dataPack;
 		return;
 	}
 	if (serverID == -1)
@@ -1297,6 +1301,7 @@ public void SelectBanIpCallback(Database db, DBResultSet results, const char[] e
 			DatabasePrefix, ip, targetAuth, targetName, (minutes * 60), (minutes * 60), reason, DatabasePrefix, adminAuth, adminAuth[8], adminIp, DatabasePrefix, ServerIp, ServerPort) >= sizeof(Query))
 		{
 			LogError("SelectBanIpCallback insert query truncated");
+			delete dataPack;
 			return;
 		}
 	} else {
@@ -1306,6 +1311,7 @@ public void SelectBanIpCallback(Database db, DBResultSet results, const char[] e
 			DatabasePrefix, ip, targetAuth, targetName, (minutes * 60), (minutes * 60), reason, DatabasePrefix, adminAuth, adminAuth[8], adminIp, serverID) >= sizeof(Query))
 		{
 			LogError("SelectBanIpCallback insert query truncated");
+			delete dataPack;
 			return;
 		}
 	}
@@ -1495,6 +1501,7 @@ public void SelectAddbanCallback(Database db, DBResultSet results, const char[] 
 		else
 			PrintToServer("%s%t", Prefix, "Ban Fail");
 
+		delete dataPack;
 		return;
 	}
 	if (results.RowCount)
@@ -1504,6 +1511,7 @@ public void SelectAddbanCallback(Database db, DBResultSet results, const char[] 
 		else
 			PrintToServer("%s%t", Prefix, "Already Banned", authid);
 
+		delete dataPack;
 		return;
 	}
 	if (serverID == -1)
@@ -1514,6 +1522,7 @@ public void SelectAddbanCallback(Database db, DBResultSet results, const char[] 
 			DatabasePrefix, authid, (minutes * 60), (minutes * 60), reason, DatabasePrefix, adminAuth, adminAuth[8], adminIp, DatabasePrefix, ServerIp, ServerPort) >= sizeof(Query))
 		{
 			LogError("SelectAddbanCallback insert query truncated");
+			delete dataPack;
 			return;
 		}
 	} else {
@@ -1523,6 +1532,7 @@ public void SelectAddbanCallback(Database db, DBResultSet results, const char[] 
 			DatabasePrefix, authid, (minutes * 60), (minutes * 60), reason, DatabasePrefix, adminAuth, adminAuth[8], adminIp, serverID) >= sizeof(Query))
 		{
 			LogError("SelectAddbanCallback insert query truncated");
+			delete dataPack;
 			return;
 		}
 	}
@@ -1628,12 +1638,12 @@ public void ProcessQueueCallback(Database db, DBResultSet results, const char[] 
 			db.Query(AddedFromSQLiteCallback, query, authPack);
 		} else {
 			// The ban is no longer valid and should be deleted from the queue
-			if (SQLiteDB.Format(query, sizeof(query), "DELETE FROM queue WHERE steam_id = '%s'", auth) >= sizeof(query))
+			if (db.Format(query, sizeof(query), "DELETE FROM queue WHERE steam_id = '%s'", auth) >= sizeof(query))
 			{
 				LogError("ProcessQueueCallback delete query truncated");
 				continue;
 			}
-			SQLiteDB.Query(ErrorCheckCallback, query);
+			db.Query(ErrorCheckCallback, query);
 		}
 	}
 	// We have finished processing the queue but should process again in ProcessQueueTime minutes
@@ -2485,7 +2495,10 @@ public int Native_SBReportPlayer(Handle plugin, int numParams)
 public void SQL_OnReportPlayer(Database db, DBResultSet results, const char[] error, DataPack dataPack)
 {
 	if (results == null)
+	{
 		LogToFile(logFile, "Failed to submit report: %s", error);
+		delete dataPack;
+	}
 	else
 	{
 		dataPack.Reset();
@@ -2603,8 +2616,34 @@ public bool CreateBan(int client, int target, int time, const char[] reason)
 	return true;
 }
 
+stock void CleanupBanDataPack(DataPack pack)
+{
+	if (pack == null)
+	{
+		return;
+	}
+
+	pack.Reset();
+	pack.ReadCell(); // admin index
+	pack.ReadCell(); // target index
+	pack.ReadCell(); // admin userid
+	pack.ReadCell(); // target userid
+	pack.ReadCell(); // time
+
+	DataPack reasonPack = view_as<DataPack>(pack.ReadCell());
+	if (reasonPack != null)
+		delete reasonPack;
+
+	delete pack;
+}
+
 stock void UTIL_InsertBan(int time, const char[] Name, const char[] Authid, const char[] Ip, const char[] Reason, const char[] AdminAuthid, const char[] AdminIp, DataPack dataPack)
 {
+	if (dataPack == null)
+	{
+		return;
+	}
+
 	//new Handle:dummy;
 	//PruneBans(dummy);
 	char Query[2048];
@@ -2616,6 +2655,7 @@ stock void UTIL_InsertBan(int time, const char[] Name, const char[] Authid, cons
 			DatabasePrefix, Ip, Authid, Name, (time * 60), (time * 60), Reason, DatabasePrefix, AdminAuthid, AdminAuthid[8], AdminIp, DatabasePrefix, ServerIp, ServerPort) >= sizeof(Query))
 		{
 			LogError("UTIL_InsertBan query truncated");
+			CleanupBanDataPack(dataPack);
 			return;
 		}
 	} else {
@@ -2625,6 +2665,7 @@ stock void UTIL_InsertBan(int time, const char[] Name, const char[] Authid, cons
 			DatabasePrefix, Ip, Authid, Name, (time * 60), (time * 60), Reason, DatabasePrefix, AdminAuthid, AdminAuthid[8], AdminIp, serverID) >= sizeof(Query))
 		{
 			LogError("UTIL_InsertBan query truncated");
+			CleanupBanDataPack(dataPack);
 			return;
 		}
 	}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR updates both SourceBans++ scripting plugins to apply a consistent SQL construction and error-handling pattern.

Updated files:
- sbpp_main.sp
- sbpp_comms.sp

Key changes:
- Replaced manual escaping patterns with DB.Format/SQLiteDB.Format where applicable.
- Standardized placeholder usage:
  - %!s for internal SQL values (DatabasePrefix, table/fragment internals).
  - %s for user/runtime inputs.
- Added/kept defensive query buffer truncation checks before DB.Query calls.
- Harmonized truncation diagnostics to use LogError consistently across both plugins.
- Removed early DataPack creation on code paths where query formatting can fail:
  - DataPack is now created after successful query formatting in affected command/query paths.
  - This removes unnecessary rollback-style delete usage introduced only for failed pre-query guards.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This change improves safety and consistency in SQL handling across plugins:
- Prevents double-escaping mistakes from mixed Escape + Format patterns.
- Enforces a clear placeholder contract for internal vs user-provided values.
- Makes truncation failures visible in the same way across both plugins (LogError).
- Simplifies ownership/lifecycle of DataPack objects by allocating them only when needed.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Editor diagnostics check:
  - No errors reported for both updated files.
- Pattern verification checks:
  - No remaining .Escape(...) usages.
  - Truncation guard logs use LogError consistently in both plugins.
- Lifecycle verification:
  - DataPack allocation moved after successful query formatting in modified guard paths.
  - Remaining delete dataPack calls are in normal callback/cleanup flows.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.

---

**Note:** If your PR touches `web/**` and this is your first
contribution to the web panel, the CLA bot will comment within
~30 seconds with one-line sign instructions. You only need to sign
once per repo. See `CLA.md` for the full text and
`CONTRIBUTING.md` for the rationale.