### PR TITLE
fix(page_comms): column order, copy steamid, block reason

### DIFF
--- a/web/themes/default/page_comms.tpl
+++ b/web/themes/default/page_comms.tpl
@@ -201,10 +201,11 @@
                     <th>Type</th>
                     <th>Player</th>
                     <th>SteamID</th>
-                    <th class="col-length col-tier-3">Length</th>
+                    <th class="col-tier-2">Reason</th>
                     <th class="col-tier-2">Server</th>
                     <th class="col-admin col-tier-2">Admin</th>
-                    <th class="col-tier-3">Started</th>
+                    <th class="col-length col-tier-3">Length</th>
+                    <th class="col-tier-3">Invoked on</th>
                     <th class="col-status">Status</th>
                     <th class="col-actions" aria-label="Actions"></th>
                 </tr>
@@ -309,8 +310,7 @@
                             </div>
                         </td>
                         <td class="font-mono text-xs text-muted">{$comm.steam|escape}</td>
-                        <td class="col-length col-tier-3 tabular-nums text-muted"
-                            {if !empty($comm.length_human)}title="{$comm.length_human|escape}"{/if}>{$comm.length_human|escape}</td>
+                        <td class="col-tier-2 text-muted">{if !empty($comm.reason)}{$comm.reason|escape}{else}<span class="text-faint">—</span>{/if}</td>
                         <td class="col-tier-2 text-muted">{$comm.sname|escape}</td>
                         <td class="col-admin col-tier-2 text-muted">
                             {if $comm.admin}
@@ -319,6 +319,8 @@
                                 <span class="text-faint">—</span>
                             {/if}
                         </td>
+                        <td class="col-length col-tier-3 tabular-nums text-muted"
+                            {if !empty($comm.length_human)}title="{$comm.length_human|escape}"{/if}>{$comm.length_human|escape}</td>
                         <td class="col-tier-3 text-muted text-xs">
                             <time datetime="{$comm.started_iso|escape}">{$comm.started_human|escape}</time>
                         </td>
@@ -372,6 +374,16 @@
                                         Re-apply
                                     </a>
                                 {/if}
+                                {if !empty($comm.steam)}
+                                <button class="btn btn--ghost btn--sm" type="button"
+                                        data-copy="{$comm.steam|escape}"
+                                        data-testid="row-action-copy-steam-mobile"
+                                        aria-label="Copy SteamID"
+                                        title="Copy SteamID">
+                                    <i data-lucide="copy" style="width:13px;height:13px"></i>
+                                    Copy
+                                </button>
+                                {/if}
                                 {if $can_delete_comm}
                                     <button type="button"
                                             class="btn btn--ghost btn--sm"
@@ -397,7 +409,7 @@
                        `can_add_comm`); otherwise it stays "Clear filters". *}
                     <tr>
                         {if $is_filtered}
-                        <td colspan="9"
+                        <td colspan="10"
                             style="padding:0"
                             data-testid="comms-empty"
                             data-filtered="true">
@@ -418,7 +430,7 @@
                             </div>
                         </td>
                         {else}
-                        <td colspan="9"
+                        <td colspan="10"
                             style="padding:0"
                             data-testid="comms-empty"
                             data-filtered="false">


### PR DESCRIPTION
## Description

Refactors `themes/default/page_comms.tpl` to match the design spec for the public communications blocklist page like Ban list.

1. **Column reorder** — the desktop table and all related structures now follow the canonical order:
`Type | Player | SteamID | Reason | Server | Admin | Length | Invoked on | Status | Actions`

2. **Reason column added** — surfaces `$comm.reason` (with a `—` fallback for empty values) as a tier-2 column, consistent with the banlist shape.

3. **Copy SteamID button** — ports the `data-copy` button from `page_bans.tpl` to the commslist mobile cards, gated by `!empty($comm.steam)`, with the matching `data-testid="row-action-copy-steam-mobile"` hook.

## Motivation and Context

Closes #1543 — Harmonize column order between Bans and Comms pages.
Closes #1542 — `Reason` column was missing from the commslist table despite being available on the view (`$comm.reason`).

This brings the commslist page to full parity with `page_bans.tpl` in terms of column structure, empty-state handling, and mobile card actions.

## How Has This Been Tested?

- Verified column order visually against the B4 design spec at multiple viewport widths (tier-2 and tier-3 breakpoints).
- Confirmed `Reason` renders correctly for rows with and without a reason string (fallback `—` displays as expected).
- Confirmed `colspan="10"` on both empty-state rows (filtered and first-run) matches the new 10-column layout.
- Confirmed mobile cards are unaffected by the column reorder.
- Confirmed "Copy SteamID" button appears on mobile cards only when `$comm.steam` is non-empty, and copies the correct value via the `data-copy` attribute.
- No JS changes; existing `data-testid` hooks and the inline IIFE are unchanged.

## Screenshots (if appropriate):
### Before
<img width="2483" height="1290" alt="image" src="https://github.com/user-attachments/assets/e7b178d3-d926-43af-a79c-d851ab3c60a8" />

### After
<img width="2482" height="1295" alt="image" src="https://github.com/user-attachments/assets/faecd535-4c8d-4473-befc-507c8cad4ae6" />

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](CONTRIBUTING.md) document.