### PR TITLE
Composer(deps-dev): Bump staabm/phpstan-dba to 0.4.9 (+ PHPStan ignore fix)

### DIFF
--- a/web/composer.lock
+++ b/web/composer.lock
@@ -2032,16 +2032,16 @@
         },
         {
             "name": "doctrine/dbal",
-            "version": "4.4.3",
+            "version": "4.4.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/dbal.git",
-                "reference": "61e730f1658814821a85f2402c945f3883407dec"
+                "reference": "fb9e0ffe15e1590e24dc61c0c0a23f9a33ee42ce"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/dbal/zipball/61e730f1658814821a85f2402c945f3883407dec",
-                "reference": "61e730f1658814821a85f2402c945f3883407dec",
+                "url": "https://api.github.com/repos/doctrine/dbal/zipball/fb9e0ffe15e1590e24dc61c0c0a23f9a33ee42ce",
+                "reference": "fb9e0ffe15e1590e24dc61c0c0a23f9a33ee42ce",
                 "shasum": ""
             },
             "require": {
@@ -2118,7 +2118,7 @@
             ],
             "support": {
                 "issues": "https://github.com/doctrine/dbal/issues",
-                "source": "https://github.com/doctrine/dbal/tree/4.4.3"
+                "source": "https://github.com/doctrine/dbal/tree/4.4.4"
             },
             "funding": [
                 {
@@ -2134,7 +2134,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-20T08:52:12+00:00"
+            "time": "2026-07-21T14:34:40+00:00"
         },
         {
             "name": "doctrine/deprecations",
@@ -2421,11 +2421,11 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "2.2.1",
+            "version": "2.2.7",
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/dea9c8f2d25cc849391042b71e429c1a4bf82660",
-                "reference": "dea9c8f2d25cc849391042b71e429c1a4bf82660",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/692db47b9dddb0487934e5236e77d48594aef921",
+                "reference": "692db47b9dddb0487934e5236e77d48594aef921",
                 "shasum": ""
             },
             "require": {
@@ -2481,7 +2481,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-05-28T14:44:12+00:00"
+            "time": "2026-07-29T17:39:32+00:00"
         },
         {
             "name": "phpstan/phpstan-deprecation-rules",
@@ -4166,16 +4166,16 @@
         },
         {
             "name": "staabm/phpstan-dba",
-            "version": "0.4.2",
+            "version": "0.4.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/staabm/phpstan-dba.git",
-                "reference": "b4a6084d9c08db2d208cef81184bbf26d1581864"
+                "reference": "78c763fe4fd60cf0f59bad5930669c7d797b8acb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/staabm/phpstan-dba/zipball/b4a6084d9c08db2d208cef81184bbf26d1581864",
-                "reference": "b4a6084d9c08db2d208cef81184bbf26d1581864",
+                "url": "https://api.github.com/repos/staabm/phpstan-dba/zipball/78c763fe4fd60cf0f59bad5930669c7d797b8acb",
+                "reference": "78c763fe4fd60cf0f59bad5930669c7d797b8acb",
                 "shasum": ""
             },
             "require": {
@@ -4183,9 +4183,10 @@
                 "composer/semver": "^3.2",
                 "doctrine/dbal": "3.*|4.*",
                 "php": "^7.4 || ^8.0",
-                "phpstan/phpstan": "^2.0"
+                "phpstan/phpstan": "^2.1.2"
             },
             "conflict": {
+                "phpstan/phpstan": "2.1.55||2.1.56||2.2.0||2.2.1",
                 "sqlftw/sqlftw": "<0.1.16"
             },
             "require-dev": {
@@ -4199,7 +4200,7 @@
                 "phpstan/phpstan-strict-rules": "^2.0",
                 "phpunit/phpunit": "^8.5|^9.5",
                 "symplify/easy-coding-standard": "^12.5",
-                "tomasvotruba/unused-public": "^2.0",
+                "tomasvotruba/unused-public": "^2.2",
                 "vlucas/phpdotenv": "^5.4"
             },
             "type": "phpstan-extension",
@@ -4232,7 +4233,7 @@
             ],
             "support": {
                 "issues": "https://github.com/staabm/phpstan-dba/issues",
-                "source": "https://github.com/staabm/phpstan-dba/tree/0.4.2"
+                "source": "https://github.com/staabm/phpstan-dba/tree/0.4.9"
             },
             "funding": [
                 {
@@ -4240,7 +4241,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-08-07T09:33:14+00:00"
+            "time": "2026-07-16T06:48:25+00:00"
         },
         {
             "name": "staabm/side-effects-detector",

--- a/web/install/pages/page.3.php
+++ b/web/install/pages/page.3.php
@@ -52,20 +52,15 @@ $warnings = 0;
 // PHP requirements
 $phpRows = [];
 
-// PHPStan sees the analyser's PHP_VERSION as a fixed string (the
-// container is locked to 8.5+) so the `version_compare(...)` here
-// looks always-true to it. The check still has runtime value: a
-// self-hoster on PHP 8.4 hitting this surface is exactly who needs
-// the "you're on too old a version" feedback.
+// Runtime gate for self-hosters below the PHP 8.5 floor. The analyser
+// environment is locked to 8.5+, so this branch is not exercised there.
 $phpVersionOk = version_compare(PHP_VERSION, '8.5', '>=');
 $phpRows[] = [
     'label'    => 'PHP version',
     'required' => '8.5 or newer',
-    // @phpstan-ignore ternary.alwaysTrue
     'status'   => $phpVersionOk ? 'ok' : 'err',
     'detail'   => PHP_VERSION,
 ];
-// @phpstan-ignore booleanNot.alwaysFalse
 if (!$phpVersionOk) {
     $errors++;
 }


### PR DESCRIPTION
## Summary
- Bumps `staabm/phpstan-dba` from 0.4.2 to 0.4.9 in `/web` (same as #1535).
- That bump conflicts with PHPStan 2.2.1, so Composer pulls PHPStan 2.2.7.
- 2.2.7 no longer reports `ternary.alwaysTrue` / `booleanNot.alwaysFalse` on the install wizard PHP version gate in `web/install/pages/page.3.php`, so the existing `@phpstan-ignore`s fail `reportUnmatchedIgnoredErrors` and CI Static analysis fails.
- Removes those unused ignores; keeps the runtime version check.

Supersedes #1535 (cannot push to the Dependabot branch from this fork).

## Test plan
- [ ] Confirm Static analysis (phpstan.yml) is green
- [ ] Spot-check install wizard step 3 still surfaces a PHP version row