### PR TITLE
fix(plugin): resolve admin group references case-insensitively (#1503)

### DIFF
--- a/game/addons/sourcemod/scripting/sbpp_admcfg.sp
+++ b/game/addons/sourcemod/scripting/sbpp_admcfg.sp
@@ -46,6 +46,12 @@ int g_IgnoreLevel = 0; /* Nested ignored section count, so users can screw up fi
 int g_CurrentLine = 0; /* Current line we're on */
 char g_Filename[PLATFORM_MAX_PATH]; /* Used for error messages */
 
+/* Maps a lowercased server-group name to its GroupId. Populated while the
+ * groups config is parsed and consulted as the case-insensitive fallback in
+ * FindAdmGroupInsensitive (issue #1503). Declared before the sub-file includes
+ * so ReadGroups() (which fills it) can see it. */
+StringMap g_GroupNameMap = null;
+
 #include "sbpp_admcfg/sbpp_admin_groups.sp"
 #include "sbpp_admcfg/sbpp_admin_users.sp"
 
@@ -56,6 +62,13 @@ public void OnRebuildAdminCache(AdminCachePart part)
 	} else if (part == AdminCache_Admins) {
 		ReadUsers();
 	}
+}
+
+public void OnPluginEnd()
+{
+	// SourceMod reclaims the handle on unload anyway; released explicitly for
+	// hygiene so the case-insensitive group map doesn't linger.
+	delete g_GroupNameMap;
 }
 
 void ParseError(const char[] format, any...)
@@ -81,4 +94,94 @@ void InitGlobalStates()
 	g_IgnoreLevel = 0;
 	g_CurrentLine = 0;
 	g_LoggedFileName = false;
+}
+
+// Copy src into dest, lowercasing every character. Used to build/consult the
+// case-insensitive group-name map keys (StringMap keys are case-sensitive).
+// CharToLower is ASCII-only, which is fine here: the case drift this fixes is
+// ASCII (e.g. "Admin" vs "admin"), and any multibyte bytes pass through
+// unchanged and identically on both the register and lookup sides, so a
+// non-ASCII name still maps to itself.
+void LowercaseCopy(char[] dest, int maxlength, const char[] src)
+{
+	if (maxlength <= 0)
+	{
+		return;
+	}
+
+	int i = 0;
+	for (; i < maxlength - 1 && src[i] != '\0'; i++)
+	{
+		dest[i] = CharToLower(src[i]);
+	}
+	dest[i] = '\0';
+}
+
+// Record a parsed server-group name so FindAdmGroupInsensitive can resolve a
+// later reference to it regardless of case. Called as each group section is
+// created while reading sb_admin_groups.cfg. The key is the case-folded name,
+// so if two group sections differ only in case ("Admin" and "admin") they map
+// to one key and the last-registered id wins in the case-folded fallback
+// keyspace. That collision only affects references that miss the exact-case
+// FindAdmGroup below; SourceMod itself keeps such groups distinct.
+void RegisterGroupName(const char[] group_name, GroupId id)
+{
+	if (g_GroupNameMap == null || id == INVALID_GROUP_ID)
+	{
+		return;
+	}
+
+	// srvgroups.name is varchar(120); the generator fetches it into a
+	// 128-char buffer, so size to match and avoid truncating long names.
+	char lower[128];
+	LowercaseCopy(lower, sizeof(lower), group_name);
+	g_GroupNameMap.SetValue(lower, id);
+}
+
+// Resolve an admin-group name to its GroupId, tolerating case differences.
+//
+// SourceMod's admin cache matches group names case-sensitively (both
+// FindAdmGroup and CreateAdmGroup key off a case-sensitive map) and exposes no
+// native to enumerate loaded groups, so we track the names ourselves as the
+// groups config is parsed. The SourceBans++ config files (sb_admin_groups.cfg /
+// sb_admins.cfg) are generated from a database where a group's name can drift
+// in case between the group definition and an admin's group reference: legacy
+// AMXBans / SourceBans imports, manual DB edits, case-sensitive DB collations,
+// or an older generator build that copied the admin's raw srv_group string
+// instead of the canonical srvgroups.name. A group defined as "admin" but
+// referenced as "Admin" would otherwise fail with a spurious "Unknown group"
+// error and silently drop the admin's group inheritance. Try the fast
+// exact-case lookup first (covers groups created by any plugin), then fall back
+// to the case-folded map (covers the SourceBans++ groups this reader tracks) so
+// the reference resolves regardless of the stored case (issue #1503).
+//
+// Freshness invariant: the GroupIds in the map are only valid for the current
+// admin-cache generation. This holds because SourceMod rebuilds groups before
+// admins and ReadGroups() clears+repopulates the map on every AdminCache_Groups
+// rebuild, so the map never outlives the group cache it describes. The map does
+// legitimately persist across an admins-only rebuild (SourceMod leaves the group
+// cache untouched then, so the stored ids stay valid).
+GroupId FindAdmGroupInsensitive(const char[] group_name)
+{
+	GroupId id = FindAdmGroup(group_name);
+	if (id != INVALID_GROUP_ID)
+	{
+		return id;
+	}
+
+	if (g_GroupNameMap == null)
+	{
+		return INVALID_GROUP_ID;
+	}
+
+	char lower[128];
+	LowercaseCopy(lower, sizeof(lower), group_name);
+
+	int mapped;
+	if (g_GroupNameMap.GetValue(lower, mapped))
+	{
+		return view_as<GroupId>(mapped);
+	}
+
+	return INVALID_GROUP_ID;
 }

--- a/game/addons/sourcemod/scripting/sbpp_admcfg/sbpp_admin_groups.sp
+++ b/game/addons/sourcemod/scripting/sbpp_admcfg/sbpp_admin_groups.sp
@@ -66,6 +66,9 @@ public SMCResult ReadGroups_NewSection(SMCParser smc, const char[] name, bool op
 		{
 			g_CurGrp = FindAdmGroup(name);
 		}
+		// Track the name so a later case-mismatched reference (from an admin
+		// or a group-immunity line) still resolves to this group (#1503).
+		RegisterGroupName(name, g_CurGrp);
 		g_GroupState = GroupState_InGroup;
 	} else if (g_GroupState == GroupState_InGroup) {
 		if (StrEqual(name, "Overrides", false))
@@ -144,12 +147,15 @@ public SMCResult ReadGroups_KeyValue(SMCParser smc,
 				{
 					g_CurGrp.ImmunityLevel = level;
 				} else {
+					// Case-insensitive so a group-immunity reference survives a
+					// case mismatch against the referenced group's definition,
+					// same drift class as the admin group reference (#1503).
 					GroupId id;
 					if (value[0] == '@')
 					{
-						id = FindAdmGroup(value[1]);
+						id = FindAdmGroupInsensitive(value[1]);
 					} else {
-						id = FindAdmGroup(value);
+						id = FindAdmGroupInsensitive(value);
 					}
 					if (id != INVALID_GROUP_ID)
 					{
@@ -231,6 +237,18 @@ static void InternalReadGroups(const char[] path, GroupPass pass)
 void ReadGroups()
 {
 	InitializeGroupParser();
+
+	// Reset the case-insensitive lookup table for this rebuild. The GroupIds
+	// stored below are only valid for the cache we are about to (re)build, so
+	// a stale entry from a prior pass must never leak into the next one.
+	if (g_GroupNameMap == null)
+	{
+		g_GroupNameMap = new StringMap();
+	}
+	else
+	{
+		g_GroupNameMap.Clear();
+	}
 
 	BuildPath(Path_SM, g_Filename, sizeof(g_Filename), "configs/sourcebans/sb_admin_groups.cfg");
 

--- a/game/addons/sourcemod/scripting/sbpp_admcfg/sbpp_admin_users.sp
+++ b/game/addons/sourcemod/scripting/sbpp_admcfg/sbpp_admin_users.sp
@@ -104,10 +104,14 @@ public SMCResult ReadUsers_KeyValue(SMCParser smc,
 	}
 	else if (StrEqual(key, "group", false))
 	{
-		GroupId id = FindAdmGroup(value);
+		// Case-insensitive so a case mismatch between the group definition
+		// in sb_admin_groups.cfg and this reference doesn't drop the admin's
+		// group inheritance with a spurious "Unknown group" error (#1503).
+		GroupId id = FindAdmGroupInsensitive(value);
 		if (id == INVALID_GROUP_ID)
 		{
 			ParseError("Unknown group \"%s\"", value);
+			return SMCParse_Continue;
 		}
 
 		g_GroupArray.Push(id);


### PR DESCRIPTION
## Summary

Fixes #1503. SourceMod's admin cache matches group names **case-sensitively**, so a server group defined as `admin` in `sb_admin_groups.cfg` but referenced as `Admin` in `sb_admins.cfg` fails with a spurious `Unknown group "Admin"` error and **silently drops the admin's group inheritance** (flags, immunity). The same drift breaks group-immunity references between groups.

The case mismatch originates upstream of the reader: legacy AMXBans / SourceBans imports, manual DB edits, case-sensitive DB collations, or an older generator build that copied the admin's raw `srv_group` string instead of the canonical `srvgroups.name`.

## Root cause & scope

`FindAdmGroup()` (SourceMod native) is case-sensitive and there is no native to enumerate loaded groups. The fix lives in the **config reader** (`sbpp_admcfg`), not the generator (`sbpp_main`):

- The reader must tolerate a mismatch **regardless of its source** (config files can be hand-edited, legacy, or from a divergent generator).
- The generator's in-memory admin path already normalises group names on the canonical `srvgroups.name` via SQL, so `BackupConfigs 0` (in-memory) deployments don't exhibit the drift. Touching the DB-facing generator would add risk without covering the file-based path this issue reports.

## Changes

- **`sbpp_admcfg.sp`** — new `g_GroupNameMap` (`StringMap`, case-folded name → `GroupId`) plus helpers `LowercaseCopy`, `RegisterGroupName`, and `FindAdmGroupInsensitive` (exact-case `FindAdmGroup` first, then the case-folded fallback). Released in `OnPluginEnd`.
- **`sbpp_admcfg/sbpp_admin_groups.sp`** — register each parsed group's name; clear+repopulate the map on every `AdminCache_Groups` rebuild so stored `GroupId`s never outlive the group cache; route group-immunity references through the case-insensitive lookup.
- **`sbpp_admcfg/sbpp_admin_users.sp`** — route the admin `group` key through the case-insensitive lookup; skip pushing an invalid id after the `Unknown group` `ParseError`.

Group **creation** stays case-sensitive (SourceMod owns that); only **references** are resolved leniently, and only as a fallback after the exact-case match misses.

## Adversarial review

Self-reviewed with an adversarial pass. No blockers. Addressed non-blocking findings: documented the map's freshness invariant (groups always rebuild before admins), clarified the case-collapse ("last one wins") comment, added a `maxlength <= 0` guard to `LowercaseCopy`, noted the ASCII-only `CharToLower` limitation (benign — non-ASCII bytes pass through identically on both sides), and added explicit map teardown on unload. Confirmed the two-pass immunity parse fully populates the map in pass 1, `view_as<GroupId>` round-trips cleanly, and the immunity `ParseError` parity matches upstream.

## Test plan

- [x] `spcomp 1.12` compiles `sbpp_admcfg.sp` clean (exit 0, no warnings) — matches the `plugin-build.yml` gate.
- [ ] Runtime: define a group `admin` and an admin referencing `Admin`; confirm no `Unknown group` in the SM log and the admin inherits the group's flags/immunity.
- [ ] Regression: matched-case configs and cross-group immunity still resolve; a genuinely-unknown group still logs `Unknown group`.