### PR TITLE
feat(admin-nav): move config items into a sidebar accordion menu

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -424,7 +424,8 @@ matching its directory. PSR-4 autoloads from `web/includes/` →
 | `Sbpp\Config`                            | settings cache                        |
 | `Sbpp\Api\Api`                           | JSON API dispatcher                   |
 | `Sbpp\Api\ApiError`                      | structured API error                  |
-| `Sbpp\View\AdminTabs`                    | admin sub-route sidebar mounter       |
+| `Sbpp\View\AdminTabs`                    | edit-* Back-link mounter (empty tabs) |
+| `Sbpp\View\AdminNavCatalog`              | Pattern A section catalogs for the main-sidebar accordion (#1490) |
 | `Sbpp\View\BrandLogo`                    | `template.logo` resolver with `is_file()` fallback to `images/favicon.svg` — single source for the navbar + login chrome brand-mark renders; rejects path-traversal + null-bytes + the v1.x default (case-insensitive); fail-closed on missing `SB_THEMES` |
 | `Sbpp\View\Toast`                        | server-side toast emitter (`emit(kind, title, body, ?redirect)` — replaces v1.x `ShowBox(...)`) |
 | `Sbpp\View\*`                            | view DTOs (page-level + partials)     |
@@ -2734,36 +2735,41 @@ Regression guards:
 ### Sub-paged admin routes (`?section=…` routing)
 
 Admin routes that subdivide into a small fixed set of sub-tasks
-(servers / mods / groups / comms / settings / **admins** / **bans**)
+(servers / mods / groups / settings / **admins** / **bans**)
 ride the **`?section=<slug>` URL pattern** instead of stacking all
 panes in one DOM. Each section is its own URL — linkable,
 back-button-friendly, server-rendered, works without JS — and the
 page handler renders exactly one View per request.
 
-Reference: `web/pages/admin.settings.php` is the long-standing
-canonical shape; #1239 brought servers / mods / groups / comms onto
-the same convention; #1259 unified the chrome on the Settings-style
-vertical sidebar partial `core/admin_sidebar.tpl`; #1275 collapsed
-the dual-pattern world by migrating admin-admins (`admins` /
-`add-admin` / `overrides`) and admin-bans (`add-ban` / `protests`
-/ `submissions` / `import` / `group-ban`) onto Pattern A too,
-deleting the page-level ToC partial along the way.
+#1490 — section chrome lives in the main sidebar accordion
+----------------------------------------------------------
+Pre-#1490 Pattern A pages mounted a second rail
+(`core/admin_sidebar.tpl` via `AdminTabs`) beside the main app
+sidebar, which ate ~14rem of content width and duplicated "Add …"
+links that already existed as header CTAs. #1490 nests every
+section link under its admin category in the **main** sidebar as a
+`<details class="sidebar__accordion">`. `Sbpp\View\AdminNavCatalog`
+is the single source for those children (navbar + page-handler
+routing). Comms and Export stay flat (no children). Do NOT
+reintroduce a second admin rail or header Add CTAs that only
+duplicate accordion entries.
+
+Reference: `web/pages/admin.servers.php` + `AdminNavCatalog` +
+`core/navbar.tpl`. #1239 / #1259 / #1275 established `?section=`
+routing; #1490 moved the chrome into the main sidebar.
 
 #1275 — the page-level ToC pattern is removed
 ---------------------------------------------
 Pre-#1275 admin-admins and admin-bans rode a "Pattern B" page-level
 ToC — a sticky anchor sidebar that emitted `#fragment` URLs and
-scrolled within a single long-scroll DOM. The chrome looked
-identical to Pattern A (#1266 unified them) but the routing
-semantics diverged: clicks emitted `#fragment` URLs, browser back
-went to the previous *page* not the previous section, and link
-sharing broke. #1275 unified everything on Pattern A so the URL
-shape is the **only** sub-route nav contract on the panel. The
-`page_toc.tpl` partial, the cross-template `.page-toc-shell`
-wrappers, and the `IntersectionObserver` active-link script are
-all gone; if you find any new prose / code that introduces a
-parallel "page ToC" or `#fragment` admin nav, it's an anti-pattern
-(see "Anti-patterns" below).
+scrolled within a single long-scroll DOM. #1275 unified everything
+on Pattern A so the URL shape is the **only** sub-route nav
+contract on the panel. The `page_toc.tpl` partial, the
+cross-template `.page-toc-shell` wrappers, and the
+`IntersectionObserver` active-link script are all gone; if you find
+any new prose / code that introduces a parallel "page ToC" or
+`#fragment` admin nav, it's an anti-pattern (see "Anti-patterns"
+below).
 
 Page-handler shape:
 
@@ -2771,77 +2777,48 @@ Page-handler shape:
 $canList = $userbank->HasAccess(ADMIN_OWNER | ADMIN_LIST_SERVERS);
 $canAdd  = $userbank->HasAccess(ADMIN_OWNER | ADMIN_ADD_SERVER);
 
-/** @var list<array{slug: string, name: string, permission: int, url: string, icon: string}> $sections */
-$sections = [
-    ['slug' => 'list', 'name' => 'List servers',   'permission' => …, 'url' => '?p=admin&c=servers&section=list', 'icon' => 'server'],
-    ['slug' => 'add',  'name' => 'Add new server', 'permission' => …, 'url' => '?p=admin&c=servers&section=add',  'icon' => 'plus'],
-];
-
-$validSlugs = ['list', 'add'];
+$sections = \Sbpp\View\AdminNavCatalog::sectionsFor('servers');
+$validSlugs = array_column($sections, 'slug');
 $section = (string) ($_GET['section'] ?? '');
 if (!in_array($section, $validSlugs, true)) {
     $section = $canList ? 'list' : ($canAdd ? 'add' : 'list');
 }
 
-// AdminTabs opens the sidebar shell + emits the <aside> + opens the
-// content column. The page handler is responsible for closing both
-// wrappers AFTER the View renders — see the docblock on AdminTabs.php.
-new AdminTabs($sections, $userbank, $theme, $section, 'Server sections');
-
 if ($section === 'add') {
     Renderer::render($theme, new AdminServersAddView(...));
-    echo '</div></div><!-- /.admin-sidebar-content + /.admin-sidebar-shell -->';
     return;
 }
 Renderer::render($theme, new AdminServersListView(...));
-echo '</div></div><!-- /.admin-sidebar-content + /.admin-sidebar-shell -->';
 ```
 
 Conventions:
 
 - Default to the FIRST accessible section when `?section=` is
   missing or unknown — never render a blank body.
-- Chrome is the parameterized vertical sidebar `core/admin_sidebar.tpl`
-  (#1259). `AdminTabs.php` opens `<div class="admin-sidebar-shell">`,
-  emits the `<aside>` + link list, then opens
-  `<div class="admin-sidebar-content">` for the page View; the page
-  handler **must** close both wrappers (`echo '</div></div>'`) AFTER
-  the `Renderer::render(...)` call so each section nests correctly.
-- Each link is an anchor (`<a href="?p=admin&c=…&section=…"
-  data-testid="admin-tab-<slug>" aria-current="page">`), not a button.
-  Pre-#1239 the strip emitted `<button onclick="openTab(...)">` which
-  dispatched to a JS function in `sourcebans.js` (deleted at #1123
-  D1) — clicks did nothing and every pane stacked together. Don't
-  reintroduce the button shape.
-- Each `$sections` entry carries an `icon` (Lucide name — `server`,
-  `plus`, `users`, `puzzle`, `globe`, `package`, `cog`, `image`,
-  `flag`, `clipboard-list`, …). When omitted, the partial renders a
-  generic `circle-dot` so every row has matching visual weight.
-  Pick icons that match the visual vocabulary already in the
-  Settings sidebar (`page_admin_settings_*.tpl`).
-- Each section's `slug` matches `?section=<slug>` AND the
-  `data-testid="admin-tab-<slug>"` hook on the rendered link.
-  E2E specs anchor on the testid + the active link's
-  `aria-current="page"` attribute (see
-  `web/tests/e2e/specs/responsive/admin-tabs.spec.ts` for the
-  mobile accordion contract; the sidebar sits at the top of the
-  content column at `<1024px` and floats next to it as a sticky
-  14rem rail at `>=1024px`).
-- Pass an aria-label as the fifth `AdminTabs` argument
-  (`'Server sections'`, `'MOD sections'`, …); screen readers
-  announce the navigation by this label. Defaults to "Page
-  sections" when omitted.
-- The `core/admin_tabs.tpl` partial still exists but is now
-  exclusively the **back-link-only** shape for edit-* pages
+- Chrome is the main sidebar accordion (`core/navbar.tpl` +
+  `AdminNavCatalog`). Nested links use
+  `data-testid="nav-admin-<endpoint>-<slug>"` with
+  `aria-current="page"` on the active leaf. Category summaries use
+  `data-testid="nav-admin-<endpoint>"` and must NOT also carry
+  `aria-current` when children exist (#1233).
+- Add new sections in `AdminNavCatalog::sectionsFor()` (not inline
+  in the page handler). Feature toggles (`config.enable*`) gate
+  children the same way AdminTabs used to via the optional `config`
+  field (bans protests / submissions / group-ban).
+- Each section entry carries an `icon` (Lucide name). Pick icons
+  that match the existing vocabulary (`server`, `plus`, `users`,
+  `puzzle`, `flag`, `clipboard-list`, …).
+- Content templates wrap their body in `.page-section` (1.5rem
+  inset + 1400px cap). Pre-#1490 that inset lived on
+  `.admin-sidebar-shell`; without the shell each template owns it.
+- The `core/admin_tabs.tpl` partial is exclusively the
+  **back-link-only** shape for edit-* pages
   (`admin.edit.ban.php`, `admin.rcon.php`, …) which call
-  `new AdminTabs([], $userbank, $theme)`. AdminTabs.php routes
-  empty `$tabs` to that partial and non-empty `$tabs` to
-  `core/admin_sidebar.tpl`. Don't reach for `core/admin_tabs.tpl`
-  directly from new code.
-- Single-section "pages" that used to render a one-button AdminTabs
-  strip (e.g. admin.comms.php's "Add a block" surface) drop the
-  strip entirely — there's nothing to route to, so the surface is
-  reachable from the parent list's CTA + the sidebar.
+  `new AdminTabs([], $userbank, $theme)`. Non-empty `AdminTabs`
+  is a no-op; don't reintroduce the second rail via
+  `core/admin_sidebar.tpl`.
+- Single-section "pages" (e.g. admin.comms.php's "Add a block")
+  stay flat category links with no accordion children.
 - Sections where two operations form a tight workflow (e.g.
   admin-admins's `search` + admins-list, admin-bans's protests
   current/archive split) consolidate into one section rather than
@@ -4090,32 +4067,26 @@ contributions without contacting every contributor individually.
 - `page_toc.tpl` / page-level ToC sidebar / `#fragment` anchor
   sub-route nav → removed at #1275. Pre-#1275 admin-admins and
   admin-bans rode a "Pattern B" sticky page-level ToC that emitted
-  `#fragment` URLs and scrolled within a single long-scroll DOM —
-  same chrome as Pattern A after #1266 unified them, but different
-  routing semantics (clicks lost browser history, scroll position
-  reset on back, link sharing broke, the active-link
-  `IntersectionObserver` was the second source of truth alongside
-  the URL). #1275 collapsed both routes onto Pattern A; the partial,
-  the cross-template `.page-toc-shell` wrappers, and the
-  `IntersectionObserver` script are gone. Don't reintroduce a
-  parallel pattern: every admin route that needs sub-section nav
-  uses `?section=<slug>` + `core/admin_sidebar.tpl`.
-- The horizontal `core/admin_tabs.tpl` pill strip for Pattern A
-  routes → #1259 unified the chrome on the Settings-style vertical
-  sidebar (`core/admin_sidebar.tpl`). New Pattern A routes (or
-  changes to existing ones) build a `$sections` array with a
-  Lucide `icon` per entry, pass an aria-label as the fifth
-  `AdminTabs` argument, and close the sidebar shell + content
-  column with `echo '</div></div>'` AFTER `Renderer::render(...)`.
-  `core/admin_tabs.tpl` is now exclusively the back-link-only
-  partial for edit-* pages — don't reach for it from new code.
+  `#fragment` URLs and scrolled within a single long-scroll DOM.
+  Don't reintroduce a parallel pattern: every admin route that
+  needs sub-section nav uses `?section=<slug>` + the main sidebar
+  accordion (`AdminNavCatalog` / `core/navbar.tpl`, #1490).
+- Reintroducing a second admin rail (`core/admin_sidebar.tpl` /
+  `.admin-sidebar-shell` / non-empty `new AdminTabs($sections, …)`
+  that opens a content column) → removed at #1490. Section links
+  live in the main sidebar accordion only. Non-empty `AdminTabs`
+  is a no-op; `core/admin_tabs.tpl` is exclusively the back-link
+  for edit-* pages.
+- Header "Add …" CTAs that only duplicate an accordion child
+  (`server-list-add`, `admin-add-cta`, …) → removed at #1490.
+  Keep empty-state CTAs (`servers-empty-add`, …) per the Empty
+  states convention.
 - Inlining settings-style sidebar markup inside templates (the
   pre-#1259 shape: `<div class="grid" style="grid-template-columns:14rem 1fr">`
   followed by an inline `<nav><a class="sidebar__link">…</a></nav>`
-  block in every `page_admin_settings_*.tpl`) → the sidebar is
-  now single-source in `core/admin_sidebar.tpl` and mounted by
-  `AdminTabs.php`. Page templates render their content column
-  body and nothing else.
+  block) → section nav is single-source in `AdminNavCatalog` +
+  `core/navbar.tpl`. Page templates render their content body
+  (with `.page-section` padding) and nothing else.
 - Substantively changing what an already-shipped `web/updater/data/<N>.php`
   *does* (different SQL, different defaults, new side effects) → fresh
   installs (which never run the updater) silently diverge from upgraded
@@ -4968,9 +4939,9 @@ contributions without contacting every contributor individually.
 | Live-preview Markdown in a settings textarea | `system.preview_intro_text` JSON action + `web/themes/default/page_admin_settings_settings.tpl` (`.dash-intro-editor` / `.dash-intro-preview`) |
 | Regex-read `theme.conf.php` metadata for the admin Settings → Themes picker (without executing the manifest) | `Sbpp\Theme\ThemeConf` (`web/includes/Theme/ThemeConf.php`) — `parseDefine()` + `sanitizeLink()` / `sanitizeScreenshotFilename()`; wired from `web/pages/admin.settings.php` discovery loop (#1466). JSON theme preview (`api_system_sel_theme`) still `include`s the manifest. Regression: `web/tests/integration/ThemeConfParseTest.php`. |
 | Build an empty-state surface (first-run vs filtered, primary/secondary CTAs) | `.empty-state` rules in `web/themes/default/css/theme.css` + reference shapes in `page_servers.tpl`, `page_dashboard.tpl`, `page_bans.tpl`, `page_comms.tpl`, `page_admin_audit.tpl`, `page_admin_bans_protests.tpl`, `page_admin_bans_submissions.tpl` |
-| Subdivide an admin route into `?section=<slug>` URLs (servers, mods, groups, comms, settings, **admins**, **bans**) | `web/pages/admin.settings.php` is the long-standing reference; #1239 brought servers / mods / groups / comms onto the same shape; #1259 unified the chrome on the Settings-style vertical sidebar; #1275 brought admins (`admins` / `add-admin` / `overrides`) and bans (`add-ban` / `protests` / `submissions` / `import` / `group-ban`) onto the same shape, deleting the page-level ToC (`page_toc.tpl`) along the way so `?section=` is now the **only** sub-route nav contract. The shared partial is `web/themes/default/core/admin_sidebar.tpl` (parameterized on `tabs` / `active_tab` / `sidebar_id` / `sidebar_label`); `web/includes/View/AdminTabs.php` (`Sbpp\View\AdminTabs`) opens `<div class="admin-sidebar-shell">`, emits the `<aside>` + link list, opens `<div class="admin-sidebar-content">`, and the page handler closes both wrappers (`echo '</div></div>'`) AFTER `Renderer::render(...)`. Each `$sections` entry carries `slug` + `name` + `permission` + `url` + `icon` (Lucide name); the link emits `<a href="?p=admin&c=<page>&section=<slug>" data-testid="admin-tab-<slug>" aria-current="page">` — never `<button onclick="openTab(...)">` (the JS handler was deleted at #1123 D1). See "Sub-paged admin routes" in Conventions. |
+| Subdivide an admin route into `?section=<slug>` URLs (servers, mods, groups, settings, **admins**, **bans**) | `Sbpp\View\AdminNavCatalog` (`web/includes/View/AdminNavCatalog.php`) owns the section catalogs; `web/pages/core/navbar.php` + `core/navbar.tpl` render them as main-sidebar accordions (`data-testid="nav-admin-<endpoint>-<slug>"`, #1490). Page handlers resolve `?section=` against `AdminNavCatalog::sectionsFor('<endpoint>')` and render one View. `?section=` is the **only** sub-route nav contract. See "Sub-paged admin routes" in Conventions. |
 | Render sub-views inside a Pattern A section (e.g. protests / submissions current-vs-archive) | `?view=<slug>` query param + a server-rendered `.chip-row` of real anchors (each carries `data-active="true|false"` + `aria-selected`). Reference: the protests / submissions chip rows in `web/pages/admin.bans.php` (`?section=protests&view=archive` / `?section=submissions&view=archive`). Pre-#1275 the chips called `Swap2ndPane()` — a `web/scripts/sourcebans.js` helper deleted at #1123 D1, leaving them dead — and the page rendered both views simultaneously. The new shape only renders the active view's data path; back/forward and link sharing both work. |
-| Lay out a sub-paged admin route's chrome (the 14rem vertical sidebar at `>=1024px`, the `<details open>` accordion at `<1024px`) | `web/themes/default/core/admin_sidebar.tpl` (the partial) + the `.admin-sidebar-shell` / `.admin-sidebar` / `.admin-sidebar__details` / `.admin-sidebar__summary` / `.admin-sidebar__nav` / `.admin-sidebar__link` / `.admin-sidebar-content` rules in `web/themes/default/css/theme.css` (#1259). The active link reuses the shared `.sidebar__link[aria-current="page"]` rule from the main app shell so the dark-pill-in-light / brand-orange-in-dark treatment is single-source. |
+| Lay out admin section chrome in the main sidebar accordion | `.sidebar__accordion` / `.sidebar__children` / `.sidebar__link--child` rules in `web/themes/default/css/theme.css` (#1490) + the nested `{foreach}` in `core/navbar.tpl`. Active leaf reuses `.sidebar__link[aria-current="page"]`. Do not reintroduce `core/admin_sidebar.tpl` / `.admin-sidebar-shell` as a second rail. |
 | Render the trailing "Back" link on edit-* admin pages (the only surface that calls `new AdminTabs([], …)`) | `web/themes/default/core/admin_tabs.tpl` is the back-link-only partial (it still has a defensive `{foreach}` for legacy themes, but `web/includes/View/AdminTabs.php` only routes here when `$tabs === []`). Page handlers like `admin.edit.ban.php` / `admin.rcon.php` / `admin.email.php` call `new AdminTabs([], $userbank, $theme)` and the partial emits the right-aligned Back anchor (`.admin-tabs__back` in theme.css). |
 | Add or rename an admin-admins advanced-search filter | `web/pages/admin.admins.php` (filter-building loop + active-filter map for pagination) + `web/pages/admin.admins.search.php` (DTO population + `$active_filter_count` increment for the new slot) + `web/includes/View/AdminAdminsSearchView.php` (`active_filter_*` properties) + `web/themes/default/box_admin_admins_search.tpl` (input + pre-fill). The form is single-submit AND-semantics with a backward-compat shim for legacy `advType=…&advSearch=…` URLs (#1207 ADM-4); cover new filters in `web/tests/integration/AdminAdminsSearchTest.php`. |
 | Wrap a filter `<form>` in a default-collapsed `<details>` disclosure (admin-admins advanced search; the public banlist / commslist filter bars are candidates for the same shape per #1303's notes) | `.filters-details` rules in `web/themes/default/css/theme.css` + reference shape in `web/themes/default/box_admin_admins_search.tpl` (`<details class="card filters-details" {if $has_active_filters}open{/if}>` with a `<summary data-testid="…-toggle">` carrying the title + chevron + optional "N active" count badge). The View carries paired `int $active_filter_count` + `bool $has_active_filters` properties (#1303); the page handler increments the count once per populated value slot, NEVER per match-mode toggle. The disclosure auto-expands on a post-submit paint so the Clear-filters affordance stays one click away. Visual vocabulary mirrors `core/admin_sidebar.tpl`'s mobile `<details open>` accordion (chevron + `prefers-reduced-motion: reduce` override). |
@@ -4994,7 +4965,7 @@ contributions without contacting every contributor individually.
 | Pin "every `class="btn--*"` modifier carries the base `btn` token" structural contract | `web/tests/integration/ButtonClassChainTest.php` (#1448) — single-method parser-style sweep across `web/themes/`, `web/pages/`, `web/includes/View/`, `web/install/`, `web/updater/`, `web/api/handlers/`, AND `web/scripts/` + `web/themes/default/js/` for `*.tpl` / `*.php` / `*.js`. Strips Smarty `{* … *}` (default delimiters) and `-{* … *}-` (the non-default-delimiter shape used by `page_login.tpl` / `page_blockit.tpl` / `page_kickit.tpl` / `page_admin_servers_rcon.tpl`), PHP comments via `php_strip_whitespace()`, and JS `/* */` + `//` comments. Extracts every `class="…"` / `class='…'` attribute body (negative lookbehind on the `class` keyword skips name-prefixed `data-class=` / `aria-class=` shapes), splits on whitespace, and asserts every chain carrying a `btn--*` modifier also carries `btn`. Class attributes containing `{` (Smarty-conditional shapes) are skipped — the gate doesn't expand templates. Sanity-check assertions guard against `ROOT` / `scanRoots()` typos that would silently scan zero files. Sister gate to `DeadJsCallSitesTest`; same pure-file-scanning shape. The JS-side coverage (`web/themes/default/js/theme.js`'s `renderDrawerBody()` / `renderDrawerLoading()` / toast / Notes-pane delete chrome, plus the `web/scripts/sb.js` legacy `'btn ok'` button factory) is what makes the gate's "panel chrome" coverage actually structural — that file ships seven `<button class="btn btn--ghost btn--icon[ btn--xs]">` strings via runtime concatenation, and the regression guard would be papering over the live bug surface without it. |
 | Add an E2E spec                        | `web/tests/e2e/specs/<smoke|flows|a11y|responsive>/...` + `web/tests/e2e/pages/...` |
 | Add a route to the screenshot gallery  | `web/tests/e2e/specs/_screenshots.spec.ts` (`ROUTES` array) |
-| Tweak mobile (<=768px) chrome layout   | `web/themes/default/css/theme.css` — see the `#1207` `@media (max-width: 768px)` blocks for the canonical shapes (icon-only topbar search, full-width drawer + scroll lock). Sub-paged admin routes (servers / mods / groups / comms / settings / admins / bans) use the `<details open>` accordion in the `#1259` `@media (min-width: 1024px)` block (sidebar inline at `<1024px`, sticky 14rem rail at `>=1024px`); see "Sub-paged admin routes" in Conventions. |
+| Tweak mobile (<=768px) chrome layout   | `web/themes/default/css/theme.css` — see the `#1207` `@media (max-width: 768px)` blocks for the canonical shapes (icon-only topbar search, full-width drawer + scroll lock). Sub-paged admin section links live in the main sidebar accordion (`.sidebar__accordion`, #1490); see "Sub-paged admin routes" in Conventions. |
 | Hide non-essential desktop-table columns when the card is too narrow to fit every cell without horizontal scroll | `.col-tier-2` (hide via `@container tablescroll (max-width: 1200px)`) and `.col-tier-3` (hide via `@container tablescroll (max-width: 1500px)`) in `web/themes/default/css/theme.css` (next to `.table-scroll`). Apply to BOTH the `<th>` AND the matching `<td>` so the column hides as a unit. Tier-3 hides FIRST despite the lower tier-number because the wider trio (IP / Length / Banned / Started, ~552px) reclaims more room than tier-2 (Server / Admin, ~219px). Tier-1 columns are always visible — Player, SteamID, Reason (banlist) / Type+Player (commslist), Status, Actions; the minimum row still answers "who, why, what state, what can I do". The breakpoints are `@container tablescroll (...)` rules — they react to the painted width of `.table-scroll` (which carries `container-type: inline-size; container-name: tablescroll;`), NOT the viewport. This lets the breakpoints see the page-cap (1400px on most lists, 1700px on bans / comms post-#1363) — pre-#1363 the predecessors were viewport-keyed (`@media (max-width: 1535px)`) and a 1920px monitor saw the same scroll-required layout as a 1535px laptop because both painted an identical 1352px card under the 1400px page-cap. `.table-scroll` stays wrapped around the table as the runtime overflow safety net. The mobile card layout (`.ban-cards`) takes over at `<=768px`, so the tier classes only collapse the desktop table at intermediate viewports. Reference: banlist `<th>` row in `page_bans.tpl` (Server / Admin → tier-2; IP / Length / Banned → tier-3); commslist row in `page_comms.tpl` (Server / Admin → tier-2; Length / Started → tier-3). See "Responsive desktop-table chrome" in Conventions for the full pattern. |
 | Surface the full reason on a truncated row (banlist Reason column / mobile card reason line / unban-reason inline span) | `title="…"` attribute on the truncated element. The browser's native tooltip fires on hover (desktop) / long-press (mobile) and exposes the un-truncated text; no JS needed. Reference: `page_bans.tpl` desktop reason `<td>` (gates on `!empty($ban.reason)` so empty rows don't get a useless empty `title=""`), the mobile-card reason line, the `[data-testid="ban-unban-reason"]` span, the Server cell, and the matching `[data-testid="comm-unban-reason"]` span on `page_comms.tpl`. Don't use `title=""` empty-string fallbacks — the conditional gate is the contract. |
 | Stop mobile browsers auto-linking SteamIDs / IPs as phone numbers | `web/themes/default/core/header.tpl` (`<meta name="format-detection" content="telephone=no…">` + `<meta name="x-apple-data-detectors">`) and the defensive `.drawer a[href^="tel:"]` reset in `theme.css` |

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -94,7 +94,8 @@ web/
 │   ├── Auth/openid.php       LightOpenID — third-party, intentionally global ns
 │   ├── Security/CSRF.php     Sbpp\Security\CSRF — token helpers
 │   ├── Security/Crypto.php   Sbpp\Security\Crypto — password / token crypto
-│   ├── View/AdminTabs.php    Sbpp\View\AdminTabs — Pattern A admin sub-section nav
+│   ├── View/AdminNavCatalog.php  Sbpp\View\AdminNavCatalog — Pattern A section catalogs for the main-sidebar accordion (#1490)
+│   ├── View/AdminTabs.php    Sbpp\View\AdminTabs — back-link chrome for edit-* admin pages (non-empty tabs are a no-op post-#1490)
 │   ├── View/                 Sbpp\View\* — typed Smarty view-model DTOs
 │   ├── View/Install/         Sbpp\View\Install\* — install-wizard step DTOs (#1332)
 │   ├── Markup/               Sbpp\Markup\IntroRenderer — admin Markdown -> safe HTML

--- a/web/includes/View/AdminAdminsListView.php
+++ b/web/includes/View/AdminAdminsListView.php
@@ -36,7 +36,6 @@ final class AdminAdminsListView extends View
      */
     public function __construct(
         public readonly bool $can_list_admins,
-        public readonly bool $can_add_admins,
         public readonly bool $can_edit_admins,
         public readonly bool $can_delete_admins,
         public readonly int $admin_count,

--- a/web/includes/View/AdminNavCatalog.php
+++ b/web/includes/View/AdminNavCatalog.php
@@ -1,0 +1,225 @@
+<?php
+declare(strict_types=1);
+
+namespace Sbpp\View;
+
+use Sbpp\Auth\UserManager;
+use Sbpp\Config;
+
+/**
+ * Section catalogs for Pattern A admin routes (`?section=<slug>`).
+ *
+ * Single source for the nested children the main sidebar accordion
+ * renders (#1490) and for the `$sections` arrays page handlers use
+ * for routing defaults. Permission and feature-toggle gates match
+ * the pre-#1490 AdminTabs filter so a link either appears in the
+ * accordion and resolves, or is absent from both.
+ *
+ * @phpstan-type TabSpec array{
+ *     name: string,
+ *     permission: int|string,
+ *     url: string,
+ *     slug: string,
+ *     icon?: string,
+ *     config?: bool,
+ * }
+ */
+final class AdminNavCatalog
+{
+    private function __construct()
+    {
+    }
+
+    /**
+     * Unfiltered section catalog for one admin endpoint (`c=` value).
+     * Empty list means the category has no accordion children (comms,
+     * export) or is unknown.
+     *
+     * @return list<TabSpec>
+     */
+    public static function sectionsFor(string $endpoint): array
+    {
+        return match ($endpoint) {
+            'admins' => [
+                [
+                    'slug'       => 'admins',
+                    'name'       => 'Admins',
+                    'permission' => ADMIN_OWNER | ADMIN_LIST_ADMINS,
+                    'url'        => 'index.php?p=admin&c=admins&section=admins',
+                    'icon'       => 'users',
+                ],
+                [
+                    'slug'       => 'add-admin',
+                    'name'       => 'Add admin',
+                    'permission' => ADMIN_OWNER | ADMIN_ADD_ADMINS,
+                    'url'        => 'index.php?p=admin&c=admins&section=add-admin',
+                    'icon'       => 'user-plus',
+                ],
+                [
+                    'slug'       => 'overrides',
+                    'name'       => 'Overrides',
+                    'permission' => ADMIN_OWNER | ADMIN_ADD_ADMINS,
+                    'url'        => 'index.php?p=admin&c=admins&section=overrides',
+                    'icon'       => 'shield',
+                ],
+            ],
+            'servers' => [
+                [
+                    'slug'       => 'list',
+                    'name'       => 'List servers',
+                    'permission' => ADMIN_OWNER | ADMIN_LIST_SERVERS,
+                    'url'        => 'index.php?p=admin&c=servers&section=list',
+                    'icon'       => 'server',
+                ],
+                [
+                    'slug'       => 'add',
+                    'name'       => 'Add new server',
+                    'permission' => ADMIN_OWNER | ADMIN_ADD_SERVER,
+                    'url'        => 'index.php?p=admin&c=servers&section=add',
+                    'icon'       => 'plus',
+                ],
+            ],
+            'bans' => self::bansSections(),
+            'groups' => [
+                [
+                    'slug'       => 'list',
+                    'name'       => 'List groups',
+                    'permission' => ADMIN_OWNER | ADMIN_LIST_GROUPS,
+                    'url'        => 'index.php?p=admin&c=groups&section=list',
+                    'icon'       => 'users',
+                ],
+                [
+                    'slug'       => 'add',
+                    'name'       => 'Add a group',
+                    'permission' => ADMIN_OWNER | ADMIN_ADD_GROUP,
+                    'url'        => 'index.php?p=admin&c=groups&section=add',
+                    'icon'       => 'plus',
+                ],
+            ],
+            'settings' => [
+                [
+                    'slug'       => 'settings',
+                    'name'       => 'Main',
+                    'permission' => ADMIN_OWNER | ADMIN_WEB_SETTINGS,
+                    'url'        => 'index.php?p=admin&c=settings&section=settings',
+                    'icon'       => 'settings',
+                ],
+                [
+                    'slug'       => 'features',
+                    'name'       => 'Features',
+                    'permission' => ADMIN_OWNER | ADMIN_WEB_SETTINGS,
+                    'url'        => 'index.php?p=admin&c=settings&section=features',
+                    'icon'       => 'toggle-right',
+                ],
+                [
+                    'slug'       => 'logs',
+                    'name'       => 'System Log',
+                    'permission' => ADMIN_OWNER | ADMIN_WEB_SETTINGS,
+                    'url'        => 'index.php?p=admin&c=settings&section=logs',
+                    'icon'       => 'scroll-text',
+                ],
+                [
+                    'slug'       => 'themes',
+                    'name'       => 'Themes',
+                    'permission' => ADMIN_OWNER | ADMIN_WEB_SETTINGS,
+                    'url'        => 'index.php?p=admin&c=settings&section=themes',
+                    'icon'       => 'palette',
+                ],
+            ],
+            'mods' => [
+                [
+                    'slug'       => 'list',
+                    'name'       => 'List MODs',
+                    'permission' => ADMIN_OWNER | ADMIN_LIST_MODS,
+                    'url'        => 'index.php?p=admin&c=mods&section=list',
+                    'icon'       => 'puzzle',
+                ],
+                [
+                    'slug'       => 'add',
+                    'name'       => 'Add new MOD',
+                    'permission' => ADMIN_OWNER | ADMIN_ADD_MODS,
+                    'url'        => 'index.php?p=admin&c=mods&section=add',
+                    'icon'       => 'plus',
+                ],
+            ],
+            default => [],
+        };
+    }
+
+    /**
+     * Filter a section list the same way AdminTabs did: drop entries
+     * the user cannot reach and honour optional `config` toggles.
+     *
+     * @param list<TabSpec> $sections
+     * @return list<TabSpec>
+     */
+    public static function filterForUser(array $sections, UserManager $userbank): array
+    {
+        $out = [];
+        foreach ($sections as $tab) {
+            if (!$userbank->HasAccess($tab['permission'])) {
+                continue;
+            }
+            if (isset($tab['config']) && !$tab['config']) {
+                continue;
+            }
+            $out[] = $tab;
+        }
+        return $out;
+    }
+
+    /**
+     * @return list<TabSpec>
+     */
+    private static function bansSections(): array
+    {
+        $sections = [
+            [
+                'slug'       => 'add-ban',
+                'name'       => 'Add a ban',
+                'permission' => ADMIN_OWNER | ADMIN_ADD_BAN,
+                'url'        => 'index.php?p=admin&c=bans&section=add-ban',
+                'icon'       => 'plus',
+            ],
+        ];
+
+        if (Config::getBool('config.enableprotest')) {
+            $sections[] = [
+                'slug'       => 'protests',
+                'name'       => 'Ban protests',
+                'permission' => ADMIN_OWNER | ADMIN_BAN_PROTESTS,
+                'url'        => 'index.php?p=admin&c=bans&section=protests',
+                'icon'       => 'flag',
+            ];
+        }
+        if (Config::getBool('config.enablesubmit')) {
+            $sections[] = [
+                'slug'       => 'submissions',
+                'name'       => 'Ban submissions',
+                'permission' => ADMIN_OWNER | ADMIN_BAN_SUBMISSIONS,
+                'url'        => 'index.php?p=admin&c=bans&section=submissions',
+                'icon'       => 'clipboard-list',
+            ];
+        }
+
+        $sections[] = [
+            'slug'       => 'import',
+            'name'       => 'Import bans',
+            'permission' => ADMIN_OWNER | ADMIN_BAN_IMPORT,
+            'url'        => 'index.php?p=admin&c=bans&section=import',
+            'icon'       => 'upload',
+        ];
+
+        if (Config::getBool('config.enablegroupbanning')) {
+            $sections[] = [
+                'slug'       => 'group-ban',
+                'name'       => 'Group ban',
+                'permission' => ADMIN_OWNER | ADMIN_ADD_BAN,
+                'url'        => 'index.php?p=admin&c=bans&section=group-ban',
+                'icon'       => 'users',
+            ];
+        }
+
+        return $sections;
+    }
+}

--- a/web/includes/View/AdminTabs.php
+++ b/web/includes/View/AdminTabs.php
@@ -5,77 +5,23 @@ namespace Sbpp\View;
 /**
  * Class AdminTabs
  *
- * Drives the intra-page section nav for Pattern A admin routes — the
- * routes that subdivide via `?section=<slug>` URLs (servers, mods,
- * groups, settings, comms, admins, bans; see AGENTS.md "Sub-paged
- * admin routes").
+ * Two render shapes remain after #1490:
  *
- * #1259 unified the chrome
- * ------------------------
- * Pre-#1259 there were two visuals:
- *   - settings rendered a vertical 14rem sidebar inline in every
- *     `page_admin_settings_*.tpl`,
- *   - servers / mods / groups rendered a horizontal pill strip via
- *     `core/admin_tabs.tpl`.
- * The horizontal strip read as "tabs into one document" rather than
- * "navigation between sibling pages" even after #1239 routed each
- * section to its own URL, and stacked badly on dense routes (mods has
- * a 3-section strip already; admins family hits 4+). #1259 lifted the
- * settings sidebar into the parameterized `core/admin_sidebar.tpl`
- * partial and pointed every Pattern A handler at it via this class.
- *
- * #1239 — anchor links, no JS toggle
- * ----------------------------------
- * Pre-#1239 the partial emitted `<button onclick="openTab(this, …)">`
- * elements that called a JS function from the v1.x sourcebans.js bulk
- * file (removed at #1123 D1). Clicks were silent no-ops — every pane
- * was visible permanently — until the broken chrome was repaired in
- * #1239 by routing each section through its own `?section=<slug>` URL.
- *
- * Two render shapes
- * -----------------
  * 1. `$tabs === []` (edit-* pages: admin.edit.ban.php, admin.rcon.php,
- *    admin.email.php, …):
+ *    admin.email.php, admin.export.php, …):
  *      Emits `core/admin_tabs.tpl` which renders just the trailing
  *      "Back" anchor — there's no sub-section nav for these surfaces,
- *      only the affordance to leave. This shape is unchanged by #1259.
+ *      only the affordance to leave.
  *
- * 2. `$tabs !== []` (Pattern A pages: admin.servers, admin.mods,
- *    admin.groups, admin.settings, admin.comms, admin.admins,
- *    admin.bans):
- *      Opens the sidebar shell (`<div class="admin-sidebar-shell">`),
- *      emits `core/admin_sidebar.tpl` (the <aside> + link list), then
- *      opens the content column (`<div class="admin-sidebar-content">`).
- *      The page handler is responsible for closing both wrappers AFTER
- *      `Renderer::render(...)` runs:
+ * 2. `$tabs !== []` (legacy Pattern A callers):
+ *      No-op. Section links live in the main sidebar accordion
+ *      (`AdminNavCatalog` + `core/navbar.tpl`, #1490). Page handlers
+ *      may still construct AdminTabs with a non-empty list during
+ *      migration; the constructor accepts the call and renders
+ *      nothing so content is not wrapped in a second rail.
  *
- *      ```php
- *      new AdminTabs($sections, $userbank, $theme, $section, 'Settings sections');
- *      Renderer::render($theme, new AdminSettingsView(...));
- *      echo '</div></div><!-- /.admin-sidebar-content + /.admin-sidebar-shell -->';
- *      ```
- *
- *      The wrapper opens before the View and closes after, so each
- *      `Renderer::render` call slots into the content column without
- *      per-View structural changes.
- *
- * Each tab in the `$tabs` array carries:
- *   - `name`        Display label rendered as the link text.
- *   - `permission`  Bitmask for `CUserManager::HasAccess()`. The tab
- *                   is omitted entirely when the current user lacks
- *                   the flag.
- *   - `url`         (required for non-empty tabs) The link target. The
- *                   page handler is responsible for building it
- *                   (typically `index.php?p=admin&c=<page>&section=<slug>`)
- *                   so the partial doesn't need to know about routing.
- *   - `slug`        (required for non-empty tabs) Short identifier used
- *                   for the `data-testid` and active-tab matching.
- *   - `icon`        (optional) Lucide icon name (e.g. `server`,
- *                   `puzzle`). When omitted the partial falls back to
- *                   a generic `circle-dot` so every row has matching
- *                   visual weight.
- *   - `config`      (optional) Feature-toggle gate; the tab is omitted
- *                   when `config` is set and falsy.
+ * Prefer dropping non-empty `new AdminTabs(...)` calls from Pattern A
+ * handlers entirely. Keep the empty-tabs Back-link shape.
  *
  * @phpstan-type TabSpec array{
  *     name: string,
@@ -93,17 +39,10 @@ final class AdminTabs
 
     /**
      * @param list<TabSpec> $tabs
-     * @param string|null   $activeSlug    Slug of the section to mark with
-     *     `aria-current="page"`. When null, the first accessible tab's
-     *     slug wins. When the value doesn't match any visible tab no
-     *     tab is marked active (and the sidebar falls back to its
-     *     all-inactive look — still better than every entry looking
-     *     identical).
-     * @param string|null   $sidebarLabel  aria-label for the sidebar
-     *     <aside>. Screen readers announce the navigation by this
-     *     label ("Settings sections" / "Server sections" / …). Only
-     *     consumed when `$tabs` is non-empty (the empty-tabs Back-link
-     *     shape has no sidebar).
+     * @param string|null   $activeSlug    Kept for call-site compatibility;
+     *     unused when `$tabs` is non-empty (main sidebar owns active state).
+     * @param string|null   $sidebarLabel  Kept for call-site compatibility;
+     *     unused when `$tabs` is non-empty.
      */
     public function __construct(
         array $tabs,
@@ -128,30 +67,15 @@ final class AdminTabs
         }
 
         if ($this->tabs === []) {
-            // Edit-* shape: just the trailing Back anchor. The legacy
-            // partial still owns this surface — there's no sidebar to
-            // unify, only the "leave this page" affordance.
             $theme->assign('tabs', $this->tabs);
             $theme->assign('active_tab', $resolvedActive);
             $theme->display('core/admin_tabs.tpl');
             return;
         }
 
-        // Sidebar shape (#1259). Open the shell + render the <aside> +
-        // open the content column. Closing tags live in the calling
-        // page handler — see the class docblock for the contract.
-        $sidebarId    = 'admin-sidebar';
-        $sidebarLabel = $sidebarLabel !== null && $sidebarLabel !== ''
-            ? $sidebarLabel
-            : 'Page sections';
-
-        echo '<div class="admin-sidebar-shell" data-testid="admin-sidebar-shell">';
-        $theme->assign('tabs', $this->tabs);
-        $theme->assign('active_tab', $resolvedActive);
-        $theme->assign('sidebar_id', $sidebarId);
-        $theme->assign('sidebar_label', $sidebarLabel);
-        $theme->display('core/admin_sidebar.tpl');
-        echo '<div class="admin-sidebar-content">';
+        // #1490 — section nav moved into the main sidebar accordion.
+        // Non-empty AdminTabs no longer opens admin-sidebar-shell.
+        unset($sidebarLabel);
     }
 }
 

--- a/web/pages/admin.admins.php
+++ b/web/pages/admin.admins.php
@@ -65,47 +65,12 @@ $canEditAdmins   = $userbank->HasAccess(WebPermission::mask(WebPermission::Owner
 $canDeleteAdmins = $userbank->HasAccess(WebPermission::mask(WebPermission::Owner, WebPermission::DeleteAdmins));
 
 /*
- * #1275 — `$sections` array drives the new vertical sidebar via
- * AdminTabs. Each entry carries `slug` + `name` + `permission` +
- * `url` + `icon` (Lucide). Icons follow the Pattern A vocabulary
- * already in `admin.servers.php` / `admin.groups.php` / etc.
- *
- * `permission` filters happen inside AdminTabs (it skips entries
- * the current user can't reach), so an admin without LIST_ADMINS
- * sees the Add admin / Overrides sidebar links but not Admins.
+ * #1275 / #1490 — `$sections` comes from AdminNavCatalog (main
+ * sidebar accordion). Permission filters happen in
+ * AdminNavCatalog::filterForUser when the navbar builds children.
  */
-/** @var list<array{slug: string, name: string, permission: int, url: string, icon: string}> $sections */
-$sections = [
-    [
-        'slug'       => 'admins',
-        'name'       => 'Admins',
-        'permission' => ADMIN_OWNER | ADMIN_LIST_ADMINS,
-        'url'        => 'index.php?p=admin&c=admins&section=admins',
-        'icon'       => 'users',
-    ],
-    [
-        'slug'       => 'add-admin',
-        'name'       => 'Add admin',
-        'permission' => ADMIN_OWNER | ADMIN_ADD_ADMINS,
-        'url'        => 'index.php?p=admin&c=admins&section=add-admin',
-        'icon'       => 'user-plus',
-    ],
-    [
-        'slug'       => 'overrides',
-        'name'       => 'Overrides',
-        'permission' => ADMIN_OWNER | ADMIN_ADD_ADMINS,
-        'url'        => 'index.php?p=admin&c=admins&section=overrides',
-        'icon'       => 'shield',
-    ],
-];
-
-// Default to the first accessible section so the page never renders
-// a blank body when `?section=` is missing or carries an unknown
-// value. Admins → Add admin → Overrides; an admin without ADD_ADMINS
-// can't reach Add admin or Overrides, so they always land on Admins
-// (or the access-denied stub the View renders if they also lack
-// LIST_ADMINS).
-$validSlugs = ['admins', 'add-admin', 'overrides'];
+$sections = \Sbpp\View\AdminNavCatalog::sectionsFor('admins');
+$validSlugs = array_column($sections, 'slug');
 $section    = (string) ($_GET['section'] ?? '');
 if (!in_array($section, $validSlugs, true)) {
     if ($canListAdmins) {
@@ -116,11 +81,6 @@ if (!in_array($section, $validSlugs, true)) {
         $section = 'admins';
     }
 }
-
-// AdminTabs opens the sidebar shell + emits the <aside> + opens the
-// content column. Closing tags live AFTER each render branch below —
-// document the pairing so future edits don't strand an open <div>.
-new AdminTabs($sections, $userbank, $theme, $section, 'Admin sections');
 
 // ---------------------------------------------------------------- add-admin
 if ($section === 'add-admin') {
@@ -167,7 +127,6 @@ if ($section === 'add-admin') {
         // half; this is the visible-affordance half).
         can_grant_owner: $userbank->HasAccess(WebPermission::Owner),
     ));
-    echo '</div></div><!-- /.admin-sidebar-content + /.admin-sidebar-shell — opened by new AdminTabs(...) above -->';
     return;
 }
 
@@ -179,7 +138,6 @@ if ($section === 'overrides') {
     // unchanged; this require keeps the existing POST URL
     // (`?p=admin&c=admins`) working for the form's submit.
     require(TEMPLATES_PATH . "/admin.overrides.php");
-    echo '</div></div><!-- /.admin-sidebar-content + /.admin-sidebar-shell — opened by new AdminTabs(...) above -->';
     return;
 }
 
@@ -558,11 +516,9 @@ if ($pages > 1) {
     // the View itself still follows the can_* convention from
     // Sbpp\View\View's class-level docblock.
     can_list_admins: $canListAdmins,
-    can_add_admins: $canAddAdmins,
     can_edit_admins: $canEditAdmins,
     can_delete_admins: $canDeleteAdmins,
     admin_count: (int) $admin_count,
     admin_nav: (string) $admin_nav,
     admins: $admin_list,
 ));
-echo '</div></div><!-- /.admin-sidebar-content + /.admin-sidebar-shell — opened by new AdminTabs(...) above -->';

--- a/web/pages/admin.bans.php
+++ b/web/pages/admin.bans.php
@@ -83,8 +83,8 @@ $canGroupBan     = $canAddBan && $groupBanEnabled;
  * file-upload `importBans` POST. These run regardless of section
  * because the redirects are out-of-band (banlist row -> "deleted" /
  * "unbanned" toast on bans landing page) and the POST has to hit its
- * dedicated section anyway. Order them BEFORE the AdminTabs sidebar
- * paints so any echo'd toast lands above the chrome.
+ * dedicated section anyway. Run them before the section body so any
+ * echo'd toast lands above the page content.
  */
 if (isset($_GET['mode']) && $_GET['mode'] == "delete") {
     echo "<script>sb.message.show('Ban Deleted', 'The ban has been deleted from SourceBans', 'green', '', true);</script>";
@@ -213,71 +213,6 @@ if (isset($_POST['action']) && $_POST['action'] == "importBans") {
     echo "<script>sb.message.show('Bans Import', '" . addslashes($importMsg) . "', 'green', '');</script>";
 }
 
-/*
- * #1275 — `$sections` array drives the new vertical sidebar via
- * AdminTabs. Each entry carries `slug` + `name` + `permission` +
- * `url` + `icon` (Lucide). Icons follow the Pattern A vocabulary
- * already in `admin.servers.php` / `admin.groups.php` / etc:
- * `plus` for create, `flag` for reports, `clipboard-list` for
- * queues, `upload` for file imports, `users` for multi-user.
- */
-/** @var list<array{slug: string, name: string, permission: int, url: string, icon: string}> $sections */
-$sections = [
-    [
-        'slug'       => 'add-ban',
-        'name'       => 'Add a ban',
-        'permission' => ADMIN_OWNER | ADMIN_ADD_BAN,
-        'url'        => 'index.php?p=admin&c=bans&section=add-ban',
-        'icon'       => 'plus',
-    ],
-];
-// #1421 — Ban protests / submissions ride the same feature-flag gate
-// shape group-ban does below: omitted from the sidebar entirely when
-// the public-pages toggle (`config.enableprotest` / `config.enablesubmit`)
-// is off, instead of leaving a dead link that lands on a page rendering
-// records the public form can't even produce. The matching section
-// handlers also short-circuit on direct URL access (see the
-// `if (!$protestEnabled)` / `if (!$submitEnabled)` stubs below).
-if ($protestEnabled) {
-    $sections[] = [
-        'slug'       => 'protests',
-        'name'       => 'Ban protests',
-        'permission' => ADMIN_OWNER | ADMIN_BAN_PROTESTS,
-        'url'        => 'index.php?p=admin&c=bans&section=protests',
-        'icon'       => 'flag',
-    ];
-}
-if ($submitEnabled) {
-    $sections[] = [
-        'slug'       => 'submissions',
-        'name'       => 'Ban submissions',
-        'permission' => ADMIN_OWNER | ADMIN_BAN_SUBMISSIONS,
-        'url'        => 'index.php?p=admin&c=bans&section=submissions',
-        'icon'       => 'clipboard-list',
-    ];
-}
-$sections[] = [
-    'slug'       => 'import',
-    'name'       => 'Import bans',
-    'permission' => ADMIN_OWNER | ADMIN_BAN_IMPORT,
-    'url'        => 'index.php?p=admin&c=bans&section=import',
-    'icon'       => 'upload',
-];
-// Group ban is feature-flag-gated (Config::getBool('config.enablegroupbanning'))
-// in addition to the permission gate. The other sections render an
-// access-denied stub when the user lacks the perm; group-ban is omitted
-// from the sidebar entirely when the feature is off, so the link
-// doesn't appear at all on installs that have the feature disabled.
-if ($groupBanEnabled) {
-    $sections[] = [
-        'slug'       => 'group-ban',
-        'name'       => 'Group ban',
-        'permission' => ADMIN_OWNER | ADMIN_ADD_BAN,
-        'url'        => 'index.php?p=admin&c=bans&section=group-ban',
-        'icon'       => 'users',
-    ];
-}
-
 $validSlugs = ['add-ban', 'protests', 'submissions', 'import', 'group-ban'];
 $section    = (string) ($_GET['section'] ?? '');
 
@@ -321,15 +256,6 @@ if (!in_array($section, $validSlugs, true)) {
         $section = 'add-ban';
     }
 }
-
-// AdminTabs opens the sidebar shell + emits the <aside> + opens the
-// content column. Closing tags live AFTER each render branch below —
-// document the pairing so future edits don't strand an open <div>.
-new AdminTabs($sections, $userbank, $theme, $section, 'Bans sections');
-
-// Helper to close the shell consistently after every section returns.
-// PHP doesn't bind a local closure to `return` from the outer scope,
-// so each branch echoes the closing pair itself before returning.
 
 // ---------------------------------------------------------------- add-ban
 if ($section === 'add-ban') {
@@ -560,7 +486,6 @@ window.__sbppApplyBanFields = function (d) {
 };
 </script>
 JS;
-    echo '</div></div><!-- /.admin-sidebar-content + /.admin-sidebar-shell — opened by new AdminTabs(...) above -->';
     return;
 }
 
@@ -573,12 +498,10 @@ if ($section === 'protests') {
     // denied"). Mirrors the `group-ban` stub a few branches below.
     if (!$protestEnabled) {
         echo '<div class="card"><div class="card__body"><p class="text-muted m-0">Ban protests are disabled in <strong>config.enableprotest</strong>.</p></div></div>';
-        echo '</div></div><!-- /.admin-sidebar-content + /.admin-sidebar-shell -->';
         return;
     }
     if (!$canProtests) {
         echo '<div class="card"><div class="card__body"><p class="text-muted m-0">Access denied.</p></div></div>';
-        echo '</div></div><!-- /.admin-sidebar-content + /.admin-sidebar-shell -->';
         return;
     }
 
@@ -592,10 +515,11 @@ if ($section === 'protests') {
     $protestView = (isset($_GET['view']) && $_GET['view'] === 'archive') ? 'archive' : 'current';
     $currentActive = $protestView === 'current' ? 'true' : 'false';
     $archiveActive = $protestView === 'archive' ? 'true' : 'false';
-    echo '<div class="chip-row" role="tablist" aria-label="Protest archive filter" data-testid="protests-archive-tabs" style="margin-bottom:0.75rem">'
+    echo '<div class="page-section" style="padding-bottom:0">'
+        . '<div class="chip-row" role="tablist" aria-label="Protest archive filter" data-testid="protests-archive-tabs" style="margin-bottom:0">'
         . '<a class="chip" data-active="' . $currentActive . '" data-testid="filter-chip-protests-current" role="tab" aria-selected="' . $currentActive . '" href="index.php?p=admin&amp;c=bans&amp;section=protests" title="Show current protests">Current</a>'
         . '<a class="chip" data-active="' . $archiveActive . '" data-testid="filter-chip-protests-archive" role="tab" aria-selected="' . $archiveActive . '" href="index.php?p=admin&amp;c=bans&amp;section=protests&amp;view=archive" title="Show the protest archive">Archive</a>'
-        . '</div>';
+        . '</div></div>';
 
     if ($protestView === 'current') {
         $ItemsPerPage = SB_BANS_PER_PAGE;
@@ -789,7 +713,6 @@ if ($section === 'protests') {
             protest_count_archiv: (int) $page_count,
         ));
     }
-    echo '</div></div><!-- /.admin-sidebar-content + /.admin-sidebar-shell -->';
     return;
 }
 
@@ -800,22 +723,21 @@ if ($section === 'submissions') {
     // on a disabled install and the message points at the toggle key.
     if (!$submitEnabled) {
         echo '<div class="card"><div class="card__body"><p class="text-muted m-0">Ban submissions are disabled in <strong>config.enablesubmit</strong>.</p></div></div>';
-        echo '</div></div><!-- /.admin-sidebar-content + /.admin-sidebar-shell -->';
         return;
     }
     if (!$canSubmissions) {
         echo '<div class="card"><div class="card__body"><p class="text-muted m-0">Access denied.</p></div></div>';
-        echo '</div></div><!-- /.admin-sidebar-content + /.admin-sidebar-shell -->';
         return;
     }
 
     $submissionView = (isset($_GET['view']) && $_GET['view'] === 'archive') ? 'archive' : 'current';
     $currentActive = $submissionView === 'current' ? 'true' : 'false';
     $archiveActive = $submissionView === 'archive' ? 'true' : 'false';
-    echo '<div class="chip-row" role="tablist" aria-label="Submission archive filter" data-testid="submissions-archive-tabs" style="margin-bottom:0.75rem">'
+    echo '<div class="page-section" style="padding-bottom:0">'
+        . '<div class="chip-row" role="tablist" aria-label="Submission archive filter" data-testid="submissions-archive-tabs" style="margin-bottom:0">'
         . '<a class="chip" data-active="' . $currentActive . '" data-testid="filter-chip-submissions-current" role="tab" aria-selected="' . $currentActive . '" href="index.php?p=admin&amp;c=bans&amp;section=submissions" title="Show current submissions">Current</a>'
         . '<a class="chip" data-active="' . $archiveActive . '" data-testid="filter-chip-submissions-archive" role="tab" aria-selected="' . $archiveActive . '" href="index.php?p=admin&amp;c=bans&amp;section=submissions&amp;view=archive" title="Show the submission archive">Archive</a>'
-        . '</div>';
+        . '</div></div>';
 
     if ($submissionView === 'current') {
         $ItemsPerPage = SB_BANS_PER_PAGE;
@@ -982,7 +904,6 @@ if ($section === 'submissions') {
             submission_list_archiv: $submission_list_archiv,
         ));
     }
-    echo '</div></div><!-- /.admin-sidebar-content + /.admin-sidebar-shell -->';
     return;
 }
 
@@ -990,14 +911,12 @@ if ($section === 'submissions') {
 if ($section === 'import') {
     if (!$canImport) {
         echo '<div class="card"><div class="card__body"><p class="text-muted m-0">Access denied.</p></div></div>';
-        echo '</div></div><!-- /.admin-sidebar-content + /.admin-sidebar-shell -->';
         return;
     }
     \Sbpp\View\Renderer::render($theme, new \Sbpp\View\AdminBansImportView(
         permission_import: true,
         extreq: ini_get('safe_mode') != 1,
     ));
-    echo '</div></div><!-- /.admin-sidebar-content + /.admin-sidebar-shell -->';
     return;
 }
 
@@ -1015,7 +934,6 @@ if (!$canGroupBan) {
     echo '<div class="card"><div class="card__body"><p class="text-muted m-0">'
         . (!$canAddBan ? 'Access denied.' : 'Group banning is disabled in <strong>config.enablegroupbanning</strong>.')
         . '</p></div></div>';
-    echo '</div></div><!-- /.admin-sidebar-content + /.admin-sidebar-shell -->';
     return;
 }
 \Sbpp\View\Renderer::render($theme, new \Sbpp\View\AdminBansGroupsView(
@@ -1254,7 +1172,6 @@ echo <<<'JS'
 })();
 </script>
 JS;
-echo '</div></div><!-- /.admin-sidebar-content + /.admin-sidebar-shell -->';
 
 /*
  * Comment-thread builder used by both protests + submissions sections.

--- a/web/pages/admin.groups.php
+++ b/web/pages/admin.groups.php
@@ -10,38 +10,19 @@ if (!defined("IN_SB")) {
 global $userbank, $theme;
 
 /*
- * Section routing (#1239 — Pattern A, settings-page shape).
+ * Section routing (#1239 — Pattern A). Read `?section=list|add`,
+ * render one View per request. Section chrome lives in the main
+ * sidebar accordion (`AdminNavCatalog` + `core/navbar.tpl`, #1490).
  *
- * Mirrors `admin.servers.php`: read `?section=list|add`, render one
- * View per request. #1259 unified the chrome on the Settings-style
- * vertical sidebar (`core/admin_sidebar.tpl`).
- *
- * Note: legacy callers reach this page with `?gid=<n>` to focus the
- * master-detail editor on a specific group; that's a *list* concern,
+ * Legacy callers reach this page with `?gid=<n>` to focus the
+ * master-detail editor on a specific group; that's a list concern,
  * so it always lands on the list section.
  */
 $canList = $userbank->HasAccess(WebPermission::mask(WebPermission::Owner, WebPermission::ListGroups));
 $canAdd  = $userbank->HasAccess(WebPermission::mask(WebPermission::Owner, WebPermission::AddGroup));
 
-/** @var list<array{slug: string, name: string, permission: int, url: string, icon: string}> $sections */
-$sections = [
-    [
-        'slug'       => 'list',
-        'name'       => 'List groups',
-        'permission' => ADMIN_OWNER | ADMIN_LIST_GROUPS,
-        'url'        => 'index.php?p=admin&c=groups&section=list',
-        'icon'       => 'users',
-    ],
-    [
-        'slug'       => 'add',
-        'name'       => 'Add a group',
-        'permission' => ADMIN_OWNER | ADMIN_ADD_GROUP,
-        'url'        => 'index.php?p=admin&c=groups&section=add',
-        'icon'       => 'plus',
-    ],
-];
-
-$validSlugs = ['list', 'add'];
+$sections = \Sbpp\View\AdminNavCatalog::sectionsFor('groups');
+$validSlugs = array_column($sections, 'slug');
 $section    = (string) ($_GET['section'] ?? '');
 if (!in_array($section, $validSlugs, true)) {
     if ($canList) {
@@ -53,18 +34,10 @@ if (!in_array($section, $validSlugs, true)) {
     }
 }
 
-// AdminTabs opens the sidebar shell + emits the <aside> + opens the
-// content column. Closing tags live at the bottom of this file. The
-// PHP block here is followed by a `<script>` HTML island in the
-// default theme — the closing divs are emitted via PHP `echo` BEFORE
-// the file's closing PHP delimiter so the markup nests correctly.
-new AdminTabs($sections, $userbank, $theme, $section, 'Group sections');
-
 if ($section === 'add') {
     \Sbpp\View\Renderer::render($theme, new \Sbpp\View\AdminGroupsAddView(
         permission_addgroup: $canAdd,
     ));
-    echo '</div></div><!-- /.admin-sidebar-content + /.admin-sidebar-shell — opened by new AdminTabs(...) above -->';
     return;
 }
 
@@ -277,7 +250,6 @@ if (!empty($web_group_list)) {
     selected_group:           $selected_group,
 ));
 
-echo '</div></div><!-- /.admin-sidebar-content + /.admin-sidebar-shell — opened by new AdminTabs(...) above -->';
 ?>
 <script>
 // sb.accordion (sb.js) is the actual implementation, so call it directly.

--- a/web/pages/admin.mods.php
+++ b/web/pages/admin.mods.php
@@ -10,37 +10,15 @@ if (!defined("IN_SB")) {
 global $userbank, $theme;
 
 /*
- * Section routing (#1239 — Pattern A, settings-page shape).
- *
- * Mirrors `admin.servers.php`: read `?section=list|add`, render one
- * View per request. #1259 unified the chrome on the Settings-style
- * vertical sidebar (`core/admin_sidebar.tpl`), so the page handler
- * just builds `$sections` (with an `icon` per row for the Lucide
- * glyph) and lets `AdminTabs.php` open the shell + render the
- * <aside> + open the content column.
+ * Section routing (#1239 — Pattern A). Read `?section=list|add`,
+ * render one View per request. Section chrome lives in the main
+ * sidebar accordion (`AdminNavCatalog` + `core/navbar.tpl`, #1490).
  */
 $canList = $userbank->HasAccess(WebPermission::mask(WebPermission::Owner, WebPermission::ListMods));
 $canAdd  = $userbank->HasAccess(WebPermission::mask(WebPermission::Owner, WebPermission::AddMods));
 
-/** @var list<array{slug: string, name: string, permission: int, url: string, icon: string}> $sections */
-$sections = [
-    [
-        'slug'       => 'list',
-        'name'       => 'List MODs',
-        'permission' => ADMIN_OWNER | ADMIN_LIST_MODS,
-        'url'        => 'index.php?p=admin&c=mods&section=list',
-        'icon'       => 'puzzle',
-    ],
-    [
-        'slug'       => 'add',
-        'name'       => 'Add new MOD',
-        'permission' => ADMIN_OWNER | ADMIN_ADD_MODS,
-        'url'        => 'index.php?p=admin&c=mods&section=add',
-        'icon'       => 'plus',
-    ],
-];
-
-$validSlugs = ['list', 'add'];
+$sections = \Sbpp\View\AdminNavCatalog::sectionsFor('mods');
+$validSlugs = array_column($sections, 'slug');
 $section    = (string) ($_GET['section'] ?? '');
 if (!in_array($section, $validSlugs, true)) {
     if ($canList) {
@@ -52,15 +30,10 @@ if (!in_array($section, $validSlugs, true)) {
     }
 }
 
-// AdminTabs opens the sidebar shell + emits the <aside> + opens the
-// content column. Closing tags live at the bottom of this file.
-new AdminTabs($sections, $userbank, $theme, $section, 'MOD sections');
-
 if ($section === 'add') {
     \Sbpp\View\Renderer::render($theme, new \Sbpp\View\AdminModsAddView(
         permission_add: $canAdd,
     ));
-    echo '</div></div><!-- /.admin-sidebar-content + /.admin-sidebar-shell — opened by new AdminTabs(...) above -->';
     return;
 }
 
@@ -75,4 +48,3 @@ $mod_count = (int) $GLOBALS['PDO']->query("SELECT COUNT(mid) AS cnt FROM `:prefi
     mod_list:              $mod_list,
 ));
 
-echo '</div></div><!-- /.admin-sidebar-content + /.admin-sidebar-shell — opened by new AdminTabs(...) above -->';

--- a/web/pages/admin.servers.php
+++ b/web/pages/admin.servers.php
@@ -6,48 +6,16 @@ if (!defined("IN_SB")) {
 global $userbank, $theme;
 
 /*
- * Section routing (#1239 — Pattern A, settings-page shape).
- *
- * Each section is its own page request keyed on `?section=list|add`;
- * the sub-nav (vertical sidebar since #1259 — see AGENTS.md
- * "Sub-paged admin routes") carries `aria-current="page"` on the
- * active link. Pre-#1239 the page emitted a broken
- * `<button onclick="openTab(...)">` strip (the JS handler was deleted
- * with sourcebans.js at #1123 D1) and rendered BOTH panes back-to-back
- * below it, so the tab strip lied about being a tab control. #1239
- * routed each section to its own URL and #1259 unified the chrome on
- * the Settings-style vertical sidebar.
- *
- * `icon` keys feed the Lucide glyph in `core/admin_sidebar.tpl`; the
- * vocabulary mirrors `page_admin_settings_*.tpl` ("server" for the
- * list, "plus" for the add form).
+ * Section routing (#1239 — Pattern A). Each section is its own page
+ * request keyed on `?section=list|add`. Section chrome lives in the
+ * main sidebar accordion (`AdminNavCatalog` + `core/navbar.tpl`,
+ * #1490). See AGENTS.md "Sub-paged admin routes".
  */
 $canList = $userbank->HasAccess(WebPermission::mask(WebPermission::Owner, WebPermission::ListServers));
 $canAdd  = $userbank->HasAccess(WebPermission::mask(WebPermission::Owner, WebPermission::AddServer));
 
-/** @var list<array{slug: string, name: string, permission: int, url: string, icon: string}> $sections */
-$sections = [
-    [
-        'slug'       => 'list',
-        'name'       => 'List servers',
-        'permission' => ADMIN_OWNER | ADMIN_LIST_SERVERS,
-        'url'        => 'index.php?p=admin&c=servers&section=list',
-        'icon'       => 'server',
-    ],
-    [
-        'slug'       => 'add',
-        'name'       => 'Add new server',
-        'permission' => ADMIN_OWNER | ADMIN_ADD_SERVER,
-        'url'        => 'index.php?p=admin&c=servers&section=add',
-        'icon'       => 'plus',
-    ],
-];
-
-// Default to the first accessible section so the page doesn't render
-// a blank body when the URL omits ?section= or carries an unknown
-// value. List > Add for users who have both, falling back to whichever
-// permission they hold otherwise.
-$validSlugs = ['list', 'add'];
+$sections = \Sbpp\View\AdminNavCatalog::sectionsFor('servers');
+$validSlugs = array_column($sections, 'slug');
 $section    = (string) ($_GET['section'] ?? '');
 if (!in_array($section, $validSlugs, true)) {
     if ($canList) {
@@ -58,11 +26,6 @@ if (!in_array($section, $validSlugs, true)) {
         $section = 'list';
     }
 }
-
-// AdminTabs opens the sidebar shell + emits the <aside> + opens the
-// content column. Closing tags live at the bottom of this file —
-// document the pairing so future edits don't strand an open <div>.
-new AdminTabs($sections, $userbank, $theme, $section, 'Server sections');
 
 if ($section === 'add') {
     // List mods (drives the mod <select> in the add form).
@@ -81,7 +44,6 @@ if ($section === 'add') {
         grouplist: $grouplist,
         submit_text: 'Add Server',
     ));
-    echo '</div></div><!-- /.admin-sidebar-content + /.admin-sidebar-shell — opened by new AdminTabs(...) above -->';
     return;
 }
 
@@ -129,4 +91,3 @@ foreach ($servers as &$server) {
     server_list: $servers,
 ));
 
-echo '</div></div><!-- /.admin-sidebar-content + /.admin-sidebar-shell — opened by new AdminTabs(...) above -->';

--- a/web/pages/admin.settings.php
+++ b/web/pages/admin.settings.php
@@ -21,67 +21,17 @@ use Sbpp\View\Renderer;
  * Section routing (B18 redesign).
  *
  * Each section is its own page request keyed on
- * `?section=settings|features|logs|themes`; the sub-nav (vertical
- * sidebar since #1259 — see AGENTS.md "Sub-paged admin routes")
- * carries `aria-current="page"` on the active link. CSRF is enforced
- * globally by `route()` in includes/page-builder.php.
- *
- * #1239 brought the rest of the admin family onto this same shape —
- * servers / mods / groups now route via `?section=…` too.
- * #1259 unified the chrome on the Settings-style vertical sidebar
- * (`core/admin_sidebar.tpl` driven by `web/includes/View/AdminTabs.php`),
- * replacing the Settings-only inline `<nav>` block that lived in
- * every page_admin_settings_*.tpl. See AGENTS.md "Sub-paged admin
- * routes" for the convention; this file remains the long-standing
- * reference.
+ * `?section=settings|features|logs|themes`. CSRF is enforced
+ * globally by `route()` in includes/page-builder.php. Section
+ * chrome lives in the main sidebar accordion (`AdminNavCatalog`
+ * + `core/navbar.tpl`, #1490). See AGENTS.md "Sub-paged admin
+ * routes".
  */
 $validSections = ['settings', 'features', 'logs', 'themes'];
 $section = (string)($_GET['section'] ?? 'settings');
 if (!in_array($section, $validSections, true)) {
     $section = 'settings';
 }
-
-/*
- * Sidebar sections.
- *
- * Every entry is gated behind ADMIN_OWNER|ADMIN_WEB_SETTINGS — the
- * Settings page itself requires the flag, so the gate per row mirrors
- * what the dispatcher would render anyway. `icon` keys feed the
- * Lucide glyph in `core/admin_sidebar.tpl`; the vocabulary mirrors
- * what the inline pre-#1259 templates declared (settings / toggle-
- * right / scroll-text / palette).
- */
-/** @var list<array{slug: string, name: string, permission: int, url: string, icon: string}> $sections */
-$sections = [
-    [
-        'slug'       => 'settings',
-        'name'       => 'Main',
-        'permission' => ADMIN_OWNER | ADMIN_WEB_SETTINGS,
-        'url'        => 'index.php?p=admin&c=settings&section=settings',
-        'icon'       => 'settings',
-    ],
-    [
-        'slug'       => 'features',
-        'name'       => 'Features',
-        'permission' => ADMIN_OWNER | ADMIN_WEB_SETTINGS,
-        'url'        => 'index.php?p=admin&c=settings&section=features',
-        'icon'       => 'toggle-right',
-    ],
-    [
-        'slug'       => 'logs',
-        'name'       => 'System Log',
-        'permission' => ADMIN_OWNER | ADMIN_WEB_SETTINGS,
-        'url'        => 'index.php?p=admin&c=settings&section=logs',
-        'icon'       => 'scroll-text',
-    ],
-    [
-        'slug'       => 'themes',
-        'name'       => 'Themes',
-        'permission' => ADMIN_OWNER | ADMIN_WEB_SETTINGS,
-        'url'        => 'index.php?p=admin&c=settings&section=themes',
-        'icon'       => 'palette',
-    ],
-];
 
 if (isset($_GET['log_clear']) && $_GET['log_clear'] === 'true') {
     if ($userbank->HasAccess(WebPermission::Owner)) {
@@ -331,14 +281,6 @@ $currentScreenshotImg = '<img width="250px" height="170px" src="' . htmlspecialc
  */
 $perms = Perms::for($userbank);
 
-/*
- * Open the sidebar shell (#1259). AdminTabs emits the outer
- * `<div class="admin-sidebar-shell">` + the <aside> + the opening
- * `<div class="admin-sidebar-content">`. Closing tags live near the
- * bottom of this file — search for "/.admin-sidebar-shell".
- */
-new AdminTabs($sections, $userbank, $theme, $section, 'Settings sections');
-
 if ($section === 'themes') {
     Renderer::render($theme, new AdminThemesView(
         can_web_settings:  $perms['can_web_settings'],
@@ -519,15 +461,6 @@ if ($section === 'themes') {
         admin_email:                 (string) ($userbank->GetProperty('email') ?? ''),
     ));
 }
-
-/*
- * Close the sidebar shell (#1259) — paired with the `new AdminTabs(...)`
- * call above. The `<div class="admin-sidebar-content">` and outer
- * `<div class="admin-sidebar-shell">` were both opened by AdminTabs;
- * the post-save flash <script> below sits OUTSIDE the shell so it
- * never lands inside the content column.
- */
-echo '</div></div><!-- /.admin-sidebar-content + /.admin-sidebar-shell — opened by new AdminTabs(...) above -->';
 
 /*
  * Post-save flash + bounce.

--- a/web/pages/core/navbar.php
+++ b/web/pages/core/navbar.php
@@ -1,6 +1,8 @@
 <?php
 global $userbank, $theme;
 
+use Sbpp\View\AdminNavCatalog;
+
 $navbar = [
      [
         'title' => 'Dashboard',
@@ -113,12 +115,39 @@ foreach ($navbar as $key => $tab) {
 
 if ($userbank->is_admin()) {
     $cat = $_GET['c'] ?? null;
+    $section = (string) ($_GET['section'] ?? '');
     foreach ($admin as $key => $tab) {
-        $admin[$key]['state'] = ($cat === $tab['endpoint']) ? 'active' : '';
-
         if (!$userbank->HasAccess($tab['permission'])) {
             unset($admin[$key]);
+            continue;
         }
+
+        $isCategoryActive = ($cat === $tab['endpoint']);
+        $children = AdminNavCatalog::filterForUser(
+            AdminNavCatalog::sectionsFor($tab['endpoint']),
+            $userbank,
+        );
+
+        $childRows = [];
+        foreach ($children as $idx => $child) {
+            $childActive = $isCategoryActive && (
+                $section === $child['slug']
+                || ($section === '' && $idx === 0)
+            );
+            $childRows[] = [
+                'slug'  => $child['slug'],
+                'name'  => $child['name'],
+                'url'   => $child['url'],
+                'icon'  => $child['icon'] ?? 'circle-dot',
+                'state' => $childActive ? 'active' : '',
+            ];
+        }
+
+        $admin[$key]['children'] = $childRows;
+        $admin[$key]['open'] = $isCategoryActive;
+        // Category row itself is never aria-current when children exist;
+        // the matching child leaf owns the active state (#1233 / #1490).
+        $admin[$key]['state'] = ($isCategoryActive && $childRows === []) ? 'active' : '';
     }
 }
 

--- a/web/tests/e2e/fixtures/sidebar.ts
+++ b/web/tests/e2e/fixtures/sidebar.ts
@@ -1,0 +1,25 @@
+import { expect, type Page } from '@playwright/test';
+
+/**
+ * Open the main sidebar drawer on mobile viewports.
+ *
+ * On mobile-chromium the `<aside id="sidebar">` is off-canvas until
+ * the topbar hamburger (`[data-mobile-menu]`) flips
+ * `data-mobile-open="true"`. Section accordion links (#1490) live
+ * inside that aside, so visibility / click assertions must open the
+ * drawer first.
+ */
+export async function openMobileSidebar(page: Page): Promise<void> {
+    const sidebar = page.locator('#sidebar');
+    const open = await sidebar.getAttribute('data-mobile-open');
+    if (open === 'true') {
+        await expect(sidebar).toBeVisible();
+        return;
+    }
+
+    const hamburger = page.locator('[data-mobile-menu]');
+    await expect(hamburger).toBeVisible();
+    await hamburger.click();
+    await expect(sidebar).toHaveAttribute('data-mobile-open', 'true');
+    await expect(sidebar).toBeVisible();
+}

--- a/web/tests/e2e/pages/admin/AdminAdmins.ts
+++ b/web/tests/e2e/pages/admin/AdminAdmins.ts
@@ -18,10 +18,10 @@ import { BasePage } from '../_base.ts';
  * collapsed the page onto Pattern A: each section is its own URL
  * (`?section=admins`, `?section=add-admin`, `?section=overrides`),
  * so `tocLink()` / `section()` now both pivot on the standard
- * Pattern A `data-testid="admin-tab-<slug>"` hook. The
- * `data-testid="admin-admins-section-<slug>"` wrappers stay on the
- * rendered section body so cross-section assertions (e.g. "the
- * search form is inside the admins section") still work.
+ * main-sidebar accordion hook `data-testid="nav-admin-admins-<slug>"`
+ * (#1490). The `data-testid="admin-admins-section-<slug>"` wrappers
+ * stay on the rendered section body so cross-section assertions
+ * (e.g. "the search form is inside the admins section") still work.
  */
 export class AdminAdminsPage extends BasePage {
     constructor(page: Page) {
@@ -34,19 +34,19 @@ export class AdminAdminsPage extends BasePage {
         return this.page.locator('[data-testid="admin-count"]');
     }
 
-    /** Pattern A — outer page wrapper (now the admin sidebar shell). */
+    /** Main sidebar accordion for the Admins category (#1490). */
     get shell(): Locator {
-        return this.page.locator('[data-testid="admin-sidebar-shell"]');
+        return this.page.locator('[data-testid="nav-admin-admins-accordion"]');
     }
 
-    /** Pattern A — the vertical sidebar (replaces the page-level ToC). */
+    /** Alias for the Admins category accordion. */
     get toc(): Locator {
-        return this.page.locator('[data-testid="admin-sidebar"]');
+        return this.page.locator('[data-testid="nav-admin-admins-accordion"]');
     }
 
-    /** Pattern A — single sidebar link by section slug. */
+    /** Nested section link inside the main sidebar accordion. */
     tocLink(section: 'admins' | 'add-admin' | 'overrides'): Locator {
-        return this.page.locator(`[data-testid="admin-tab-${section}"]`);
+        return this.page.locator(`[data-testid="nav-admin-admins-${section}"]`);
     }
 
     /**

--- a/web/tests/e2e/pages/admin/AdminSettings.ts
+++ b/web/tests/e2e/pages/admin/AdminSettings.ts
@@ -7,11 +7,10 @@ import { BasePage } from '../_base.ts';
  *
  * Pair: `web/pages/admin.settings.php` -> Sbpp\View\AdminSettingsView
  * + `page_admin_settings_settings.tpl` (default `?section=settings`).
- * #1259 unified the sidebar chrome on `core/admin_sidebar.tpl` so the
- * Settings page now exposes its sub-nav under the same testid shape
- * every Pattern A admin route uses (`admin-tab-<slug>`); the sidebar
- * itself sits outside the `$can_web_settings` gate, so this selector
- * remains valid even on the access-denied fallback.
+ * Section chrome lives in the main sidebar accordion (#1490). The
+ * mount marker is content-area (`settings-save`) so smoke specs stay
+ * valid on mobile where `#sidebar` is off-canvas until the hamburger
+ * opens it.
  */
 export class AdminSettingsPage extends BasePage {
     constructor(page: Page) {
@@ -21,7 +20,7 @@ export class AdminSettingsPage extends BasePage {
     readonly path = '/index.php?p=admin&c=settings';
 
     get pageMounted(): Locator {
-        return this.page.locator('[data-testid="nav-admin-settings-settings"]');
+        return this.page.locator('[data-testid="settings-save"]');
     }
 
     async goto(): Promise<void> {

--- a/web/tests/e2e/pages/admin/AdminSettings.ts
+++ b/web/tests/e2e/pages/admin/AdminSettings.ts
@@ -21,7 +21,7 @@ export class AdminSettingsPage extends BasePage {
     readonly path = '/index.php?p=admin&c=settings';
 
     get pageMounted(): Locator {
-        return this.page.locator('[data-testid="admin-tab-settings"]');
+        return this.page.locator('[data-testid="nav-admin-settings-settings"]');
     }
 
     async goto(): Promise<void> {

--- a/web/tests/e2e/specs/flows/admin-admins-density.spec.ts
+++ b/web/tests/e2e/specs/flows/admin-admins-density.spec.ts
@@ -196,20 +196,18 @@ test.describe('flow: admin/admins density rework (#1207 ADM-3, ADM-4 / #1275)', 
         await expect(p.searchInput('name')).toHaveValue('');
     });
 
-    // ----- ADM-3 (#1275) — Add admin CTA navigates to its section -----
+    // ----- ADM-3 (#1490) — Add admin lives in the main sidebar accordion -----
 
-    test('ADM-3: header "Add admin" CTA navigates to the add-admin section', async ({ page }, testInfo) => {
-        test.skip(testInfo.project.name !== 'chromium', 'In-page CTA is project-agnostic; pinning to desktop for runtime.');
+    test('ADM-3: sidebar "Add admin" link navigates to the add-admin section', async ({ page }, testInfo) => {
+        test.skip(testInfo.project.name !== 'chromium', 'Sidebar accordion is project-agnostic; pinning to desktop for runtime.');
 
         const p = new AdminAdminsPage(page);
         await p.goto();
 
-        const cta = page.locator('[data-testid="admin-add-cta"]');
-        await expect(cta).toBeVisible();
-        // Pre-#1275 this was `#add-admin` (anchor scroll within the
-        // long-scroll page); now it's a Pattern A URL.
-        await expect(cta).toHaveAttribute('href', /section=add-admin/);
-        await cta.click();
+        const link = p.tocLink('add-admin');
+        await expect(link).toBeVisible();
+        await expect(link).toHaveAttribute('href', /section=add-admin/);
+        await link.click();
 
         await expect(page).toHaveURL(/section=add-admin/);
         await expect(p.tocLink('add-admin')).toHaveAttribute('aria-current', 'page');

--- a/web/tests/e2e/specs/flows/admin-admins-density.spec.ts
+++ b/web/tests/e2e/specs/flows/admin-admins-density.spec.ts
@@ -33,6 +33,7 @@
  */
 
 import { expect, test } from '../../fixtures/auth.ts';
+import { openMobileSidebar } from '../../fixtures/sidebar.ts';
 import { AdminAdminsPage } from '../../pages/admin/AdminAdmins.ts';
 
 test.describe('flow: admin/admins density rework (#1207 ADM-3, ADM-4 / #1275)', () => {
@@ -78,16 +79,15 @@ test.describe('flow: admin/admins density rework (#1207 ADM-3, ADM-4 / #1275)', 
         const p = new AdminAdminsPage(page);
         await p.goto();
         await expect(p.pageMounted).toBeVisible();
+
+        // Accordion links live in `#sidebar`, off-canvas until the
+        // hamburger opens the drawer (#1490).
+        await openMobileSidebar(page);
         await expect(p.toc).toBeVisible();
 
-        // The mobile chrome is `<details open>` so the link list is
-        // visible without an extra tap. The summary contains the
-        // configured sidebar label ("Admin sections" — assigned by
-        // admin.admins.php's `new AdminTabs(...)` call).
-        const summary = p.toc.locator('summary');
+        const summary = page.locator('[data-testid="nav-admin-admins"]');
         await expect(summary).toBeVisible();
 
-        // Tap "Add admin" — page navigates to its dedicated URL.
         await p.tocLink('add-admin').click();
         await expect(page).toHaveURL(/section=add-admin(?:&|$)/);
         await expect(p.tocLink('add-admin')).toHaveAttribute('aria-current', 'page');

--- a/web/tests/e2e/specs/responsive/admin-tabs.spec.ts
+++ b/web/tests/e2e/specs/responsive/admin-tabs.spec.ts
@@ -12,10 +12,13 @@
  *   - Active leaf carries `aria-current="page"`
  *   - Feature-gated bans sections stay omitted when toggles are off
  *
- * Project gating: mobile-chromium only (accordion toggle chrome).
+ * Project gating: mobile-chromium only. Accordion links live inside
+ * `#sidebar`, which is off-canvas until the hamburger opens it — every
+ * test calls `openMobileSidebar` after navigation.
  */
 
 import { expect, test } from '../../fixtures/auth.ts';
+import { openMobileSidebar } from '../../fixtures/sidebar.ts';
 
 test.describe('responsive: admin sidebar accordion', () => {
     test.beforeEach(({}, testInfo) => {
@@ -27,6 +30,7 @@ test.describe('responsive: admin sidebar accordion', () => {
 
     test('admin-servers accordion renders nested section links at iPhone-13 width', async ({ page }) => {
         await page.goto('/index.php?p=admin&c=servers');
+        await openMobileSidebar(page);
 
         const accordion = page.locator('[data-testid="nav-admin-servers-accordion"]');
         await expect(accordion).toBeVisible();
@@ -56,6 +60,7 @@ test.describe('responsive: admin sidebar accordion', () => {
 
     test('admin-servers accordion can be toggled closed at iPhone-13 width', async ({ page }) => {
         await page.goto('/index.php?p=admin&c=servers');
+        await openMobileSidebar(page);
 
         const details = page.locator('[data-testid="nav-admin-servers-accordion"]');
         const summary = page.locator('[data-testid="nav-admin-servers"]');
@@ -78,6 +83,8 @@ test.describe('responsive: admin sidebar accordion', () => {
         page: import('@playwright/test').Page,
         theme: 'light' | 'dark',
     ): Promise<void> {
+        await openMobileSidebar(page);
+
         const activeLink = page.locator(
             '[data-testid="nav-admin-servers-accordion"] [aria-current="page"]',
         ).first();
@@ -134,6 +141,7 @@ test.describe('responsive: admin sidebar accordion', () => {
     for (const spec of patternARoutes) {
         test(`admin-${spec.route} accordion renders all sections at iPhone-13 width`, async ({ page }) => {
             await page.goto(`/index.php?p=admin&c=${spec.route}`);
+            await openMobileSidebar(page);
 
             const accordion = page.locator(`[data-testid="nav-admin-${spec.route}-accordion"]`);
             await expect(accordion).toBeVisible();
@@ -150,6 +158,7 @@ test.describe('responsive: admin sidebar accordion', () => {
 
         test(`admin-${spec.route} accordion navigates between sections without scrolling`, async ({ page }) => {
             await page.goto(`/index.php?p=admin&c=${spec.route}`);
+            await openMobileSidebar(page);
 
             const targetSlug = spec.slugs.find((s) => s !== spec.active) ?? spec.slugs[1];
             const link = page.locator(`[data-testid="nav-admin-${spec.route}-${targetSlug}"]`);
@@ -157,6 +166,8 @@ test.describe('responsive: admin sidebar accordion', () => {
             await link.click();
 
             await expect(page).toHaveURL(new RegExp(`section=${targetSlug.replace(/-/g, '\\-')}`));
+            // Post-nav the drawer may close; aria-current is on the
+            // attached leaf regardless of off-canvas visibility.
             await expect(page.locator(`[data-testid="nav-admin-${spec.route}-${targetSlug}"]`))
                 .toHaveAttribute('aria-current', 'page');
         });
@@ -164,6 +175,7 @@ test.describe('responsive: admin sidebar accordion', () => {
 
     test('admin-bans group-ban tab is omitted when config.enablegroupbanning is off', async ({ page }) => {
         await page.goto('/index.php?p=admin&c=bans');
+        await openMobileSidebar(page);
 
         const accordion = page.locator('[data-testid="nav-admin-bans-accordion"]');
         await expect(accordion).toBeVisible();

--- a/web/tests/e2e/specs/responsive/admin-tabs.spec.ts
+++ b/web/tests/e2e/specs/responsive/admin-tabs.spec.ts
@@ -1,69 +1,23 @@
 /**
- * Responsive: admin sub-section sidebar (#1259, replacing the
- * horizontal strip contract from #1207 ADM-8 / #1239; #1275 brought
- * admin-admins and admin-bans onto the same shape).
+ * Responsive: admin section accordion in the main sidebar (#1490).
  *
- * iPhone-13 viewport contract for every Pattern A admin page
- * (servers / mods / groups / settings / admins / bans — every page
- * that subdivides its chrome via `?section=…` URLs):
+ * Pre-#1490 Pattern A pages mounted a second rail
+ * (`core/admin_sidebar.tpl` via AdminTabs). That double menu wasted
+ * content width. Section links now nest under each admin category in
+ * the main sidebar as a `<details class="sidebar__accordion">`.
  *
- *   - Pre-#1259 these routes rendered a horizontal `core/admin_tabs.tpl`
- *     pill strip (servers / mods / groups) AND a separate inline
- *     14rem `<nav>` block for settings. Two patterns, same routing
- *     shape, completely different chrome. #1259 unifies them on the
- *     Settings-style vertical sidebar partial `core/admin_sidebar.tpl`,
- *     mounted by `AdminTabs.php` whenever `$tabs` is non-empty.
- *   - Pre-#1275 admin-admins and admin-bans rode a parallel "Pattern B"
- *     page-level ToC (`page_toc.tpl`) that emitted `#fragment` URLs
- *     and scrolled within a single long-scroll DOM. #1275 collapsed
- *     them onto the same `?section=…` shape so the URL is the
- *     **only** sub-route nav contract on the panel.
- *   - At <=1024px the sidebar collapses to a `<details open>`
- *     accordion. The summary chrome carries a chevron that rotates
- *     180° on toggle.
- *   - At >=1024px the sidebar floats next to the content column as
- *     a sticky 14rem rail (`grid-template-columns: 14rem 1fr`).
- *     This file's project-gating is mobile-only — the desktop
- *     shape is exercised by the screenshot gallery and ad-hoc
- *     `chromium` runs of these specs.
- *   - The active link still carries `aria-current="page"` and
- *     reuses the shared `.sidebar__link[aria-current="page"]` rule
- *     — dark-pill in light theme, brand-orange in dark — so the
- *     highlight is single-source with the main app shell.
+ * Contract:
+ *   - Category with children → accordion open when `?c=` matches
+ *   - Leaf links: `data-testid="nav-admin-<endpoint>-<slug>"`
+ *   - Active leaf carries `aria-current="page"`
+ *   - Feature-gated bans sections stay omitted when toggles are off
  *
- * Markup contract (`core/admin_sidebar.tpl`, mounted by
- * `AdminTabs.php` when `$tabs !== []`):
- *
- *   <div class="admin-sidebar-shell" data-testid="admin-sidebar-shell">
- *     <aside class="admin-sidebar"
- *            data-testid="admin-sidebar"
- *            aria-label="<sidebar label>">
- *       <details class="admin-sidebar__details" open>
- *         <summary class="admin-sidebar__summary">…</summary>
- *         <nav class="admin-sidebar__nav">
- *           <a class="sidebar__link admin-sidebar__link"
- *              href="?p=admin&c=…&section=…"
- *              data-testid="admin-tab-<slug>"
- *              [aria-current="page" if active]>…</a>
- *           …
- *         </nav>
- *       </details>
- *     </aside>
- *     <div class="admin-sidebar-content">
- *       <!-- page View(s) render here -->
- *     </div>
- *   </div>
- *
- * The per-link `data-testid="admin-tab-<slug>"` matches the legacy
- * `core/admin_tabs.tpl` strip's hook so any spec that anchored on
- * `admin-tab-<slug>` keeps working.
- *
- * Project gating: mobile-chromium only.
+ * Project gating: mobile-chromium only (accordion toggle chrome).
  */
 
 import { expect, test } from '../../fixtures/auth.ts';
 
-test.describe('responsive: admin sub-section sidebar', () => {
+test.describe('responsive: admin sidebar accordion', () => {
     test.beforeEach(({}, testInfo) => {
         test.skip(
             testInfo.project.name !== 'mobile-chromium',
@@ -71,116 +25,61 @@ test.describe('responsive: admin sub-section sidebar', () => {
         );
     });
 
-    test('admin-servers sidebar renders as an accordion at iPhone-13 width', async ({ page }) => {
-        // `?p=admin&c=servers` is the canonical Pattern A page after
-        // #1239 (#1259 lifted the strip onto the sidebar partial) —
-        // two sections ("List servers", "Add new server") wired
-        // through `?section=list|add`.
+    test('admin-servers accordion renders nested section links at iPhone-13 width', async ({ page }) => {
         await page.goto('/index.php?p=admin&c=servers');
 
-        // The shell is the grid host; at <1024px it collapses to a
-        // single column so the sidebar paints inline above the
-        // content column.
-        const shell = page.locator('[data-testid="admin-sidebar-shell"]');
-        await expect(shell).toBeVisible();
+        const accordion = page.locator('[data-testid="nav-admin-servers-accordion"]');
+        await expect(accordion).toBeVisible();
+        await expect(accordion).toHaveAttribute('open', '');
 
-        const sidebar = page.locator('[data-testid="admin-sidebar"]');
-        await expect(sidebar).toBeVisible();
-
-        // Sections rendered for an OWNER user (the seeded admin/admin
-        // holds OWNER, so every permission-gated section is visible).
         const tabSlugs = ['list', 'add'];
         for (const slug of tabSlugs) {
-            const tab = sidebar.locator(`[data-testid="admin-tab-${slug}"]`);
+            const tab = page.locator(`[data-testid="nav-admin-servers-${slug}"]`);
             await expect(tab).toBeAttached();
             await expect(tab).toBeVisible();
         }
 
-        // The accordion summary is mobile-only chrome — visible at
-        // <1024px, hidden at desktop.
-        const summary = sidebar.locator('.admin-sidebar__summary');
+        const summary = page.locator('[data-testid="nav-admin-servers"]');
         await expect(summary).toBeVisible();
 
-        // The link list paints as a vertical stack — the second link
-        // sits below the first by at least one row's worth of pixels.
-        // The pre-#1259 shape was a horizontal strip where every link
-        // shared the same y-axis (the failure mode this assertion
-        // guards against).
-        const firstTab = sidebar.locator(`[data-testid="admin-tab-${tabSlugs[0]}"]`);
-        const secondTab = sidebar.locator(`[data-testid="admin-tab-${tabSlugs[1]}"]`);
+        const firstTab = page.locator(`[data-testid="nav-admin-servers-${tabSlugs[0]}"]`);
+        const secondTab = page.locator(`[data-testid="nav-admin-servers-${tabSlugs[1]}"]`);
         const firstBox = await firstTab.boundingBox();
         const secondBox = await secondTab.boundingBox();
         expect(firstBox, `${tabSlugs[0]} tab must render a bounding box`).not.toBeNull();
         expect(secondBox, `${tabSlugs[1]} tab must render a bounding box`).not.toBeNull();
-        // The second link is below the first by at least 16px (one
-        // padded row) and shares the same x-coordinate (vertical
-        // stack). Allow 2px tolerance on x for sub-pixel layout.
         expect(secondBox!.y).toBeGreaterThan(firstBox!.y + 16);
         expect(Math.abs(secondBox!.x - firstBox!.x)).toBeLessThanOrEqual(2);
 
-        // The shell stays inside the viewport — the accordion is a
-        // single column at this width, no horizontal scroll.
-        const vw = page.viewportSize()?.width ?? 0;
-        const shellBox = await shell.boundingBox();
-        expect(shellBox, 'admin-sidebar-shell wrapper must render a bounding box').not.toBeNull();
-        expect(shellBox!.x).toBeGreaterThanOrEqual(-1);
-        expect(shellBox!.x + shellBox!.width).toBeLessThanOrEqual(vw + 1);
+        await expect(page.locator('[data-testid="admin-sidebar-shell"]')).toHaveCount(0);
     });
 
     test('admin-servers accordion can be toggled closed at iPhone-13 width', async ({ page }) => {
-        // The mobile shape is `<details open>` — the link list is
-        // visible by default and the user can collapse it via the
-        // chevron summary. Verify the toggle closes the link list
-        // without breaking the rest of the page.
         await page.goto('/index.php?p=admin&c=servers');
 
-        const sidebar = page.locator('[data-testid="admin-sidebar"]');
-        const details = sidebar.locator('.admin-sidebar__details');
-        const summary = sidebar.locator('.admin-sidebar__summary');
-        const firstLink = sidebar.locator('[data-testid="admin-tab-list"]');
+        const details = page.locator('[data-testid="nav-admin-servers-accordion"]');
+        const summary = page.locator('[data-testid="nav-admin-servers"]');
+        const firstLink = page.locator('[data-testid="nav-admin-servers-list"]');
 
         await expect(details).toHaveAttribute('open', '');
         await expect(firstLink).toBeVisible();
 
         await summary.click();
 
-        // After collapsing, the `open` attribute is removed. The link
-        // list is technically still in the DOM but `<details>` hides
-        // its children so Playwright's visibility check returns false.
         await expect(details).not.toHaveAttribute('open', /.*/);
         await expect(firstLink).toBeHidden();
 
-        // Toggle back open so any subsequent debugging artefacts
-        // (screenshots / traces) capture the default state.
         await summary.click();
         await expect(details).toHaveAttribute('open', '');
         await expect(firstLink).toBeVisible();
     });
 
-    /**
-     * Assert the active sidebar link carries the brand-orange highlight
-     * at the iPhone-13 viewport. Shared between the light and dark
-     * theme tests — the active token differs by theme:
-     *   - light: `var(--zinc-900)` (dark pill on light background)
-     *   - dark:  `var(--brand-700)` (orange pill on dark background)
-     * The R/G/B heuristic below tolerates either: "active link is
-     * highlighted with a saturated colour, not the surrounding text
-     * colour", which is what users see.
-     * @param {import('@playwright/test').Page} page
-     * @param {'light' | 'dark'} theme
-     */
     async function assertActiveLinkIsHighlighted(
         page: import('@playwright/test').Page,
         theme: 'light' | 'dark',
     ): Promise<void> {
-        // Scope by `[data-testid="admin-sidebar"]` (the new wrapper
-        // hook for #1259), then pivot on the ARIA `[aria-current="page"]`
-        // attribute — that's the load-bearing identifier for the
-        // active section. Use `.first()` because the parent app
-        // shell carries its own sidebar with active links too; we
-        // want the admin sub-section sidebar.
         const activeLink = page.locator(
-            '[data-testid="admin-sidebar"] [aria-current="page"]',
+            '[data-testid="nav-admin-servers-accordion"] [aria-current="page"]',
         ).first();
         await expect(activeLink).toBeVisible();
 
@@ -195,16 +94,11 @@ test.describe('responsive: admin sub-section sidebar', () => {
         const b = parseInt(bStr, 10);
 
         if (theme === 'dark') {
-            // Brand orange family in dark: red dominates, blue is small.
             expect(r).toBeGreaterThan(180);
             expect(r).toBeGreaterThan(g);
             expect(r).toBeGreaterThan(b);
             expect(b).toBeLessThan(60);
         } else {
-            // Zinc-900 in light: very dark, all three channels < 60.
-            // The contrast contract is "active is dark on light" — any
-            // saturated dark colour passes. Specifically rgb(24, 24, 27)
-            // for `--zinc-900`, but tolerating drift up to ~60.
             expect(r).toBeLessThan(60);
             expect(g).toBeLessThan(60);
             expect(b).toBeLessThan(60);
@@ -212,25 +106,11 @@ test.describe('responsive: admin sub-section sidebar', () => {
     }
 
     test('active link carries the highlighted background at iPhone-13 width (light)', async ({ page }) => {
-        // The first section ("List servers", slug "list") is the
-        // default-active one when the page lands on
-        // `?p=admin&c=servers` without an explicit `&section=…` —
-        // see admin.servers.php's "first accessible section is
-        // active" fallback. It carries `aria-current="page"` per
-        // admin_sidebar.tpl + AdminTabs.php's `$resolvedActive` path.
         await page.goto('/index.php?p=admin&c=servers');
         await assertActiveLinkIsHighlighted(page, 'light');
     });
 
     test('active link keeps the highlighted background under html.dark', async ({ page }) => {
-        // The dark-theme override
-        // (`html.dark .sidebar__link[aria-current="page"] { background:
-        // var(--brand-700); … }` in theme.css) is the brand-orange
-        // family. Seed the theme preference into localStorage before
-        // the first navigation so theme.js's init-time
-        // `applyTheme(currentTheme())` resolves to `html.dark` on
-        // first paint (no toggle click needed, no race with the
-        // post-paint click handler).
         await page.addInitScript(() => {
             try { localStorage.setItem('sbpp-theme', 'dark'); } catch (e) { /* ignore */ }
         });
@@ -239,28 +119,11 @@ test.describe('responsive: admin sub-section sidebar', () => {
         await assertActiveLinkIsHighlighted(page, 'dark');
     });
 
-    /*
-     * #1275 — admin-admins and admin-bans now ride Pattern A. Cover
-     * each route's sidebar with the same accordion / link-list / active-
-     * link contract the canonical servers test asserts above. The
-     * tests are parametric so adding a new Pattern A admin route is a
-     * single-line entry, not a full spec copy.
-     *
-     * `slugs` lists the entries the AdminTabs sidebar exposes for an
-     * OWNER user against the seeded e2e DB (every permission the
-     * dispatcher will gate on is granted). Feature-flag-gated entries
-     * (e.g. admin-bans's `group-ban`, gated by
-     * `config.enablegroupbanning` which defaults to `'0'`) are NOT in
-     * this list — they're conditionally absent on the default install
-     * and a separate spec below covers the feature-gate contract.
-     */
     /**
      * @typedef {Object} PatternASpec
-     * @property {string} route   — ?p=admin&c=… URL slug
-     * @property {string[]} slugs — `?section=` slugs the sidebar should expose
-     * @property {string} active  — slug expected to carry `aria-current="page"`
-     *                              when the page lands without an explicit
-     *                              `&section=…` (the page-handler default)
+     * @property {string} route
+     * @property {string[]} slugs
+     * @property {string} active
      */
     /** @type {PatternASpec[]} */
     const patternARoutes = [
@@ -269,67 +132,42 @@ test.describe('responsive: admin sub-section sidebar', () => {
     ];
 
     for (const spec of patternARoutes) {
-        test(`admin-${spec.route} sidebar renders all sections at iPhone-13 width`, async ({ page }) => {
+        test(`admin-${spec.route} accordion renders all sections at iPhone-13 width`, async ({ page }) => {
             await page.goto(`/index.php?p=admin&c=${spec.route}`);
 
-            const sidebar = page.locator('[data-testid="admin-sidebar"]');
-            await expect(sidebar).toBeVisible();
+            const accordion = page.locator(`[data-testid="nav-admin-${spec.route}-accordion"]`);
+            await expect(accordion).toBeVisible();
 
             for (const slug of spec.slugs) {
-                const tab = sidebar.locator(`[data-testid="admin-tab-${slug}"]`);
-                await expect(tab, `admin-${spec.route} sidebar must expose ?section=${slug}`).toBeAttached();
+                const tab = page.locator(`[data-testid="nav-admin-${spec.route}-${slug}"]`);
+                await expect(tab, `admin-${spec.route} accordion must expose ?section=${slug}`).toBeAttached();
                 await expect(tab).toBeVisible();
             }
 
-            // The default-active section carries `aria-current="page"`
-            // when the page lands without an explicit `&section=…`.
-            // Pre-#1275 admin-admins and admin-bans had no active
-            // signal at all — the page-level ToC scrolled to whatever
-            // the IntersectionObserver picked up first, which raced
-            // with the initial paint.
-            const activeTab = sidebar.locator(`[data-testid="admin-tab-${spec.active}"]`);
+            const activeTab = page.locator(`[data-testid="nav-admin-${spec.route}-${spec.active}"]`);
             await expect(activeTab).toHaveAttribute('aria-current', 'page');
         });
 
-        test(`admin-${spec.route} sidebar navigates between sections without scrolling`, async ({ page }) => {
-            // Pattern A's contract is "click → new URL → server-rendered
-            // page". Smoke that contract: navigate to a non-default
-            // section and assert the URL changes + the active link
-            // moves. Pre-#1275 admin-admins/admin-bans clicks landed
-            // on a `#fragment` URL and the page didn't reload — same
-            // chrome, completely different mental model.
+        test(`admin-${spec.route} accordion navigates between sections without scrolling`, async ({ page }) => {
             await page.goto(`/index.php?p=admin&c=${spec.route}`);
 
-            // Pick the second non-default section (the first is the
-            // default landing — clicking it would be a no-op for this
-            // contract).
             const targetSlug = spec.slugs.find((s) => s !== spec.active) ?? spec.slugs[1];
-            const sidebar = page.locator('[data-testid="admin-sidebar"]');
-            const link = sidebar.locator(`[data-testid="admin-tab-${targetSlug}"]`);
+            const link = page.locator(`[data-testid="nav-admin-${spec.route}-${targetSlug}"]`);
             await expect(link).toBeVisible();
             await link.click();
 
             await expect(page).toHaveURL(new RegExp(`section=${targetSlug.replace(/-/g, '\\-')}`));
-            await expect(sidebar.locator(`[data-testid="admin-tab-${targetSlug}"]`))
+            await expect(page.locator(`[data-testid="nav-admin-${spec.route}-${targetSlug}"]`))
                 .toHaveAttribute('aria-current', 'page');
         });
     }
 
     test('admin-bans group-ban tab is omitted when config.enablegroupbanning is off', async ({ page }) => {
-        // The seeded e2e DB uses the fresh-install defaults from
-        // `web/install/includes/sql/data.sql`, where
-        // `config.enablegroupbanning` is '0'. AdminTabs filters out
-        // any tab whose `config` field is falsy — verify the
-        // group-ban link is not rendered (and consequently can't be
-        // clicked) until the feature flag is flipped on. Pre-#1275
-        // there was no per-section gate at all (the old toc just
-        // skipped the section's render block when the flag was off
-        // but kept a dead anchor in the rail).
         await page.goto('/index.php?p=admin&c=bans');
 
-        const sidebar = page.locator('[data-testid="admin-sidebar"]');
-        await expect(sidebar).toBeVisible();
-        await expect(sidebar.locator('[data-testid="admin-tab-add-ban"]')).toBeVisible();
-        await expect(sidebar.locator('[data-testid="admin-tab-group-ban"]')).toHaveCount(0);
+        const accordion = page.locator('[data-testid="nav-admin-bans-accordion"]');
+        await expect(accordion).toBeVisible();
+        await expect(page.locator('[data-testid="nav-admin-bans-add-ban"]')).toBeVisible();
+        await expect(page.locator('[data-testid="nav-admin-bans-group-ban"]')).toHaveCount(0);
     });
 });

--- a/web/tests/e2e/specs/responsive/sidebar-sticky.spec.ts
+++ b/web/tests/e2e/specs/responsive/sidebar-sticky.spec.ts
@@ -84,11 +84,10 @@ test.describe('responsive: sidebar sticky at desktop', () => {
 
     test('sidebar stays pinned at viewport y=0 across the entire scroll range of admin-settings', async ({ page }) => {
         await page.goto('/index.php?p=admin&c=settings');
-        // The settings page mounts the AdminTabs sidebar shell + the
-        // settings View. Anchor on the sidebar shell as the
-        // "page mounted" signal — it's the wrapper AdminTabs opens
-        // before the page body renders.
-        await expect(page.locator('[data-testid="admin-sidebar-shell"]')).toBeVisible();
+        // Settings lands with the main-sidebar Settings accordion open
+        // (#1490) and the Main section body painted.
+        await expect(page.locator('[data-testid="nav-admin-settings-accordion"]')).toBeVisible();
+        await expect(page.locator('[data-testid="nav-admin-settings-settings"]')).toHaveAttribute('aria-current', 'page');
 
         // Sanity: the page has to be taller than the viewport for the
         // sticky test to be meaningful. If the page fits in the

--- a/web/tests/e2e/specs/smoke/admin/settings.spec.ts
+++ b/web/tests/e2e/specs/smoke/admin/settings.spec.ts
@@ -6,8 +6,8 @@
  * by default), so the route is accessible without a per-spec login.
  *
  * Selector contract: see `pages/admin/AdminSettings.ts` (pinned on
- * the settings sub-nav, which sits outside the `$can_web_settings`
- * gate so the selector remains stable on the access-denied fallback).
+ * the content-area Save button so the mount marker stays visible on
+ * mobile where the main sidebar is off-canvas).
  */
 import { test, expect } from '../../../fixtures/auth.ts';
 import { expectNoCriticalA11y } from '../../../fixtures/axe.ts';

--- a/web/tests/e2e/specs/smoke/routing-truthiness.spec.ts
+++ b/web/tests/e2e/specs/smoke/routing-truthiness.spec.ts
@@ -99,7 +99,7 @@ test.describe('#1207 routing + truthiness fixes', () => {
             // active. The selector follows the standard
             // `data-testid="admin-tab-<slug>"` shape used by every
             // Pattern A route after #1259's chrome unification.
-            await expect(page.locator('[data-testid="admin-tab-overrides"]')).toHaveAttribute('aria-current', 'page');
+            await expect(page.locator('[data-testid="nav-admin-admins-overrides"]')).toHaveAttribute('aria-current', 'page');
         });
     });
 

--- a/web/tests/integration/AdminAdminsSearchTest.php
+++ b/web/tests/integration/AdminAdminsSearchTest.php
@@ -498,7 +498,7 @@ final class AdminAdminsSearchTest extends ApiTestCase
 
         $html = $this->renderAdminsPage();
 
-        $sidebarLinks = $this->renderedSidebarLinkSlugs($html);
+        $sidebarLinks = $this->catalogAdminsSlugs();
         $this->assertSame(
             ['add-admin', 'admins', 'overrides'],
             $sidebarLinks,
@@ -553,14 +553,14 @@ final class AdminAdminsSearchTest extends ApiTestCase
 
         $html = $this->renderAdminsPage();
 
-        $sidebarLinks = $this->renderedSidebarLinkSlugs($html);
+        $sidebarLinks = $this->catalogAdminsSlugs();
 
         // ADMIN_ADD_ADMINS gates both `add-admin` and `overrides`
         // (the two Pattern A sections that surface the SourceMod
         // override editor + the Add admin form). `admins` is gated
         // on ADMIN_LIST_ADMINS and must be elided.
         $this->assertSame(['add-admin', 'overrides'], $sidebarLinks);
-        $this->assertStringNotContainsString('data-testid="admin-tab-admins"', $html);
+        $this->assertNotContains('admins', $sidebarLinks);
 
         // The dispatcher's first-accessible-section default kicks in
         // here: with no `?section=`, the user lands on `add-admin`
@@ -705,19 +705,23 @@ final class AdminAdminsSearchTest extends ApiTestCase
     }
 
     /**
-     * Extract every Pattern A sidebar link slug (`admins`,
-     * `add-admin`, `overrides`) from `[data-testid="admin-tab-<slug>"]`
-     * attributes in the rendered HTML. Sorted so callers can compare
-     * against a fixed ordering without depending on emit order.
+     * Slugs the main-sidebar Admins accordion would expose for the
+     * current user (#1490 / AdminNavCatalog). Sorted for stable
+     * assertSame comparisons.
      *
      * @return list<string>
      */
-    private function renderedSidebarLinkSlugs(string $html): array
+    private function catalogAdminsSlugs(): array
     {
-        preg_match_all('/data-testid="admin-tab-([a-z-]+)"/', $html, $m);
-        $slugs = $m[1];
+        /** @var \Sbpp\Auth\UserManager $userbank */
+        $userbank = $GLOBALS['userbank'];
+        $sections = \Sbpp\View\AdminNavCatalog::filterForUser(
+            \Sbpp\View\AdminNavCatalog::sectionsFor('admins'),
+            $userbank,
+        );
+        $slugs = array_column($sections, 'slug');
         sort($slugs);
-        return array_values(array_unique($slugs));
+        return array_values($slugs);
     }
 
     /**

--- a/web/tests/integration/AdminBansFeatureToggleTest.php
+++ b/web/tests/integration/AdminBansFeatureToggleTest.php
@@ -178,49 +178,37 @@ final class AdminBansFeatureToggleTest extends ApiTestCase
     }
 
     /**
-     * Extract the comma-separated tab slugs from the stub's
-     * `<!--SBPP_DISPLAY:core/admin_sidebar.tpl:…-->` marker. Returns
-     * an empty list when the sidebar never rendered (which is itself
-     * an assertable signal — every test case below either expects
-     * the marker present with specific slugs, or expects a specific
-     * slug missing from the marker).
-     *
-     * Non-greedy `(.*?)` capture: slugs themselves carry `-`
-     * (`add-ban`, `group-ban`) so the slugs body can't be `[^-]+`;
-     * we anchor on the closing `-->` of the comment marker instead.
+     * Slugs the main-sidebar Bans accordion would expose for the
+     * current user + config toggles (#1490 / AdminNavCatalog).
      *
      * @return list<string>
      */
-    private static function sidebarSlugs(string $out): array
+    private function catalogBansSlugs(): array
     {
-        if (preg_match('/<!--SBPP_DISPLAY:core\/admin_sidebar\.tpl:(.*?)-->/', $out, $m) !== 1) {
-            return [];
-        }
-        $csv = trim((string) $m[1]);
-        if ($csv === '') {
-            return [];
-        }
-        return array_values(array_filter(explode(',', $csv), static fn($s) => $s !== ''));
+        /** @var \Sbpp\Auth\UserManager $userbank */
+        $userbank = $GLOBALS['userbank'];
+        $sections = \Sbpp\View\AdminNavCatalog::filterForUser(
+            \Sbpp\View\AdminNavCatalog::sectionsFor('bans'),
+            $userbank,
+        );
+        return array_values(array_column($sections, 'slug'));
     }
 
     /**
      * Baseline: with both toggles on (the `data.sql` default), the
-     * sidebar `tabs` array passed to `core/admin_sidebar.tpl` must
-     * carry BOTH the `protests` and `submissions` slugs. Same shape
+     * AdminNavCatalog bans children must carry BOTH the `protests`
+     * and `submissions` slugs. Same shape
      * `PaletteActionsTest::testPublicTogglesGateEntries` pins for the
-     * sibling palette + navbar surfaces. Without this baseline the
-     * negative tests below could pass for a different reason (e.g.
-     * the marker format drifted) and the user-reported regression
-     * would stay open.
+     * sibling palette + navbar surfaces.
      */
     #[RunInSeparateProcess]
     #[PreserveGlobalState(false)]
     public function testSidebarShowsBothEntriesWhenTogglesAreOn(): void
     {
         $this->loginAsAdmin();
+        $this->bootRenderHarness();
 
-        $out   = $this->renderAdminBans([]);
-        $slugs = self::sidebarSlugs($out);
+        $slugs = $this->catalogBansSlugs();
 
         $this->assertContains('protests', $slugs,
             'Ban protests entry must appear in the sidebar when config.enableprotest is on (baseline for #1421).');
@@ -241,9 +229,9 @@ final class AdminBansFeatureToggleTest extends ApiTestCase
     {
         $this->loginAsAdmin();
         $this->setSetting('config.enableprotest', '0');
+        $this->bootRenderHarness();
 
-        $out   = $this->renderAdminBans([]);
-        $slugs = self::sidebarSlugs($out);
+        $slugs = $this->catalogBansSlugs();
 
         $this->assertNotContains('protests', $slugs,
             'Ban protests entry must NOT appear in the sidebar when config.enableprotest=0 (#1421).');
@@ -260,9 +248,9 @@ final class AdminBansFeatureToggleTest extends ApiTestCase
     {
         $this->loginAsAdmin();
         $this->setSetting('config.enablesubmit', '0');
+        $this->bootRenderHarness();
 
-        $out   = $this->renderAdminBans([]);
-        $slugs = self::sidebarSlugs($out);
+        $slugs = $this->catalogBansSlugs();
 
         $this->assertNotContains('submissions', $slugs,
             'Ban submissions entry must NOT appear in the sidebar when config.enablesubmit=0 (#1421).');
@@ -535,9 +523,9 @@ final class AdminBansFeatureToggleTest extends ApiTestCase
         $this->loginAsAdmin();
         $this->setSetting('config.enableprotest', '0');
         $this->setSetting('config.enablesubmit', '0');
+        $this->bootRenderHarness();
 
-        $out   = $this->renderAdminBans([]);
-        $slugs = self::sidebarSlugs($out);
+        $slugs = $this->catalogBansSlugs();
 
         $this->assertNotContains('protests', $slugs,
             'Both toggles off: protests entry must be absent from the sidebar (#1421).');

--- a/web/tests/integration/AdminNavCatalogTest.php
+++ b/web/tests/integration/AdminNavCatalogTest.php
@@ -1,0 +1,140 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sbpp\Tests\Integration;
+
+use Sbpp\Tests\ApiTestCase;
+use Sbpp\Tests\Fixture;
+use Sbpp\View\AdminNavCatalog;
+
+/**
+ * Issue #1490: Pattern A section catalogs for the main-sidebar
+ * accordion. Pins endpoint coverage, slug uniqueness, and the
+ * feature-toggle gates on bans children.
+ */
+final class AdminNavCatalogTest extends ApiTestCase
+{
+    public function testKnownEndpointsExposeExpectedSlugs(): void
+    {
+        $this->assertSame(
+            ['admins', 'add-admin', 'overrides'],
+            array_column(AdminNavCatalog::sectionsFor('admins'), 'slug'),
+        );
+        $this->assertSame(
+            ['list', 'add'],
+            array_column(AdminNavCatalog::sectionsFor('servers'), 'slug'),
+        );
+        $this->assertSame(
+            ['list', 'add'],
+            array_column(AdminNavCatalog::sectionsFor('groups'), 'slug'),
+        );
+        $this->assertSame(
+            ['settings', 'features', 'logs', 'themes'],
+            array_column(AdminNavCatalog::sectionsFor('settings'), 'slug'),
+        );
+        $this->assertSame(
+            ['list', 'add'],
+            array_column(AdminNavCatalog::sectionsFor('mods'), 'slug'),
+        );
+        $this->assertSame([], AdminNavCatalog::sectionsFor('comms'));
+        $this->assertSame([], AdminNavCatalog::sectionsFor('export'));
+        $this->assertSame([], AdminNavCatalog::sectionsFor('unknown'));
+    }
+
+    public function testEverySectionCarriesUrlSlugAndPermission(): void
+    {
+        foreach (['admins', 'servers', 'groups', 'settings', 'mods', 'bans'] as $endpoint) {
+            foreach (AdminNavCatalog::sectionsFor($endpoint) as $tab) {
+                $this->assertNotSame('', $tab['slug']);
+                $this->assertNotSame('', $tab['name']);
+                $this->assertNotSame('', $tab['url']);
+                $this->assertStringContainsString('section=' . $tab['slug'], $tab['url']);
+                $this->assertIsInt($tab['permission']);
+            }
+        }
+    }
+
+    public function testBansCatalogHonoursFeatureToggles(): void
+    {
+        $this->setSetting('config.enableprotest', '0');
+        $this->setSetting('config.enablesubmit', '0');
+        $this->setSetting('config.enablegroupbanning', '0');
+        \Sbpp\Config::init($GLOBALS['PDO']);
+
+        $slugsOff = array_column(AdminNavCatalog::sectionsFor('bans'), 'slug');
+        $this->assertSame(['add-ban', 'import'], $slugsOff);
+
+        $this->setSetting('config.enableprotest', '1');
+        $this->setSetting('config.enablesubmit', '1');
+        $this->setSetting('config.enablegroupbanning', '1');
+        \Sbpp\Config::init($GLOBALS['PDO']);
+
+        $slugsOn = array_column(AdminNavCatalog::sectionsFor('bans'), 'slug');
+        $this->assertSame(
+            ['add-ban', 'protests', 'submissions', 'import', 'group-ban'],
+            $slugsOn,
+        );
+    }
+
+    public function testFilterForUserDropsInaccessibleChildren(): void
+    {
+        $this->loginAsAdmin();
+        /** @var \CUserManager $owner */
+        $owner = $GLOBALS['userbank'];
+        $filtered = AdminNavCatalog::filterForUser(
+            AdminNavCatalog::sectionsFor('servers'),
+            $owner,
+        );
+        $this->assertSame(['list', 'add'], array_column($filtered, 'slug'));
+
+        $aid = $this->createAdminWithFlags(ADMIN_LIST_SERVERS);
+        $this->loginAs($aid);
+        /** @var \CUserManager $listOnly */
+        $listOnly = $GLOBALS['userbank'];
+        $listFiltered = AdminNavCatalog::filterForUser(
+            AdminNavCatalog::sectionsFor('servers'),
+            $listOnly,
+        );
+        $this->assertSame(['list'], array_column($listFiltered, 'slug'));
+
+        $aidEmpty = $this->createAdminWithFlags(ADMIN_LIST_ADMINS);
+        $this->loginAs($aidEmpty);
+        /** @var \CUserManager $noServerFlags */
+        $noServerFlags = $GLOBALS['userbank'];
+        $empty = AdminNavCatalog::filterForUser(
+            AdminNavCatalog::sectionsFor('servers'),
+            $noServerFlags,
+        );
+        $this->assertSame([], $empty);
+    }
+
+    private function setSetting(string $key, string $value): void
+    {
+        $pdo = Fixture::rawPdo();
+        $stmt = $pdo->prepare(sprintf(
+            'REPLACE INTO `%s_settings` (`setting`, `value`) VALUES (?, ?)',
+            DB_PREFIX,
+        ));
+        $stmt->execute([$key, $value]);
+        \Sbpp\Config::init($GLOBALS['PDO']);
+    }
+
+    private function createAdminWithFlags(int $mask): int
+    {
+        $pdo = Fixture::rawPdo();
+        $stmt = $pdo->prepare(sprintf(
+            'INSERT INTO `%s_admins` (user, authid, password, gid, email, validate, extraflags, immunity)
+             VALUES (?, ?, ?, -1, ?, NULL, ?, 50)',
+            DB_PREFIX,
+        ));
+        $stmt->execute([
+            'navcat-flagged-' . $mask,
+            'STEAM_0:0:' . (4_000_000 + $mask),
+            password_hash('x', PASSWORD_BCRYPT),
+            'navcat-flagged@example.test',
+            $mask,
+        ]);
+        return (int) $pdo->lastInsertId();
+    }
+}

--- a/web/themes/default/core/navbar.tpl
+++ b/web/themes/default/core/navbar.tpl
@@ -87,13 +87,37 @@
                     {/if}
                 {/foreach}
                 {foreach from=$adminbar item=admin}
-                    <a class="sidebar__link"
-                       href="index.php?p=admin&c={$admin.endpoint}"
-                       data-testid="nav-admin-{$admin.endpoint}"
-                       {if $admin.state == 'active'}aria-current="page"{/if}>
-                        <i data-lucide="{if $admin.endpoint == 'admins'}users{elseif $admin.endpoint == 'servers'}server{elseif $admin.endpoint == 'bans'}ban{elseif $admin.endpoint == 'comms'}mic-off{elseif $admin.endpoint == 'groups'}shield-check{elseif $admin.endpoint == 'settings'}settings{elseif $admin.endpoint == 'mods'}puzzle{else}circle{/if}"></i>
-                        {$admin.title}
-                    </a>
+                    {if !empty($admin.children)}
+                        <details class="sidebar__accordion"
+                                 data-testid="nav-admin-{$admin.endpoint}-accordion"
+                                 {if $admin.open}open{/if}>
+                            <summary class="sidebar__link sidebar__accordion-summary"
+                                     data-testid="nav-admin-{$admin.endpoint}">
+                                <i data-lucide="{if $admin.endpoint == 'admins'}users{elseif $admin.endpoint == 'servers'}server{elseif $admin.endpoint == 'bans'}ban{elseif $admin.endpoint == 'comms'}mic-off{elseif $admin.endpoint == 'groups'}shield-check{elseif $admin.endpoint == 'settings'}settings{elseif $admin.endpoint == 'mods'}puzzle{else}circle{/if}"></i>
+                                <span class="sidebar__accordion-label">{$admin.title}</span>
+                                <i data-lucide="chevron-down" class="sidebar__accordion-chevron" aria-hidden="true"></i>
+                            </summary>
+                            <div class="sidebar__children" role="group" aria-label="{$admin.title} sections">
+                                {foreach from=$admin.children item=child}
+                                    <a class="sidebar__link sidebar__link--child"
+                                       href="{$child.url}"
+                                       data-testid="nav-admin-{$admin.endpoint}-{$child.slug}"
+                                       {if $child.state == 'active'}aria-current="page"{/if}>
+                                        <i data-lucide="{$child.icon}"></i>
+                                        {$child.name}
+                                    </a>
+                                {/foreach}
+                            </div>
+                        </details>
+                    {else}
+                        <a class="sidebar__link"
+                           href="index.php?p=admin&c={$admin.endpoint}"
+                           data-testid="nav-admin-{$admin.endpoint}"
+                           {if $admin.state == 'active'}aria-current="page"{/if}>
+                            <i data-lucide="{if $admin.endpoint == 'admins'}users{elseif $admin.endpoint == 'servers'}server{elseif $admin.endpoint == 'bans'}ban{elseif $admin.endpoint == 'comms'}mic-off{elseif $admin.endpoint == 'groups'}shield-check{elseif $admin.endpoint == 'settings'}settings{elseif $admin.endpoint == 'mods'}puzzle{else}circle{/if}"></i>
+                            {$admin.title}
+                        </a>
+                    {/if}
                 {/foreach}
             </div>
         {/if}

--- a/web/themes/default/css/theme.css
+++ b/web/themes/default/css/theme.css
@@ -217,6 +217,60 @@ a { color: inherit; text-decoration: none; }
 html.dark .sidebar__link[aria-current="page"] { background: var(--brand-700); color: var(--on-accent, #fff); }
 .sidebar__link-count { margin-left: auto; font-size: 0.625rem; padding: 0 0.375rem; height: 1rem; display: inline-flex; align-items: center; border-radius: var(--radius-sm); background: var(--bg-muted); color: var(--text-muted); font-variant-numeric: tabular-nums; }
 
+/* #1490 — admin category accordion in the main sidebar. Nested section
+   links replace the Pattern A second rail (admin-sidebar-shell). */
+.sidebar__accordion { display: flex; flex-direction: column; gap: 0.125rem; }
+.sidebar__accordion-summary {
+  cursor: pointer;
+  list-style: none;
+  user-select: none;
+}
+.sidebar__accordion-summary::-webkit-details-marker { display: none; }
+.sidebar__accordion-label { flex: 1; min-width: 0; }
+.sidebar__accordion-chevron {
+  margin-left: auto;
+  width: 0.875rem;
+  height: 0.875rem;
+  color: var(--text-muted);
+  transition: transform .15s ease;
+  flex-shrink: 0;
+}
+.sidebar__accordion[open] > .sidebar__accordion-summary .sidebar__accordion-chevron {
+  transform: rotate(180deg);
+}
+/* Nest under the parent icon: summary padding-left (0.75rem) + half of
+   Lucide's default 1.5rem icon = 1.5rem. The 1px rail sits on that
+   centerline; children pad further right for hierarchy. */
+.sidebar__children {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 0.125rem;
+  margin-left: 1.5rem;
+  padding-left: 0.5rem;
+}
+.sidebar__children::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  top: 0.125rem;
+  bottom: 0.125rem;
+  width: 1px;
+  background: var(--border);
+  pointer-events: none;
+}
+.sidebar__link--child {
+  height: 1.75rem;
+  font-size: var(--fs-sm);
+  font-weight: 500;
+  color: var(--text-muted);
+}
+.sidebar__link--child:hover { color: var(--text); }
+.sidebar__link--child[aria-current="page"] { color: inherit; }
+@media (prefers-reduced-motion: reduce) {
+  .sidebar__accordion-chevron { transition: none; }
+}
+
 .main { flex: 1; min-width: 0; display: flex; flex-direction: column; }
 
 .topbar {

--- a/web/themes/default/page_admin_admins_add.tpl
+++ b/web/themes/default/page_admin_admins_add.tpl
@@ -37,7 +37,7 @@
     `admin-admins-section-add-admin` so existing E2E selectors keep
     matching the surface.
 *}
-<div data-testid="admin-admins-section-add-admin">
+<div class="page-section" data-testid="admin-admins-section-add-admin">
     {if !$can_add_admins}
         <div class="card">
             <div class="card__body">

--- a/web/themes/default/page_admin_admins_list.tpl
+++ b/web/themes/default/page_admin_admins_list.tpl
@@ -35,24 +35,20 @@
     filters). See the docblock on web/pages/admin.admins.php.
 *}
 {if !$can_list_admins}
-    <div class="card">
-        <div class="card__body">
-            <p class="text-sm text-muted m-0">Access denied.</p>
+    <div class="page-section">
+        <div class="card">
+            <div class="card__body">
+                <p class="text-sm text-muted m-0">Access denied.</p>
+            </div>
         </div>
     </div>
 {else}
-    <div class="flex items-end justify-between gap-3 mb-4" style="flex-wrap:wrap">
-        <div>
-            <h1 style="font-size:var(--fs-xl);font-weight:600;margin:0">Admins
-                <span class="text-faint" style="font-weight:400;margin-left:0.375rem" data-testid="admin-count">({$admin_count})</span>
-            </h1>
-            <p class="text-sm text-muted m-0 mt-2">Click an admin row's actions to edit details, permissions, or server access.</p>
-        </div>
-        {if $can_add_admins}
-            <a class="btn btn--primary btn--sm"
-               href="index.php?p=admin&amp;c=admins&amp;section=add-admin"
-               data-testid="admin-add-cta"><i data-lucide="user-plus"></i> Add admin</a>
-        {/if}
+<div class="page-section">
+    <div class="mb-4">
+        <h1 style="font-size:var(--fs-xl);font-weight:600;margin:0">Admins
+            <span class="text-faint" style="font-weight:400;margin-left:0.375rem" data-testid="admin-count">({$admin_count})</span>
+        </h1>
+        <p class="text-sm text-muted m-0 mt-2">Click an admin row's actions to edit details, permissions, or server access.</p>
     </div>
 
     <div data-testid="admin-admins-section-search">
@@ -438,4 +434,5 @@
     })();
     </script>
     {/literal}
+</div>
 {/if}

--- a/web/themes/default/page_admin_bans_protests.tpl
+++ b/web/themes/default/page_admin_bans_protests.tpl
@@ -23,7 +23,7 @@
         </div>
     </div>
 {else}
-    <section class="p-6" data-testid="protests-section" style="max-width:1400px">
+    <section class="page-section" data-testid="protests-section" style="padding-top:0.75rem">
         <div class="flex items-center justify-between gap-4 mb-4" style="flex-wrap:wrap">
             <div>
                 <h1 style="font-size:1.5rem;font-weight:600;margin:0">

--- a/web/themes/default/page_admin_bans_protests_archiv.tpl
+++ b/web/themes/default/page_admin_bans_protests_archiv.tpl
@@ -20,7 +20,7 @@
         </div>
     </div>
 {else}
-    <section class="p-6" data-testid="protests-archive-section" style="max-width:1400px">
+    <section class="page-section" data-testid="protests-archive-section" style="padding-top:0.75rem">
         <div class="flex items-center justify-between gap-4 mb-4" style="flex-wrap:wrap">
             <div>
                 <h1 style="font-size:1.5rem;font-weight:600;margin:0">

--- a/web/themes/default/page_admin_bans_submissions.tpl
+++ b/web/themes/default/page_admin_bans_submissions.tpl
@@ -28,7 +28,7 @@
         </div>
     </div>
 {else}
-    <section class="p-6" data-testid="submissions-section" style="max-width:1400px">
+    <section class="page-section" data-testid="submissions-section" style="padding-top:0.75rem">
         <div class="flex items-center justify-between gap-4 mb-4" style="flex-wrap:wrap">
             <div>
                 <h1 style="font-size:1.5rem;font-weight:600;margin:0">

--- a/web/themes/default/page_admin_bans_submissions_archiv.tpl
+++ b/web/themes/default/page_admin_bans_submissions_archiv.tpl
@@ -21,7 +21,7 @@
         </div>
     </div>
 {else}
-    <section class="p-6" data-testid="submissions-archive-section" style="max-width:1400px">
+    <section class="page-section" data-testid="submissions-archive-section" style="padding-top:0.75rem">
         <div class="flex items-center justify-between gap-4 mb-4" style="flex-wrap:wrap">
             <div>
                 <h1 style="font-size:1.5rem;font-weight:600;margin:0">

--- a/web/themes/default/page_admin_groups_add.tpl
+++ b/web/themes/default/page_admin_groups_add.tpl
@@ -19,7 +19,7 @@
    `.admin-sidebar-shell` (the AdminTabs grid host). The `max-width:
    48rem` form clamp stays so the form column doesn't grow past a
    readable line length on wide viewports. *}
-<div style="max-width:48rem">
+<div class="page-section" style="max-width:48rem">
     <div class="mb-4">
         <h1 style="font-size:var(--fs-2xl);font-weight:600;margin:0">Create a group</h1>
         <p class="text-sm text-muted m-0 mt-2">Pick a name and a type. You can edit permission flags from the <strong>List groups</strong> tab once the group exists.</p>

--- a/web/themes/default/page_admin_groups_list.tpl
+++ b/web/themes/default/page_admin_groups_list.tpl
@@ -21,7 +21,7 @@
    stays so the per-section vertical rhythm holds; the `max-width`
    cap is also unnecessary here because the outer shell already
    clamps to 1400px. *}
-<div class="space-y-6">
+<div class="page-section space-y-6">
 
     {* ------------------------------------------------------------ *}
     {* Master-detail: Web admin groups                              *}

--- a/web/themes/default/page_admin_overrides.tpl
+++ b/web/themes/default/page_admin_overrides.tpl
@@ -22,7 +22,7 @@
     "add an override" form sits inline below the editable table —
     one `<form>`, one Save button, both rows submit together.
 *}
-<div data-testid="admin-admins-section-overrides">
+<div class="page-section" data-testid="admin-admins-section-overrides">
 {if not $permission_addadmin}
     <div class="card">
         <div class="card__body">

--- a/web/themes/default/page_admin_servers_list.tpl
+++ b/web/themes/default/page_admin_servers_list.tpl
@@ -48,13 +48,6 @@
                     Live host / map / player counts hydrate after first paint.
                 </p>
             </div>
-            {if $permission_addserver}
-                <a class="btn btn--primary"
-                   href="index.php?p=admin&amp;c=servers&amp;section=add"
-                   data-testid="server-list-add">
-                    Add server
-                </a>
-            {/if}
         </div>
 
         {if $server_count == 0}

--- a/web/themes/default/page_admin_settings_features.tpl
+++ b/web/themes/default/page_admin_settings_features.tpl
@@ -61,7 +61,7 @@
     #1266 — outer `.p-6` removed; the page inset lives on
     `.admin-sidebar-shell` so both grid columns share the same top y.
 *}
-<div>
+<div class="page-section">
     <div class="mb-6">
         <h1 style="font-size:var(--fs-2xl);font-weight:600;margin:0">Settings</h1>
         <p class="text-sm text-muted m-0 mt-2">Optional features and integrations.</p>

--- a/web/themes/default/page_admin_settings_logs.tpl
+++ b/web/themes/default/page_admin_settings_logs.tpl
@@ -48,7 +48,7 @@
     JS-free expansion + keyboard reachability + screen-reader
     announce out of the box. Desktop chrome unchanged.
 *}
-<div>
+<div class="page-section">
     <div class="mb-6">
         <h1 style="font-size:var(--fs-2xl);font-weight:600;margin:0">Settings</h1>
         <p class="text-sm text-muted m-0 mt-2">System log of admin actions and warnings.</p>

--- a/web/themes/default/page_admin_settings_settings.tpl
+++ b/web/themes/default/page_admin_settings_settings.tpl
@@ -80,7 +80,7 @@
     intentionally kept so the heading still gets its bottom gap to
     the first card.
 *}
-<div>
+<div class="page-section">
     <div class="mb-6">
         <h1 style="font-size:var(--fs-2xl);font-weight:600;margin:0">Settings</h1>
         <p class="text-sm text-muted m-0 mt-2">Site-wide configuration. Changes apply immediately.</p>

--- a/web/themes/default/page_admin_settings_themes.tpl
+++ b/web/themes/default/page_admin_settings_themes.tpl
@@ -55,7 +55,7 @@
     #1266 — outer `.p-6` removed; the page inset lives on
     `.admin-sidebar-shell` so both grid columns share the same top y.
 *}
-<div>
+<div class="page-section">
     <div class="mb-6">
         <h1 style="font-size:var(--fs-2xl);font-weight:600;margin:0">Settings</h1>
         <p class="text-sm text-muted m-0 mt-2">Pick the theme that paints the panel chrome for every visitor.</p>


### PR DESCRIPTION
## Summary

Closes #1490

Admin section nav no longer lives in a second rail next to the main sidebar. Pattern A pages (`?section=…`) keep the same URLs and routing, but their children now open as accordions under Admins / Servers / Bans / Groups / Settings / Mods in the main sidebar. That frees ~14rem of content width and kills the double-menu feel the issue called out.

- **`Sbpp\View\AdminNavCatalog`** is the single source for section catalogs (navbar accordion + page-handler slug defaults). Permission and `config.enable*` gates match the old `AdminTabs` filter.
- **`AdminTabs`** with a non-empty tab list is a no-op. Empty calls still render the edit-* Back link.
- Duplicate header **Add …** CTAs on servers / admins lists are gone. Those destinations already sit in the accordion.
- Accordion chrome: nested indent, vertical rail under the parent icon, chevron on the summary.
- Protests / submissions Current|Archive chips share `.page-section` inset so they line up with the page body after the second rail went away.

Docs (`AGENTS.md`, `ARCHITECTURE.md`), E2E selectors, and PHPUnit (including `AdminNavCatalogTest`) updated for the new testids (`nav-admin-<endpoint>-<slug>`).

<img width="1894" height="1286" alt="image" src="https://github.com/user-attachments/assets/d228efff-d453-47a9-bebc-8fae5cc69e32" />

<img width="765" height="1097" alt="image" src="https://github.com/user-attachments/assets/7b5b19a5-68b1-4f0e-ad36-b435d3224101" />


## Test plan

- [ ] Log in as owner. Expand Admins / Servers / Bans / Settings. Confirm children render, active leaf has `aria-current="page"`, category summary does not when children exist.
- [ ] Visit `?p=admin&c=servers&section=add` and `?p=admin&c=admins&section=add-admin`. Confirm no second left rail and no duplicate Add button in the page header.
- [ ] Ban protests / submissions. Confirm Current|Archive chips align with the heading and empty state (not flush against the sidebar).
- [ ] Partial-permission admin (e.g. list servers only). Confirm accordion children match reachable sections.
- [ ] Toggle off `config.enableprotest` / `config.enablesubmit` / `config.enablegroupbanning`. Confirm those Bans children disappear from the accordion.
- [ ] Edit-* page (e.g. edit ban). Confirm Back link still works.
- [ ] `./sbpp.sh phpstan` and `./sbpp.sh test --filter=AdminNavCatalogTest|AdminBansFeatureToggleTest|AdminAdminsSearchTest`
- [ ] `./sbpp.sh e2e --grep "admin-tabs|sidebar-sticky|admin-admins-density|routing-truthiness"`