### PR TITLE
fix(admin-servers): vertically align Server ID value with its label

### DIFF
--- a/web/themes/default/page_admin_servers_list.tpl
+++ b/web/themes/default/page_admin_servers_list.tpl
@@ -150,7 +150,16 @@
                             {/if}
                         </header>
 
-                        <dl class="text-xs text-muted" style="margin:0;display:grid;grid-template-columns:auto 1fr;gap:0.25rem 0.5rem">
+                        {*
+                            align-items:center keeps each label/value pair on the
+                            same vertical line. The "Server ID" row's <dd> is a flex
+                            container whose copy button (btn--xs, 1.5rem) makes the
+                            row taller than a single line of text; without centering
+                            the grid, the <dt> label sits top-aligned while the
+                            button-driven <dd> content centres, so the ID reads as
+                            dropped below its label (#1523 follow-up).
+                        *}
+                        <dl class="text-xs text-muted" style="margin:0;display:grid;grid-template-columns:auto 1fr;align-items:center;gap:0.25rem 0.5rem">
                             {*
                                 Server ID (#1504): the numeric sid the SourceMod
                                 plugin's sourcebans.cfg "ServerID" field needs.


### PR DESCRIPTION
## Summary

Follow-up to #1523.

#1523 added a labelled, copyable **Server ID** row to each admin server card. The row's `<dd>` is a flex container (`display:flex;align-items:center`) whose copy button (`btn btn--ghost btn--icon btn--xs`, 1.5rem tall) makes the row taller than a single line of text. Its sibling `<dt>` label inherited the `<dl>` grid's default `align-items:stretch`, so the label sat **top-aligned** while the button-driven value **centered**. The result: the numeric ID reads as dropped below its "Server ID" label instead of sitting inline with it.

This adds `align-items:center` to the card's inner `<dl>` grid in `web/themes/default/page_admin_servers_list.tpl` so every label/value pair lines up on the same vertical level.

- **Server ID row** — label now lines up with the value + copy button.
- **Mod / Players / Map rows** — single-line text of equal height, so `center` vs `stretch` is a visual no-op (no regression). Their hydrated cells (`server-players` / `server-map`) are patched with single-line `textContent`, so nothing multi-line is affected.

Template-only change: one inline-CSS property + an explanatory comment. No new Smarty variables, testids, or content, so it doesn't touch the `SmartyTemplateRule` (PHPStan) contract, `AdminServersListHydrationTest` (asserts testids/content), ts-check, or the `admin-server-id.spec.ts` render contract.

## Test plan

- [ ] Visual: open **Admin Panel → Servers**, confirm the **Server ID** value + copy button sit on the same vertical line as the "Server ID" label on both enabled and disabled cards.
- [ ] Confirm Mod / Players / Map rows are unchanged.
- [x] Existing `AdminServersListHydrationTest::testTileRendersCopyableServerId` assertions (testids/value/copy payload/label) still hold — structure unchanged.