### PR TITLE
fix: remove debug log, fix typos, logic inversion, and wrong return values

### DIFF
--- a/game/addons/sourcemod/scripting/sbpp_main.sp
+++ b/game/addons/sourcemod/scripting/sbpp_main.sp
@@ -1257,8 +1257,6 @@ public void SelectBanIpCallback(Database db, DBResultSet results, const char[] e
 	DB.Escape(reason, banReason, sizeof(banReason));
 	DB.Escape(targetName, sTEscapedName, sizeof(sTEscapedName));
 
-	LogMessage("******************************Tagetauth: %s", targetAuth);
-
 	if (results == null)
 	{
 		LogToFile(logFile, "Ban IP Select Query Failed: %s", error);
@@ -1327,7 +1325,7 @@ public void InsertBanIpCallback(Database db, DBResultSet results, const char[] e
 		{
 			char length[32];
 			if(minutes == 0)
-				FormatEx(length, sizeof(length), "permament");
+				FormatEx(length, sizeof(length), "permanent");
 			else
 				FormatEx(length, sizeof(length), "%d %s", minutes, minutes == 1 ? "minute" : "minutes");
 
@@ -1609,7 +1607,7 @@ public void AddedFromSQLiteCallback(Database db, DBResultSet results, const char
 	char auth[MAX_AUTHID_LENGTH];
 
 	dataPack.ReadString(auth, sizeof(auth));
-	if (results == null)
+	if (results != null)
 	{
 		// The insert was successful so delete the record from the queue
 		FormatEx(buffer, sizeof(buffer), "DELETE FROM queue WHERE steam_id = '%s'", auth);
@@ -2599,7 +2597,7 @@ stock void UTIL_InsertTempBan(int time, const char[] name, const char[] auth, co
 	{
 		char length[32];
 		if(time == 0)
-			FormatEx(length, sizeof(length), "permament");
+			FormatEx(length, sizeof(length), "permanent");
 		else
 			FormatEx(length, sizeof(length), "%d %s", time, time == 1 ? "minute" : "minutes");
 		KickClient(client, "%t\n\n%t", "Banned Check Site", WebsiteAddress, "Kick Reason", admin, reason, length);

--- a/game/addons/sourcemod/scripting/sbpp_report.sp
+++ b/game/addons/sourcemod/scripting/sbpp_report.sp
@@ -67,7 +67,7 @@ public Action CmdReport(int iClient, int iArgs)
 
 	char sName[MAX_NAME_LENGTH], sIndex[4];
 
-	for (int i = 0; i <= MaxClients; i++)
+	for (int i = 1; i <= MaxClients; i++)
 	{
 		if (!IsValidClient(i))
 			continue;

--- a/game/addons/sourcemod/scripting/sbpp_sleuth.sp
+++ b/game/addons/sourcemod/scripting/sbpp_sleuth.sp
@@ -182,7 +182,7 @@ public Action ReloadListCallBack(int client, int args)
 		PrintToChat(client, "%sWhiteList has been reloaded!", PREFIX);
 	}
 
-	return Plugin_Continue;
+	return Plugin_Handled;
 }
 
 public void OnClientPostAdminCheck(int client)


### PR DESCRIPTION
## Summary

Three files with five bugs caught during a review pass:

**sbpp_main.sp**
- Remove accidental debug `LogMessage` left in production code (`"******************************Tagetauth: %s"`)
- Fix `"permament"` -> `"permanent"` typo in two places (`CommandBan`, `CommandSBBan`)
- Fix inverted condition in `AddedFromSQLiteCallback`: `results == null` was the success branch but `null` means the query *failed*. Should be `results != null`. With the original code, successful offline-queue inserts were treated as failures (temp ban extended, record kept in queue) and failed inserts were treated as successes (record deleted from queue, temp ban removed) -- breaking offline-ban queue recovery silently.

**sbpp_report.sp**
- Player list loop started at `i = 0` instead of `i = 1`. Client 0 is the server console and is never a valid report target. `IsValidClient(0)` filters it out, so this is harmless in practice, but semantically wrong.

**sbpp_sleuth.sp**
- `sm_slreload` command handler returned `Plugin_Continue`, causing "Unknown command" to appear in the caller's console after reloading the whitelist. Changed to `Plugin_Handled`.

## Test notes

The `AddedFromSQLiteCallback` fix is the only one with observable behaviour change -- it corrects the offline-ban queue recovery path when SBPP reconnects to the main database after an outage.
