### PR TITLE
fix(docker): stop "more than one MPM loaded" crash

### DIFF
--- a/docker/Dockerfile.prod
+++ b/docker/Dockerfile.prod
@@ -175,6 +175,17 @@ RUN { \
     } > /etc/apache2/conf-available/zz-sbpp-tokens.conf \
  && a2enconf zz-sbpp-tokens
 
+# `mod_php` only works under the `prefork` MPM. The base `php:8.5-apache`
+# image ships `prefork` enabled by default, but a dpkg trigger fired by
+# one of the `apt-get install` steps above (or by a downstream layer in a
+# platform's own build pipeline) can re-run apache2's package-level MPM
+# auto-selection and leave `event` (or `worker`) enabled alongside it —
+# Apache then refuses to start with "AH00534: More than one MPM loaded."
+# Re-assert the exclusive state as the last Apache-touching step so
+# nothing after this point can silently flip it back.
+RUN a2dismod -f mpm_event mpm_worker \
+ && a2enmod mpm_prefork
+
 # Copy the panel tree from the builder stage (vendor/ already populated).
 # We chown to www-data:www-data so the runtime user can write to cache/
 # templates_c/ + the demos/ volume mount target.

--- a/docker/php/prod-entrypoint.sh
+++ b/docker/php/prod-entrypoint.sh
@@ -369,6 +369,18 @@ validate_identifiers() {
 configure_apache() {
     log "step 2: configuring Apache (PORT=${PORT}, trusted proxies: ${SBPP_TRUSTED_PROXIES:-<none>})"
 
+    # Defense-in-depth re-assertion of the MPM pin the Dockerfile already
+    # applies at build time. Some platforms overlay or reset parts of
+    # /etc/apache2/mods-enabled between the image build and the container
+    # boot (e.g. a re-applied base layer, a build-cache restore that
+    # predates the pin); if that happens, `event`/`worker` can end up
+    # re-enabled alongside `prefork` and Apache dies on startup with
+    # "AH00534: More than one MPM loaded." mod_php only works under
+    # prefork, so re-pin it here every boot, before apache2-foreground
+    # ever runs.
+    a2dismod -f mpm_event mpm_worker >/dev/null 2>&1 || true
+    a2enmod mpm_prefork >/dev/null 2>&1 || true
+
     # Rewrite `Listen 80` -> `Listen ${PORT}` in /etc/apache2/ports.conf
     # and `<VirtualHost *:80>` in the default site. Only when PORT
     # differs from 80 (the image default) — saves a write on the


### PR DESCRIPTION
## Context

Found while deploying the published `ghcr.io/sbpp/sourcebans-pp` image to Railway. The container went into a crash loop on boot, with this in the logs:

```
AH00534: apache2: Configuration error: More than one MPM loaded.
```

The container restarted itself, ran the entrypoint again, and hit the exact same error every time, so the panel never came up.

## Summary

Fixes the Apache crash on boot above.

This happens when both the `prefork` MPM and another MPM (`event` or `worker`) are enabled at the same time. `mod_php`, which this panel uses, only works with `prefork`. If another MPM also gets enabled, Apache refuses to start.

This fix forces `prefork` to be the only MPM enabled, in two places:

1. `docker/Dockerfile.prod`: added a build step that disables `mpm_event` and `mpm_worker` and enables `mpm_prefork`, placed after every other Apache related step in the build.
2. `docker/php/prod-entrypoint.sh`: added the same disable/enable commands at the start of Apache configuration, so this runs every time the container boots. This is the important part, because it fixes the module state right before Apache starts, no matter what caused the wrong state in the first place, and it covers platforms like Railway where the container's runtime state can end up different from a plain local Docker run.

## Testing

This was tested with Podman.

- Built the full production image with `podman build`, no errors.
- Manually forced a broken state (both `prefork` and `event` enabled at once) inside a container and confirmed it reproduces the exact same error seen on Railway.
- Ran the new entrypoint fix against that broken state and confirmed `apache2ctl -M` shows only `prefork` afterward.
- Ran `apache2ctl configtest` after the fix and got `Syntax OK`.