### PR TITLE
fix(admin-mods): modernize mods list and forms (#1552)

### DIFF
--- a/web/includes/View/AdminModsListView.php
+++ b/web/includes/View/AdminModsListView.php
@@ -16,7 +16,8 @@ namespace Sbpp\View;
  * Property names keep the historical `permission_*` shape (rather than
  * the newer `can_*` convention `Sbpp\View\Perms::for()` produces) because
  * the template references `{$permission_listmods}` /
- * `{$permission_editmods}` / `{$permission_deletemods}`. See
+ * `{$permission_addmods}` / `{$permission_editmods}` /
+ * `{$permission_deletemods}`. See
  * `AdminServersListView` / `AdminBansAddView` for the canonical
  * `can_*` convention on Views that don't have to honour a historical
  * variable name.
@@ -30,6 +31,7 @@ final class AdminModsListView extends View
      */
     public function __construct(
         public readonly bool $permission_listmods,
+        public readonly bool $permission_addmods,
         public readonly bool $permission_editmods,
         public readonly bool $permission_deletemods,
         public readonly int $mod_count,

--- a/web/pages/admin.edit.mod.php
+++ b/web/pages/admin.edit.mod.php
@@ -12,8 +12,6 @@ if (!defined('IN_SB')) {
 
 global $userbank, $theme;
 
-new \Sbpp\View\AdminTabs([], $userbank, $theme);
-
 require_once __DIR__ . '/_admin_edit_helpers.php';
 
 $modId = isset($_GET['id']) ? (int) $_GET['id'] : 0;

--- a/web/pages/admin.edit.mod.php
+++ b/web/pages/admin.edit.mod.php
@@ -12,6 +12,8 @@ if (!defined('IN_SB')) {
 
 global $userbank, $theme;
 
+new \Sbpp\View\AdminTabs([], $userbank, $theme);
+
 require_once __DIR__ . '/_admin_edit_helpers.php';
 
 $modId = isset($_GET['id']) ? (int) $_GET['id'] : 0;

--- a/web/pages/admin.mods.php
+++ b/web/pages/admin.mods.php
@@ -43,6 +43,7 @@ $mod_count = (int) $GLOBALS['PDO']->query("SELECT COUNT(mid) AS cnt FROM `:prefi
 
 \Sbpp\View\Renderer::render($theme, new \Sbpp\View\AdminModsListView(
     permission_listmods:   $canList,
+    permission_addmods:    $canAdd,
     permission_editmods:   $userbank->HasAccess(WebPermission::mask(WebPermission::Owner, WebPermission::EditMods)),
     permission_deletemods: $userbank->HasAccess(WebPermission::mask(WebPermission::Owner, WebPermission::DeleteMods)),
     mod_count:             $mod_count,

--- a/web/pages/admin.mods.php
+++ b/web/pages/admin.mods.php
@@ -37,8 +37,9 @@ if ($section === 'add') {
     return;
 }
 
+// mid=0 is the reserved Web pseudo-mod, not a configurable game mod.
 $mod_list  = $GLOBALS['PDO']->query("SELECT * FROM `:prefix_mods` WHERE mid > 0 ORDER BY name ASC")->resultset();
-$mod_count = (int) $GLOBALS['PDO']->query("SELECT COUNT(mid) AS cnt FROM `:prefix_mods`")->single()['cnt'];
+$mod_count = (int) $GLOBALS['PDO']->query("SELECT COUNT(mid) AS cnt FROM `:prefix_mods` WHERE mid > 0")->single()['cnt'];
 
 \Sbpp\View\Renderer::render($theme, new \Sbpp\View\AdminModsListView(
     permission_listmods:   $canList,

--- a/web/tests/e2e/specs/flows/mod-delete-confirm.spec.ts
+++ b/web/tests/e2e/specs/flows/mod-delete-confirm.spec.ts
@@ -210,7 +210,7 @@ test.describe('flow: admin mod delete confirm modal (#1397 — RemoveMod zombie)
         // Count badge decrements by exactly one (defensive — the
         // chrome's `decrementCount` reads the span's text and writes
         // back `n - 1`).
-        await expect(countBadge).toHaveText(String(startingCount - 1));
+        await expect(countBadge).toHaveText(`(${startingCount - 1})`);
 
         // Success toast surfaces. Anchor on `data-kind="success"` plus
         // a hasText filter on the title our handler emits ("Mod

--- a/web/tests/e2e/specs/flows/mod-delete-confirm.spec.ts
+++ b/web/tests/e2e/specs/flows/mod-delete-confirm.spec.ts
@@ -43,11 +43,11 @@
  *
  * Project gating
  * --------------
- * Pin to chromium (desktop). The flow mutates `:prefix_mods` and the
- * suite shares a single `sourcebans_e2e` DB across projects
- * (`workers: 1` is the suite-wide mitigation per AGENTS.md). Mobile
- * coverage doesn't add value for an admin-only chrome that's
- * structurally identical at every viewport.
+ * Pin to chromium. The flow mutates `:prefix_mods` and the suite shares
+ * a single `sourcebans_e2e` DB across projects (`workers: 1` is the
+ * suite-wide mitigation per AGENTS.md). The main mutation flow resizes
+ * that desktop context to exercise the mobile-card mirror without
+ * adding a second mutating project.
  */
 
 import { expect, test } from '../../fixtures/auth.ts';
@@ -64,6 +64,10 @@ const FIXTURE = {
 };
 
 test.describe('flow: admin mod delete confirm modal (#1397 — RemoveMod zombie)', () => {
+    // Both tests truncate and mutate the shared E2E database. Keep focused
+    // local runs serial even though the project enables full parallelism.
+    test.describe.configure({ mode: 'serial' });
+
     test.skip(({ isMobile }) => isMobile, 'flow spec runs only on desktop chromium');
 
     test.beforeEach(async () => {
@@ -128,13 +132,25 @@ test.describe('flow: admin mod delete confirm modal (#1397 — RemoveMod zombie)
         const targetMid = Number(targetMidAttr);
         expect(Number.isFinite(targetMid) && targetMid > 0).toBe(true);
 
-        // The count badge text is a bare digit. Read the starting value
-        // so we can assert it decrements by exactly one after the delete.
+        // The hidden mobile mirror must be removed by the same successful
+        // response, otherwise resizing after deletion resurrects the mod.
+        const targetCard = page
+            .locator('[data-testid="mods-list-card"]')
+            .filter({ hasText: FIXTURE.name })
+            .first();
+        await expect(targetCard).toHaveCount(1);
+
+        // Read the parenthesised starting value so we can assert it
+        // decrements by exactly one after the delete.
         const countBadge = page.locator('[data-testid="mod-count"]').first();
         await expect(countBadge).toBeVisible();
         const startingCountText = (await countBadge.textContent()) ?? '';
         const startingCount = Number(startingCountText.replace(/[^0-9]/g, ''));
         expect(Number.isFinite(startingCount) && startingCount > 0).toBe(true);
+        expect(await page.locator('[data-testid="mod-row"]').count())
+            .toBe(startingCount);
+        expect(await page.locator('[data-testid="mods-list-card"]').count())
+            .toBe(startingCount);
 
         // ---- 3. Click the trash button — dialog must open ----------------
         // The delete button is inside `.row-actions` on the row's
@@ -177,8 +193,18 @@ test.describe('flow: admin mod delete confirm modal (#1397 — RemoveMod zombie)
         // The row is still there — cancel didn't delete anything.
         await expect(targetRow).toBeVisible();
 
-        // ---- 5. Re-open + supply reason + confirm -----------------------
-        await deleteButton.click();
+        // ---- 5. Switch to mobile + re-open + confirm --------------------
+        await page.setViewportSize({ width: 390, height: 844 });
+        await expect(page.locator('[data-testid="mods-table"]')).toBeHidden();
+        await expect(page.locator('[data-testid="mods-list-cards"]')).toBeVisible();
+        await expect(targetCard).toBeVisible();
+        await expect(targetCard.locator('[data-testid="editmod-link-mobile"]')).toBeVisible();
+
+        const mobileDeleteButton = targetCard.locator(
+            '[data-testid="deletemod-btn-mobile"]',
+        );
+        await expect(mobileDeleteButton).toBeVisible();
+        await mobileDeleteButton.click();
         await expect(dialog).toBeVisible();
 
         const reasonInput = dialog.locator('[data-testid="mod-delete-reason"]');
@@ -204,6 +230,7 @@ test.describe('flow: admin mod delete confirm modal (#1397 — RemoveMod zombie)
 
         // ---- 6. Row removed in place ------------------------------------
         await expect(targetRow).toHaveCount(0);
+        await expect(targetCard).toHaveCount(0);
         // Dialog closes after success.
         await expect(dialog).toBeHidden();
 
@@ -221,6 +248,7 @@ test.describe('flow: admin mod delete confirm modal (#1397 — RemoveMod zombie)
         await expect(successToast).toBeVisible();
 
         // ---- 7. Audit log carries the reason ----------------------------
+        await page.setViewportSize({ width: 1280, height: 720 });
         // Navigate to the audit log and assert the most recent
         // "MOD Deleted" entry's body contains the reason. The audit
         // page's row body is `<div class="audit-row__detail">`.

--- a/web/tests/e2e/specs/flows/mod-delete-confirm.spec.ts
+++ b/web/tests/e2e/specs/flows/mod-delete-confirm.spec.ts
@@ -300,6 +300,33 @@ test.describe('flow: admin mod delete confirm modal (#1397 — RemoveMod zombie)
             .first();
         await expect(row).toBeVisible();
 
+        // Model the final visible mod without deleting fixture rows from the
+        // shared DB. This isolates the client-side 1 → 0 transition that must
+        // reveal the already-mounted empty state after a successful delete.
+        const targetMid = await row.getAttribute('data-id');
+        expect(targetMid).not.toBeNull();
+        await page.locator('[data-testid="mod-row"]').evaluateAll((nodes, keepMid) => {
+            nodes.forEach((node) => {
+                if (node.getAttribute('data-id') !== keepMid) node.remove();
+            });
+        }, targetMid);
+        await page.locator('[data-testid="mods-list-card"]').evaluateAll((nodes, keepMid) => {
+            nodes.forEach((node) => {
+                if (node.getAttribute('data-id') !== keepMid) node.remove();
+            });
+        }, targetMid);
+
+        const targetCard = page
+            .locator('[data-testid="mods-list-card"]')
+            .filter({ hasText: 'e2e-no-reason-mod' });
+        const countBadge = page.locator('[data-testid="mod-count"]');
+        await countBadge.evaluate((node) => {
+            node.textContent = '(1)';
+        });
+        await expect(page.locator('[data-testid="mod-row"]')).toHaveCount(1);
+        await expect(targetCard).toHaveCount(1);
+        await expect(page.locator('[data-testid="mods-empty"]')).toBeHidden();
+
         await row.locator('[data-testid="deletemod-btn"]').click();
         const dialog = page.locator('[data-testid="mod-delete-dialog"]');
         await expect(dialog).toBeVisible();
@@ -314,7 +341,17 @@ test.describe('flow: admin mod delete confirm modal (#1397 — RemoveMod zombie)
         expect(env.ok, JSON.stringify(env)).toBe(true);
 
         await expect(row).toHaveCount(0);
+        await expect(targetCard).toHaveCount(0);
+        await expect(countBadge).toHaveText('(0)');
+        await expect(page.locator('[data-testid="mods-table-wrap"]')).toHaveAttribute('hidden', '');
+        await expect(page.locator('[data-testid="mods-list-cards"]')).toHaveAttribute('hidden', '');
+        await expect(page.locator('[data-testid="mods-empty"]')).toBeVisible();
 
+        await page.setViewportSize({ width: 390, height: 844 });
+        await expect(page.locator('[data-testid="mods-list-cards"]')).toBeHidden();
+        await expect(page.locator('[data-testid="mods-empty"]')).toBeVisible();
+
+        await page.setViewportSize({ width: 1280, height: 720 });
         await page.goto(AUDIT_ROUTE);
         const auditDetail = page
             .locator('.audit-row__detail')

--- a/web/tests/integration/EditAdminTabsChromeTest.php
+++ b/web/tests/integration/EditAdminTabsChromeTest.php
@@ -103,4 +103,36 @@ final class EditAdminTabsChromeTest extends TestCase
             );
         }
     }
+
+    public function testStandaloneEditModKeepsBackStrip(): void
+    {
+        $src = (string) file_get_contents(ROOT . 'pages/admin.edit.mod.php');
+
+        $this->assertStringContainsString(
+            'new \\Sbpp\\View\\AdminTabs([],',
+            $src,
+            'The standalone mod editor must keep the shared Back strip; it has no in-template section tabs.',
+        );
+    }
+
+    public function testEditModMetadataDoesNotRenderAsRawHtml(): void
+    {
+        $src = (string) file_get_contents(self::THEME . 'page_admin_edit_mod.tpl');
+
+        $this->assertStringContainsString(
+            'Edit mod · {$name|unescape:\'html\'}',
+            $src,
+            'Stored entities should be decoded before Smarty applies its final automatic escape.',
+        );
+        $this->assertSame(
+            5,
+            substr_count($src, '|unescape:\'html\''),
+            'The title plus every name, folder, and icon sink must decode once before the final escape.',
+        );
+        $this->assertStringNotContainsString(
+            'nofilter',
+            $src,
+            'Legacy or externally seeded raw mod metadata must never bypass Smarty escaping.',
+        );
+    }
 }

--- a/web/tests/integration/EditAdminTabsChromeTest.php
+++ b/web/tests/integration/EditAdminTabsChromeTest.php
@@ -124,6 +124,11 @@ final class EditAdminTabsChromeTest extends TestCase
             $src,
             'Stored entities should be decoded before Smarty applies its final automatic escape.',
         );
+        $this->assertStringContainsString(
+            'overflow-wrap:anywhere',
+            $src,
+            'A schema-width mod name must not overflow the edit heading on narrow viewports.',
+        );
         $this->assertSame(
             5,
             substr_count($src, '|unescape:\'html\''),

--- a/web/tests/integration/ModsDeleteDialogTest.php
+++ b/web/tests/integration/ModsDeleteDialogTest.php
@@ -218,18 +218,17 @@ final class ModsDeleteDialogTest extends ApiTestCase
      * The mod count badge must carry `data-testid="mod-count"` so the
      * page-tail script can decrement it after a delete and the E2E
      * spec can read it as the pre / post-delete oracle. Without the
-     * testid the badge is unreachable in a theme-agnostic way (the
-     * surrounding `<p>… configured</p>` shape is too brittle to
-     * regex against).
+     * testid the badge is unreachable in a theme-agnostic way. The
+     * rendered text is `(N)` (same shape as the Admins list badge).
      */
     public function testCountBadgeCarriesTestid(): void
     {
         $html = $this->renderModsPage();
 
         $this->assertMatchesRegularExpression(
-            '/<span[^>]*data-testid="mod-count"[^>]*>\s*\d+\s*<\/span>/',
+            '/<span[^>]*data-testid="mod-count"[^>]*>\s*\(?\d+\)?\s*<\/span>/',
             $html,
-            'The mod count number must be wrapped in <span data-testid="mod-count">.'
+            'The mod count number must be wrapped in <span data-testid="mod-count"> (optionally parenthesised, matching the Admins list badge).'
         );
     }
 

--- a/web/tests/integration/ModsDeleteDialogTest.php
+++ b/web/tests/integration/ModsDeleteDialogTest.php
@@ -112,6 +112,8 @@ final class ModsDeleteDialogTest extends ApiTestCase
         $this->assertStringContainsString('data-name="' . $this->targetName . '"', $html);
         $this->assertStringContainsString('src="images/games/default&amp;alt.png"', $html);
         $this->assertStringContainsString('>delete&amp;target</span>', $html);
+        $this->assertStringContainsString('title="delete&amp;target"', $html,
+            'The truncated mobile folder must expose its full value.');
         $this->assertStringNotContainsString('&amp;amp;', $html,
             'Entity-encoded mod metadata must be decoded before Smarty applies its final escape.');
         $this->assertStringContainsString('data-fallback-href="index.php?p=admin&amp;c=mods"', $html,
@@ -266,12 +268,36 @@ final class ModsDeleteDialogTest extends ApiTestCase
     {
         $html = $this->renderModsPage();
 
-        $this->assertStringContainsString("String(n - 1) + ')'", $html);
+        $this->assertStringContainsString("String(next) + ')'", $html);
+        $this->assertStringContainsString('if (next === 0) showEmptyState();', $html);
         $this->assertStringNotContainsString(
             '(n - 1).toLocaleString()',
             $html,
             'Localized numerals cannot be parsed by the next ASCII-digit decrement.',
         );
+    }
+
+    public function testZeroGameModsRendersActionableEmptyState(): void
+    {
+        Fixture::rawPdo()->exec(sprintf(
+            'DELETE FROM `%s_mods` WHERE mid > 0',
+            DB_PREFIX,
+        ));
+
+        $html = $this->renderModsPage();
+
+        $this->assertStringContainsString('data-testid="mod-count">(0)</span>', $html);
+        $this->assertSame(0, preg_match_all('/<tr\b[^>]*data-testid="mod-row"[^>]*>/', $html));
+        $this->assertStringContainsString('data-testid="mods-empty-add"', $html);
+
+        $matched = preg_match(
+            '/<div class="empty-state"[^>]*data-testid="mods-empty"[^>]*>/s',
+            $html,
+            $emptyTag,
+        );
+        $this->assertSame(1, $matched, 'The mods empty state must render.');
+        $this->assertStringNotContainsString(' hidden', $emptyTag[0],
+            'The server-rendered empty state must be visible when no game mods remain.');
     }
 
     private function seedTargetMod(): void

--- a/web/tests/integration/ModsDeleteDialogTest.php
+++ b/web/tests/integration/ModsDeleteDialogTest.php
@@ -110,6 +110,10 @@ final class ModsDeleteDialogTest extends ApiTestCase
 
         // Verify the supporting attributes are all present.
         $this->assertStringContainsString('data-name="' . $this->targetName . '"', $html);
+        $this->assertStringContainsString('src="images/games/default&amp;alt.png"', $html);
+        $this->assertStringContainsString('>delete&amp;target</span>', $html);
+        $this->assertStringNotContainsString('&amp;amp;', $html,
+            'Entity-encoded mod metadata must be decoded before Smarty applies its final escape.');
         $this->assertStringContainsString('data-fallback-href="index.php?p=admin&amp;c=mods"', $html,
             'The fallback URL lands the no-JS / no-dispatcher operator on the mods list ' .
             '(no legacy GET handler exists for `o=remove`).');
@@ -226,9 +230,47 @@ final class ModsDeleteDialogTest extends ApiTestCase
         $html = $this->renderModsPage();
 
         $this->assertMatchesRegularExpression(
-            '/<span[^>]*data-testid="mod-count"[^>]*>\s*\(?\d+\)?\s*<\/span>/',
+            '/<span[^>]*data-testid="mod-count"[^>]*>\s*\(\d+\)\s*<\/span>/',
             $html,
-            'The mod count number must be wrapped in <span data-testid="mod-count"> (optionally parenthesised, matching the Admins list badge).'
+            'The mod count must be parenthesised inside <span data-testid="mod-count">, matching the Admins list badge.'
+        );
+    }
+
+    /**
+     * `mid = 0` is the reserved Web pseudo-mod. It is deliberately absent
+     * from both list renderings, so the heading count must exclude it too.
+     */
+    public function testCountBadgeMatchesDesktopRowsAndMobileCards(): void
+    {
+        $html = $this->renderModsPage();
+
+        $matched = preg_match(
+            '/<span[^>]*data-testid="mod-count"[^>]*>\s*\((\d+)\)\s*<\/span>/',
+            $html,
+            $countMatch,
+        );
+        $this->assertSame(1, $matched, 'The parenthesised mod count must render.');
+
+        $desktopRows = preg_match_all('/<tr\b[^>]*data-testid="mod-row"[^>]*>/', $html);
+        $mobileCards = preg_match_all('/<div\b[^>]*data-testid="mods-list-card"[^>]*>/', $html);
+
+        $this->assertNotFalse($desktopRows);
+        $this->assertNotFalse($mobileCards);
+        $this->assertSame((int) $countMatch[1], $desktopRows,
+            'The heading count must equal the visible game-mod rows, excluding the reserved Web pseudo-mod.');
+        $this->assertSame($desktopRows, $mobileCards,
+            'Every desktop mod row must have one mobile-card mirror.');
+    }
+
+    public function testCountDecrementKeepsAsciiDigitsForSubsequentDeletes(): void
+    {
+        $html = $this->renderModsPage();
+
+        $this->assertStringContainsString("String(n - 1) + ')'", $html);
+        $this->assertStringNotContainsString(
+            '(n - 1).toLocaleString()',
+            $html,
+            'Localized numerals cannot be parsed by the next ASCII-digit decrement.',
         );
     }
 
@@ -236,15 +278,14 @@ final class ModsDeleteDialogTest extends ApiTestCase
     {
         $pdo = Fixture::rawPdo();
 
-        // Use a name that's safe through htmlspecialchars and survives
-        // the data-name attribute round-trip without escaping noise so
-        // the data-name assertion stays readable.
-        $this->targetName = 'DeleteTargetMod';
+        // Mirror api_mods_add's escaping-on-store shape. The rendered
+        // list should decode this once, then let Smarty escape it once.
+        $this->targetName = 'Delete &amp; Target';
 
         $pdo->prepare(sprintf(
             'INSERT INTO `%s_mods` (name, icon, modfolder, steam_universe, enabled) VALUES (?, ?, ?, ?, ?)',
             DB_PREFIX,
-        ))->execute([$this->targetName, 'default.png', 'deletetargetmod', 0, 1]);
+        ))->execute([$this->targetName, 'default&amp;alt.png', 'delete&amp;target', 0, 1]);
         $this->targetMid = (int) $pdo->lastInsertId();
     }
 

--- a/web/themes/default/css/theme.css
+++ b/web/themes/default/css/theme.css
@@ -2130,6 +2130,11 @@ details.queue-row > summary > .row-actions {
 .admins-list-card:last-child { border-bottom: none; }
 .admins-list-card__body { padding: 0.75rem 1rem 0.25rem; }
 
+.mods-list-cards { display: none; }
+.mods-list-card { border-bottom: 1px solid var(--border); }
+.mods-list-card:last-child { border-bottom: none; }
+.mods-list-card__body { padding: 0.75rem 1rem 0.25rem; }
+
 /* ---- Responsive ---- */
 [data-mobile-menu] { display: none; }
 @media (max-width: 1024px) {
@@ -2148,6 +2153,7 @@ details.queue-row > summary > .row-actions {
      dance as `.ban-cards` — hidden at desktop, block at mobile. */
   .log-cards { display: block; }
   .admins-list-cards { display: block; }
+  .mods-list-cards { display: block; }
   /* #1181: filter chip rows wrap onto multiple lines on mobile
      instead of horizontal-scrolling, so every chip is reachable
      without a swipe. The .scroll-x desktop affordance is the
@@ -2159,6 +2165,7 @@ details.queue-row > summary > .row-actions {
   .ban-cards { display: none; }
   .log-cards { display: none; }
   .admins-list-cards { display: none; }
+  .mods-list-cards { display: none; }
 }
 
 /* ---- Utility classes used by templates ---- */

--- a/web/themes/default/css/theme.css
+++ b/web/themes/default/css/theme.css
@@ -2131,6 +2131,7 @@ details.queue-row > summary > .row-actions {
 .admins-list-card__body { padding: 0.75rem 1rem 0.25rem; }
 
 .mods-list-cards { display: none; }
+.mods-list-cards[hidden] { display: none; }
 .mods-list-card { border-bottom: 1px solid var(--border); }
 .mods-list-card:last-child { border-bottom: none; }
 .mods-list-card__body { padding: 0.75rem 1rem 0.25rem; }
@@ -2245,6 +2246,7 @@ details.queue-row > summary > .row-actions {
   padding: 2.5rem 1.5rem;
   color: var(--text-muted);
 }
+.empty-state[hidden] { display: none; }
 .empty-state__icon {
   width: 2.5rem;
   height: 2.5rem;

--- a/web/themes/default/page_admin_edit_mod.tpl
+++ b/web/themes/default/page_admin_edit_mod.tpl
@@ -27,7 +27,18 @@
     template variable — no MooTools-era `$('enabled').checked = …`
     re-paint script.
 *}
-<div class="page-section">
+<div class="page-section" data-testid="editmod-section" style="max-width:48rem">
+    <div class="mb-6">
+        {* nofilter: name is htmlspecialchars'd on store in admin.edit.mod.php;
+           auto-escaping here would double-encode (#1108 / #1113). *}
+        <h1 style="font-size:var(--fs-xl);font-weight:600;margin:0" data-testid="editmod-title">
+            Edit mod · {$name nofilter}
+        </h1>
+        <p class="text-sm text-muted m-0 mt-2">
+            Update the configuration for this game mod.
+        </p>
+    </div>
+
 <form method="post"
       action=""
       enctype="multipart/form-data"
@@ -35,13 +46,7 @@
       data-testid="editmod-form">
     {csrf_field}
     <div class="card">
-        <div class="card__header">
-            <div>
-                <h3>Edit Mod</h3>
-                <p>Update the configuration for this game mod.</p>
-            </div>
-        </div>
-        <div class="card__body space-y-4" style="max-width:42rem">
+        <div class="card__body space-y-4">
             <input type="hidden" name="insert_type" value="add">
 
             {* nofilter: mod metadata is htmlspecialchars(strip_tags($_POST[…]))'d in admin.edit.mod.php before INSERT/UPDATE, so values pulled back out of `:prefix_mods` are already entity-encoded; auto-escaping the value attribute would double-encode (#1113 audit). The id="icon_hid" element is the channel the popup uploader writes into via window.opener.icon(). *}

--- a/web/themes/default/page_admin_edit_mod.tpl
+++ b/web/themes/default/page_admin_edit_mod.tpl
@@ -29,10 +29,10 @@
 *}
 <div class="page-section" data-testid="editmod-section" style="max-width:48rem">
     <div class="mb-6">
-        {* nofilter: name is htmlspecialchars'd on store in admin.edit.mod.php;
-           auto-escaping here would double-encode (#1108 / #1113). *}
+        {* Mod names are entity-encoded on store. Decode before Smarty's
+           automatic final escape so the heading stays both readable and safe. *}
         <h1 style="font-size:var(--fs-xl);font-weight:600;margin:0" data-testid="editmod-title">
-            Edit mod · {$name nofilter}
+            Edit mod · {$name|unescape:'html'}
         </h1>
         <p class="text-sm text-muted m-0 mt-2">
             Update the configuration for this game mod.
@@ -49,18 +49,19 @@
         <div class="card__body space-y-4">
             <input type="hidden" name="insert_type" value="add">
 
-            {* nofilter: mod metadata is htmlspecialchars(strip_tags($_POST[…]))'d in admin.edit.mod.php before INSERT/UPDATE, so values pulled back out of `:prefix_mods` are already entity-encoded; auto-escaping the value attribute would double-encode (#1113 audit). The id="icon_hid" element is the channel the popup uploader writes into via window.opener.icon(). *}
-            <input type="hidden" id="icon_hid" name="icon_hid" value="{$mod_icon nofilter}">
+            {* Mod metadata is entity-encoded on store. Decode that layer
+               before Smarty's automatic final escape so legacy raw values
+               cannot break out of text or attribute contexts. *}
+            <input type="hidden" id="icon_hid" name="icon_hid" value="{$mod_icon|unescape:'html'}">
 
             <div>
                 <label class="label" for="name">Mod name</label>
-                {* nofilter: see the icon_hid annotation above — name is htmlspecialchars'd on store, double-encoding it in the value attribute would render literal &amp;… to admins (#1108 / #1113 audit). *}
                 <input class="input"
                        type="text"
                        id="name"
                        name="name"
                        data-testid="editmod-name"
-                       value="{$name nofilter}"
+                       value="{$name|unescape:'html'}"
                        required>
                 <div id="name.msg"
                      class="text-xs"
@@ -69,13 +70,12 @@
 
             <div>
                 <label class="label" for="folder">Mod folder</label>
-                {* nofilter: see the icon_hid annotation above — folder is htmlspecialchars'd on store. *}
                 <input class="input"
                        type="text"
                        id="folder"
                        name="folder"
                        data-testid="editmod-folder"
-                       value="{$folder nofilter}"
+                       value="{$folder|unescape:'html'}"
                        required>
                 <p class="text-xs text-muted" style="margin-top:0.25rem">
                     Folder name on disk (e.g. <span class="font-mono">cstrike</span> for Counter-Strike: Source).
@@ -125,8 +125,7 @@
                     {if $mod_icon}
                         <span class="text-xs text-muted">
                             Current:
-                            {* nofilter: see the icon_hid annotation above — icon filename is htmlspecialchars'd on store. *}
-                            <span class="font-mono" data-testid="editmod-current-icon">{$mod_icon nofilter}</span>
+                            <span class="font-mono" data-testid="editmod-current-icon">{$mod_icon|unescape:'html'}</span>
                         </span>
                     {/if}
                 </div>

--- a/web/themes/default/page_admin_edit_mod.tpl
+++ b/web/themes/default/page_admin_edit_mod.tpl
@@ -31,7 +31,7 @@
     <div class="mb-6">
         {* Mod names are entity-encoded on store. Decode before Smarty's
            automatic final escape so the heading stays both readable and safe. *}
-        <h1 style="font-size:var(--fs-xl);font-weight:600;margin:0" data-testid="editmod-title">
+        <h1 style="font-size:var(--fs-xl);font-weight:600;margin:0;overflow-wrap:anywhere" data-testid="editmod-title">
             Edit mod · {$name|unescape:'html'}
         </h1>
         <p class="text-sm text-muted m-0 mt-2">

--- a/web/themes/default/page_admin_mods_add.tpl
+++ b/web/themes/default/page_admin_mods_add.tpl
@@ -42,7 +42,7 @@
     without depending on element ids. The icon-callback hidden input is
     `#icon_hid` to mirror the edit-mod template.
 *}
-<div class="page-section">
+<div class="page-section" data-testid="addmod-section" style="max-width:48rem">
 {if NOT $permission_add}
     <div class="card">
         <div class="card__body">
@@ -50,6 +50,15 @@
         </div>
     </div>
 {else}
+    <div class="mb-6">
+        <h1 style="font-size:var(--fs-xl);font-weight:600;margin:0" data-testid="addmod-title">
+            Add mod
+        </h1>
+        <p class="text-sm text-muted m-0 mt-2">
+            Configure a new game mod that can be assigned to bans and servers.
+        </p>
+    </div>
+
     <form method="post"
           action=""
           enctype="multipart/form-data"
@@ -58,13 +67,7 @@
           data-testid="addmod-form">
         {csrf_field}
         <div class="card">
-            <div class="card__header">
-                <div>
-                    <h3>Add Mod</h3>
-                    <p>Configure a new game mod that can be assigned to bans and servers.</p>
-                </div>
-            </div>
-            <div class="card__body space-y-4" style="max-width:42rem">
+            <div class="card__body space-y-4">
                 {* #1402: the legacy `<input id="fromsub">` hidden was a vestigial
                    reference to the v1.x ProcessMod() flow; the new submit handler
                    has no equivalent. Replaced with `#icon_hid` so the upload-icon

--- a/web/themes/default/page_admin_mods_list.tpl
+++ b/web/themes/default/page_admin_mods_list.tpl
@@ -43,15 +43,20 @@
         </div>
     </div>
 {else}
-    <div class="card">
-        <div class="card__header">
-            <div>
-                <h3>Server Mods</h3>
-                <p><span data-testid="mod-count">{$mod_count}</span> configured</p>
-            </div>
-        </div>
+    <div class="mb-4">
+        <h1 style="font-size:var(--fs-xl);font-weight:600;margin:0" data-testid="mods-list-title">
+            Mods
+            <span class="text-faint" style="font-weight:400;margin-left:0.375rem" data-testid="mod-count">({$mod_count})</span>
+        </h1>
+        <p class="text-sm text-muted m-0 mt-2">
+            Game mods that can be assigned to bans and servers.
+        </p>
+    </div>
+
+    <div class="card" style="overflow:hidden">
         {if $mod_count > 0}
-            <table class="table" data-testid="mods-table">
+            <div class="table-scroll">
+            <table class="table table--compact" data-testid="mods-table">
                 <thead>
                     <tr>
                         <th style="width:40%">Name</th>
@@ -67,11 +72,11 @@
                     {foreach from=$mod_list item=mod}
                         <tr id="mid_{$mod.mid}" data-testid="mod-row" data-id="{$mod.mid}">
                             <td>
-                                <div class="flex items-center gap-3">
+                                <div class="flex items-center gap-2">
                                     <img src="images/games/{$mod.icon}"
                                          alt=""
-                                         width="20"
-                                         height="20"
+                                         width="18"
+                                         height="18"
                                          loading="lazy"
                                          onerror="this.style.visibility='hidden'">
                                     <span class="font-medium">{$mod.name}</span>
@@ -87,12 +92,20 @@
                                 {/if}
                             </td>
                             {if $permission_editmods || $permission_deletemods}
-                                <td style="text-align:right">
-                                    <div class="flex justify-end gap-2">
+                                <td class="col-actions" style="text-align:right">
+                                    {* Icon-only row actions matching banlist / admins list:
+                                       Lucide icon + `data-tooltip` + `aria-label` inside
+                                       `.row-actions--icons`. Keep `data-testid` / `data-action`
+                                       / `data-fallback-href` wiring unchanged. *}
+                                    <div class="row-actions row-actions--icons">
                                         {if $permission_editmods}
-                                            <a class="btn btn--ghost btn--sm"
+                                            <a class="btn btn--ghost btn--icon btn--sm"
                                                href="index.php?p=admin&c=mods&o=edit&id={$mod.mid|escape:'url'}"
-                                               data-testid="editmod-link">Edit</a>
+                                               data-testid="editmod-link"
+                                               data-tooltip="Edit"
+                                               aria-label="Edit mod {$mod.name|escape}">
+                                                <i data-lucide="pencil" style="width:14px;height:14px"></i>
+                                            </a>
                                         {/if}
                                         {if $permission_deletemods}
                                             {* #1397: data-action wires the delete button to the inline
@@ -110,14 +123,17 @@
                                                beyond the bug; the fallback is a graceful degradation
                                                for the rare case where the JSON dispatcher itself is
                                                missing (e.g. third-party theme that stripped api.js). *}
-                                            <button class="btn btn--ghost btn--sm"
+                                            <button class="btn btn--ghost btn--icon btn--sm"
                                                     type="button"
                                                     data-action="mod-delete"
                                                     data-mid="{$mod.mid}"
                                                     data-name="{$mod.name|escape}"
                                                     data-fallback-href="index.php?p=admin&amp;c=mods"
                                                     data-testid="deletemod-btn"
-                                                    aria-label="Delete mod {$mod.name|escape}">Delete</button>
+                                                    data-tooltip="Delete"
+                                                    aria-label="Delete mod {$mod.name|escape}">
+                                                <i data-lucide="trash-2" style="width:14px;height:14px;color:var(--danger)"></i>
+                                            </button>
                                         {/if}
                                     </div>
                                 </td>
@@ -126,6 +142,65 @@
                     {/foreach}
                 </tbody>
             </table>
+            </div>
+
+            {* Mobile cards — paired surface for the global
+               `@media (max-width: 768px) { .table { display: none } }`
+               rule. Same display dance as `.admins-list-cards`. *}
+            <div class="mods-list-cards" data-testid="mods-list-cards">
+                {foreach from=$mod_list item=mod}
+                    <div class="mods-list-card" data-testid="mods-list-card" data-id="{$mod.mid}">
+                        <div class="mods-list-card__body flex items-center gap-3">
+                            <img src="images/games/{$mod.icon}"
+                                 alt=""
+                                 width="28"
+                                 height="28"
+                                 loading="lazy"
+                                 onerror="this.style.visibility='hidden'">
+                            <div style="flex:1;min-width:0">
+                                <div class="font-medium text-sm truncate">{$mod.name}</div>
+                                <div class="text-xs text-muted truncate" style="margin-top:0.125rem">
+                                    <span class="font-mono">{$mod.modfolder}</span>
+                                    · SU {$mod.steam_universe}
+                                </div>
+                                <div style="margin-top:0.35rem">
+                                    {if $mod.enabled}
+                                        <span class="pill pill--online">Enabled</span>
+                                    {else}
+                                        <span class="pill pill--offline">Disabled</span>
+                                    {/if}
+                                </div>
+                            </div>
+                        </div>
+                        {if $permission_editmods || $permission_deletemods}
+                        <div class="row-actions row-actions--icons ban-card__actions">
+                            {if $permission_editmods}
+                                <a class="btn btn--ghost btn--icon btn--sm"
+                                   href="index.php?p=admin&amp;c=mods&amp;o=edit&amp;id={$mod.mid|escape:'url'}"
+                                   data-testid="editmod-link-mobile"
+                                   data-tooltip="Edit"
+                                   aria-label="Edit mod {$mod.name|escape}">
+                                    <i data-lucide="pencil" style="width:14px;height:14px"></i>
+                                </a>
+                            {/if}
+                            {if $permission_deletemods}
+                                <button class="btn btn--ghost btn--icon btn--sm"
+                                        type="button"
+                                        data-action="mod-delete"
+                                        data-mid="{$mod.mid}"
+                                        data-name="{$mod.name|escape}"
+                                        data-fallback-href="index.php?p=admin&amp;c=mods"
+                                        data-testid="deletemod-btn-mobile"
+                                        data-tooltip="Delete"
+                                        aria-label="Delete mod {$mod.name|escape}">
+                                    <i data-lucide="trash-2" style="width:14px;height:14px;color:var(--danger)"></i>
+                                </button>
+                            {/if}
+                        </div>
+                        {/if}
+                    </div>
+                {/foreach}
+            </div>
         {else}
             <div class="card__body">
                 <p class="text-muted">No mods configured yet.</p>
@@ -258,10 +333,13 @@
 
         /**
          * @param {string} mid
-         * @returns {Element|null}
+         * @returns {NodeListOf<Element>}
          */
-        function rowForMid(mid) {
-            return document.querySelector('[data-testid="mod-row"][data-id="' + mid + '"]');
+        function rowsForMid(mid) {
+            return document.querySelectorAll(
+                '[data-testid="mod-row"][data-id="' + mid + '"],'
+                + '[data-testid="mods-list-card"][data-id="' + mid + '"]'
+            );
         }
 
         /**
@@ -276,7 +354,7 @@
             if (!el) return;
             var n = Number((el.textContent || '').replace(/[^0-9]/g, ''));
             if (!Number.isFinite(n) || n <= 0) return;
-            el.textContent = String(n - 1);
+            el.textContent = '(' + (n - 1).toLocaleString() + ')';
         }
 
         /** @returns {HTMLDialogElement|null} */
@@ -397,8 +475,11 @@
                     toast('error', 'Delete failed', msg);
                     return;
                 }
-                var row = rowForMid(ctx.mid);
-                if (row && row.parentNode) row.parentNode.removeChild(row);
+                var rows = rowsForMid(ctx.mid);
+                for (var i = 0; i < rows.length; i++) {
+                    var row = rows[i];
+                    if (row && row.parentNode) row.parentNode.removeChild(row);
+                }
                 decrementCount();
                 closeDeleteDialog();
                 toast('success', 'Mod deleted', ctx.name + ' has been removed.');

--- a/web/themes/default/page_admin_mods_list.tpl
+++ b/web/themes/default/page_admin_mods_list.tpl
@@ -7,6 +7,7 @@
 
     Variable contract (kept in sync by SmartyTemplateRule):
         - $permission_listmods   — gate the whole tab body.
+        - $permission_addmods    — gate the empty-state "Add mod" CTA.
         - $permission_editmods   — gate the per-row "Edit" link.
         - $permission_deletemods — gate the per-row "Delete" button.
         - $mod_count             — total mods configured.
@@ -55,7 +56,7 @@
 
     <div class="card" style="overflow:hidden">
         {if $mod_count > 0}
-            <div class="table-scroll">
+            <div class="table-scroll" data-testid="mods-table-wrap">
             <table class="table table--compact" data-testid="mods-table">
                 <thead>
                     <tr>
@@ -162,9 +163,11 @@
                                  onerror="this.style.visibility='hidden'">
                             <div style="flex:1;min-width:0">
                                 <div class="font-medium text-sm truncate">{$mod.name|unescape:'html'}</div>
-                                <div class="text-xs text-muted truncate" style="margin-top:0.125rem">
-                                    <span class="font-mono">{$mod.modfolder|unescape:'html'}</span>
-                                    · SU {$mod.steam_universe}
+                                <div class="flex items-center gap-2 text-xs text-muted" style="margin-top:0.125rem">
+                                    <span class="font-mono truncate"
+                                          style="min-width:0"
+                                          title="{$mod.modfolder|unescape:'html'}">{$mod.modfolder|unescape:'html'}</span>
+                                    <span class="tabular-nums" style="flex-shrink:0">SU {$mod.steam_universe}</span>
                                 </div>
                                 <div style="margin-top:0.35rem">
                                     {if $mod.enabled}
@@ -204,11 +207,28 @@
                     </div>
                 {/foreach}
             </div>
-        {else}
-            <div class="card__body">
-                <p class="text-muted">No mods configured yet.</p>
-            </div>
         {/if}
+
+        <div class="empty-state"
+             data-testid="mods-empty"
+             data-filtered="false"
+             {if $mod_count > 0}hidden{/if}>
+            <div class="empty-state__icon" aria-hidden="true">
+                <i data-lucide="puzzle"></i>
+            </div>
+            <h2 class="empty-state__title">No mods configured yet</h2>
+            <p class="empty-state__body">Add a game mod before assigning it to bans or servers.</p>
+            {if $permission_addmods}
+                <div class="empty-state__actions">
+                    <a class="btn btn--primary btn--sm"
+                       href="index.php?p=admin&amp;c=mods&amp;section=add"
+                       data-testid="mods-empty-add">
+                        <i data-lucide="plus"></i>
+                        Add mod
+                    </a>
+                </div>
+            {/if}
+        </div>
     </div>
 
     {if $permission_deletemods}
@@ -345,6 +365,16 @@
             );
         }
 
+        /** @returns {void} */
+        function showEmptyState() {
+            var tableWrap = document.querySelector('[data-testid="mods-table-wrap"]');
+            var cards = document.querySelector('[data-testid="mods-list-cards"]');
+            var empty = document.querySelector('[data-testid="mods-empty"]');
+            if (tableWrap) tableWrap.setAttribute('hidden', '');
+            if (cards) cards.setAttribute('hidden', '');
+            if (empty) empty.removeAttribute('hidden');
+        }
+
         /**
          * Drop one from the count badge. Reads the digits out of the badge's
          * textContent so a third-party theme that wraps the count
@@ -357,7 +387,9 @@
             if (!el) return;
             var n = Number((el.textContent || '').replace(/[^0-9]/g, ''));
             if (!Number.isFinite(n) || n <= 0) return;
-            el.textContent = '(' + String(n - 1) + ')';
+            var next = n - 1;
+            el.textContent = '(' + String(next) + ')';
+            if (next === 0) showEmptyState();
         }
 
         /** @returns {HTMLDialogElement|null} */

--- a/web/themes/default/page_admin_mods_list.tpl
+++ b/web/themes/default/page_admin_mods_list.tpl
@@ -69,20 +69,23 @@
                     </tr>
                 </thead>
                 <tbody>
+                    {* Mod metadata is entity-encoded on store. Decode before
+                       Smarty's automatic final escape at every text and
+                       attribute sink so values stay readable without raw HTML. *}
                     {foreach from=$mod_list item=mod}
                         <tr id="mid_{$mod.mid}" data-testid="mod-row" data-id="{$mod.mid}">
                             <td>
                                 <div class="flex items-center gap-2">
-                                    <img src="images/games/{$mod.icon}"
+                                    <img src="images/games/{$mod.icon|unescape:'html'}"
                                          alt=""
                                          width="18"
                                          height="18"
                                          loading="lazy"
                                          onerror="this.style.visibility='hidden'">
-                                    <span class="font-medium">{$mod.name}</span>
+                                    <span class="font-medium">{$mod.name|unescape:'html'}</span>
                                 </div>
                             </td>
-                            <td><span class="font-mono text-xs">{$mod.modfolder}</span></td>
+                            <td><span class="font-mono text-xs">{$mod.modfolder|unescape:'html'}</span></td>
                             <td class="tabular-nums">{$mod.steam_universe}</td>
                             <td>
                                 {if $mod.enabled}
@@ -103,7 +106,7 @@
                                                href="index.php?p=admin&c=mods&o=edit&id={$mod.mid|escape:'url'}"
                                                data-testid="editmod-link"
                                                data-tooltip="Edit"
-                                               aria-label="Edit mod {$mod.name|escape}">
+                                               aria-label="Edit mod {$mod.name|unescape:'html'}">
                                                 <i data-lucide="pencil" style="width:14px;height:14px"></i>
                                             </a>
                                         {/if}
@@ -127,11 +130,11 @@
                                                     type="button"
                                                     data-action="mod-delete"
                                                     data-mid="{$mod.mid}"
-                                                    data-name="{$mod.name|escape}"
+                                                    data-name="{$mod.name|unescape:'html'}"
                                                     data-fallback-href="index.php?p=admin&amp;c=mods"
                                                     data-testid="deletemod-btn"
                                                     data-tooltip="Delete"
-                                                    aria-label="Delete mod {$mod.name|escape}">
+                                                    aria-label="Delete mod {$mod.name|unescape:'html'}">
                                                 <i data-lucide="trash-2" style="width:14px;height:14px;color:var(--danger)"></i>
                                             </button>
                                         {/if}
@@ -151,16 +154,16 @@
                 {foreach from=$mod_list item=mod}
                     <div class="mods-list-card" data-testid="mods-list-card" data-id="{$mod.mid}">
                         <div class="mods-list-card__body flex items-center gap-3">
-                            <img src="images/games/{$mod.icon}"
+                            <img src="images/games/{$mod.icon|unescape:'html'}"
                                  alt=""
                                  width="28"
                                  height="28"
                                  loading="lazy"
                                  onerror="this.style.visibility='hidden'">
                             <div style="flex:1;min-width:0">
-                                <div class="font-medium text-sm truncate">{$mod.name}</div>
+                                <div class="font-medium text-sm truncate">{$mod.name|unescape:'html'}</div>
                                 <div class="text-xs text-muted truncate" style="margin-top:0.125rem">
-                                    <span class="font-mono">{$mod.modfolder}</span>
+                                    <span class="font-mono">{$mod.modfolder|unescape:'html'}</span>
                                     · SU {$mod.steam_universe}
                                 </div>
                                 <div style="margin-top:0.35rem">
@@ -179,7 +182,7 @@
                                    href="index.php?p=admin&amp;c=mods&amp;o=edit&amp;id={$mod.mid|escape:'url'}"
                                    data-testid="editmod-link-mobile"
                                    data-tooltip="Edit"
-                                   aria-label="Edit mod {$mod.name|escape}">
+                                   aria-label="Edit mod {$mod.name|unescape:'html'}">
                                     <i data-lucide="pencil" style="width:14px;height:14px"></i>
                                 </a>
                             {/if}
@@ -188,11 +191,11 @@
                                         type="button"
                                         data-action="mod-delete"
                                         data-mid="{$mod.mid}"
-                                        data-name="{$mod.name|escape}"
+                                        data-name="{$mod.name|unescape:'html'}"
                                         data-fallback-href="index.php?p=admin&amp;c=mods"
                                         data-testid="deletemod-btn-mobile"
                                         data-tooltip="Delete"
-                                        aria-label="Delete mod {$mod.name|escape}">
+                                        aria-label="Delete mod {$mod.name|unescape:'html'}">
                                     <i data-lucide="trash-2" style="width:14px;height:14px;color:var(--danger)"></i>
                                 </button>
                             {/if}
@@ -354,7 +357,7 @@
             if (!el) return;
             var n = Number((el.textContent || '').replace(/[^0-9]/g, ''));
             if (!Number.isFinite(n) || n <= 0) return;
-            el.textContent = '(' + (n - 1).toLocaleString() + ')';
+            el.textContent = '(' + String(n - 1) + ')';
         }
 
         /** @returns {HTMLDialogElement|null} */


### PR DESCRIPTION
## Description

Brings the admin Mods surfaces in line with the rest of the v2 panel list / form chrome.

### List mods (`?p=admin&c=mods&section=list`)
- Dense `table--compact` desktop table (less vertical padding per row).
- Icon-only row actions (`pencil` / `trash-2`) with `data-tooltip` + `aria-label`, matching banlist / admins.
- Page-level **Mods (N)** title outside the card (same shape as Admins).
- Mobile card mirror (`.mods-list-cards`) so the table is not hidden and does not force horizontal scroll under 768px. Delete removes both the desktop row and the mobile card.

### Add mod (`section=add`)
- Page-level **Add mod** title + subtitle outside the card (no title trapped in `card__header`).

### Edit mod (`o=edit`)
- Removes the empty `AdminTabs` Back strip that left dead space above the form (redundant with the footer Back next to Save).
- Page-level **Edit mod · &lt;name&gt;** title + subtitle, matching Edit admin / Edit ban.

## Motivation and Context

Mods list / add / edit still used the older “title inside the card + text Edit/Delete + keep-mobile table” shape after bans, comms, and admins moved to compact tables, icon actions, page titles, and mobile cards. This PR closes that visual and responsive gap without changing mod semantics or APIs.

## How Has This Been Tested?

- Local Docker panel at `:8080`
- Manual check: list (desktop + narrow viewport), add, edit
- Existing E2E/integration hooks (`mod-row`, `deletemod-btn`, mod-delete dialog) kept; count badge format now `(N)` like admins

## Screenshots (if appropriate):

### Before


https://github.com/user-attachments/assets/e5198ac0-ae8d-494b-a8fb-9e32a2581d92

### After


https://github.com/user-attachments/assets/a85b3df7-74f1-4639-8e56-64950554f2af



## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](CONTRIBUTING.md) document.