### PR TITLE
Improve Admin Management UX: permissions, search, table, tooltips, and mobile fixes

### DIFF
--- a/web/includes/View/AdminAdminsSearchView.php
+++ b/web/includes/View/AdminAdminsSearchView.php
@@ -22,16 +22,11 @@ namespace Sbpp\View;
  * `{load_template file="admin.admins.search"}` Smarty plugin.
  *
  * The form submits as a plain `GET` to `?p=admin&c=admins` with one
- * parameter per populated filter (`name`, `name_match`, `steamid`,
- * `steam_match`, `admemail`, `admemail_match`, `webgroup`,
- * `srvadmgroup`, `srvgroup`, `admwebflag[]`, `admsrvflag[]`,
- * `server`). admin.admins.php AND-combines every non-empty filter —
- * see #1207 ADM-4. No CSRF field — search is read-only.
- *
- * `name_match` / `admemail_match` were added in #1231 so Login and
- * E-mail can be flipped between exact / partial mode the way SteamID
- * already could; defaults are partial ('1') to preserve pre-#1231
- * substring behaviour for legacy URLs.
+ * parameter per populated filter (`name`, `steamid`, `admemail`,
+ * `webgroup`, `srvadmgroup`, `srvgroup`, `admwebflag[]`, `admsrvflag[]`,
+ * `server`). Text filters are always partial (`LIKE %…%`).
+ * admin.admins.php AND-combines every non-empty filter. No CSRF
+ * field — search is read-only.
  *
  * `$active_filter_*` mirror the corresponding $_GET keys so the
  * template can pre-fill the form without splattering
@@ -40,14 +35,11 @@ namespace Sbpp\View;
  * given $_GET shape came from a modern submit, a legacy
  * `advType=…&advSearch=…` URL, or nothing at all.
  *
- * #1303 — collapsible disclosure
- * ------------------------------
  * The form is wrapped in a `<details class="card filters-details">`
  * default-collapsed disclosure so the unfiltered admin list paints
- * above the fold. `$has_active_filters` (derived from the nine
- * `active_filter_*` value slots — match-mode toggles don't count
- * because they always carry a default) drives the `[open]` attribute,
- * so any post-submit page paints with the form expanded. The chrome
+ * above the fold. `$has_active_filters` (derived from the
+ * `active_filter_*` value slots) drives the `[open]` attribute, so
+ * any post-submit page paints with the form expanded. The chrome
  * mirrors `core/admin_sidebar.tpl`'s mobile `<details open>` pattern
  * (chevron + label + `prefers-reduced-motion: reduce` override). The
  * count badge ("Filters · N active") rides `$active_filter_count`.
@@ -88,10 +80,8 @@ final class AdminAdminsSearchView extends View
      *     `admsrvflag[]` values.
      * @param int $active_filter_count Number of non-empty filter
      *     value slots — drives the `<summary>` count badge ("Filters
-     *     · N active") and `$has_active_filters`. Match-mode toggles
-     *     (`name_match` / `steam_match` / `admemail_match`) are NOT
-     *     counted: they always carry a default ('0' or '1') and only
-     *     refine the matching filter, they don't filter on their own.
+     *     · N active") and `$has_active_filters`. Empty multi-select
+     *     arrays count as zero.
      * @param bool $has_active_filters Convenience boolean derived from
      *     `$active_filter_count > 0`. The template uses it to decide
      *     whether the disclosure paints `<details open>` (post-submit
@@ -107,11 +97,8 @@ final class AdminAdminsSearchView extends View
         public readonly array $admwebflag_list,
         public readonly array $admsrvflag_list,
         public readonly string $active_filter_name = '',
-        public readonly string $active_filter_name_match = '1',
         public readonly string $active_filter_steamid = '',
-        public readonly string $active_filter_steam_match = '0',
         public readonly string $active_filter_admemail = '',
-        public readonly string $active_filter_admemail_match = '1',
         public readonly string $active_filter_webgroup = '',
         public readonly string $active_filter_srvadmgroup = '',
         public readonly string $active_filter_srvgroup = '',

--- a/web/includes/View/EditAdminDetailsView.php
+++ b/web/includes/View/EditAdminDetailsView.php
@@ -10,8 +10,9 @@ namespace Sbpp\View;
  * The page handler (`admin.edit.admindetails.php`) gates entry on
  * `ADMIN_OWNER | ADMIN_EDIT_ADMINS` (or self-edit) before reaching the
  * template, so the View doesn't carry its own access boolean. `$change_pass`
- * is a per-request capability flag from the handler — true when the current
- * user is allowed to set the target admin's password (root or self).
+ * mirrors that gate: true when the current user may edit the target
+ * (including setting their password). Edit-admins callers cannot open
+ * owner targets; that block lives in the page handler.
  *
  * The property set is intentionally identical to the legacy handler's
  * `$theme->assign(...)` calls so the existing `$theme->display(...)` path

--- a/web/includes/View/EditAdminDetailsView.php
+++ b/web/includes/View/EditAdminDetailsView.php
@@ -10,9 +10,9 @@ namespace Sbpp\View;
  * The page handler (`admin.edit.admindetails.php`) gates entry on
  * `ADMIN_OWNER | ADMIN_EDIT_ADMINS` (or self-edit) before reaching the
  * template, so the View doesn't carry its own access boolean. `$change_pass`
- * mirrors that gate: true when the current user may edit the target
- * (including setting their password). Edit-admins callers cannot open
- * owner targets; that block lives in the page handler.
+ * is always true here: anyone allowed to open this page may also set
+ * the target's password. Edit-admins callers cannot open owner targets;
+ * that block lives in the page handler.
  *
  * The property set is intentionally identical to the legacy handler's
  * `$theme->assign(...)` calls so the existing `$theme->display(...)` path

--- a/web/includes/system-functions.php
+++ b/web/includes/system-functions.php
@@ -36,10 +36,12 @@ if (!defined('IN_SB')) {
  * still build link strings server-side.
  *
  * NOTE: the `$tooltip`-bearing arm picks up the `tip` / `perm` CSS
- * class (legacy default theme); the bare arm has no class. The HTML
- * is whitespace-padded between the opening and closing tag for
- * legacy-template compatibility — the v1.x consumer relied on the
- * leading + trailing space when concatenating links inline.
+ * class (legacy default theme) and emits `data-tooltip` for the
+ * themed tip in `sb.js` (not the native `title=` bubble). The bare
+ * arm has no class. The HTML is whitespace-padded between the
+ * opening and closing tag for legacy-template compatibility — the
+ * v1.x consumer relied on the leading + trailing space when
+ * concatenating links inline.
  */
 function CreateLinkR(string $title, string $url, string $tooltip = '', string $target = '_self', bool $wide = false, string $onclick = ''): string
 {
@@ -50,7 +52,7 @@ function CreateLinkR(string $title, string $url, string $tooltip = '', string $t
     ];
     if ($hasTooltip) {
         $attrs['class'] = $wide ? 'perm' : 'tip';
-        $attrs['title'] = $tooltip;
+        $attrs['data-tooltip'] = $tooltip;
     } else {
         $attrs['onclick'] = $onclick;
     }

--- a/web/pages/admin.admins.php
+++ b/web/pages/admin.admins.php
@@ -475,10 +475,10 @@ foreach ($admins as $admin) {
     $admin['web_group']    = $userbank->GetProperty("group_name", $admin['aid']);
     $admin['server_group'] = $userbank->GetProperty("srv_groups", $admin['aid']);
     if (empty($admin['web_group']) || $admin['web_group'] == " ") {
-        $admin['web_group'] = "No Group/Individual Permissions";
+        $admin['web_group'] = "No groups";
     }
     if (empty($admin['server_group']) || $admin['server_group'] == " ") {
-        $admin['server_group'] = "No Group/Individual Permissions";
+        $admin['server_group'] = "No groups";
     }
     $GLOBALS['PDO']->query("SELECT count(authid) AS num FROM `:prefix_bans` WHERE aid = :aid");
     $GLOBALS['PDO']->bind(':aid', $admin['aid']);

--- a/web/pages/admin.admins.php
+++ b/web/pages/admin.admins.php
@@ -200,11 +200,12 @@ if (isset($_GET['page']) && $_GET['page'] > 0) {
  * combined filter form and AND the populated filters server-side.
  *
  * The new wire format reads each filter from its own query parameter
- * (`name`, `steamid`, `steam_match`, `admemail`, `webgroup`,
+ * (`name`, `steamid`, `admemail`, `webgroup`,
  * `srvadmgroup`, `srvgroup`, `admwebflag[]`, `admsrvflag[]`, `server`)
- * so a single GET submit carries the full filter snapshot. URL-shareable
- * searches are preserved by the legacy-shim block below: any incoming
- * `?advType=…&advSearch=…` is translated into the new shape so old
+ * so a single GET submit carries the full filter snapshot. Text filters
+ * always substring-match (`LIKE %…%`). URL-shareable searches are
+ * preserved by the legacy-shim block below: any incoming
+ * `?advType=…&advSearch=…` is translated into the modern shape so old
  * bookmarks and cross-page links keep working.
  *
  * Server-side filters are AND-combined: a request with two non-empty
@@ -243,10 +244,9 @@ if (isset($_GET['advType']) && isset($_GET['advSearch']) && $_GET['advSearch'] !
         case 'steam':
             // The legacy form distinguished exact (`steamid`) from
             // partial (`steam`) matches as two distinct advTypes. The
-            // modern form folds both onto `steamid` + `steam_match`.
+            // modern form folds both onto `steamid` (always partial).
             if (!isset($_GET['steamid']) || $_GET['steamid'] === '') {
-                $_GET['steamid']     = $legacyValue;
-                $_GET['steam_match'] = '1';
+                $_GET['steamid'] = $legacyValue;
             }
             break;
         case 'admwebflag':
@@ -258,52 +258,26 @@ if (isset($_GET['advType']) && isset($_GET['advSearch']) && $_GET['advSearch'] !
     }
 }
 
-// 1) Login name (exact or partial against ADM.user).
-//    `name_match` was added in #1231; default is partial ('1') so
-//    pre-#1231 URLs (`?name=alice` with no name_match) keep their
-//    substring semantics. `0` flips to exact.
+// 1) Login name (partial against ADM.user).
 if (!empty($_GET['name']) && is_string($_GET['name'])) {
-    $partialName = !isset($_GET['name_match']) || (string) $_GET['name_match'] !== '0';
-    if ($partialName) {
-        $where        .= " AND ADM.user LIKE ?";
-        $whereParams[] = '%' . $_GET['name'] . '%';
-    } else {
-        $where        .= " AND ADM.user = ?";
-        $whereParams[] = $_GET['name'];
-    }
-    $activeFilters['name']       = (string) $_GET['name'];
-    $activeFilters['name_match'] = $partialName ? '1' : '0';
+    $where                       .= " AND ADM.user LIKE ?";
+    $whereParams[]                = '%' . $_GET['name'] . '%';
+    $activeFilters['name']        = (string) $_GET['name'];
 }
 
-// 2) Steam ID (exact or partial against ADM.authid).
+// 2) Steam ID (partial against ADM.authid).
 if (!empty($_GET['steamid']) && is_string($_GET['steamid'])) {
-    $partial = isset($_GET['steam_match']) && (string) $_GET['steam_match'] === '1';
-    if ($partial) {
-        $where        .= " AND ADM.authid LIKE ?";
-        $whereParams[] = '%' . $_GET['steamid'] . '%';
-    } else {
-        $where        .= " AND ADM.authid = ?";
-        $whereParams[] = $_GET['steamid'];
-    }
-    $activeFilters['steamid']     = (string) $_GET['steamid'];
-    $activeFilters['steam_match'] = $partial ? '1' : '0';
+    $where                        .= " AND ADM.authid LIKE ?";
+    $whereParams[]                 = '%' . $_GET['steamid'] . '%';
+    $activeFilters['steamid']      = (string) $_GET['steamid'];
 }
 
-// 3) E-mail (exact or partial; `admemail_match` was added in #1231,
-//    same default-partial shape as `name_match`). Gated on the same
-//    flag the search box gates the input field on so URL forgery
-//    can't bypass the visibility gate.
+// 3) E-mail (partial). Gated on the same flag the search box gates
+//    the input field on so URL forgery can't bypass the visibility gate.
 if (!empty($_GET['admemail']) && is_string($_GET['admemail']) && $userbank->HasAccess(WebPermission::mask(WebPermission::Owner, WebPermission::EditAdmins))) {
-    $partialEmail = !isset($_GET['admemail_match']) || (string) $_GET['admemail_match'] !== '0';
-    if ($partialEmail) {
-        $where        .= " AND ADM.email LIKE ?";
-        $whereParams[] = '%' . $_GET['admemail'] . '%';
-    } else {
-        $where        .= " AND ADM.email = ?";
-        $whereParams[] = $_GET['admemail'];
-    }
-    $activeFilters['admemail']       = (string) $_GET['admemail'];
-    $activeFilters['admemail_match'] = $partialEmail ? '1' : '0';
+    $where                         .= " AND ADM.email LIKE ?";
+    $whereParams[]                  = '%' . $_GET['admemail'] . '%';
+    $activeFilters['admemail']      = (string) $_GET['admemail'];
 }
 
 // 4) Web group (`:prefix_groups.gid` -> `:prefix_admins.gid`).
@@ -365,7 +339,9 @@ if (is_array($rawWebFlags)) {
     }
 }
 
-// 8) Server permission flags (multi).
+// 8) Server permission flags (multi). SM_* constants are single-char
+// strings (`SM_ROOT` = `z`); pass them to HasAccess as strings so the
+// srv_flags path runs. SM_ROOT implies every other server flag.
 $rawSrvFlags = $_GET['admsrvflag'] ?? null;
 if (is_string($rawSrvFlags)) {
     $rawSrvFlags = explode(',', $rawSrvFlags);
@@ -374,27 +350,29 @@ if (is_array($rawSrvFlags)) {
     /** @var list<string> $srvFlagNames */
     $srvFlagNames = [];
     foreach ($rawSrvFlags as $candidate) {
-        if (is_string($candidate) && preg_match('/^SM_[A-Z_]+$/', $candidate) && defined($candidate)) {
+        if (is_string($candidate) && preg_match('/^SM_[A-Z0-9_]+$/', $candidate) && defined($candidate)) {
             $srvFlagNames[] = $candidate;
         }
     }
     if (!empty($srvFlagNames)) {
-        $flagBits = array_map(fn(string $name): int => (int) constant($name), $srvFlagNames);
-        $alladmins = $GLOBALS['PDO']->query("SELECT aid, authid FROM `:prefix_admins` WHERE aid > 0")->resultset();
+        /** @var list<string> $flagChars */
+        $flagChars = array_map(fn(string $name): string => (string) constant($name), $srvFlagNames);
+        $alladmins = $GLOBALS['PDO']->query("SELECT aid FROM `:prefix_admins` WHERE aid > 0")->resultset();
         $accessAids = [];
         foreach ($alladmins as $row) {
+            $aid = (int) $row['aid'];
             $matched = false;
-            foreach ($flagBits as $fla) {
-                if ($userbank->HasAccess($fla, $row['authid'])) {
+            foreach ($flagChars as $fla) {
+                if ($userbank->HasAccess($fla, $aid)) {
                     $matched = true;
                     break;
                 }
             }
-            if (!$matched && $userbank->HasAccess(SM_ROOT, $row['authid'])) {
+            if (!$matched && $userbank->HasAccess(SM_ROOT, $aid)) {
                 $matched = true;
             }
             if ($matched) {
-                $accessAids[] = (int) $row['aid'];
+                $accessAids[] = $aid;
             }
         }
         if (empty($accessAids)) {

--- a/web/pages/admin.admins.php
+++ b/web/pages/admin.admins.php
@@ -56,7 +56,12 @@ global $userbank, $theme;
  */
 
 /** @var bool $canListAdmins */
-$canListAdmins   = $userbank->HasAccess(WebPermission::mask(WebPermission::Owner, WebPermission::ListAdmins));
+$canListAdmins   = $userbank->HasAccess(WebPermission::mask(
+    WebPermission::Owner,
+    WebPermission::ListAdmins,
+    WebPermission::EditAdmins,
+    WebPermission::DeleteAdmins,
+));
 /** @var bool $canAddAdmins */
 $canAddAdmins    = $userbank->HasAccess(WebPermission::mask(WebPermission::Owner, WebPermission::AddAdmins));
 /** @var bool $canEditAdmins */
@@ -79,7 +84,7 @@ $sections = [
     [
         'slug'       => 'admins',
         'name'       => 'Admins',
-        'permission' => ADMIN_OWNER | ADMIN_LIST_ADMINS,
+        'permission' => ADMIN_OWNER | ADMIN_LIST_ADMINS | ADMIN_EDIT_ADMINS | ADMIN_DELETE_ADMINS,
         'url'        => 'index.php?p=admin&c=admins&section=admins',
         'icon'       => 'users',
     ],

--- a/web/pages/admin.admins.search.php
+++ b/web/pages/admin.admins.search.php
@@ -158,19 +158,12 @@ if (is_string($rawSrvFlag)) {
 $activeSrvFlags = [];
 if (is_array($rawSrvFlag)) {
     foreach ($rawSrvFlag as $f) {
-        if (is_string($f) && preg_match('/^SM_[A-Z_]+$/', $f)) {
+        if (is_string($f) && preg_match('/^SM_[A-Z0-9_]+$/', $f)) {
             $activeSrvFlags[] = $f;
         }
     }
 }
 
-// Match-mode defaults differ per filter (#1231):
-//   - steam_match defaults to '0' (exact) — typical SteamID
-//     queries are "find this one admin by their full ID".
-//   - name_match / admemail_match default to '1' (partial) so
-//     pre-#1231 URLs (`?name=alice`) keep their substring
-//     behaviour. Adding the toggle widens the UI without
-//     regressing the default.
 $activeFilterName        = is_string($_GET['name']        ?? null) ? (string) $_GET['name']        : '';
 $activeFilterSteamid     = is_string($_GET['steamid']     ?? null) ? (string) $_GET['steamid']     : '';
 $activeFilterAdmemail    = is_string($_GET['admemail']    ?? null) ? (string) $_GET['admemail']    : '';
@@ -179,26 +172,20 @@ $activeFilterSrvadmgroup = is_string($_GET['srvadmgroup'] ?? null) ? (string) $_
 $activeFilterSrvgroup    = is_scalar($_GET['srvgroup']    ?? null) ? (string) $_GET['srvgroup']    : '';
 $activeFilterServer      = is_scalar($_GET['server']      ?? null) ? (string) $_GET['server']      : '';
 
-// #1303 — the `admemail` filter is permission-gated by
-// `$can_editadmin` in both the rendering template AND the page
-// handler (`admin.admins.php` ignores `?admemail=` from a user without
-// `EditAdmins | Owner`). For URL-forgery cases where a non-admin
-// passes `?admemail=foo`, the input is hidden in the form and the
-// server narrows nothing; the count must mirror that — otherwise the
-// "N active" badge would say "1 active" while every visible filter
-// row reads empty. Mirror the gate locally so the count stays an
-// honest summary of what the visible form actually filters on.
+// The `admemail` filter is permission-gated by `$can_editadmin` in
+// both the rendering template AND the page handler (`admin.admins.php`
+// ignores `?admemail=` from a user without `EditAdmins | Owner`). For
+// URL-forgery cases where a non-admin passes `?admemail=foo`, the
+// input is hidden in the form and the server narrows nothing; the
+// count must mirror that — otherwise the "N active" badge would say
+// "1 active" while every visible filter row reads empty.
 $canFilterByEmail = $userbank->HasAccess(WebPermission::mask(WebPermission::EditAdmins, WebPermission::Owner));
 
 // #1303 — count populated filter slots so the disclosure can paint a
 // "Filters · N active" badge on the <summary> and auto-expand on
-// post-submit. Match-mode selects (`name_match` / `steam_match` /
-// `admemail_match`) deliberately don't count: they always carry a
-// default ('0' or '1') and only refine the matching filter, they
-// don't filter on their own. Empty multi-select arrays count as zero
-// even though the array itself "exists" — the user hasn't picked a
-// permission. The `admemail` slot only counts when the user can
-// actually filter by it (see `$canFilterByEmail` above).
+// post-submit. Empty multi-select arrays count as zero even though
+// the array itself "exists". The `admemail` slot only counts when
+// the user can actually filter by it (see `$canFilterByEmail`).
 $activeFilterCount =
       ($activeFilterName        !== '' ? 1 : 0)
     + ($activeFilterSteamid     !== '' ? 1 : 0)
@@ -220,11 +207,8 @@ $activeFilterCount =
     admwebflag_list:           $webflag,
     admsrvflag_list:           $serverflag,
     active_filter_name:           $activeFilterName,
-    active_filter_name_match:     is_scalar($_GET['name_match']     ?? null) ? (string) $_GET['name_match']     : '1',
     active_filter_steamid:        $activeFilterSteamid,
-    active_filter_steam_match:    is_scalar($_GET['steam_match']    ?? null) ? (string) $_GET['steam_match']    : '0',
     active_filter_admemail:       $activeFilterAdmemail,
-    active_filter_admemail_match: is_scalar($_GET['admemail_match'] ?? null) ? (string) $_GET['admemail_match'] : '1',
     active_filter_webgroup:       $activeFilterWebgroup,
     active_filter_srvadmgroup:    $activeFilterSrvadmgroup,
     active_filter_srvgroup:       $activeFilterSrvgroup,

--- a/web/pages/admin.edit.admindetails.php
+++ b/web/pages/admin.edit.admindetails.php
@@ -47,7 +47,6 @@ if (!$canEditTarget) {
     return;
 }
 
-$canEditPasswords = $canEditTarget;
 $webBitmask        = (int) $userbank->GetProperty('extraflags', $adminId);
 $webGroupId        = (int) $userbank->GetProperty('gid', $adminId);
 $hasWebPermissions = $webBitmask !== 0 || $webGroupId > 0;
@@ -127,33 +126,32 @@ if (isset($_POST['adminname'])) {
     }
 
     // Passwords ---------------------------------------------------------
+    // Editable for anyone who passed the !$canEditTarget gate above.
     $passwordChanged   = false;
     $serverPassChanged = false;
 
-    if ($canEditPasswords) {
-        if ($newPassword !== '') {
-            $passwordChanged = true;
-            if (strlen($newPassword) < MIN_PASS_LENGTH) {
-                $validationErrors['password'] = 'Your password must be at least '
-                    . MIN_PASS_LENGTH . ' characters long.';
-            } elseif ($newPassword2 === '') {
-                $validationErrors['password2'] = 'You must confirm the password.';
-            } elseif ($newPassword !== $newPassword2) {
-                $validationErrors['password2'] = "Your passwords don't match.";
-            }
+    if ($newPassword !== '') {
+        $passwordChanged = true;
+        if (strlen($newPassword) < MIN_PASS_LENGTH) {
+            $validationErrors['password'] = 'Your password must be at least '
+                . MIN_PASS_LENGTH . ' characters long.';
+        } elseif ($newPassword2 === '') {
+            $validationErrors['password2'] = 'You must confirm the password.';
+        } elseif ($newPassword !== $newPassword2) {
+            $validationErrors['password2'] = "Your passwords don't match.";
         }
+    }
 
-        if ($useServerPass) {
-            if ($newServerPass !== '') {
-                $serverPassChanged = true;
-            }
-            $existingServerPass = (string) $userbank->GetProperty('srv_password', $adminId);
-            if ($newServerPass === '' && $existingServerPass === '') {
-                $validationErrors['a_serverpass'] = 'You must type a server password or uncheck the box.';
-            } elseif ($newServerPass !== '' && strlen($newServerPass) < MIN_PASS_LENGTH) {
-                $validationErrors['a_serverpass'] = 'Your password must be at least '
-                    . MIN_PASS_LENGTH . ' characters long.';
-            }
+    if ($useServerPass) {
+        if ($newServerPass !== '') {
+            $serverPassChanged = true;
+        }
+        $existingServerPass = (string) $userbank->GetProperty('srv_password', $adminId);
+        if ($newServerPass === '' && $existingServerPass === '') {
+            $validationErrors['a_serverpass'] = 'You must type a server password or uncheck the box.';
+        } elseif ($newServerPass !== '' && strlen($newServerPass) < MIN_PASS_LENGTH) {
+            $validationErrors['a_serverpass'] = 'Your password must be at least '
+                . MIN_PASS_LENGTH . ' characters long.';
         }
     }
 
@@ -226,7 +224,7 @@ if (isset($_POST['adminname'])) {
     authid:      $authidValue,
     email:       $emailDisplay,
     a_spass:     $haveServerPw,
-    change_pass: $canEditPasswords,
+    change_pass: true,
 ));
 
 sbpp_admin_edit_emit_tail_script(

--- a/web/pages/admin.edit.admindetails.php
+++ b/web/pages/admin.edit.admindetails.php
@@ -49,7 +49,7 @@ if (!$canEditTarget) {
     return;
 }
 
-$canEditPasswords = $isOwnerEditor || $isSelfEdit;
+$canEditPasswords = $canEditTarget;
 $webBitmask        = (int) $userbank->GetProperty('extraflags', $adminId);
 $webGroupId        = (int) $userbank->GetProperty('gid', $adminId);
 $hasWebPermissions = $webBitmask !== 0 || $webGroupId > 0;

--- a/web/pages/admin.edit.admindetails.php
+++ b/web/pages/admin.edit.admindetails.php
@@ -12,8 +12,6 @@ if (!defined('IN_SB')) {
 
 global $userbank, $theme;
 
-new \Sbpp\View\AdminTabs([], $userbank, $theme);
-
 require_once __DIR__ . '/_admin_edit_helpers.php';
 
 $adminId = isset($_GET['id']) ? (int) $_GET['id'] : 0;

--- a/web/pages/admin.edit.admingroup.php
+++ b/web/pages/admin.edit.admingroup.php
@@ -12,8 +12,6 @@ if (!defined('IN_SB')) {
 
 global $userbank, $theme;
 
-new \Sbpp\View\AdminTabs([], $userbank, $theme);
-
 require_once __DIR__ . '/_admin_edit_helpers.php';
 
 $adminId = isset($_GET['id']) ? (int) $_GET['id'] : 0;

--- a/web/pages/admin.edit.adminperms.php
+++ b/web/pages/admin.edit.adminperms.php
@@ -12,8 +12,6 @@ if (!defined('IN_SB')) {
 
 global $userbank, $theme;
 
-new \Sbpp\View\AdminTabs([], $userbank, $theme);
-
 require_once __DIR__ . '/_admin_edit_helpers.php';
 
 $adminId = isset($_GET['id']) ? (int) $_GET['id'] : 0;
@@ -159,6 +157,61 @@ $smHas = static fn(string $flag): bool => str_contains($srvFlags, $flag);
         syncParentFromChildren();
     });
 
+    function scopeBoxes(scope) {
+        var table = form.querySelector('table[data-perms-scope="' + scope + '"]');
+        if (!table) return [];
+        if (scope === 'server') {
+            return Array.prototype.slice.call(table.querySelectorAll('input[data-sm-flag]'));
+        }
+        return Array.prototype.slice.call(table.querySelectorAll('input[type="checkbox"]'));
+    }
+
+    function syncSelectAll(scope) {
+        var master = form.querySelector('input[data-select-all="' + scope + '"]');
+        if (!master) return;
+        var boxes = scopeBoxes(scope);
+        var on = 0;
+        for (var i = 0; i < boxes.length; i++) {
+            if (boxes[i].checked) on++;
+        }
+        master.checked = boxes.length > 0 && on === boxes.length;
+        master.indeterminate = on > 0 && on < boxes.length;
+    }
+
+    function wireSelectAll(scope) {
+        var master = form.querySelector('input[data-select-all="' + scope + '"]');
+        if (!master) return;
+        master.addEventListener('change', function () {
+            var on = master.checked;
+            scopeBoxes(scope).forEach(function (c) { c.checked = on; });
+            if (scope === 'web') {
+                form.querySelectorAll('input[data-parent]').forEach(function (parent) {
+                    var name = parent.getAttribute('data-parent');
+                    var children = form.querySelectorAll('input[data-child="' + name + '"]');
+                    var anyOn = false;
+                    for (var i = 0; i < children.length; i++) {
+                        if (children[i].checked) { anyOn = true; break; }
+                    }
+                    parent.checked = anyOn;
+                });
+            }
+            master.indeterminate = false;
+            syncSelectAll(scope);
+        });
+        syncSelectAll(scope);
+    }
+
+    wireSelectAll('web');
+    wireSelectAll('server');
+
+    form.addEventListener('change', function (e) {
+        var t = e.target;
+        if (!t || t.type !== 'checkbox' || t.hasAttribute('data-select-all')) return;
+        var table = t.closest('table[data-perms-scope]');
+        if (!table) return;
+        syncSelectAll(table.getAttribute('data-perms-scope'));
+    });
+
     // OWNER tick implies every other web flag — keep this passive
     // visual hint (the server still trusts the bitmask we send).
     var ownerCb = document.getElementById('p2');
@@ -168,6 +221,9 @@ $smHas = static fn(string $flag): bool => str_contains($srvFlags, $flag);
             form.querySelectorAll('input[data-child], input[data-parent]').forEach(function (c) {
                 c.checked = true;
             });
+            var settingsCb = document.getElementById('p26');
+            if (settingsCb) settingsCb.checked = true;
+            syncSelectAll('web');
         });
     }
 
@@ -180,6 +236,7 @@ $smHas = static fn(string $flag): bool => str_contains($srvFlags, $flag);
             form.querySelectorAll('input[data-sm-flag]').forEach(function (c) {
                 if (c !== smRootCb) c.checked = true;
             });
+            syncSelectAll('server');
         });
     }
 

--- a/web/pages/admin.edit.adminservers.php
+++ b/web/pages/admin.edit.adminservers.php
@@ -12,8 +12,6 @@ if (!defined('IN_SB')) {
 
 global $userbank, $theme;
 
-new \Sbpp\View\AdminTabs([], $userbank, $theme);
-
 require_once __DIR__ . '/_admin_edit_helpers.php';
 
 $adminId = isset($_GET['id']) ? (int) $_GET['id'] : 0;

--- a/web/scripts/sb.js
+++ b/web/scripts/sb.js
@@ -262,67 +262,201 @@
     };
 
     // ---------------------------------------------------------------
-    // Tooltips (replaces MooTools `Tips`).
-    // Reads `title` of "Header::Body" (or just "Body") and shows a
-    // floating tooltip on hover.
+    // Tooltips — themed replacement for the MooTools Tips / native
+    // title= bubble. Event-delegated on document so dynamically added
+    // rows (and third-party themes that keep emitting `class="tip"
+    // title="…"`) pick it up without a per-page init call.
+    //
+    // Prefer `data-tooltip="Label"` on the trigger. Legacy
+    // `a.tip[title]` / `button.tip[title]` (CreateLinkR) still works:
+    // the first hover migrates `title` → `data-tooltip` so the browser
+    // bubble never races the themed tip. Keep `aria-label` for AT;
+    // the tip is visual-only (`role="tooltip"` + aria-describedby).
     // ---------------------------------------------------------------
+    const SB_TOOLTIP_ID = 'sb-tooltip';
+    const SB_TOOLTIP_DELAY_MS = 350;
+    /** @type {HTMLDivElement | null} */
+    let sbTooltipEl = null;
+    /** @type {Element | null} */
+    let sbTooltipActive = null;
+    /** @type {ReturnType<typeof setTimeout> | null} */
+    let sbTooltipTimer = null;
+
+    /**
+     * @returns {HTMLDivElement}
+     */
+    function sbTooltipEnsure() {
+        if (sbTooltipEl && document.body.contains(sbTooltipEl)) {
+            return sbTooltipEl;
+        }
+        const tip = document.createElement('div');
+        tip.id = SB_TOOLTIP_ID;
+        tip.className = 'sb-tooltip';
+        tip.setAttribute('role', 'tooltip');
+        tip.hidden = true;
+        document.body.appendChild(tip);
+        sbTooltipEl = tip;
+        return tip;
+    }
+
+    /**
+     * @param {Element} el
+     * @returns {string}
+     */
+    function sbTooltipLabel(el) {
+        const data = el.getAttribute('data-tooltip');
+        if (data !== null && data.trim() !== '') {
+            return data.trim();
+        }
+        const title = el.getAttribute('title');
+        return title ? title.trim() : '';
+    }
+
+    /**
+     * @param {Element} el
+     * @returns {void}
+     */
+    function sbTooltipAdoptTitle(el) {
+        if (!el.hasAttribute('title')) {
+            return;
+        }
+        const title = el.getAttribute('title') || '';
+        if (!el.hasAttribute('data-tooltip') && title.trim() !== '') {
+            el.setAttribute('data-tooltip', title);
+        }
+        el.removeAttribute('title');
+    }
+
+    /**
+     * @returns {void}
+     */
+    function sbTooltipHide() {
+        if (sbTooltipTimer !== null) {
+            clearTimeout(sbTooltipTimer);
+            sbTooltipTimer = null;
+        }
+        if (sbTooltipEl) {
+            sbTooltipEl.hidden = true;
+            sbTooltipEl.textContent = '';
+        }
+        if (sbTooltipActive) {
+            sbTooltipActive.removeAttribute('aria-describedby');
+            sbTooltipActive = null;
+        }
+    }
+
+    /**
+     * @param {Element} el
+     * @returns {void}
+     */
+    function sbTooltipPlace(el) {
+        const tip = sbTooltipEnsure();
+        const r = el.getBoundingClientRect();
+        const tr = tip.getBoundingClientRect();
+        let top = r.bottom + 6;
+        if (top + tr.height > window.innerHeight - 8) {
+            top = r.top - tr.height - 6;
+        }
+        let left = r.left + (r.width - tr.width) / 2;
+        left = Math.max(8, Math.min(left, window.innerWidth - tr.width - 8));
+        tip.style.top = Math.round(top) + 'px';
+        tip.style.left = Math.round(left) + 'px';
+    }
+
+    /**
+     * @param {Element} el
+     * @returns {void}
+     */
+    function sbTooltipShow(el) {
+        sbTooltipAdoptTitle(el);
+        const text = sbTooltipLabel(el);
+        if (text === '') {
+            return;
+        }
+        const tip = sbTooltipEnsure();
+        tip.textContent = text;
+        tip.hidden = false;
+        el.setAttribute('aria-describedby', SB_TOOLTIP_ID);
+        sbTooltipActive = el;
+        sbTooltipPlace(el);
+    }
+
+    /**
+     * @param {EventTarget | null} target
+     * @returns {Element | null}
+     */
+    function sbTooltipTriggerFrom(target) {
+        if (!(target instanceof Element)) {
+            return null;
+        }
+        return target.closest('[data-tooltip], a.tip[title], button.tip[title], a.tip[data-tooltip], button.tip[data-tooltip]');
+    }
+
+    document.addEventListener('pointerover', (e) => {
+        const el = sbTooltipTriggerFrom(e.target);
+        if (!el || el === sbTooltipActive) {
+            return;
+        }
+        sbTooltipHide();
+        sbTooltipTimer = setTimeout(() => {
+            sbTooltipTimer = null;
+            sbTooltipShow(el);
+        }, SB_TOOLTIP_DELAY_MS);
+    });
+
+    document.addEventListener('pointerout', (e) => {
+        const el = sbTooltipTriggerFrom(e.target);
+        if (!el) {
+            return;
+        }
+        const related = /** @type {MouseEvent} */ (e).relatedTarget;
+        if (related instanceof Node && el.contains(related)) {
+            return;
+        }
+        sbTooltipHide();
+    });
+
+    document.addEventListener('focusin', (e) => {
+        const el = sbTooltipTriggerFrom(e.target);
+        if (!el || !el.hasAttribute('data-tooltip')) {
+            return;
+        }
+        sbTooltipHide();
+        sbTooltipShow(el);
+    });
+
+    document.addEventListener('focusout', () => {
+        sbTooltipHide();
+    });
+
+    document.addEventListener('scroll', () => {
+        sbTooltipHide();
+    }, true);
+
+    document.addEventListener('keydown', (e) => {
+        if (e.key === 'Escape') {
+            sbTooltipHide();
+        }
+    });
+
+    document.addEventListener('pointerdown', () => {
+        sbTooltipHide();
+    });
+
+    /**
+     * Back-compat: migrate `title` → `data-tooltip` on a selector set.
+     * Delegation already covers `[data-tooltip]` and legacy `.tip[title]`;
+     * this is for callers that want an eager migrate (e.g. strip native
+     * bubbles before first hover).
+     *
+     * @param {string} selector
+     * @param {{ className?: string }} [opts] ignored; kept for call-site compat
+     * @returns {void}
+     */
     sb.tooltip = function (selector, opts) {
-        opts = opts || {};
-        const className = opts.className || 'tool-tip';
+        void opts;
         sb.$qsa(selector).forEach((el) => {
-            const raw = el.getAttribute('title');
-            if (!raw) return;
-            // Save original title and prevent the browser from showing it.
-            el.setAttribute('data-sb-title', raw);
-            el.removeAttribute('title');
-
-            const parts = raw.split('::');
-            const head  = parts.length > 1 ? parts[0] : '';
-            const body  = parts.length > 1 ? parts.slice(1).join('::') : raw;
-
-            /** @type {HTMLDivElement | null} */
-            let tip = null;
-            /** @param {MouseEvent} e */
-            const show = (e) => {
-                if (tip) return;
-                tip = document.createElement('div');
-                tip.className = className;
-                tip.style.position = 'absolute';
-                tip.style.zIndex = '10000';
-                tip.style.opacity = '0';
-                tip.style.pointerEvents = 'none';
-                if (head) {
-                    const t = document.createElement('span');
-                    t.className = 'tool-title';
-                    t.textContent = head;
-                    tip.appendChild(t);
-                }
-                const tx = document.createElement('span');
-                tx.className = 'tool-text';
-                tx.innerHTML = body;
-                tip.appendChild(tx);
-                document.body.appendChild(tip);
-                position(e);
-                requestAnimationFrame(() => {
-                    if (!tip) return;
-                    tip.style.transition = 'opacity 200ms';
-                    tip.style.opacity = '1';
-                });
-            };
-            /** @param {MouseEvent} e */
-            const move = (e) => { if (tip) position(e); };
-            const hide = () => { if (tip) { tip.remove(); tip = null; } };
-            /** @param {MouseEvent} e */
-            const position = (e) => {
-                if (!tip) return;
-                tip.style.left = (e.pageX + 16) + 'px';
-                tip.style.top  = (e.pageY + 16) + 'px';
-            };
-
-            el.addEventListener('mouseover', show);
-            el.addEventListener('mousemove', move);
-            el.addEventListener('mouseout',  hide);
-            el.addEventListener('click',     hide);
+            sbTooltipAdoptTitle(el);
         });
     };
 

--- a/web/tests/Synthesizer.php
+++ b/web/tests/Synthesizer.php
@@ -70,49 +70,52 @@ final class Synthesizer
      */
     public const SCALES = [
         'small' => [
-            'players'     => 80,
-            'bans'        => 30,
-            'comms'       => 10,
-            'servers'     => 5,
-            'admins'      => 5,
-            'groups'      => 3,
-            'banlog'      => 50,
-            'submissions' => 10,
-            'protests'    => 5,
-            'comments'    => 30,
-            'demos'       => 15,
-            'notes'       => 15,
-            'audit'       => 80,
+            'players'            => 80,
+            'bans'               => 30,
+            'comms'              => 10,
+            'servers'            => 5,
+            'admins'             => 5,
+            'groups'             => 3,
+            'server_org_groups'  => 3,
+            'banlog'             => 50,
+            'submissions'        => 10,
+            'protests'           => 5,
+            'comments'           => 30,
+            'demos'              => 15,
+            'notes'              => 15,
+            'audit'              => 80,
         ],
         'medium' => [
-            'players'     => 400,
-            'bans'        => 200,
-            'comms'       => 100,
-            'servers'     => 8,
-            'admins'      => 8,
-            'groups'      => 4,
-            'banlog'      => 400,
-            'submissions' => 60,
-            'protests'    => 25,
-            'comments'    => 200,
-            'demos'       => 80,
-            'notes'       => 120,
-            'audit'       => 600,
+            'players'            => 400,
+            'bans'               => 200,
+            'comms'              => 100,
+            'servers'            => 8,
+            'admins'             => 8,
+            'groups'             => 4,
+            'server_org_groups'  => 4,
+            'banlog'             => 400,
+            'submissions'        => 60,
+            'protests'           => 25,
+            'comments'           => 200,
+            'demos'              => 80,
+            'notes'              => 120,
+            'audit'              => 600,
         ],
         'large' => [
-            'players'     => 3000,
-            'bans'        => 2000,
-            'comms'       => 800,
-            'servers'     => 12,
-            'admins'      => 12,
-            'groups'      => 5,
-            'banlog'      => 4000,
-            'submissions' => 400,
-            'protests'    => 150,
-            'comments'    => 1500,
-            'demos'       => 800,
-            'notes'       => 800,
-            'audit'       => 5000,
+            'players'            => 3000,
+            'bans'               => 2000,
+            'comms'              => 800,
+            'servers'            => 12,
+            'admins'             => 12,
+            'groups'             => 5,
+            'server_org_groups'  => 5,
+            'banlog'             => 4000,
+            'submissions'        => 400,
+            'protests'           => 150,
+            'comments'           => 1500,
+            'demos'              => 800,
+            'notes'              => 800,
+            'audit'              => 5000,
         ],
     ];
 
@@ -153,8 +156,16 @@ final class Synthesizer
     private array $adminAids = [];
     /** @var list<int> */
     private array $groupGids = [];
+    /** Type=3 org groups in `:prefix_groups` (Server groups UI). @var list<int> */
+    private array $serverOrgGids = [];
     /** @var list<int> */
     private array $srvGroupIds = [];
+    /** Parallel to `$srvGroupIds` — `:prefix_srvgroups.name` for admins.srv_group. @var list<string> */
+    private array $srvGroupNames = [];
+    /** @var list<string> */
+    private array $srvGroupFlags = [];
+    /** Baseline `admin/admin` aid (usually 1). */
+    private int $ownerAid = 0;
     /** @var list<int> */
     private array $serverSids = [];
     /** @var list<int> */
@@ -247,6 +258,7 @@ final class Synthesizer
 
         $counts = [];
         $counts['groups']                = $this->insertGroups();
+        $counts['server_org_groups']     = $this->insertServerOrgGroups();
         $counts['srvgroups']             = $this->insertSrvGroups();
         $counts['admins']                = $this->insertAdmins();
         $counts['servers']               = $this->insertServers();
@@ -328,6 +340,7 @@ final class Synthesizer
             DB_PREFIX
         ));
         $stmt->execute(['admin', 'STEAM_0:0:0', $hash, 'admin@example.test', 16777216]);
+        $this->ownerAid = (int) $this->pdo->lastInsertId();
     }
 
     private function loadModIds(): void
@@ -554,30 +567,68 @@ final class Synthesizer
         return $count;
     }
 
+    private function insertServerOrgGroups(): int
+    {
+        // Server groups (`:prefix_groups` WHERE type = 3) — the
+        // "Server groups" admin UI section. Distinct from
+        // `:prefix_srvgroups` (SourceMod flag groups) and type=1 web
+        // groups. `servers_groups.group_id` points here.
+        $defs = [
+            ['name' => 'EU Cluster',   'flags' => 0],
+            ['name' => 'NA Cluster',   'flags' => 0],
+            ['name' => 'Competitive',  'flags' => 0],
+            ['name' => 'Scrim / Pub',  'flags' => 0],
+            ['name' => 'Event / LAN',  'flags' => 0],
+        ];
+        $want = min((int) ($this->scale['server_org_groups'] ?? 3), count($defs));
+        $stmt = $this->pdo->prepare(sprintf(
+            'INSERT INTO `%s_groups` (`type`, `name`, `flags`) VALUES (3, ?, ?)',
+            DB_PREFIX
+        ));
+        for ($i = 0; $i < $want; $i++) {
+            $stmt->execute([$defs[$i]['name'], $defs[$i]['flags']]);
+            $this->serverOrgGids[] = (int) $this->pdo->lastInsertId();
+        }
+        return $want;
+    }
+
     private function insertSrvGroups(): int
     {
         $defs = [
-            ['name' => 'sm_root',   'flags' => 'z',  'immunity' => 100],
-            ['name' => 'sm_admin',  'flags' => 'bcdefijklmpq', 'immunity' => 50],
-            ['name' => 'sm_mod',    'flags' => 'bdjkm', 'immunity' => 25],
+            ['name' => 'sm_root',   'flags' => 'z',  'immunity' => 100, 'immune' => ''],
+            ['name' => 'sm_admin',  'flags' => 'bcdefijklmpq', 'immunity' => 50, 'immune' => 'sm_mod'],
+            ['name' => 'sm_mod',    'flags' => 'bdjkm', 'immunity' => 25, 'immune' => ''],
         ];
         $stmt = $this->pdo->prepare(sprintf(
             'INSERT INTO `%s_srvgroups` (`immunity`, `flags`, `name`, `groups_immune`) VALUES (?, ?, ?, ?)',
             DB_PREFIX
         ));
         foreach ($defs as $g) {
-            $stmt->execute([$g['immunity'], $g['flags'], $g['name'], ' ']);
-            $this->srvGroupIds[] = (int) $this->pdo->lastInsertId();
+            $immune = $g['immune'] !== '' ? $g['immune'] : ' ';
+            $stmt->execute([$g['immunity'], $g['flags'], $g['name'], $immune]);
+            $this->srvGroupIds[]   = (int) $this->pdo->lastInsertId();
+            $this->srvGroupNames[] = $g['name'];
+            $this->srvGroupFlags[] = $g['flags'];
         }
         return count($defs);
     }
 
     private function insertAdmins(): int
     {
-        // Synth admins beyond the seeded admin/admin row. Each one gets a
-        // tapered group + a small extraflags bonus so the admin list
-        // shows mixed perm masks. All passwords are bcrypt of "admin"
-        // so a dev can log in as any of them with the same password.
+        // Owner is always an actor so bans/comms/audit show the logged-in
+        // admin's name on a realistic share of rows.
+        if ($this->ownerAid > 0) {
+            $this->adminAids[] = $this->ownerAid;
+            if ($this->srvGroupNames !== []) {
+                $upd = $this->pdo->prepare(sprintf(
+                    'UPDATE `%s_admins` SET `srv_group` = ?, `srv_flags` = ?, `immunity` = 100 WHERE `aid` = ?',
+                    DB_PREFIX
+                ));
+                $upd->execute([$this->srvGroupNames[0], $this->srvGroupFlags[0], $this->ownerAid]);
+            }
+        }
+
+        // Synth admins beyond admin/admin. Passwords are bcrypt of "admin".
         $names = [
             'sentinel',
             'fragmaster',
@@ -596,8 +647,9 @@ final class Synthesizer
         $count = min($this->scale['admins'], count($names));
         $stmt  = $this->pdo->prepare(sprintf(
             'INSERT INTO `%s_admins`
-                (`user`, `authid`, `password`, `gid`, `email`, `validate`, `extraflags`, `immunity`, `lastvisit`)
-             VALUES (?, ?, ?, ?, ?, NULL, ?, ?, ?)',
+                (`user`, `authid`, `password`, `gid`, `email`, `validate`, `extraflags`,
+                 `immunity`, `srv_group`, `srv_flags`, `lastvisit`)
+             VALUES (?, ?, ?, ?, ?, NULL, ?, ?, ?, ?, ?)',
             DB_PREFIX
         ));
         $hash = password_hash('admin', PASSWORD_BCRYPT);
@@ -605,6 +657,13 @@ final class Synthesizer
         for ($i = 0; $i < $count; $i++) {
             $name      = $names[$i];
             $gid       = $this->groupGids[$i % count($this->groupGids)];
+            $sgIdx     = $this->srvGroupNames === [] ? -1 : ($i % count($this->srvGroupNames));
+            $srvGroup  = $sgIdx >= 0 ? $this->srvGroupNames[$sgIdx] : null;
+            $srvFlags  = $sgIdx >= 0 ? $this->srvGroupFlags[$sgIdx] : null;
+            // ~1 in 4 carry individual SM flags on top of the group.
+            if ($srvFlags !== null && mt_rand(0, 3) === 0) {
+                $srvFlags .= 'o';
+            }
             $extra     = mt_rand(0, 3) === 0 ? 16777216 : 0; // ~25% Owner-flagged
             $immunity  = mt_rand(0, 99);
             $lastvisit = $this->now - mt_rand(60, 60 * 60 * 24 * 30);
@@ -616,6 +675,8 @@ final class Synthesizer
                 "$name@example.test",
                 $extra,
                 $immunity,
+                $srvGroup,
+                $srvFlags,
                 $lastvisit,
             ]);
             $this->adminAids[] = (int) $this->pdo->lastInsertId();
@@ -644,7 +705,7 @@ final class Synthesizer
 
     private function insertServersGroups(): int
     {
-        if ($this->serverSids === [] || $this->srvGroupIds === []) {
+        if ($this->serverSids === [] || $this->serverOrgGids === []) {
             return 0;
         }
         $stmt = $this->pdo->prepare(sprintf(
@@ -652,12 +713,23 @@ final class Synthesizer
             DB_PREFIX
         ));
         $n = 0;
-        foreach ($this->serverSids as $sid) {
-            // Each server lives in exactly one srvgroup so the admin
-            // server-group page renders multiple memberships.
-            $gid = $this->srvGroupIds[mt_rand(0, count($this->srvGroupIds) - 1)];
-            $stmt->execute([$sid, $gid]);
+        foreach ($this->serverSids as $i => $sid) {
+            // Every server joins one org group; ~30% also join a second
+            // so Server groups cards show multi-server + multi-group.
+            $primary = $this->serverOrgGids[$i % count($this->serverOrgGids)];
+            $stmt->execute([$sid, $primary]);
             $n++;
+            if (count($this->serverOrgGids) > 1 && mt_rand(0, 9) < 3) {
+                $secondary = $this->serverOrgGids[mt_rand(0, count($this->serverOrgGids) - 1)];
+                if ($secondary !== $primary) {
+                    try {
+                        $stmt->execute([$sid, $secondary]);
+                        $n++;
+                    } catch (\PDOException) {
+                        // UNIQUE (server_id, group_id) — ignore collision.
+                    }
+                }
+            }
         }
         return $n;
     }
@@ -672,14 +744,29 @@ final class Synthesizer
             DB_PREFIX
         ));
         $n = 0;
-        foreach ($this->adminAids as $aid) {
-            // Bind each admin to ~half the servers across a mix of srvgroups
-            // so the admin-server-group matrix isn't trivial.
-            $bindings = max(1, intdiv(count($this->serverSids), 2));
-            for ($j = 0; $j < $bindings; $j++) {
-                $sid    = $this->serverSids[mt_rand(0, count($this->serverSids) - 1)];
-                $sgid   = $this->srvGroupIds === [] ? 0 : $this->srvGroupIds[mt_rand(0, count($this->srvGroupIds) - 1)];
-                $stmt->execute([$aid, 0, $sgid, $sid]);
+        foreach ($this->adminAids as $aidIdx => $aid) {
+            // Match api_admins_add shape:
+            //   single server: (aid, srvgroups.id, -1, sid)
+            //   org group:     (aid, srvgroups.id, type3.gid, -1)
+            $smGroupId = $this->srvGroupIds === []
+                ? -1
+                : $this->srvGroupIds[$aidIdx % count($this->srvGroupIds)];
+
+            $singleBindings = max(1, intdiv(count($this->serverSids), 2));
+            $usedSids = [];
+            for ($j = 0; $j < $singleBindings; $j++) {
+                $sid = $this->serverSids[mt_rand(0, count($this->serverSids) - 1)];
+                if (isset($usedSids[$sid])) {
+                    continue;
+                }
+                $usedSids[$sid] = true;
+                $stmt->execute([$aid, $smGroupId, -1, $sid]);
+                $n++;
+            }
+
+            if ($this->serverOrgGids !== [] && mt_rand(0, 1) === 0) {
+                $orgGid = $this->serverOrgGids[mt_rand(0, count($this->serverOrgGids) - 1)];
+                $stmt->execute([$aid, $smGroupId, $orgGid, -1]);
                 $n++;
             }
         }
@@ -723,11 +810,18 @@ final class Synthesizer
     private function insertOverrides(): int
     {
         $defs = [
-            ['type' => 'command', 'name' => 'sm_kick',     'flags' => 'd'],
-            ['type' => 'command', 'name' => 'sm_slay',     'flags' => 'e'],
-            ['type' => 'command', 'name' => 'sm_ban',      'flags' => 'd'],
-            ['type' => 'command', 'name' => 'sm_admin',    'flags' => 'a'],
-            ['type' => 'group',   'name' => 'sm_root',     'flags' => 'z'],
+            ['type' => 'command', 'name' => 'sm_kick',      'flags' => 'd'],
+            ['type' => 'command', 'name' => 'sm_slay',      'flags' => 'e'],
+            ['type' => 'command', 'name' => 'sm_ban',       'flags' => 'd'],
+            ['type' => 'command', 'name' => 'sm_admin',     'flags' => 'a'],
+            ['type' => 'command', 'name' => 'sm_map',       'flags' => 'g'],
+            ['type' => 'command', 'name' => 'sm_cvar',      'flags' => 'h'],
+            ['type' => 'command', 'name' => 'sm_rcon',      'flags' => 'm'],
+            ['type' => 'command', 'name' => 'sm_reloadadmins', 'flags' => 'z'],
+            ['type' => 'command', 'name' => 'sm_who',       'flags' => 'b'],
+            ['type' => 'group',   'name' => 'sm_root',      'flags' => 'z'],
+            ['type' => 'group',   'name' => 'sm_ban',       'flags' => 'd'],
+            ['type' => 'group',   'name' => 'sm_chat',      'flags' => 'j'],
         ];
         $stmt = $this->pdo->prepare(sprintf(
             'INSERT INTO `%s_overrides` (`type`, `name`, `flags`) VALUES (?, ?, ?)',
@@ -794,18 +888,17 @@ final class Synthesizer
             $identityKey   = $isIpOnly ? 'ip:' . $player['ip'] : 'auth:' . $player['steam'];
             $alreadyActive = isset($activeIdentities[$identityKey]);
 
-            // State distribution: 60% active (incl. permanent), 25% expired,
-            // 15% admin-removed (RemoveType U/D + RemovedBy + ureason).
+            // State distribution: 55% active, 20% naturally expired
+            // (RemoveType=E + RemovedBy=0, PruneBans shape), 10% expired
+            // pre-migration (RemoveType NULL), 15% admin-removed (U/D).
             // Subsequent active rolls for an already-banned identity
-            // collapse into the expired branch (forced timed + ends < now)
-            // so the player accumulates a realistic "lifted-then-rebanned"
-            // history without violating the at-most-one-active invariant.
+            // collapse into the expired branch.
             $roll       = mt_rand(0, 99);
             $removeType = null;
             $removedBy  = null;
             $removedOn  = null;
             $ureason    = '';
-            if ($roll < 60 && !$alreadyActive) {
+            if ($roll < 55 && !$alreadyActive) {
                 // Active. Force ends > now if timed.
                 if ($length !== 0 && $ends < $this->now) {
                     $created = $this->now - mt_rand(0, $length - 60 * 60 * 24);
@@ -821,6 +914,13 @@ final class Synthesizer
                 if ($ends > $this->now) {
                     $created = $this->now - $length - mt_rand(60, 60 * 60 * 24 * 7);
                     $ends    = $created + $length;
+                }
+                // ~2/3 of expired rows carry the post-prune RemoveType=E
+                // shape so ?state=expired exercises both arms.
+                if (!$alreadyActive && mt_rand(0, 2) !== 0) {
+                    $removeType = \BanRemoval::Expired->value;
+                    $removedBy  = 0;
+                    $removedOn  = $ends;
                 }
             } else {
                 // Admin-removed (~15%).
@@ -917,7 +1017,10 @@ final class Synthesizer
             $length  = mt_rand(0, 3) === 0 ? 0 : mt_rand(60 * 30, 60 * 60 * 24 * 14);
             $ends    = $length === 0 ? 0 : $created + $length;
 
-            $commType      = mt_rand(1, 2); // 1 = mute, 2 = gag
+            // 1=mute, 2=gag, 3=silence (~15% silence so the Silence chip
+            // and mute_kind export path are non-empty).
+            $typeRoll = mt_rand(0, 99);
+            $commType = $typeRoll < 15 ? 3 : ($typeRoll < 55 ? 1 : 2);
             $identityKey   = 'auth:' . $player['steam'] . ':type:' . $commType;
             $alreadyActive = isset($activeIdentities[$identityKey]);
 
@@ -995,7 +1098,9 @@ final class Synthesizer
         $protestShare = max(0, $total - $banShare - $commShare - $subShare);
 
         $stmt = $this->pdo->prepare(sprintf(
-            'INSERT INTO `%s_comments` (`bid`, `type`, `aid`, `commenttxt`, `added`) VALUES (?, ?, ?, ?, ?)',
+            'INSERT INTO `%s_comments`
+                (`bid`, `type`, `aid`, `commenttxt`, `added`, `editaid`, `edittime`)
+             VALUES (?, ?, ?, ?, ?, ?, ?)',
             DB_PREFIX
         ));
 
@@ -1029,7 +1134,15 @@ final class Synthesizer
             $parent = $parentIds[mt_rand(0, count($parentIds) - 1)];
             $aid    = $this->randomAdminAid();
             $body   = $bodies[mt_rand(0, count($bodies) - 1)];
-            $stmt->execute([$parent, $type, $aid, $body, $this->now - mt_rand(60, 60 * 60 * 24 * 60)]);
+            $added  = $this->now - mt_rand(60, 60 * 60 * 24 * 60);
+            // ~10% edited so banlist/commslist "last edit" chrome paints.
+            $editaid  = null;
+            $edittime = null;
+            if (mt_rand(0, 9) === 0) {
+                $editaid  = $this->randomAdminAid();
+                $edittime = min($this->now, $added + mt_rand(60, 60 * 60 * 24 * 7));
+            }
+            $stmt->execute([$parent, $type, $aid, $body, $added, $editaid, $edittime]);
             $n++;
         }
         return $n;

--- a/web/tests/e2e/specs/flows/admin-admins-density.spec.ts
+++ b/web/tests/e2e/specs/flows/admin-admins-density.spec.ts
@@ -124,12 +124,12 @@ test.describe('flow: admin/admins density rework (#1207 ADM-3, ADM-4 / #1275)', 
         await p.searchToggle.click();
 
         // Two filters at once: a deliberately not-matching login
-        // ("zzznoadminmatchesthis") + a steam_match=1 (partial). The
-        // login filter narrows the result list to zero — locking the
+        // ("zzznoadminmatchesthis") + a steamid substring. The login
+        // filter narrows the result list to zero — locking the
         // server-side AND contract — while still emitting both
         // filters on the wire so we can assert two-param submission.
         await p.searchInput('name').fill('zzznoadminmatchesthis');
-        await page.locator('[data-testid="search-admins-steam-match"]').selectOption('1');
+        await p.searchInput('steamid').fill('STEAM_0:0:0');
 
         // Single submit → single document navigation. Capture every
         // document-level request kicked off after we click submit so
@@ -146,7 +146,8 @@ test.describe('flow: admin/admins density rework (#1207 ADM-3, ADM-4 / #1275)', 
 
         const url = new URL(page.url());
         expect(url.searchParams.get('name')).toBe('zzznoadminmatchesthis');
-        expect(url.searchParams.get('steam_match')).toBe('1');
+        expect(url.searchParams.get('steamid')).toBe('STEAM_0:0:0');
+        expect(url.searchParams.get('steam_match')).toBeNull();
         // #1275 — the form carries `<input type="hidden" name="section" value="admins">`
         // so the post-submit URL keeps the user on the admins section.
         expect(url.searchParams.get('section')).toBe('admins');
@@ -171,15 +172,14 @@ test.describe('flow: admin/admins density rework (#1207 ADM-3, ADM-4 / #1275)', 
         test.skip(testInfo.project.name !== 'chromium', 'Pre-fill contract is project-agnostic; pinning to desktop for runtime.');
 
         const p = new AdminAdminsPage(page);
-        await page.goto('/index.php?p=admin&c=admins&section=admins&name=admin&steamid=STEAM_0:0:0&steam_match=1');
+        await page.goto('/index.php?p=admin&c=admins&section=admins&name=admin&steamid=STEAM_0:0:0');
         await expect(p.pageMounted).toBeVisible();
 
         // The form re-paints from `$active_filter_*` on the View
         // DTO; values land in the inputs without JS assistance.
         await expect(p.searchInput('name')).toHaveValue('admin');
         await expect(p.searchInput('steamid')).toHaveValue('STEAM_0:0:0');
-        const matchSelect = page.locator('[data-testid="search-admins-steam-match"]');
-        await expect(matchSelect).toHaveValue('1');
+        await expect(page.locator('[data-testid="search-admins-steam-match"]')).toHaveCount(0);
     });
 
     // ----- ADM-4 — Clear filters resets form state --------------------

--- a/web/tests/e2e/specs/flows/admin-admins-search-disclosure.spec.ts
+++ b/web/tests/e2e/specs/flows/admin-admins-search-disclosure.spec.ts
@@ -110,9 +110,7 @@ test.describe('flow: admin/admins advanced-search disclosure (#1303)', () => {
         test.skip(testInfo.project.name !== 'chromium', 'Count badge contract is project-agnostic; pinning to desktop for runtime.');
 
         // Three populated value slots: `name`, `steamid`, `webgroup`.
-        // `name_match` / `steam_match` are refinements on `name` /
-        // `steamid` and must NOT lift the count.
-        await page.goto('/index.php?p=admin&c=admins&section=admins&name=admin&name_match=0&steamid=STEAM_0:0:0&steam_match=1&webgroup=1');
+        await page.goto('/index.php?p=admin&c=admins&section=admins&name=admin&steamid=STEAM_0:0:0&webgroup=1');
         const p = new AdminAdminsPage(page);
         await expect(p.pageMounted).toBeVisible();
 

--- a/web/tests/integration/AdminAdminsSearchTest.php
+++ b/web/tests/integration/AdminAdminsSearchTest.php
@@ -192,111 +192,54 @@ final class AdminAdminsSearchTest extends ApiTestCase
     }
 
     /**
-     * Steam-ID exact / partial split. Modern shape uses
-     * `steamid=<text>&steam_match=0|1`. The filter is exact when
-     * `steam_match` is unset or `0`, partial when `1`.
+     * Steam ID / login / e-mail always substring-match (`LIKE %…%`).
+     * Legacy `*_match` query params are ignored when present.
      */
-    public function testSteamIdExactMatchSplit(): void
+    public function testTextFiltersAreAlwaysPartial(): void
     {
+        $_GET = [
+            'p'       => 'admin',
+            'c'       => 'admins',
+            'steamid' => 'STEAM_0:0:1001',
+        ];
+        $exactShape = $this->renderAdminsPage();
+        $this->assertSame(1, $this->extractAdminCount($exactShape), 'full steamid still matches alice');
+
         $_GET = [
             'p'           => 'admin',
             'c'           => 'admins',
-            'steamid'     => 'STEAM_0:0:1001',
+            'steamid'     => 'STEAM_0:0:10',
             'steam_match' => '0',
         ];
-        $exact = $this->renderAdminsPage();
-        $this->assertSame(1, $this->extractAdminCount($exact), 'exact match on alice steamid');
+        $partialSteam = $this->renderAdminsPage();
+        $this->assertSame(3, $this->extractAdminCount($partialSteam), 'steamid substring matches even when steam_match=0 is present');
 
-        $_GET = [
-            'p'           => 'admin',
-            'c'           => 'admins',
-            'steamid'     => 'STEAM_0:0:10', // partial substring (matches 1001/1002/1003 → all 3)
-            'steam_match' => '1',
-        ];
-        $partial = $this->renderAdminsPage();
-        $this->assertSame(3, $this->extractAdminCount($partial), 'partial match on STEAM_0:0:10 substring');
-    }
-
-    /**
-     * Login-name and E-mail exact / partial split (#1231).
-     *
-     * Pre-#1231, only SteamID shipped a `<select>` to flip between
-     * exact and partial; Login and E-mail silently substring-matched
-     * with no way to ask for "give me the row whose login is
-     * literally `admin`". The fix mirrors the steam_match shape onto
-     * both filters as `name_match` and `admemail_match`.
-     *
-     * Match-mode default is `'1'` (partial) for both — i.e. when the
-     * URL omits the new param, the filter behaves the way it always
-     * did. That preserves every legacy bookmark and the
-     * `?advType=name&advSearch=…` shim's contract; the new feature is
-     * purely opt-in via `…_match=0`.
-     */
-    public function testLoginAndEmailExactMatchSplit(): void
-    {
-        // Login name: 'ali' is a substring of 'alice' but not exact.
-        // Partial → 1 row (alice). Exact → 0 rows. Then 'alice' exact
-        // → 1 row (the literal alice), proving exact mode resolves
-        // the "find me the single admin" contract.
         $_GET = [
             'p'          => 'admin',
             'c'          => 'admins',
             'name'       => 'ali',
-            'name_match' => '1',
+            'name_match' => '0',
         ];
         $partialName = $this->renderAdminsPage();
-        $this->assertSame(1, $this->extractAdminCount($partialName), 'partial name=ali matches alice');
+        $this->assertSame(1, $this->extractAdminCount($partialName), 'name=ali matches alice; name_match is ignored');
 
-        $_GET = [
-            'p'          => 'admin',
-            'c'          => 'admins',
-            'name'       => 'ali',
-            'name_match' => '0',
-        ];
-        $exactNameMiss = $this->renderAdminsPage();
-        $this->assertSame(0, $this->extractAdminCount($exactNameMiss), 'exact name=ali matches no admin (none is literally ali)');
-
-        $_GET = [
-            'p'          => 'admin',
-            'c'          => 'admins',
-            'name'       => 'alice',
-            'name_match' => '0',
-        ];
-        $exactNameHit = $this->renderAdminsPage();
-        $this->assertSame(1, $this->extractAdminCount($exactNameHit), 'exact name=alice matches alice');
-        $this->assertStringContainsString('>alice<', $exactNameHit);
-
-        // E-mail: every seeded row (admin, alice, bob, charlie) shares
-        // '@example.test', so partial 'example.test' returns 4 and
-        // exact 'example.test' returns 0; exact 'alice@example.test'
-        // narrows back to alice.
         $_GET = [
             'p'              => 'admin',
             'c'              => 'admins',
             'admemail'       => 'example.test',
-            'admemail_match' => '1',
+            'admemail_match' => '0',
         ];
         $partialEmail = $this->renderAdminsPage();
-        $this->assertSame(4, $this->extractAdminCount($partialEmail), 'partial admemail=example.test matches all 4 admins');
+        $this->assertSame(4, $this->extractAdminCount($partialEmail), 'admemail substring matches; admemail_match is ignored');
 
         $_GET = [
-            'p'              => 'admin',
-            'c'              => 'admins',
-            'admemail'       => 'example.test',
-            'admemail_match' => '0',
+            'p'        => 'admin',
+            'c'        => 'admins',
+            'admemail' => 'alice@example.test',
         ];
-        $exactEmailMiss = $this->renderAdminsPage();
-        $this->assertSame(0, $this->extractAdminCount($exactEmailMiss), 'exact admemail=example.test matches no admin (none is literally that)');
-
-        $_GET = [
-            'p'              => 'admin',
-            'c'              => 'admins',
-            'admemail'       => 'alice@example.test',
-            'admemail_match' => '0',
-        ];
-        $exactEmailHit = $this->renderAdminsPage();
-        $this->assertSame(1, $this->extractAdminCount($exactEmailHit), 'exact admemail=alice@example.test matches alice');
-        $this->assertStringContainsString('>alice<', $exactEmailHit);
+        $emailHit = $this->renderAdminsPage();
+        $this->assertSame(1, $this->extractAdminCount($emailHit), 'full admemail still narrows to alice');
+        $this->assertStringContainsString('>alice<', $emailHit);
     }
 
     /**
@@ -381,26 +324,24 @@ final class AdminAdminsSearchTest extends ApiTestCase
     }
 
     /**
-     * #1303 — multi-filter URLs lift the active count to N. Locks the
-     * counter's behaviour against the headline ADM-4 contract: every
-     * populated value slot counts ONCE, match-mode toggles do NOT.
+     * #1303 — multi-filter URLs lift the active count to N. Every
+     * populated value slot counts ONCE. Stale `*_match` params do not
+     * lift the count.
      *
      * Two text filters (`name`, `steamid`) + one select (`webgroup`) +
-     * one multi-select (`admwebflag[]`) → 4 active. The presence of
-     * `name_match=0` (a refinement on the `name` filter) must NOT
-     * lift the count to 5; same for `steam_match=1` on `steamid`.
+     * one multi-select (`admwebflag[]`) → 4 active.
      */
     public function testDisclosureCountMatchesPopulatedFilterSlots(): void
     {
         $_GET = [
-            'p'          => 'admin',
-            'c'          => 'admins',
-            'name'       => 'alice',
-            'name_match' => '0',
-            'steamid'    => 'STEAM_0:0:1001',
+            'p'           => 'admin',
+            'c'           => 'admins',
+            'name'        => 'alice',
+            'name_match'  => '0',
+            'steamid'     => 'STEAM_0:0:1001',
             'steam_match' => '1',
-            'webgroup'   => (string) $this->powerGid,
-            'admwebflag' => ['ADMIN_OWNER'],
+            'webgroup'    => (string) $this->powerGid,
+            'admwebflag'  => ['ADMIN_OWNER'],
         ];
 
         $html = $this->renderAdminsPage();
@@ -409,6 +350,9 @@ final class AdminAdminsSearchTest extends ApiTestCase
         $this->assertStringContainsString(' open', $disclosure);
         $this->assertStringContainsString('data-active-filter-count="4"', $disclosure);
         $this->assertStringContainsString('aria-label="4 active filters"', $html);
+        $this->assertStringNotContainsString('search-admins-name-match', $html);
+        $this->assertStringNotContainsString('search-admins-steam-match', $html);
+        $this->assertStringContainsString('data-multiselect', $html);
     }
 
     /**
@@ -566,6 +510,100 @@ final class AdminAdminsSearchTest extends ApiTestCase
         // here: with no `?section=`, the user lands on `add-admin`
         // (the first entry whose permission they hold).
         $this->assertSame(['add-admin'], $this->renderedSectionSlugs($html));
+    }
+
+    /**
+     * Server-permission multi-select filters by SM_* char flags on
+     * `:prefix_admins.srv_flags`. HasAccess must receive the admin's
+     * aid (int), not authid, and the SM constant as a string char.
+     */
+    public function testServerFlagFilterMatchesSrvFlagsAndDoesNotCrash(): void
+    {
+        $pdo = Fixture::rawPdo();
+        $pdo->prepare(sprintf(
+            'UPDATE `%s_admins` SET srv_flags = ? WHERE aid = ?',
+            DB_PREFIX,
+        ))->execute(['a', $this->aliceAid]);
+        $pdo->prepare(sprintf(
+            'UPDATE `%s_admins` SET srv_flags = ? WHERE aid = ?',
+            DB_PREFIX,
+        ))->execute(['d', $this->bobAid]);
+
+        $_GET = [
+            'p'          => 'admin',
+            'c'          => 'admins',
+            'admsrvflag' => ['SM_RESERVED_SLOT'],
+        ];
+
+        $html = $this->renderAdminsPage();
+
+        $this->assertSame(1, $this->extractAdminCount($html), 'SM_RESERVED_SLOT matches alice only');
+        $this->assertStringContainsString('>alice<', $html);
+        $this->assertStringNotContainsString('>bob<', $html);
+        $this->assertStringNotContainsString('>charlie<', $html);
+    }
+
+    /**
+     * SM_ROOT on srv_flags implies every server permission, so a
+     * reserved-slot filter still returns root holders.
+     */
+    public function testServerFlagFilterIncludesSmRootHolders(): void
+    {
+        $pdo = Fixture::rawPdo();
+        $pdo->prepare(sprintf(
+            'UPDATE `%s_admins` SET srv_flags = ? WHERE aid = ?',
+            DB_PREFIX,
+        ))->execute(['z', $this->charlieAid]);
+
+        $_GET = [
+            'p'          => 'admin',
+            'c'          => 'admins',
+            'admsrvflag' => ['SM_RESERVED_SLOT'],
+        ];
+
+        $html = $this->renderAdminsPage();
+
+        $this->assertSame(1, $this->extractAdminCount($html), 'SM_ROOT implies SM_RESERVED_SLOT');
+        $this->assertStringContainsString('>charlie<', $html);
+    }
+
+    /**
+     * SM_CUSTOM1…6 end in a digit. The allowlist regex must accept
+     * digits or those flags are dropped from both the SQL filter and
+     * the form pre-fill after submit.
+     */
+    public function testServerCustomFlagFilterRoundTripsAndMatches(): void
+    {
+        $pdo = Fixture::rawPdo();
+        $pdo->prepare(sprintf(
+            'UPDATE `%s_admins` SET srv_flags = ? WHERE aid = ?',
+            DB_PREFIX,
+        ))->execute(['o', $this->aliceAid]);
+        $pdo->prepare(sprintf(
+            'UPDATE `%s_admins` SET srv_flags = ? WHERE aid = ?',
+            DB_PREFIX,
+        ))->execute(['a', $this->bobAid]);
+
+        $_GET = [
+            'p'          => 'admin',
+            'c'          => 'admins',
+            'admsrvflag' => ['SM_CUSTOM1'],
+        ];
+
+        $html = $this->renderAdminsPage();
+
+        $this->assertSame(1, $this->extractAdminCount($html), 'SM_CUSTOM1 matches alice (flag o)');
+        $this->assertStringContainsString('>alice<', $html);
+        $this->assertStringNotContainsString('>bob<', $html);
+        $this->assertStringContainsString(
+            'data-active-filter-count="1"',
+            $this->extractDisclosureTag($html),
+        );
+        $this->assertMatchesRegularExpression(
+            '/<option[^>]*value="SM_CUSTOM1"[^>]*selected/i',
+            $html,
+            'custom flag must stay selected after submit',
+        );
     }
 
     private function seedTestAdmins(): void

--- a/web/tests/integration/EditAdminTabsChromeTest.php
+++ b/web/tests/integration/EditAdminTabsChromeTest.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sbpp\Tests\Integration;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Pins the shared Details / Group / Servers / Permissions tab strip
+ * across the four edit-admin templates. Permissions must stay in the
+ * same chrome as the sibling pages.
+ */
+final class EditAdminTabsChromeTest extends TestCase
+{
+    private const THEME = ROOT . 'themes/default/';
+
+    /** @return list<string> */
+    private function editAdminTemplates(): array
+    {
+        return [
+            'page_admin_edit_admins_details.tpl',
+            'page_admin_edit_admins_group.tpl',
+            'page_admin_edit_admins_servers.tpl',
+            'page_admin_edit_admins_perms.tpl',
+        ];
+    }
+
+    public function testEveryEditAdminTemplateShipsSharedTabStrip(): void
+    {
+        $required = [
+            'role="tablist"',
+            'aria-label="Edit admin sections"',
+            'data-testid="admin-tab-details"',
+            'data-testid="admin-tab-group"',
+            'data-testid="admin-tab-servers"',
+            'data-testid="admin-tab-permissions"',
+            'data-testid="admin-tab-back"',
+            'admin-tabs__back',
+            'o=editdetails',
+            'o=editgroup',
+            'o=editservers',
+            'o=editpermissions',
+        ];
+
+        foreach ($this->editAdminTemplates() as $file) {
+            $path = self::THEME . $file;
+            $this->assertFileExists($path);
+            $src = (string) file_get_contents($path);
+            foreach ($required as $needle) {
+                $this->assertStringContainsString(
+                    $needle,
+                    $src,
+                    "{$file} must include {$needle}",
+                );
+            }
+        }
+    }
+
+    public function testPermissionsTemplateMarksPermissionsTabCurrent(): void
+    {
+        $src = (string) file_get_contents(self::THEME . 'page_admin_edit_admins_perms.tpl');
+
+        $this->assertMatchesRegularExpression(
+            '/data-testid="admin-tab-permissions"[^>]*aria-current="page"|aria-current="page"[^>]*data-testid="admin-tab-permissions"/',
+            $src,
+            'Permissions page must mark the Permissions tab as current',
+        );
+        $this->assertStringContainsString('class="card-tab page-section"', $src);
+        $this->assertStringContainsString('Edit admin · {$admin_name|escape}', $src);
+        $this->assertStringNotContainsString('Permissions for {$admin_name|escape}', $src);
+        $this->assertSame(
+            2,
+            substr_count($src, 'table--keep-mobile'),
+            'both permission tables must opt out of the mobile .table hide',
+        );
+        $this->assertStringContainsString('data-testid="edit-perms-web-select-all"', $src);
+        $this->assertStringContainsString('data-testid="edit-perms-server-select-all"', $src);
+        $this->assertStringContainsString('perms-group-head', $src);
+        $this->assertStringContainsString('perms-group-child', $src);
+        $this->assertStringContainsString('perms-group-sep', $src);
+    }
+
+    public function testEditAdminHandlersSkipOrphanBackStrip(): void
+    {
+        $handlers = [
+            'admin.edit.admindetails.php',
+            'admin.edit.admingroup.php',
+            'admin.edit.adminservers.php',
+            'admin.edit.adminperms.php',
+        ];
+        foreach ($handlers as $file) {
+            $src = (string) file_get_contents(ROOT . 'pages/' . $file);
+            $this->assertStringNotContainsString(
+                'new \\Sbpp\\View\\AdminTabs([],',
+                $src,
+                "{$file} must not mount the empty AdminTabs back strip (dead space under the topbar)",
+            );
+            $this->assertStringNotContainsString(
+                'new AdminTabs([],',
+                $src,
+                "{$file} must not mount the empty AdminTabs back strip (dead space under the topbar)",
+            );
+        }
+    }
+}

--- a/web/tests/integration/OverridesMobileTableRegressionTest.php
+++ b/web/tests/integration/OverridesMobileTableRegressionTest.php
@@ -1,0 +1,61 @@
+<?php
+// SourceBans++ (c) 2014-2026 SourceBans++ Dev Team
+// Licensed under the Elastic License 2.0.
+// See LICENSE.txt for the full license text and THIRD-PARTY-NOTICES.txt for attributions.
+
+declare(strict_types=1);
+
+namespace Sbpp\Tests\Integration;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Form tables under Admins → Overrides (and the sister group-edit
+ * overrides editor) have no paired mobile-card surface. At <=768px
+ * the global `.table { display: none }` rule would hide every
+ * editable row (including the empty-state message) unless the
+ * table opts out via `table--keep-mobile` — the same escape hatch
+ * edit-admin-permissions already uses.
+ */
+final class OverridesMobileTableRegressionTest extends TestCase
+{
+    public function testOverridesEditorKeepsTableOnMobile(): void
+    {
+        $src = (string) file_get_contents(ROOT . 'themes/default/page_admin_overrides.tpl');
+        $this->assertMatchesRegularExpression(
+            '/class="table[^"]*table--keep-mobile[^"]*"[^>]*data-testid="overrides-table"|'
+            . 'data-testid="overrides-table"[^>]*class="table[^"]*table--keep-mobile/',
+            $src,
+            'overrides editor table must carry table--keep-mobile',
+        );
+    }
+
+    public function testEditGroupFormTablesKeepOnMobile(): void
+    {
+        $src = (string) file_get_contents(ROOT . 'themes/default/page_admin_edit_group.tpl');
+        $this->assertSame(
+            3,
+            substr_count($src, 'table--keep-mobile'),
+            'web perms, server perms, and group overrides tables must all opt out',
+        );
+        $this->assertMatchesRegularExpression(
+            '/class="table[^"]*table--keep-mobile[^"]*"[^>]*id="overrides-table"|'
+            . 'id="overrides-table"[^>]*class="table[^"]*table--keep-mobile/',
+            $src,
+            'group overrides table must carry table--keep-mobile',
+        );
+    }
+
+    public function testKeepMobileOptOutRuleExistsInThemeCss(): void
+    {
+        $css = (string) file_get_contents(ROOT . 'themes/default/css/theme.css');
+        $this->assertMatchesRegularExpression(
+            '/@media\s*\(\s*max-width:\s*768px\s*\)\s*\{[^}]*\.table\s*\{\s*display:\s*none\s*;/s',
+            $css,
+        );
+        $this->assertStringContainsString(
+            '.table.table--keep-mobile { display: table; }',
+            $css,
+        );
+    }
+}

--- a/web/themes/default/box_admin_admins_search.tpl
+++ b/web/themes/default/box_admin_admins_search.tpl
@@ -9,28 +9,16 @@
     page_admin_admins_list.tpl. Submits as a plain `GET` to
     ?p=admin&c=admins with one parameter per populated filter.
 
-    Wire format (#1207 ADM-4 redesign — single submit, AND semantics;
-    extended in #1231 to give every text filter its own match-mode select):
-        name=<text>                login
-        name_match=0|1             0 = exact, 1 = partial (default 1)
-        steamid=<text>             Steam ID
-        steam_match=0|1            0 = exact, 1 = partial (default 0)
-        admemail=<text>            E-mail (gated by can_edit_admins)
-        admemail_match=0|1         0 = exact, 1 = partial (default 1)
+    Wire format (#1207 ADM-4 redesign — single submit, AND semantics):
+        name=<text>                login (always partial / LIKE)
+        steamid=<text>             Steam ID (always partial / LIKE)
+        admemail=<text>            E-mail (gated by can_edit_admins; always partial)
         webgroup=<gid>             Panel group
         srvadmgroup=<group_name>   SourceMod admin group
         srvgroup=<gid>             Server group
         admwebflag[]=ADMIN_*       Web permission flags (multi)
         admsrvflag[]=SM_*          Server permission flags (multi)
         server=<sid>               Server access
-
-    Match-mode defaults are asymmetric on purpose:
-        - SteamID defaults to exact (0) — typical use is "find one
-          admin by their full Steam ID".
-        - Login / E-mail default to partial (1) — preserves the
-          pre-#1231 substring behaviour so existing bookmarks and
-          legacy `advType=…&advSearch=…` URLs keep narrowing the
-          way admins expect.
 
     Multiple non-empty filters are combined with AND on the server side
     (admin.admins.php). The legacy single-filter shape
@@ -64,11 +52,8 @@
         data-testid="search-admins-active-count"   "N active" badge        (#1303; only when count > 0)
         data-testid="search-admins-form"           outer form
         data-testid="search-admins-name"           login <input>
-        data-testid="search-admins-name-match"     login exact / partial match (#1231)
         data-testid="search-admins-steamid"        SteamID <input>
-        data-testid="search-admins-steam-match"    SteamID exact / partial match
         data-testid="search-admins-admemail"       email <input>      (gated)
-        data-testid="search-admins-admemail-match" email exact / partial match (#1231; gated)
         data-testid="search-admins-webgroup"       web-group <select>
         data-testid="search-admins-srvadmgroup"    SM admin-group <select>
         data-testid="search-admins-srvgroup"       server-group <select>
@@ -144,76 +129,40 @@
 
     <div class="card__body space-y-3">
         <div class="grid gap-3" style="grid-template-columns:12rem 1fr;align-items:end">
-            <label class="label" for="search-admins-name" style="grid-column:1;align-self:end">Login name</label>
-            <div class="flex gap-2" style="flex-wrap:wrap">
-                <input class="input"
-                       id="search-admins-name"
-                       name="name"
-                       type="text"
-                       placeholder="Match against the panel login&hellip;"
-                       data-testid="search-admins-name"
-                       value="{$active_filter_name|escape}"
-                       style="flex:1;min-width:14rem"
-                       autocomplete="off">
-                <select class="select"
-                        id="search-admins-name-match"
-                        name="name_match"
-                        data-testid="search-admins-name-match"
-                        aria-label="Login name match mode"
-                        style="width:9rem">
-                    <option value="0"{if $active_filter_name_match == '0'} selected{/if}>Exact match</option>
-                    <option value="1"{if $active_filter_name_match != '0'} selected{/if}>Partial match</option>
-                </select>
-            </div>
+            <label class="label" for="search-admins-name">Login name</label>
+            <input class="input"
+                   id="search-admins-name"
+                   name="name"
+                   type="text"
+                   placeholder="Match against the panel login&hellip;"
+                   data-testid="search-admins-name"
+                   value="{$active_filter_name|escape}"
+                   autocomplete="off">
         </div>
 
         <div class="grid gap-3" style="grid-template-columns:12rem 1fr;align-items:end">
-            <label class="label" for="search-admins-steamid" style="grid-column:1;align-self:end">Steam ID</label>
-            <div class="flex gap-2" style="flex-wrap:wrap">
-                <input class="input font-mono"
-                       id="search-admins-steamid"
-                       name="steamid"
-                       type="text"
-                       placeholder="STEAM_0:0:1234 or [U:1:1234]&hellip;"
-                       data-testid="search-admins-steamid"
-                       value="{$active_filter_steamid|escape}"
-                       style="flex:1;min-width:14rem"
-                       autocomplete="off">
-                <select class="select"
-                        id="search-admins-steam-match"
-                        name="steam_match"
-                        data-testid="search-admins-steam-match"
-                        aria-label="Steam ID match mode"
-                        style="width:9rem">
-                    <option value="0"{if $active_filter_steam_match != '1'} selected{/if}>Exact match</option>
-                    <option value="1"{if $active_filter_steam_match == '1'} selected{/if}>Partial match</option>
-                </select>
-            </div>
+            <label class="label" for="search-admins-steamid">Steam ID</label>
+            <input class="input font-mono"
+                   id="search-admins-steamid"
+                   name="steamid"
+                   type="text"
+                   placeholder="STEAM_0:0:1234 or [U:1:1234]&hellip;"
+                   data-testid="search-admins-steamid"
+                   value="{$active_filter_steamid|escape}"
+                   autocomplete="off">
         </div>
 
         {if $can_editadmin}
             <div class="grid gap-3" style="grid-template-columns:12rem 1fr;align-items:end">
-                <label class="label" for="search-admins-admemail" style="grid-column:1;align-self:end">E-mail</label>
-                <div class="flex gap-2" style="flex-wrap:wrap">
-                    <input class="input"
-                           id="search-admins-admemail"
-                           name="admemail"
-                           type="email"
-                           placeholder="Match against the panel e-mail&hellip;"
-                           data-testid="search-admins-admemail"
-                           value="{$active_filter_admemail|escape}"
-                           style="flex:1;min-width:14rem"
-                           autocomplete="off">
-                    <select class="select"
-                            id="search-admins-admemail-match"
-                            name="admemail_match"
-                            data-testid="search-admins-admemail-match"
-                            aria-label="E-mail match mode"
-                            style="width:9rem">
-                        <option value="0"{if $active_filter_admemail_match == '0'} selected{/if}>Exact match</option>
-                        <option value="1"{if $active_filter_admemail_match != '0'} selected{/if}>Partial match</option>
-                    </select>
-                </div>
+                <label class="label" for="search-admins-admemail">E-mail</label>
+                <input class="input"
+                       id="search-admins-admemail"
+                       name="admemail"
+                       type="email"
+                       placeholder="Match against the panel e-mail&hellip;"
+                       data-testid="search-admins-admemail"
+                       value="{$active_filter_admemail|escape}"
+                       autocomplete="off">
             </div>
         {/if}
 
@@ -269,9 +218,8 @@
                         id="search-admins-admwebflag"
                         name="admwebflag[]"
                         data-testid="search-admins-admwebflag"
-                        size="6"
-                        multiple
-                        style="height:auto">
+                        data-multiselect
+                        multiple>
                     {foreach from=$admwebflag_list item="admwebflag"}
                         <option value="{$admwebflag.flag}"{if in_array($admwebflag.flag, $active_filter_admwebflag)} selected{/if}>{$admwebflag.name}</option>
                     {/foreach}
@@ -286,9 +234,8 @@
                         id="search-admins-admsrvflag"
                         name="admsrvflag[]"
                         data-testid="search-admins-admsrvflag"
-                        size="6"
-                        multiple
-                        style="height:auto">
+                        data-multiselect
+                        multiple>
                     {foreach from=$admsrvflag_list item="admsrvflag"}
                         <option value="{$admsrvflag.flag}"{if in_array($admsrvflag.flag, $active_filter_admsrvflag)} selected{/if}>{$admsrvflag.name}</option>
                     {/foreach}

--- a/web/themes/default/core/footer.tpl
+++ b/web/themes/default/core/footer.tpl
@@ -53,8 +53,10 @@
         live in web/scripts/sourcebans.js; the new theme drops that
         bulk file (#1123 D1) so the calls would error. B3 will
         re-implement the live-server widget via sb.api.call.
-      - sb.ready/tabs.init/tooltip: legacy MooTools-flavored helpers
-        replaced by theme.js's vanilla wiring.
+      - sb.ready/tabs.init: legacy MooTools-flavored helpers
+        replaced by theme.js's vanilla wiring. Tooltips live in
+        sb.js (`data-tooltip` / legacy `.tip`) and boot via event
+        delegation — no footer init call.
     Footer credits ($version + $git) are kept — pure display, no JS.
 *}
     </main>{* /.page *}

--- a/web/themes/default/css/theme.css
+++ b/web/themes/default/css/theme.css
@@ -1037,6 +1037,7 @@ input[type="checkbox"]:disabled {
 .card__header h3 { margin: 0; font-size: var(--fs-base); font-weight: 600; color: var(--text); }
 .card__header p { margin: 0.25rem 0 0; font-size: var(--fs-xs); color: var(--text-muted); }
 .card__body { padding: 1.25rem; }
+.card__body--compact { padding: 0.5rem 0.75rem; }
 
 /* ---- Collapsible filter disclosure (#1303 + #1315) ----
    Reusable `<details class="card filters-details">` shape that wraps a
@@ -1301,6 +1302,82 @@ html.dark .table thead tr { background: rgb(255 255 255 / 0.02); }
 .table tbody tr:hover { background: var(--bg-muted); }
 .table.table--clickable-rows tbody tr { cursor: pointer; }
 .table td { padding: 0.75rem; vertical-align: middle; }
+/* Dense row height for checkbox / permission grids where the default
+   0.75rem cell padding leaves too much vertical whitespace. */
+.table.table--compact {
+  font-size: var(--fs-sm);
+  margin: 0;
+}
+.table.table--compact th {
+  padding-top: 0.35rem;
+  padding-bottom: 0.35rem;
+}
+.table.table--compact td {
+  padding-top: 0.25rem;
+  padding-bottom: 0.25rem;
+}
+.table.table--compact th:first-child,
+.table.table--compact td:first-child { padding-left: 0.75rem; }
+.table.table--compact th:last-child,
+.table.table--compact td:last-child { padding-right: 0.75rem; }
+
+/* Edit-admin Permissions: Web + Server cards side-by-side when wide. */
+.edit-perms-columns {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: minmax(0, 1fr);
+  align-items: start;
+}
+@media (min-width: 1200px) {
+  .edit-perms-columns {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+  .edit-perms-columns .table-scroll,
+  .edit-perms-columns .card__body {
+    overflow-x: auto;
+  }
+}
+.edit-perms-select-all {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  margin: 0;
+  font-size: var(--fs-sm);
+  color: var(--text-muted);
+  white-space: nowrap;
+  cursor: pointer;
+  user-select: none;
+  flex-shrink: 0;
+}
+.edit-perms-select-all:hover { color: var(--text); }
+.table tr.perms-group-head td {
+  background: var(--bg-muted);
+  border-top: 1px solid var(--border);
+  padding-top: 0.55rem;
+  padding-bottom: 0.45rem;
+}
+.table tbody > tr.perms-group-head:first-child td {
+  border-top: none;
+}
+.table tr.perms-group-child + tr.perms-group-head td {
+  border-top: 1px solid var(--border);
+  box-shadow: inset 0 0.35rem 0 0 var(--bg-page);
+}
+.table tr.perms-group-child td:first-child {
+  padding-left: 1.5rem;
+  color: var(--text-muted);
+}
+.table tr.perms-group-sep td {
+  padding: 0.65rem 0.75rem 0.3rem;
+  font-size: var(--fs-xs);
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--text-faint);
+  background: transparent;
+  border-top: 1px solid var(--border);
+}
+
 /* #1207 ADM-5: row actions are *always* visible — the previous
    `opacity: 0 → 1 on tr:hover` treatment was a discoverability dead
    end (no hover on touch, hostile to `prefers-reduced-motion: reduce`,
@@ -1978,6 +2055,9 @@ details.queue-row > summary > .row-actions {
 }
 @media (max-width: 768px) {
   .table { display: none; }
+  /* Form / settings tables with no paired mobile-card surface must
+     opt out of the banlist-style hide, or the whole control vanishes. */
+  .table.table--keep-mobile { display: table; }
   .ban-cards { display: block; }
   /* #1462: paired mobile surface for the System Log table (see
      `.log-cards` block above for the full rationale). Same `display`

--- a/web/themes/default/css/theme.css
+++ b/web/themes/default/css/theme.css
@@ -804,6 +804,141 @@ html.dark .admin-tabs > [aria-current="page"] { border-bottom-color: var(--brand
 .textarea { height: auto; padding: 0.625rem 0.75rem; resize: vertical; min-height: 5rem; }
 .input--with-icon { padding-left: 2rem; }
 
+/* Visually hide an element while keeping it in the accessibility /
+   form-submit tree. Used by the data-multiselect enhancer after it
+   builds the themed control around a real <select multiple>. */
+.visually-hidden {
+  position: absolute !important;
+  width: 1px !important;
+  height: 1px !important;
+  padding: 0 !important;
+  margin: -1px !important;
+  overflow: hidden !important;
+  clip: rect(0, 0, 0, 0) !important;
+  white-space: nowrap !important;
+  border: 0 !important;
+}
+
+/* Themed multi-select (progressive enhancement on select[data-multiselect]). */
+.msel {
+  position: relative;
+  width: 100%;
+  min-width: 14rem;
+}
+.msel__trigger {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  width: 100%;
+  height: 2.25rem;
+  padding: 0 0.75rem;
+  border-radius: var(--radius-md);
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
+  color: var(--text);
+  font-size: var(--fs-base);
+  font-family: inherit;
+  cursor: pointer;
+  text-align: left;
+  transition: border-color .15s, box-shadow .15s;
+}
+.msel__trigger:hover { border-color: var(--border-strong, var(--border)); }
+.msel__trigger:focus-visible,
+.msel[data-open="true"] .msel__trigger {
+  outline: none;
+  border-color: var(--brand-500);
+  box-shadow: 0 0 0 3px rgb(234 88 12 / 0.15);
+}
+.msel__trigger-label {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--text-muted);
+}
+.msel[data-has-value="true"] .msel__trigger-label { color: var(--text); }
+.msel__chevron {
+  width: 14px;
+  height: 14px;
+  flex-shrink: 0;
+  color: var(--text-muted);
+  transition: transform .15s;
+}
+.msel[data-open="true"] .msel__chevron { transform: rotate(180deg); }
+.msel__panel {
+  position: absolute;
+  z-index: 40;
+  top: calc(100% + 0.25rem);
+  left: 0;
+  right: 0;
+  max-height: 16rem;
+  overflow-y: auto;
+  padding: 0.35rem;
+  border-radius: var(--radius-md);
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
+  box-shadow: var(--shadow-lg, 0 10px 30px rgb(0 0 0 / 0.18));
+}
+.msel__panel[hidden] { display: none !important; }
+.msel__option {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.4rem 0.5rem;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  font-size: var(--fs-sm, 0.875rem);
+  color: var(--text);
+}
+.msel__option:hover,
+.msel__option:focus-within { background: var(--bg-muted); }
+.msel__chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+  margin-top: 0.4rem;
+}
+.msel__chips:empty { display: none; }
+.msel__chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  max-width: 100%;
+  padding: 0.15rem 0.45rem;
+  border-radius: 999px;
+  background: var(--bg-muted);
+  border: 1px solid var(--border);
+  color: var(--text);
+  font-size: var(--fs-xs, 0.75rem);
+  line-height: 1.3;
+}
+.msel__chip-label {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.msel__chip-remove {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1rem;
+  height: 1rem;
+  padding: 0;
+  border: 0;
+  border-radius: 999px;
+  background: transparent;
+  color: var(--text-muted);
+  cursor: pointer;
+  font-size: 0.85rem;
+  line-height: 1;
+}
+.msel__chip-remove:hover { color: var(--text); background: var(--bg-surface); }
+@media (prefers-reduced-motion: reduce) {
+  .msel__chevron { transition: none; }
+}
+
 /* Global checkbox paint (#1256).
 
    Style the native checkbox so it reads at the same scale as

--- a/web/themes/default/css/theme.css
+++ b/web/themes/default/css/theme.css
@@ -2083,6 +2083,17 @@ details.queue-row > summary > .row-actions {
 .justify-between { justify-content: space-between; } .justify-end { justify-content: flex-end; }
 .gap-1 { gap: 0.25rem; } .gap-2 { gap: 0.5rem; } .gap-3 { gap: 0.75rem; } .gap-4 { gap: 1rem; }
 .grid { display: grid; }
+/* Overrides "Add an override" row: stack on narrow viewports so the
+   Flags input cannot overflow the card (fixed 8rem+1fr+14rem did). */
+.overrides-add-grid {
+  grid-template-columns: 1fr;
+}
+.overrides-add-grid > * { min-width: 0; }
+@media (min-width: 768px) {
+  .overrides-add-grid {
+    grid-template-columns: 8rem minmax(0, 1fr) 14rem;
+  }
+}
 .text-xs { font-size: var(--fs-xs); } .text-sm { font-size: var(--fs-sm); }
 .text-muted { color: var(--text-muted); } .text-faint { color: var(--text-faint); }
 .font-mono { font-family: var(--font-mono); }

--- a/web/themes/default/css/theme.css
+++ b/web/themes/default/css/theme.css
@@ -1198,6 +1198,9 @@ html.dark .table thead tr { background: rgb(255 255 255 / 0.02); }
   column-gap: 0.25rem;
   justify-content: flex-end;
 }
+.table .row-actions--icons {
+  flex-wrap: nowrap;
+}
 
 /* PUB-1 (#1207): banlist column widths + horizontal-scroll fallback.
    With realistic per-row content the auto-layout previously
@@ -1826,6 +1829,11 @@ details.queue-row > summary > .row-actions {
   .log-card__chevron { transition: none; }
 }
 
+.admins-list-cards { display: none; }
+.admins-list-card { border-bottom: 1px solid var(--border); }
+.admins-list-card:last-child { border-bottom: none; }
+.admins-list-card__body { padding: 0.75rem 1rem 0.25rem; }
+
 /* ---- Responsive ---- */
 [data-mobile-menu] { display: none; }
 @media (max-width: 1024px) {
@@ -1840,6 +1848,7 @@ details.queue-row > summary > .row-actions {
      `.log-cards` block above for the full rationale). Same `display`
      dance as `.ban-cards` — hidden at desktop, block at mobile. */
   .log-cards { display: block; }
+  .admins-list-cards { display: block; }
   /* #1181: filter chip rows wrap onto multiple lines on mobile
      instead of horizontal-scrolling, so every chip is reachable
      without a swipe. The .scroll-x desktop affordance is the
@@ -1850,6 +1859,7 @@ details.queue-row > summary > .row-actions {
 @media (min-width: 769px) {
   .ban-cards { display: none; }
   .log-cards { display: none; }
+  .admins-list-cards { display: none; }
 }
 
 /* ---- Utility classes used by templates ---- */

--- a/web/themes/default/css/theme.css
+++ b/web/themes/default/css/theme.css
@@ -1361,6 +1361,28 @@ html.dark .table thead tr { background: rgb(255 255 255 / 0.02); }
 /* ---- Avatar ---- */
 .avatar { display: inline-grid; place-items: center; border-radius: 50%; color: white; font-weight: 600; flex-shrink: 0; }
 
+/* ---- Themed tooltip (sb.js) ----
+   Trigger with `data-tooltip="Label"` (preferred) or legacy
+   `class="tip" title="…"`. Floating tip is position:fixed; z-index
+   sits above the drawer (51) and below toasts (80). */
+.sb-tooltip {
+  position: fixed;
+  z-index: 70;
+  max-width: min(16rem, calc(100vw - 1rem));
+  padding: 0.3125rem 0.5rem;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--border);
+  background: var(--bg-surface);
+  color: var(--text);
+  font-size: var(--fs-xs);
+  font-weight: 500;
+  line-height: 1.3;
+  box-shadow: var(--shadow-lg);
+  pointer-events: none;
+  white-space: normal;
+}
+.sb-tooltip[hidden] { display: none !important; }
+
 /* ---- Toast + drawer + palette ---- */
 .toast-stack { position: fixed; top: 1rem; right: 1rem; z-index: 80; display: flex; flex-direction: column; gap: 0.5rem; width: min(22.5rem, calc(100vw - 2rem)); }
 .toast { background: var(--bg-surface); border: 1px solid var(--border); border-radius: var(--radius-lg); box-shadow: var(--shadow-lg); padding: 0.75rem; display: flex; gap: 0.75rem; animation: slide-in .2s ease; }

--- a/web/themes/default/js/theme.js
+++ b/web/themes/default/js/theme.js
@@ -1984,4 +1984,165 @@
   }
   if (document.readyState !== 'loading') applyPlatformHints();
   else document.addEventListener('DOMContentLoaded', applyPlatformHints);
+
+  // ---- MULTI-SELECT (select[data-multiselect]) ---------------
+  // Progressive enhancement around a real <select multiple> so GET
+  // submit and no-JS still work. After enhance, the native select is
+  // visually hidden (still in the form) and a trigger + checkbox
+  // panel mirrors option.selected.
+  /**
+   * @param {HTMLSelectElement} select
+   * @returns {void}
+   */
+  function enhanceMultiselect(select) {
+    if (select.dataset.mselReady === '1') return;
+    if (!select.multiple) return;
+    select.dataset.mselReady = '1';
+
+    const parent = select.parentNode;
+    if (!parent) return;
+
+    const wrap = document.createElement('div');
+    wrap.className = 'msel';
+    wrap.setAttribute('data-msel', 'true');
+    parent.insertBefore(wrap, select);
+    wrap.appendChild(select);
+
+    select.classList.add('visually-hidden');
+    select.setAttribute('aria-hidden', 'true');
+    select.tabIndex = -1;
+
+    const trigger = document.createElement('button');
+    trigger.type = 'button';
+    trigger.className = 'msel__trigger';
+    trigger.setAttribute('aria-haspopup', 'listbox');
+    trigger.setAttribute('aria-expanded', 'false');
+    if (select.id) trigger.setAttribute('aria-controls', select.id + '-msel-panel');
+    trigger.innerHTML =
+      '<span class="msel__trigger-label"></span>' +
+      '<i data-lucide="chevron-down" class="msel__chevron" aria-hidden="true"></i>';
+
+    const panel = document.createElement('div');
+    panel.className = 'msel__panel';
+    panel.setAttribute('role', 'listbox');
+    panel.setAttribute('aria-multiselectable', 'true');
+    if (select.id) panel.id = select.id + '-msel-panel';
+    panel.hidden = true;
+
+    const chips = document.createElement('div');
+    chips.className = 'msel__chips';
+
+    wrap.insertBefore(trigger, select);
+    wrap.appendChild(panel);
+    wrap.appendChild(chips);
+
+    const labelEl = /** @type {HTMLElement} */ (trigger.querySelector('.msel__trigger-label'));
+
+    /** @returns {HTMLOptionElement[]} */
+    function optionList() {
+      return Array.prototype.slice.call(select.options);
+    }
+
+    /** @returns {void} */
+    function syncFromSelect() {
+      const selected = optionList().filter((o) => o.selected && o.value !== '');
+      const n = selected.length;
+      wrap.setAttribute('data-has-value', n > 0 ? 'true' : 'false');
+      if (labelEl) {
+        labelEl.textContent = n === 0 ? 'Any' : (n === 1 ? selected[0].textContent || selected[0].value : (n + ' selected'));
+      }
+      panel.querySelectorAll('input[type="checkbox"]').forEach((/** @type {Element} */ el) => {
+        const input = /** @type {HTMLInputElement} */ (el);
+        const opt = optionList().find((o) => o.value === input.value);
+        input.checked = !!(opt && opt.selected);
+      });
+      chips.textContent = '';
+      selected.forEach((opt) => {
+        const chip = document.createElement('span');
+        chip.className = 'msel__chip';
+        const text = document.createElement('span');
+        text.className = 'msel__chip-label';
+        text.textContent = opt.textContent || opt.value;
+        const remove = document.createElement('button');
+        remove.type = 'button';
+        remove.className = 'msel__chip-remove';
+        remove.setAttribute('aria-label', 'Remove ' + (opt.textContent || opt.value));
+        remove.textContent = '\u00d7';
+        remove.addEventListener('click', (e) => {
+          e.preventDefault();
+          e.stopPropagation();
+          opt.selected = false;
+          select.dispatchEvent(new Event('change', { bubbles: true }));
+          syncFromSelect();
+        });
+        chip.appendChild(text);
+        chip.appendChild(remove);
+        chips.appendChild(chip);
+      });
+    }
+
+    /** @returns {void} */
+    function buildPanel() {
+      panel.textContent = '';
+      optionList().forEach((opt) => {
+        if (opt.value === '') return;
+        const row = document.createElement('label');
+        row.className = 'msel__option';
+        const input = document.createElement('input');
+        input.type = 'checkbox';
+        input.value = opt.value;
+        input.checked = opt.selected;
+        input.addEventListener('change', () => {
+          opt.selected = input.checked;
+          select.dispatchEvent(new Event('change', { bubbles: true }));
+          syncFromSelect();
+        });
+        const span = document.createElement('span');
+        span.textContent = opt.textContent || opt.value;
+        row.appendChild(input);
+        row.appendChild(span);
+        panel.appendChild(row);
+      });
+    }
+
+    /** @param {boolean} open */
+    function setOpen(open) {
+      wrap.setAttribute('data-open', open ? 'true' : 'false');
+      trigger.setAttribute('aria-expanded', open ? 'true' : 'false');
+      panel.hidden = !open;
+    }
+
+    buildPanel();
+    syncFromSelect();
+
+    trigger.addEventListener('click', (e) => {
+      e.preventDefault();
+      e.stopPropagation();
+      setOpen(panel.hidden);
+    });
+
+    document.addEventListener('click', (e) => {
+      if (!wrap.contains(/** @type {Node} */ (e.target))) setOpen(false);
+    });
+
+    document.addEventListener('keydown', (e) => {
+      if (e.key === 'Escape' && !panel.hidden) {
+        setOpen(false);
+        trigger.focus();
+      }
+    });
+
+    select.addEventListener('change', syncFromSelect);
+
+    if (window.lucide) window.lucide.createIcons();
+  }
+
+  /** @returns {void} */
+  function initMultiselects() {
+    document.querySelectorAll('select[data-multiselect]').forEach((el) => {
+      if (el instanceof HTMLSelectElement) enhanceMultiselect(el);
+    });
+  }
+  if (document.readyState !== 'loading') initMultiselects();
+  else document.addEventListener('DOMContentLoaded', initMultiselects);
 })();

--- a/web/themes/default/page_admin_admins_list.tpl
+++ b/web/themes/default/page_admin_admins_list.tpl
@@ -66,6 +66,7 @@
         </div>
 
         <div class="card" style="overflow:hidden">
+            <div class="table-scroll">
             <table class="table" role="table" aria-label="Admins">
                 <thead>
                     <tr>
@@ -75,7 +76,7 @@
                         <th scope="col">Web group</th>
                         <th scope="col">Immunity</th>
                         <th scope="col">Last visit</th>
-                        <th scope="col" style="width:1%"></th>
+                        <th scope="col" class="col-actions"></th>
                     </tr>
                 </thead>
                 <tbody>
@@ -99,37 +100,37 @@
                             <a href="./index.php?p=banlist&advSearch={$admin.aid|escape:'url'}&advType=nodemo"
                                title="Show bans without demo">{$admin.nodemocount} w/o demo</a>
                         </td>
-                        <td class="text-muted">{$admin.server_group|escape}</td>
-                        <td class="text-muted">{$admin.web_group|escape}</td>
+                        <td class="text-muted truncate" style="max-width:10rem" title="{$admin.server_group|escape}">{$admin.server_group|escape}</td>
+                        <td class="text-muted truncate" style="max-width:10rem" title="{$admin.web_group|escape}">{$admin.web_group|escape}</td>
                         <td class="tabular-nums text-muted">{$admin.immunity}</td>
                         <td class="text-xs text-muted">{$admin.lastvisit|escape}</td>
-                        <td>
-                            <div class="row-actions" style="white-space:nowrap">
+                        <td class="col-actions">
+                            <div class="row-actions row-actions--icons">
                                 {if $can_edit_admins}
                                     <a class="btn btn--ghost btn--icon btn--sm"
                                        href="index.php?p=admin&c=admins&o=editdetails&id={$admin.aid|escape:'url'}"
-                                       title="Edit details"
+                                       data-tooltip="Edit details"
                                        aria-label="Edit details for {$admin.user|escape}"
                                        data-testid="admin-action-edit-details">
                                         <i data-lucide="clipboard-list" style="width:14px;height:14px"></i>
                                     </a>
                                     <a class="btn btn--ghost btn--icon btn--sm"
                                        href="index.php?p=admin&c=admins&o=editpermissions&id={$admin.aid|escape:'url'}"
-                                       title="Edit permissions"
+                                       data-tooltip="Edit permissions"
                                        aria-label="Edit permissions for {$admin.user|escape}"
                                        data-testid="admin-action-edit-perms">
                                         <i data-lucide="shield" style="width:14px;height:14px"></i>
                                     </a>
                                     <a class="btn btn--ghost btn--icon btn--sm"
                                        href="index.php?p=admin&c=admins&o=editservers&id={$admin.aid|escape:'url'}"
-                                       title="Edit server access"
+                                       data-tooltip="Edit server access"
                                        aria-label="Edit server access for {$admin.user|escape}"
                                        data-testid="admin-action-edit-servers">
                                         <i data-lucide="server" style="width:14px;height:14px"></i>
                                     </a>
                                     <a class="btn btn--ghost btn--icon btn--sm"
                                        href="index.php?p=admin&c=admins&o=editgroup&id={$admin.aid|escape:'url'}"
-                                       title="Edit groups"
+                                       data-tooltip="Edit groups"
                                        aria-label="Edit groups for {$admin.user|escape}"
                                        data-testid="admin-action-edit-group">
                                         <i data-lucide="users" style="width:14px;height:14px"></i>
@@ -155,7 +156,7 @@
                                             data-aid="{$admin.aid}"
                                             data-name="{$admin.user|escape}"
                                             data-fallback-href="index.php?p=admin&amp;c=admins"
-                                            title="Delete admin"
+                                            data-tooltip="Delete admin"
                                             aria-label="Delete admin {$admin.user|escape}"
                                             data-testid="admin-action-delete">
                                         <i data-lucide="trash-2" style="width:14px;height:14px;color:var(--danger)"></i>
@@ -167,6 +168,80 @@
                 {/foreach}
                 </tbody>
             </table>
+            </div>
+
+            {* Mobile cards — paired surface for the global
+               `@media (max-width: 768px) { .table { display: none } }`
+               rule. Same display dance as `.ban-cards` / `.log-cards`. *}
+            <div class="admins-list-cards" data-testid="admins-list-cards">
+                {foreach $admins as $admin}
+                    <div class="admins-list-card" data-testid="admins-list-card" data-id="{$admin.aid}">
+                        <div class="admins-list-card__body flex items-center gap-3">
+                            <div class="avatar" style="width:2.25rem;height:2.25rem;background:var(--brand-600);font-size:var(--fs-xs)">
+                                {$admin.user|truncate:1:'':true|upper|escape}
+                            </div>
+                            <div style="flex:1;min-width:0">
+                                <div class="font-medium text-sm truncate">{$admin.user|escape}</div>
+                                <div class="text-xs text-muted truncate" style="margin-top:0.125rem">
+                                    {$admin.web_group|escape}
+                                    · {$admin.server_group|escape}
+                                    · imm {$admin.immunity}
+                                </div>
+                                <div class="text-xs text-faint truncate" style="margin-top:0.125rem">
+                                    <a href="./index.php?p=banlist&amp;advSearch={$admin.aid|escape:'url'}&amp;advType=admin">{$admin.bancount} bans</a>
+                                    · {$admin.lastvisit|escape}
+                                </div>
+                            </div>
+                        </div>
+                        {if $can_edit_admins || $can_delete_admins}
+                        <div class="row-actions ban-card__actions">
+                            {if $can_edit_admins}
+                                <a class="btn btn--ghost btn--icon btn--sm"
+                                   href="index.php?p=admin&amp;c=admins&amp;o=editdetails&amp;id={$admin.aid|escape:'url'}"
+                                   data-tooltip="Edit details"
+                                   aria-label="Edit details for {$admin.user|escape}"
+                                   data-testid="admin-action-edit-details-mobile">
+                                    <i data-lucide="clipboard-list" style="width:14px;height:14px"></i>
+                                </a>
+                                <a class="btn btn--ghost btn--icon btn--sm"
+                                   href="index.php?p=admin&amp;c=admins&amp;o=editpermissions&amp;id={$admin.aid|escape:'url'}"
+                                   data-tooltip="Edit permissions"
+                                   aria-label="Edit permissions for {$admin.user|escape}"
+                                   data-testid="admin-action-edit-perms-mobile">
+                                    <i data-lucide="shield" style="width:14px;height:14px"></i>
+                                </a>
+                                <a class="btn btn--ghost btn--icon btn--sm"
+                                   href="index.php?p=admin&amp;c=admins&amp;o=editservers&amp;id={$admin.aid|escape:'url'}"
+                                   data-tooltip="Edit server access"
+                                   aria-label="Edit server access for {$admin.user|escape}"
+                                   data-testid="admin-action-edit-servers-mobile">
+                                    <i data-lucide="server" style="width:14px;height:14px"></i>
+                                </a>
+                                <a class="btn btn--ghost btn--icon btn--sm"
+                                   href="index.php?p=admin&amp;c=admins&amp;o=editgroup&amp;id={$admin.aid|escape:'url'}"
+                                   data-tooltip="Edit groups"
+                                   aria-label="Edit groups for {$admin.user|escape}"
+                                   data-testid="admin-action-edit-group-mobile">
+                                    <i data-lucide="users" style="width:14px;height:14px"></i>
+                                </a>
+                            {/if}
+                            {if $can_delete_admins}
+                                <button type="button" class="btn btn--ghost btn--icon btn--sm"
+                                        data-action="admins-delete"
+                                        data-aid="{$admin.aid}"
+                                        data-name="{$admin.user|escape}"
+                                        data-fallback-href="index.php?p=admin&amp;c=admins"
+                                        data-tooltip="Delete admin"
+                                        aria-label="Delete admin {$admin.user|escape}"
+                                        data-testid="admin-action-delete-mobile">
+                                    <i data-lucide="trash-2" style="width:14px;height:14px;color:var(--danger)"></i>
+                                </button>
+                            {/if}
+                        </div>
+                        {/if}
+                    </div>
+                {/foreach}
+            </div>
         </div>
     </div>
 
@@ -282,10 +357,13 @@
 
         /**
          * @param {string} aid
-         * @returns {Element|null}
+         * @returns {NodeListOf<Element>}
          */
-        function rowForAid(aid) {
-            return document.querySelector('[data-testid="admin-row"][data-id="' + aid + '"]');
+        function rowsForAid(aid) {
+            return document.querySelectorAll(
+                '[data-testid="admin-row"][data-id="' + aid + '"],'
+                + '[data-testid="admins-list-card"][data-id="' + aid + '"]'
+            );
         }
 
         /**
@@ -421,8 +499,11 @@
                     toast('error', 'Delete failed', msg);
                     return;
                 }
-                var row = rowForAid(ctx.aid);
-                if (row && row.parentNode) row.parentNode.removeChild(row);
+                var rows = rowsForAid(ctx.aid);
+                for (var i = 0; i < rows.length; i++) {
+                    var row = rows[i];
+                    if (row && row.parentNode) row.parentNode.removeChild(row);
+                }
                 decrementCount();
                 closeDeleteDialog();
                 toast('success', 'Admin deleted', ctx.name + ' has been removed.');

--- a/web/themes/default/page_admin_edit_admins_details.tpl
+++ b/web/themes/default/page_admin_edit_admins_details.tpl
@@ -22,7 +22,7 @@
         <p class="text-sm text-muted m-0 mt-2">Update identity, login credentials, and the in-game admin password.</p>
     </div>
 
-    <nav class="flex gap-2 mb-4" role="tablist" aria-label="Edit admin sections">
+    <nav class="flex gap-2 mb-4 items-center" role="tablist" aria-label="Edit admin sections">
         <a class="btn btn--secondary btn--sm" role="tab" aria-current="page"
            href="?p=admin&c=admins&o=editdetails&id={$smarty.get.id|escape:'url'}"
            data-testid="admin-tab-details">Details</a>
@@ -32,8 +32,14 @@
         <a class="btn btn--ghost btn--sm" role="tab"
            href="?p=admin&c=admins&o=editservers&id={$smarty.get.id|escape:'url'}"
            data-testid="admin-tab-servers">Servers</a>
-        <a class="btn btn--ghost btn--sm"
-           href="?p=admin&c=admins&o=editpermissions&id={$smarty.get.id|escape:'url'}">Permissions</a>
+        <a class="btn btn--ghost btn--sm" role="tab"
+           href="?p=admin&c=admins&o=editpermissions&id={$smarty.get.id|escape:'url'}"
+           data-testid="admin-tab-permissions">Permissions</a>
+        <a class="btn btn--ghost btn--sm admin-tabs__back"
+           href="index.php?p=admin&amp;c=admins"
+           data-testid="admin-tab-back">
+            <i data-lucide="arrow-left"></i> Back
+        </a>
     </nav>
 
     <form method="post" action="" class="space-y-4" autocomplete="off">

--- a/web/themes/default/page_admin_edit_admins_details.tpl
+++ b/web/themes/default/page_admin_edit_admins_details.tpl
@@ -5,9 +5,10 @@
     web/includes/View/EditAdminDetailsView.php.
 
     The handler gates entry on ADMIN_OWNER | ADMIN_EDIT_ADMINS (or
-    self-edit) before reaching this template. $change_pass mirrors that
-    gate: anyone allowed to edit the target can also set their password.
-    Edit-admins callers still cannot reach owner targets (handler-side).
+    self-edit) before reaching this template. $change_pass is always
+    true on that path: anyone allowed to edit the target can also set
+    their password. Edit-admins callers still cannot reach owner
+    targets (handler-side).
 
     The cross-page tab nav (Details / Group / Servers / Permissions)
     lifts the four legacy admin-edit handlers into a single tabbed UX;

--- a/web/themes/default/page_admin_edit_admins_details.tpl
+++ b/web/themes/default/page_admin_edit_admins_details.tpl
@@ -5,9 +5,9 @@
     web/includes/View/EditAdminDetailsView.php.
 
     The handler gates entry on ADMIN_OWNER | ADMIN_EDIT_ADMINS (or
-    self-edit) before reaching this template. $change_pass narrows the
-    in-template form: when the editor lacks password-edit rights (e.g.
-    a non-owner editing someone else), the password rows hide.
+    self-edit) before reaching this template. $change_pass mirrors that
+    gate: anyone allowed to edit the target can also set their password.
+    Edit-admins callers still cannot reach owner targets (handler-side).
 
     The cross-page tab nav (Details / Group / Servers / Permissions)
     lifts the four legacy admin-edit handlers into a single tabbed UX;

--- a/web/themes/default/page_admin_edit_admins_group.tpl
+++ b/web/themes/default/page_admin_edit_admins_group.tpl
@@ -20,7 +20,7 @@
         <p class="text-sm text-muted m-0 mt-2">Move <strong>{$group_admin_name|escape}</strong> between web and server admin groups.</p>
     </div>
 
-    <nav class="flex gap-2 mb-4" role="tablist" aria-label="Edit admin sections">
+    <nav class="flex gap-2 mb-4 items-center" role="tablist" aria-label="Edit admin sections">
         <a class="btn btn--ghost btn--sm" role="tab"
            href="?p=admin&c=admins&o=editdetails&id={$smarty.get.id|escape:'url'}"
            data-testid="admin-tab-details">Details</a>
@@ -30,8 +30,14 @@
         <a class="btn btn--ghost btn--sm" role="tab"
            href="?p=admin&c=admins&o=editservers&id={$smarty.get.id|escape:'url'}"
            data-testid="admin-tab-servers">Servers</a>
-        <a class="btn btn--ghost btn--sm"
-           href="?p=admin&c=admins&o=editpermissions&id={$smarty.get.id|escape:'url'}">Permissions</a>
+        <a class="btn btn--ghost btn--sm" role="tab"
+           href="?p=admin&c=admins&o=editpermissions&id={$smarty.get.id|escape:'url'}"
+           data-testid="admin-tab-permissions">Permissions</a>
+        <a class="btn btn--ghost btn--sm admin-tabs__back"
+           href="index.php?p=admin&amp;c=admins"
+           data-testid="admin-tab-back">
+            <i data-lucide="arrow-left"></i> Back
+        </a>
     </nav>
 
     <form method="post" action="" class="space-y-4">

--- a/web/themes/default/page_admin_edit_admins_perms.tpl
+++ b/web/themes/default/page_admin_edit_admins_perms.tpl
@@ -15,147 +15,177 @@
     `$('p2').checked = true` re-paint script. The form submits via
     `Actions.AdminsEditPerms` (existing JSON action); the page-tail
     vanilla JS handles composite-toggle behaviour and the API round-trip.
+
+    The cross-page tab nav (Details / Group / Servers / Permissions)
+    matches the sibling edit-admin templates so Permissions stays in
+    the same chrome as the rest of the edit flow.
 *}
-<div class="space-y-4" data-testid="admin-edit-perms">
+<div class="card-tab page-section" data-testid="admin-edit-perms">
     <div class="mb-4">
-        <h1 style="font-size:var(--fs-xl);font-weight:600;margin:0">
-            Permissions for {$admin_name|escape}
-        </h1>
+        <h1 style="font-size:var(--fs-xl);font-weight:600;margin:0">Edit admin · {$admin_name|escape}</h1>
         <p class="text-sm text-muted m-0 mt-2">
-            Toggle a parent group to enable / disable every child permission underneath it at once.
+            Use Select all on a card, tick a bold category row to flip its children, or toggle permissions one by one.
         </p>
     </div>
+
+    <nav class="flex gap-2 mb-4 items-center" role="tablist" aria-label="Edit admin sections">
+        <a class="btn btn--ghost btn--sm" role="tab"
+           href="?p=admin&c=admins&o=editdetails&id={$smarty.get.id|escape:'url'}"
+           data-testid="admin-tab-details">Details</a>
+        <a class="btn btn--ghost btn--sm" role="tab"
+           href="?p=admin&c=admins&o=editgroup&id={$smarty.get.id|escape:'url'}"
+           data-testid="admin-tab-group">Group</a>
+        <a class="btn btn--ghost btn--sm" role="tab"
+           href="?p=admin&c=admins&o=editservers&id={$smarty.get.id|escape:'url'}"
+           data-testid="admin-tab-servers">Servers</a>
+        <a class="btn btn--secondary btn--sm" role="tab" aria-current="page"
+           href="?p=admin&c=admins&o=editpermissions&id={$smarty.get.id|escape:'url'}"
+           data-testid="admin-tab-permissions">Permissions</a>
+        <a class="btn btn--ghost btn--sm admin-tabs__back"
+           href="index.php?p=admin&amp;c=admins"
+           data-testid="admin-tab-back">
+            <i data-lucide="arrow-left"></i> Back
+        </a>
+    </nav>
 
     <form id="edit-perms-form" class="space-y-4" autocomplete="off"
           data-aid="{$admin_id}">
         {csrf_field}
 
+        <div class="edit-perms-columns">
         {* ============ Web Admin Permissions ============ *}
         <div class="card">
-            <div class="card__header"><div>
-                <h3>Web Admin Permissions</h3>
-                <p>Permissions inside the panel itself.</p>
-            </div></div>
-            <div class="card__body">
-                <table class="table" style="margin:0;font-size:var(--fs-sm)">
+            <div class="card__header">
+                <div>
+                    <h3>Web Admin Permissions</h3>
+                    <p>Permissions inside the panel itself.</p>
+                </div>
+                <label class="edit-perms-select-all">
+                    <input type="checkbox" data-select-all="web"
+                           data-testid="edit-perms-web-select-all">
+                    <span>Select all</span>
+                </label>
+            </div>
+            <div class="card__body card__body--compact">
+                <table class="table table--compact table--keep-mobile" data-perms-scope="web">
                     <colgroup>
                         <col style="width:auto">
-                        <col style="width:5rem">
+                        <col style="width:2.5rem">
                     </colgroup>
                     <tbody>
                         {if $is_owner_editor}
-                        <tr>
+                        <tr class="perms-group-head">
                             <td><strong>Root Admin</strong> (Full access)</td>
                             <td class="text-center">
                                 <input type="checkbox" id="p2" data-perm="owner" {if $web_owner}checked{/if}>
                             </td>
                         </tr>
                         {/if}
-                        <tr>
+                        <tr class="perms-group-head">
                             <td><strong>Manage Admins</strong></td>
                             <td class="text-center">
                                 <input type="checkbox" id="p3" data-parent="admins">
                             </td>
                         </tr>
-                        <tr><td class="pl-6">List Admins</td>
+                        <tr class="perms-group-child"><td>List Admins</td>
                             <td class="text-center"><input type="checkbox" id="p4" data-child="admins" {if $web_list_admins}checked{/if}></td></tr>
-                        <tr><td class="pl-6">Add Admins</td>
+                        <tr class="perms-group-child"><td>Add Admins</td>
                             <td class="text-center"><input type="checkbox" id="p5" data-child="admins" {if $web_add_admins}checked{/if}></td></tr>
-                        <tr><td class="pl-6">Edit Admins</td>
+                        <tr class="perms-group-child"><td>Edit Admins</td>
                             <td class="text-center"><input type="checkbox" id="p6" data-child="admins" {if $web_edit_admins}checked{/if}></td></tr>
-                        <tr><td class="pl-6">Delete Admins</td>
+                        <tr class="perms-group-child"><td>Delete Admins</td>
                             <td class="text-center"><input type="checkbox" id="p7" data-child="admins" {if $web_delete_admins}checked{/if}></td></tr>
 
-                        <tr>
+                        <tr class="perms-group-head">
                             <td><strong>Server Management</strong></td>
                             <td class="text-center">
                                 <input type="checkbox" id="p8" data-parent="servers">
                             </td>
                         </tr>
-                        <tr><td class="pl-6">List Servers</td>
+                        <tr class="perms-group-child"><td>List Servers</td>
                             <td class="text-center"><input type="checkbox" id="p9" data-child="servers" {if $web_list_servers}checked{/if}></td></tr>
-                        <tr><td class="pl-6">Add New Servers</td>
+                        <tr class="perms-group-child"><td>Add New Servers</td>
                             <td class="text-center"><input type="checkbox" id="p10" data-child="servers" {if $web_add_server}checked{/if}></td></tr>
-                        <tr><td class="pl-6">Edit Servers</td>
+                        <tr class="perms-group-child"><td>Edit Servers</td>
                             <td class="text-center"><input type="checkbox" id="p11" data-child="servers" {if $web_edit_servers}checked{/if}></td></tr>
-                        <tr><td class="pl-6">Delete Servers</td>
+                        <tr class="perms-group-child"><td>Delete Servers</td>
                             <td class="text-center"><input type="checkbox" id="p12" data-child="servers" {if $web_delete_servers}checked{/if}></td></tr>
 
-                        <tr>
+                        <tr class="perms-group-head">
                             <td><strong>Ban Management</strong></td>
                             <td class="text-center">
                                 <input type="checkbox" id="p13" data-parent="bans">
                             </td>
                         </tr>
-                        <tr><td class="pl-6">Add a Ban</td>
+                        <tr class="perms-group-child"><td>Add a Ban</td>
                             <td class="text-center"><input type="checkbox" id="p14" data-child="bans" {if $web_add_ban}checked{/if}></td></tr>
-                        <tr><td class="pl-6">Edit Own Bans</td>
+                        <tr class="perms-group-child"><td>Edit Own Bans</td>
                             <td class="text-center"><input type="checkbox" id="p16" data-child="bans" {if $web_edit_own_bans}checked{/if}></td></tr>
-                        <tr><td class="pl-6">Edit Bans of Group</td>
+                        <tr class="perms-group-child"><td>Edit Bans of Group</td>
                             <td class="text-center"><input type="checkbox" id="p17" data-child="bans" {if $web_edit_group_bans}checked{/if}></td></tr>
-                        <tr><td class="pl-6">Edit All Bans</td>
+                        <tr class="perms-group-child"><td>Edit All Bans</td>
                             <td class="text-center"><input type="checkbox" id="p18" data-child="bans" {if $web_edit_all_bans}checked{/if}></td></tr>
-                        <tr><td class="pl-6">Ban Protests</td>
+                        <tr class="perms-group-child"><td>Ban Protests</td>
                             <td class="text-center"><input type="checkbox" id="p19" data-child="bans" {if $web_ban_protests}checked{/if}></td></tr>
-                        <tr><td class="pl-6">Ban Submissions</td>
+                        <tr class="perms-group-child"><td>Ban Submissions</td>
                             <td class="text-center"><input type="checkbox" id="p20" data-child="bans" {if $web_ban_submissions}checked{/if}></td></tr>
-                        <tr><td class="pl-6">Unban Own Bans</td>
+                        <tr class="perms-group-child"><td>Unban Own Bans</td>
                             <td class="text-center"><input type="checkbox" id="p38" data-child="bans" {if $web_unban_own_bans}checked{/if}></td></tr>
-                        <tr><td class="pl-6">Unban Group Bans</td>
+                        <tr class="perms-group-child"><td>Unban Group Bans</td>
                             <td class="text-center"><input type="checkbox" id="p39" data-child="bans" {if $web_unban_group_bans}checked{/if}></td></tr>
-                        <tr><td class="pl-6">Unban All Bans</td>
+                        <tr class="perms-group-child"><td>Unban All Bans</td>
                             <td class="text-center"><input type="checkbox" id="p32" data-child="bans" {if $web_unban}checked{/if}></td></tr>
-                        <tr><td class="pl-6">Delete Bans</td>
+                        <tr class="perms-group-child"><td>Delete Bans</td>
                             <td class="text-center"><input type="checkbox" id="p33" data-child="bans" {if $web_delete_ban}checked{/if}></td></tr>
-                        <tr><td class="pl-6">Import Bans</td>
+                        <tr class="perms-group-child"><td>Import Bans</td>
                             <td class="text-center"><input type="checkbox" id="p34" data-child="bans" {if $web_ban_import}checked{/if}></td></tr>
 
-                        <tr>
+                        <tr class="perms-group-head">
                             <td><strong>Group Management</strong></td>
                             <td class="text-center">
                                 <input type="checkbox" id="p21" data-parent="groups">
                             </td>
                         </tr>
-                        <tr><td class="pl-6">List Groups</td>
+                        <tr class="perms-group-child"><td>List Groups</td>
                             <td class="text-center"><input type="checkbox" id="p22" data-child="groups" {if $web_list_groups}checked{/if}></td></tr>
-                        <tr><td class="pl-6">Add Groups</td>
+                        <tr class="perms-group-child"><td>Add Groups</td>
                             <td class="text-center"><input type="checkbox" id="p23" data-child="groups" {if $web_add_group}checked{/if}></td></tr>
-                        <tr><td class="pl-6">Edit Groups</td>
+                        <tr class="perms-group-child"><td>Edit Groups</td>
                             <td class="text-center"><input type="checkbox" id="p24" data-child="groups" {if $web_edit_groups}checked{/if}></td></tr>
-                        <tr><td class="pl-6">Delete Groups</td>
+                        <tr class="perms-group-child"><td>Delete Groups</td>
                             <td class="text-center"><input type="checkbox" id="p25" data-child="groups" {if $web_delete_groups}checked{/if}></td></tr>
 
-                        <tr>
+                        <tr class="perms-group-head">
                             <td><strong>Email Notifications</strong></td>
                             <td class="text-center">
                                 <input type="checkbox" id="p35" data-parent="notify">
                             </td>
                         </tr>
-                        <tr><td class="pl-6">Notify on Submission</td>
+                        <tr class="perms-group-child"><td>Notify on Submission</td>
                             <td class="text-center"><input type="checkbox" id="p36" data-child="notify" {if $web_notify_sub}checked{/if}></td></tr>
-                        <tr><td class="pl-6">Notify on Protest</td>
+                        <tr class="perms-group-child"><td>Notify on Protest</td>
                             <td class="text-center"><input type="checkbox" id="p37" data-child="notify" {if $web_notify_protest}checked{/if}></td></tr>
 
-                        <tr>
+                        <tr class="perms-group-head">
                             <td><strong>Web Panel Settings</strong></td>
                             <td class="text-center">
                                 <input type="checkbox" id="p26" {if $web_settings}checked{/if}>
                             </td>
                         </tr>
 
-                        <tr>
+                        <tr class="perms-group-head">
                             <td><strong>Manage Mods</strong></td>
                             <td class="text-center">
                                 <input type="checkbox" id="p27" data-parent="mods">
                             </td>
                         </tr>
-                        <tr><td class="pl-6">List Mods</td>
+                        <tr class="perms-group-child"><td>List Mods</td>
                             <td class="text-center"><input type="checkbox" id="p28" data-child="mods" {if $web_list_mods}checked{/if}></td></tr>
-                        <tr><td class="pl-6">Add Mods</td>
+                        <tr class="perms-group-child"><td>Add Mods</td>
                             <td class="text-center"><input type="checkbox" id="p29" data-child="mods" {if $web_add_mods}checked{/if}></td></tr>
-                        <tr><td class="pl-6">Edit Mods</td>
+                        <tr class="perms-group-child"><td>Edit Mods</td>
                             <td class="text-center"><input type="checkbox" id="p30" data-child="mods" {if $web_edit_mods}checked{/if}></td></tr>
-                        <tr><td class="pl-6">Delete Mods</td>
+                        <tr class="perms-group-child"><td>Delete Mods</td>
                             <td class="text-center"><input type="checkbox" id="p31" data-child="mods" {if $web_delete_mods}checked{/if}></td></tr>
                     </tbody>
                 </table>
@@ -164,29 +194,39 @@
 
         {* ============ Server Admin Permissions ============ *}
         <div class="card">
-            <div class="card__header"><div>
-                <h3>Server Admin Permissions</h3>
-                <p>SourceMod admin flags applied to all servers this admin can manage.</p>
-            </div></div>
-            <div class="card__body">
-                <table class="table" style="margin:0;font-size:var(--fs-sm)">
+            <div class="card__header">
+                <div>
+                    <h3>Server Admin Permissions</h3>
+                    <p>SourceMod admin flags applied to all servers this admin can manage.</p>
+                </div>
+                <label class="edit-perms-select-all">
+                    <input type="checkbox" data-select-all="server"
+                           data-testid="edit-perms-server-select-all">
+                    <span>Select all</span>
+                </label>
+            </div>
+            <div class="card__body card__body--compact">
+                <table class="table table--compact table--keep-mobile" data-perms-scope="server">
                     <thead>
                         <tr>
                             <th>Permission</th>
-                            <th class="text-center" style="width:4rem">Flag</th>
+                            <th class="text-center" style="width:3rem">Flag</th>
                             <th>Purpose</th>
-                            <th class="text-center" style="width:4rem">On</th>
+                            <th class="text-center" style="width:2.5rem">On</th>
                         </tr>
                     </thead>
                     <tbody>
                         {if $is_owner_editor}
-                        <tr>
+                        <tr class="perms-group-head">
                             <td><strong>Root Admin</strong></td>
                             <td class="text-center font-mono">z</td>
                             <td>Magically enables every flag.</td>
                             <td class="text-center"><input type="checkbox" id="s14" data-sm-flag="z" {if $sm_root}checked{/if}></td>
                         </tr>
                         {/if}
+                        <tr class="perms-group-sep" aria-hidden="true">
+                            <td colspan="4">Core flags</td>
+                        </tr>
                         <tr><td>Reserved Slots</td><td class="text-center font-mono">a</td><td>Reserved-slot access.</td>
                             <td class="text-center"><input type="checkbox" id="s1" data-sm-flag="a" {if $sm_reserved_slot}checked{/if}></td></tr>
                         <tr><td>Generic</td><td class="text-center font-mono">b</td><td>Generic admin; required for admins.</td>
@@ -215,14 +255,20 @@
                             <td class="text-center"><input type="checkbox" id="s12" data-sm-flag="m" {if $sm_rcon}checked{/if}></td></tr>
                         <tr><td>Enable Cheats</td><td class="text-center font-mono">n</td><td>Change sv_cheats or use cheating commands.</td>
                             <td class="text-center"><input type="checkbox" id="s13" data-sm-flag="n" {if $sm_cheats}checked{/if}></td></tr>
+                        <tr class="perms-group-sep" aria-hidden="true">
+                            <td colspan="4">Immunity</td>
+                        </tr>
                         <tr>
-                            <td>Immunity</td>
+                            <td>Immunity level</td>
                             <td class="text-center font-mono">&mdash;</td>
                             <td>Higher number = more immunity.</td>
                             <td class="text-center">
                                 <input class="input" type="number" min="0" id="immunity"
                                        value="{$immunity|escape}" style="width:5rem;text-align:center">
                             </td>
+                        </tr>
+                        <tr class="perms-group-sep" aria-hidden="true">
+                            <td colspan="4">Custom flags</td>
                         </tr>
                         <tr><td>Custom flag &quot;o&quot;</td><td class="text-center font-mono">o</td><td>&nbsp;</td>
                             <td class="text-center"><input type="checkbox" id="s17" data-sm-flag="o" {if $sm_custom1}checked{/if}></td></tr>
@@ -240,6 +286,7 @@
                 </table>
             </div>
         </div>
+        </div>{* /.edit-perms-columns *}
 
         <div class="flex gap-2">
             <button type="submit" class="btn btn--primary"

--- a/web/themes/default/page_admin_edit_admins_servers.tpl
+++ b/web/themes/default/page_admin_edit_admins_servers.tpl
@@ -25,7 +25,7 @@
         <p class="text-sm text-muted m-0 mt-2">Pick the servers and server groups this admin can administer in-game.</p>
     </div>
 
-    <nav class="flex gap-2 mb-4" role="tablist" aria-label="Edit admin sections">
+    <nav class="flex gap-2 mb-4 items-center" role="tablist" aria-label="Edit admin sections">
         <a class="btn btn--ghost btn--sm" role="tab"
            href="?p=admin&c=admins&o=editdetails&id={$smarty.get.id|escape:'url'}"
            data-testid="admin-tab-details">Details</a>
@@ -35,8 +35,14 @@
         <a class="btn btn--secondary btn--sm" role="tab" aria-current="page"
            href="?p=admin&c=admins&o=editservers&id={$smarty.get.id|escape:'url'}"
            data-testid="admin-tab-servers">Servers</a>
-        <a class="btn btn--ghost btn--sm"
-           href="?p=admin&c=admins&o=editpermissions&id={$smarty.get.id|escape:'url'}">Permissions</a>
+        <a class="btn btn--ghost btn--sm" role="tab"
+           href="?p=admin&c=admins&o=editpermissions&id={$smarty.get.id|escape:'url'}"
+           data-testid="admin-tab-permissions">Permissions</a>
+        <a class="btn btn--ghost btn--sm admin-tabs__back"
+           href="index.php?p=admin&amp;c=admins"
+           data-testid="admin-tab-back">
+            <i data-lucide="arrow-left"></i> Back
+        </a>
     </nav>
 
     {if $row_count < 1}

--- a/web/themes/default/page_admin_edit_group.tpl
+++ b/web/themes/default/page_admin_edit_group.tpl
@@ -49,7 +49,7 @@
                     <h3>Web Admin Permissions</h3>
                 </div></div>
                 <div class="card__body">
-                    <table class="table" style="margin:0;font-size:var(--fs-sm)">
+                    <table class="table table--keep-mobile" style="margin:0;font-size:var(--fs-sm)">
                         <colgroup>
                             <col style="width:auto">
                             <col style="width:5rem">
@@ -152,7 +152,7 @@
                     <h3>Server Admin Permissions</h3>
                 </div></div>
                 <div class="card__body">
-                    <table class="table" style="margin:0;font-size:var(--fs-sm)">
+                    <table class="table table--keep-mobile" style="margin:0;font-size:var(--fs-sm)">
                         <thead><tr>
                             <th>Permission</th>
                             <th class="text-center" style="width:4rem">Flag</th>
@@ -237,7 +237,7 @@
                     </p>
                 </div></div>
                 <div class="card__body">
-                    <table class="table" style="margin:0;font-size:var(--fs-sm)" id="overrides-table">
+                    <table class="table table--keep-mobile" style="margin:0;font-size:var(--fs-sm)" id="overrides-table">
                         <thead><tr>
                             <th style="width:7rem">Type</th>
                             <th>Name</th>

--- a/web/themes/default/page_admin_overrides.tpl
+++ b/web/themes/default/page_admin_overrides.tpl
@@ -117,7 +117,7 @@
                 </div>
             </div>
             <div class="card__body">
-                <div class="grid gap-3" style="grid-template-columns:8rem 1fr 14rem">
+                <div class="grid gap-3 overrides-add-grid">
                     <div>
                         <label class="label" for="addoverride-type">Type</label>
                         <select class="select" id="addoverride-type" name="new_override_type"

--- a/web/themes/default/page_admin_overrides.tpl
+++ b/web/themes/default/page_admin_overrides.tpl
@@ -68,7 +68,9 @@
                 </div>
             </div>
             <div class="card__body">
-                <table class="table" data-testid="overrides-table">
+                {* Form table with no paired mobile-card surface — keep
+                   visible under the <=768px `.table` hide via keep-mobile. *}
+                <table class="table table--keep-mobile" data-testid="overrides-table">
                     <thead>
                         <tr>
                             <th style="width:8rem">Type</th>


### PR DESCRIPTION
## Summary

This PR is a focused pass over Admin Management. It fixes the broken Edit Admins permission path, brings the admins list and search up to the current panel chrome, improves the edit-admin permissions editor, and closes a few mobile layout bugs along the way.

### Permission fix
- Admins who hold **Edit Admins** (and are not Owners) can edit other admins again (fix #1527).
- Details / password editing and the related UI gates follow that same rule.

### Admins list and table
- Refreshed the admins list row actions and desktop table styling so it matches the rest of the panel.
- Kept permission tables usable on mobile by opting them out of the global hide-`.table`-under-768px rule (those forms need the table layout).

### Advanced search
- Dropped Exact / Partial toggles. Name, Steam ID, and email always substring-match.
- Web and server permission filters use a themed multi-select over a real `<select multiple>`, so GET submit and no-JS still work.
- Fixed server-permission filtering: use `aid` (not `authid`), keep SM flags as characters, and allow `SM_CUSTOM1` through `SM_CUSTOM6` in the allowlist.

### Edit admin (Details / Group / Servers / Permissions)
- Shared tab strip across all four edit-admin pages, including Permissions.
- Removed the empty AdminTabs Back strip that left dead space under the topbar.
- Put **Back** on the right of the in-page tab row (links to the admins list).
- Permissions editor: Select all per card, clearer category grouping (parent vs child rows), and section labels on the server flags table.
- Side-by-side Web / Server permission cards on wide screens, stacked on smaller ones.

### Tooltips
- Restored the tooltip UI helper in `sb.js` / theme CSS so hover help works again where templates expect it.

### Overrides mobile
- Add an override Type / Name / Flags stack on narrow viewports instead of overflowing the card (fix #1380).

## Test plan

- [ ] Log in as an admin with **Edit Admins** but not Owner. Open another admin and confirm Details / password save works.
- [ ] Admins list: row actions, desktop table, and mobile cards look correct.
- [ ] Advanced search: name / Steam / email substring search works without Exact/Partial.
- [ ] Advanced search: multi-select web + server permissions filter correctly, including custom SM flags.
- [ ] Edit admin tabs: Details / Group / Servers / Permissions share the same strip; Back returns to the admins list with no blank gap under the topbar.
- [ ] Permissions: Select all / category parent toggles / individual children behave as expected; save still works.
- [ ] Permissions on a phone-width viewport: tables stay visible.
- [ ] Overrides on mobile: Add an override fields stack and stay inside the card.
- [ ] Hover tooltips where the panel still uses them.