### PR TITLE
fix(data-export): name index.php in S3 completion redirects

### DIFF
--- a/web/export.php
+++ b/web/export.php
@@ -497,7 +497,15 @@ function sbpp_export_run_s3_mode(Manifest $manifest, EntityExporter $entities, i
  */
 function sbpp_export_redirect_success(string $bundleId): never
 {
-    header('Location: ?p=admin&c=export&result=success&bid=' . rawurlencode($bundleId));
+    // NOTE: the path is explicit (`index.php`), NOT a bare `?p=...`
+    // query-only reference. This redirect fires from `web/export.php`,
+    // so a query-only `Location` would resolve against THIS script's
+    // path (RFC 3986 §5.2: an empty-path reference keeps the base
+    // path) and bounce the browser to `export.php?p=admin&c=export...`
+    // as a GET — straight into the POST-only method gate above
+    // ("POST required."). The admin page handler lives behind
+    // `index.php`, so the router entry point has to be named.
+    header('Location: index.php?p=admin&c=export&result=success&bid=' . rawurlencode($bundleId));
     exit;
 }
 
@@ -514,6 +522,9 @@ function sbpp_export_redirect_success(string $bundleId): never
  */
 function sbpp_export_redirect_failure(string $code, string $context = ''): never
 {
-    header('Location: ?p=admin&c=export&result=error&code=' . rawurlencode($code));
+    // Explicit `index.php` path — see the note in
+    // sbpp_export_redirect_success() for why a bare `?p=...`
+    // query-only reference would re-enter export.php's POST gate.
+    header('Location: index.php?p=admin&c=export&result=error&code=' . rawurlencode($code));
     exit;
 }

--- a/web/tests/integration/AdminExportPermissionTest.php
+++ b/web/tests/integration/AdminExportPermissionTest.php
@@ -187,6 +187,46 @@ final class AdminExportPermissionTest extends TestCase
     }
 
     /**
+     * The S3-mode completion redirects (success + failure) must
+     * target `index.php?p=admin&c=export`, NOT a bare query-only
+     * `?p=admin&c=export`. This redirect fires from
+     * `web/export.php`, so a `Location: ?p=...` reference resolves
+     * against THIS script's path per RFC 3986 §5.2 (an empty-path
+     * reference keeps the base path) — the browser would follow it
+     * to `export.php?p=admin&c=export...` as a GET and hit the
+     * POST-only method gate ("POST required."). The ZIP mode
+     * streams its body and never redirects, so the bug only ever
+     * surfaced on the S3 path — the operator saw "POST required."
+     * after the upload actually ran. The admin page handler lives
+     * behind `index.php`, so the router entry point MUST be named
+     * explicitly. Regression guard for the S3 "POST required." report.
+     */
+    public function testEntryPointRedirectsNameIndexPhpNotBareQuery(): void
+    {
+        $src = $this->entryPointSource();
+
+        // A bare `Location: ?p=...` query-only reference re-enters
+        // export.php's POST gate. It must never appear.
+        $this->assertDoesNotMatchRegularExpression(
+            "/Location:\s*\?p=/",
+            $src,
+            'export.php must NOT emit a bare `Location: ?p=...` query-only redirect. It fires from export.php, so a query-only reference keeps the base path (/export.php) and bounces the browser back into the POST-only gate ("POST required."). Name index.php explicitly.',
+        );
+
+        // Both completion arms must name index.php explicitly.
+        $this->assertMatchesRegularExpression(
+            "/Location: index\.php\?p=admin&c=export&result=success/",
+            $src,
+            'export.php S3 success redirect must target index.php?p=admin&c=export&result=success (the router entry point), not export.php itself.',
+        );
+        $this->assertMatchesRegularExpression(
+            "/Location: index\.php\?p=admin&c=export&result=error/",
+            $src,
+            'export.php S3 failure redirect must target index.php?p=admin&c=export&result=error (the router entry point), not export.php itself.',
+        );
+    }
+
+    /**
      * Defence-in-depth: the page handler must re-check the
      * permission via `CheckAdminAccess(ADMIN_OWNER)` even though
      * the routing table already gated `?p=admin&c=export` on


### PR DESCRIPTION
## Description

Fixes the S3-delivery mode of the owner-only Full data export: pasting a presigned S3 URL and submitting produced a bare **"POST required."** screen instead of a success/error toast.

`web/export.php`'s two completion redirects (`sbpp_export_redirect_success` / `sbpp_export_redirect_failure`) emitted a query-only `Location: ?p=admin&c=export&result=...` reference. Because the redirect fires from `export.php`, the browser resolved the empty-path reference against `export.php`'s own path (RFC 3986 §5.2 keeps the base path) and followed it as a **GET** to `export.php?p=admin&c=export...`, landing straight in the POST-only method gate at the top of the script. The S3 upload had already run by then, so the operator saw a bogus error after a successful export.

Both arms now name the router entry point explicitly (`Location: index.php?p=admin&c=export...`), so the redirect resolves to `/index.php?p=admin&c=export...` and the admin page handler paints the toast.

ZIP mode streams its body to `php://output` and never redirects, which is exactly why only the S3 path was affected (ZIP downloads worked fine).

## Motivation and Context

Operator report: "When I paste a presigned S3 URL into the export, I get a screen 'POST required.'"

The S3 completion path is the one export branch that redirects, and it had no end-to-end coverage (only the uploader class is unit-tested via transport injection), so the bad redirect target slipped through.

## How Has This Been Tested?

- `php -l` clean on both edited files.
- Verified the new test's three assertions pass against the edited `export.php`:
  - no bare `Location: ?p=` remains,
  - success arm names `index.php`,
  - error arm names `index.php`.
- Confirmed these are the only two `Location:` redirects in `export.php` and that every S3 branch (success + all failure arms) routes through the two fixed helpers.

Added `testEntryPointRedirectsNameIndexPhpNotBareQuery()` to `AdminExportPermissionTest.php` as a regression guard (static-shape, no DB): fails if a bare `Location: ?p=` reappears.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.

<sub>Docs note: this is a redirect-path bugfix that makes the already-documented S3 flow work as written (no change to wire format, delivery modes, or the security model), so `data-export.mdx` / `ARCHITECTURE.md` need no update.</sub>
